### PR TITLE
feat(editor): editable strings, objects, enums and bytes in typed property editor

### DIFF
--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -769,9 +769,11 @@ class EditorNotifier extends StateNotifier<EditorState> {
     }
   }
 
-  /// Layout-verified typed edit: set a fixed-size scalar (int/float/bool) at
-  /// a typed property path. Only offered by the core when the strict typed
-  /// parse of the save succeeded (`private.typed.setValue` in writable).
+  /// Layout-verified typed edit: set a fixed-size scalar (int/float/bool) or
+  /// a Str/Name string at a typed property path. String edits may change the
+  /// payload length; the core fixes up every enclosing size field. Only
+  /// offered by the core when the strict typed parse of the save succeeded
+  /// (`private.typed.setValue` in writable).
   ///
   /// Path segments: property name, `{mapKey}` for map entries, `[i]` for
   /// container/object-array indices.

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -769,11 +769,12 @@ class EditorNotifier extends StateNotifier<EditorState> {
     }
   }
 
-  /// Layout-verified typed edit: set a fixed-size scalar (int/float/bool) or
-  /// a Str/Name string at a typed property path. String edits may change the
-  /// payload length; the core fixes up every enclosing size field. Only
-  /// offered by the core when the strict typed parse of the save succeeded
-  /// (`private.typed.setValue` in writable).
+  /// Layout-verified typed edit: set a fixed-size scalar (int/float/bool/
+  /// byte) or a string-valued property (Str/Name/Object/Enum and the
+  /// enum-as-byte form of ByteProperty) at a typed property path. String
+  /// edits may change the payload length; the core fixes up every enclosing
+  /// size field. Only offered by the core when the strict typed parse of the
+  /// save succeeded (`private.typed.setValue` in writable).
   ///
   /// Path segments: property name, `{mapKey}` for map entries, `[i]` for
   /// container/object-array indices.

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -2981,8 +2981,8 @@ class _AllDataPanelState extends State<_AllDataPanel> {
           ),
           const SizedBox(height: 4),
           Text(
-            'Search every typed property by name or path. Scalars (int, '
-            'float, bool) and strings are editable; structs are shown '
+            'Search every typed property by name or path. Scalars, strings, '
+            'enums and object paths are editable; structs are shown '
             'read-only for now.',
             style: theme.textTheme.bodySmall?.copyWith(
               color: const Color(0xFF64748B),
@@ -3188,9 +3188,18 @@ class _TypedPropertyRowState extends State<_TypedPropertyRow> {
       // be intentional, so no trim.
       return _controller.text;
     }
+    if (type == 'ObjectProperty' || type == 'EnumProperty') {
+      return _controller.text.trim();
+    }
     final raw = _controller.text.trim();
     if (type == 'FloatProperty' || type == 'DoubleProperty') {
       return double.tryParse(raw);
+    }
+    if (type == 'ByteProperty') {
+      // Two serialized forms share the tag type: plain byte (number) and
+      // enum-as-FString. Send a number when it parses; otherwise send the
+      // text and let the core validate against the actual form.
+      return int.tryParse(raw) ?? raw;
     }
     return int.tryParse(raw);
   }

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -2847,7 +2847,7 @@ class _InfoChip extends StatelessWidget {
 }
 
 /// Generic typed property browser: search every property in the decoded
-/// private payload and edit fixed-size scalars in place. This is the
+/// private payload and edit scalars and strings. This is the
 /// "everything is editable" surface — no curated field list, the user finds
 /// any value by name and edits the ones the core can safely patch.
 class _AllDataPanel extends StatefulWidget {
@@ -2981,8 +2981,8 @@ class _AllDataPanelState extends State<_AllDataPanel> {
           ),
           const SizedBox(height: 4),
           Text(
-            'Search every typed property by name or path. Fixed-size scalars '
-            '(int, float, bool) are editable; strings and structs are shown '
+            'Search every typed property by name or path. Scalars (int, '
+            'float, bool) and strings are editable; structs are shown '
             'read-only for now.',
             style: theme.textTheme.bodySmall?.copyWith(
               color: const Color(0xFF64748B),
@@ -3183,6 +3183,11 @@ class _TypedPropertyRowState extends State<_TypedPropertyRow> {
 
   Object? _coerce() {
     final type = widget.hit.type;
+    if (type == 'StrProperty' || type == 'NameProperty') {
+      // String values are written verbatim — leading/trailing whitespace may
+      // be intentional, so no trim.
+      return _controller.text;
+    }
     final raw = _controller.text.trim();
     if (type == 'FloatProperty' || type == 'DoubleProperty') {
       return double.tryParse(raw);

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -3499,10 +3499,20 @@ fn coerce_typed_value(
                 .and_then(|v| u8::try_from(v).ok())
                 .map(|v| scalar(ScalarValue::Byte(v)))
                 .ok_or_else(|| err("a u8 integer")),
-            properties::PropertyValue::Enum(_) => value
-                .as_str()
-                .map(|v| TypedSetValue::Text(v.to_string()))
-                .ok_or_else(|| err("a string (this ByteProperty holds an enum name)")),
+            // Enum-as-byte stores the label as an FString. A UI that cannot
+            // tell the two Byte forms apart sends a number when the input
+            // parses as one, so an all-digit enum label (e.g. an unchanged
+            // "1") would arrive as a JSON number. Accept that and stringify
+            // the integer to the label instead of rejecting the write.
+            properties::PropertyValue::Enum(_) => {
+                if let Some(s) = value.as_str() {
+                    Ok(TypedSetValue::Text(s.to_string()))
+                } else if let Some(n) = value.as_i64() {
+                    Ok(TypedSetValue::Text(n.to_string()))
+                } else {
+                    Err(err("a string or integer enum label"))
+                }
+            }
             _ => Err(CoreError::UnsupportedEdit(
                 "private.typed.setValue does not support this ByteProperty form".to_string(),
             )),
@@ -6535,14 +6545,18 @@ mod tests {
         };
         apply_private_typed_set_value_edit_to_payload(&mut payload, &edit).unwrap();
 
-        // Enum-as-byte: string accepted (length change), number rejected.
-        let copy = payload.clone();
-        let bad = PrivateTypedSetValueEdit {
+        // Enum-as-byte: a JSON number is accepted and stringified to the
+        // label, so an all-digit enum value (e.g. an unchanged "1") still
+        // saves instead of failing. A plain string label works too.
+        let edit = PrivateTypedSetValueEdit {
             path: properties::parse_path(&["m_Rank".to_string()]).unwrap(),
             value: json!(1),
         };
-        assert!(apply_private_typed_set_value_edit_to_payload(&mut payload, &bad).is_err());
-        assert_eq!(payload, copy);
+        apply_private_typed_set_value_edit_to_payload(&mut payload, &edit).unwrap();
+        assert_eq!(
+            properties::parse_private_root(&payload).unwrap().properties[1].value,
+            properties::PropertyValue::Enum("1".to_string())
+        );
         let edit = PrivateTypedSetValueEdit {
             path: properties::parse_path(&["m_Rank".to_string()]).unwrap(),
             value: json!("ERank::Master"),

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -1827,9 +1827,9 @@ fn parse_compressed_stream(data: &[u8], offset: usize) -> Result<CompressedStrea
     // Fallible reservation: even with the bound above, never panic/abort across
     // the FFI boundary on a large count — surface a parse error instead.
     let mut chunks: Vec<CompressedChunk> = Vec::new();
-    chunks.try_reserve(chunk_count).map_err(|_| {
-        CoreError::Parse(format!("cannot reserve space for {chunk_count} chunks"))
-    })?;
+    chunks
+        .try_reserve(chunk_count)
+        .map_err(|_| CoreError::Parse(format!("cannot reserve space for {chunk_count} chunks")))?;
     for index in 0..chunk_count {
         let compressed_size = r.u64()?;
         let uncompressed_size = r.u64()?;
@@ -2339,7 +2339,9 @@ fn decoded_private_payload_cached(
 ) -> Result<Vec<u8>, CoreError> {
     let save_sha1 = sha1_hex(data);
     {
-        let guard = DECODED_PAYLOAD_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = DECODED_PAYLOAD_CACHE
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if let Some(entry) = guard.as_ref() {
             if entry.path == path && entry.save_sha1 == save_sha1 {
                 return Ok(entry.payload.clone());
@@ -2353,7 +2355,9 @@ fn decoded_private_payload_cached(
 
 /// Store a freshly decoded full private payload as the single cache entry.
 fn store_decoded_payload_cache(path: &Path, save_sha1: String, payload: Vec<u8>) {
-    let mut guard = DECODED_PAYLOAD_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    let mut guard = DECODED_PAYLOAD_CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     *guard = Some(DecodedPayloadEntry {
         path: path.to_path_buf(),
         save_sha1,
@@ -2363,7 +2367,9 @@ fn store_decoded_payload_cache(path: &Path, save_sha1: String, payload: Vec<u8>)
 
 /// Drop the cached decoded payload for `path` (called after a write changes it).
 fn invalidate_decoded_payload_cache(path: &Path) {
-    let mut guard = DECODED_PAYLOAD_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    let mut guard = DECODED_PAYLOAD_CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     if guard.as_ref().is_some_and(|entry| entry.path == path) {
         *guard = None;
     }
@@ -3434,10 +3440,18 @@ fn parse_private_typed_set_value_edit(edit: &Edit) -> Result<PrivateTypedSetValu
     })
 }
 
-fn coerce_typed_scalar(
+/// Replacement value for `private.typed.setValue`: fixed-size scalars patch
+/// in place, Str/Name strings may change the payload length.
+#[derive(Debug, Clone, PartialEq)]
+enum TypedSetValue {
+    Scalar(properties::ScalarValue),
+    Text(String),
+}
+
+fn coerce_typed_value(
     property: &properties::Property,
     value: &Value,
-) -> Result<properties::ScalarValue, CoreError> {
+) -> Result<TypedSetValue, CoreError> {
     use properties::ScalarValue;
     let type_name = property.type_name.as_str();
     let err = |expected: &str| {
@@ -3445,37 +3459,43 @@ fn coerce_typed_scalar(
             "private.typed.setValue: property is {type_name}, value must be {expected}"
         ))
     };
+    let scalar = |s: ScalarValue| TypedSetValue::Scalar(s);
     match type_name {
         "IntProperty" => value
             .as_i64()
             .and_then(|v| i32::try_from(v).ok())
-            .map(ScalarValue::Int)
+            .map(|v| scalar(ScalarValue::Int(v)))
             .ok_or_else(|| err("an i32 integer")),
         "UInt32Property" => value
             .as_u64()
             .and_then(|v| u32::try_from(v).ok())
-            .map(ScalarValue::UInt32)
+            .map(|v| scalar(ScalarValue::UInt32(v)))
             .ok_or_else(|| err("a u32 integer")),
         "Int64Property" => value
             .as_i64()
-            .map(ScalarValue::Int64)
+            .map(|v| scalar(ScalarValue::Int64(v)))
             .ok_or_else(|| err("an i64 integer")),
         "FloatProperty" => value
             .as_f64()
             .filter(|v| v.is_finite() && (*v as f32).is_finite())
-            .map(|v| ScalarValue::Float(v as f32))
+            .map(|v| scalar(ScalarValue::Float(v as f32)))
             .ok_or_else(|| err("a finite number")),
         "DoubleProperty" => value
             .as_f64()
             .filter(|v| v.is_finite())
-            .map(ScalarValue::Double)
+            .map(|v| scalar(ScalarValue::Double(v)))
             .ok_or_else(|| err("a finite number")),
         "BoolProperty" => value
             .as_bool()
-            .map(ScalarValue::Bool)
+            .map(|v| scalar(ScalarValue::Bool(v)))
             .ok_or_else(|| err("a boolean")),
+        "StrProperty" | "NameProperty" => value
+            .as_str()
+            .map(|v| TypedSetValue::Text(v.to_string()))
+            .ok_or_else(|| err("a string")),
         other => Err(CoreError::UnsupportedEdit(format!(
-            "private.typed.setValue does not support {other} targets (fixed-size scalars only)"
+            "private.typed.setValue does not support {other} targets \
+             (fixed-size scalars and Str/Name strings only)"
         ))),
     }
 }
@@ -3485,9 +3505,31 @@ fn apply_private_typed_set_value_edit_to_payload(
     edit: &PrivateTypedSetValueEdit,
 ) -> Result<(), CoreError> {
     let root = properties::parse_private_root(payload)?;
-    let target = properties::resolve(&root.properties, &edit.path)?.clone();
-    let scalar = coerce_typed_scalar(&target, &edit.value)?;
-    properties::patch_scalar(payload, &target, scalar)
+    let resolved = properties::resolve_chain(&root.properties, &edit.path)?;
+    let value = coerce_typed_value(resolved.target, &edit.value)?;
+    let target = resolved.target.clone();
+    match value {
+        TypedSetValue::Scalar(scalar) => properties::patch_scalar(payload, &target, scalar),
+        TypedSetValue::Text(text) => {
+            // Length-changing patch: work on a scratch copy and prove with a
+            // strict re-parse that every enclosing size field was fixed up, so
+            // a bug cannot corrupt the caller's payload (or the save).
+            let mut patched = payload.clone();
+            properties::patch_string(
+                &mut patched,
+                &target,
+                &resolved.enclosing_size_fields,
+                &text,
+            )?;
+            properties::parse_private_root(&patched).map_err(|err| {
+                CoreError::Parse(format!(
+                    "string patch produced an inconsistent payload: {err}"
+                ))
+            })?;
+            *payload = patched;
+            Ok(())
+        }
+    }
 }
 
 fn parse_private_fstring_edit(edit: &Edit) -> Result<PrivateFStringEdit, CoreError> {
@@ -4780,6 +4822,18 @@ mod tests {
         out
     }
 
+    fn private_str_property(name: &str, value: &str) -> Vec<u8> {
+        let payload = fstring(value);
+        let mut out = Vec::new();
+        out.extend_from_slice(&fstring(name));
+        out.extend_from_slice(&fstring("StrProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        out.push(0);
+        out.extend_from_slice(&payload);
+        out
+    }
+
     fn double_property(name: &str, value: f64) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(&fstring(name));
@@ -5846,8 +5900,11 @@ mod tests {
         let backup = dir.path().join("G1R-001.sav.bak.200");
         fs::write(&path, minimal_gsav("Live")).unwrap();
         // A GVAS sidecar misnamed as a slot backup must not replace the GSAV slot.
-        fs::write(&backup, persistent_data_list(&[("G1R-001", "X", 1, "M", 1.0, false, false)]))
-            .unwrap();
+        fs::write(
+            &backup,
+            persistent_data_list(&[("G1R-001", "X", 1, "M", 1.0, false, false)]),
+        )
+        .unwrap();
 
         let result = restore_backup(&path, &backup);
         assert!(result.is_err());
@@ -5887,10 +5944,8 @@ mod tests {
         let suffix = PathBuf::from("G1R").join("Saved").join("SaveGames");
 
         // Prefers LOCALAPPDATA.
-        let from_local = default_save_root_from(
-            Some(r"D:\LocalAppData".into()),
-            Some(r"D:\Profile".into()),
-        );
+        let from_local =
+            default_save_root_from(Some(r"D:\LocalAppData".into()), Some(r"D:\Profile".into()));
         assert_eq!(from_local, PathBuf::from(r"D:\LocalAppData").join(&suffix));
 
         // Falls back to USERPROFILE\AppData\Local when LOCALAPPDATA is unset/empty.
@@ -5975,10 +6030,7 @@ mod tests {
         .unwrap();
 
         let refs = scan_fstrings(&payload, 0);
-        let name_idx = refs
-            .iter()
-            .position(|r| r.value == "m_PlayerName")
-            .unwrap();
+        let name_idx = refs.iter().position(|r| r.value == "m_PlayerName").unwrap();
         let type_ref = &refs[name_idx + 1];
         assert_eq!(type_ref.value, "StrProperty");
         let value_ref = &refs[name_idx + 2];
@@ -5987,9 +6039,7 @@ mod tests {
         // Size word lives 4 bytes after the type FString and must equal the new
         // encoded value length (4-byte len prefix + bytes + NUL).
         let size_offset = type_ref.len_offset + type_ref.total_len + 4;
-        let size = u32::from_le_bytes(
-            payload[size_offset..size_offset + 4].try_into().unwrap(),
-        );
+        let size = u32::from_le_bytes(payload[size_offset..size_offset + 4].try_into().unwrap());
         assert_eq!(size as usize, encode_fstring("Nameless").len());
         // Trailing "None" terminator survived the splice.
         assert!(refs.iter().any(|r| r.value == "None"));
@@ -6322,12 +6372,8 @@ mod tests {
             seed_uncompressed: private_payload,
         };
 
-        let value = search_typed_properties(
-            &path,
-            &json!({ "query": "MaxQuick" }),
-            Some(&backend),
-        )
-        .unwrap();
+        let value = search_typed_properties(&path, &json!({ "query": "MaxQuick" }), Some(&backend))
+            .unwrap();
 
         assert_eq!(value["count"], 1);
         assert_eq!(value["total"], 1);
@@ -6359,7 +6405,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(page1["count"], 1);
-        assert_ne!(page0["results"][0]["display"], page1["results"][0]["display"]);
+        assert_ne!(
+            page0["results"][0]["display"],
+            page1["results"][0]["display"]
+        );
     }
 
     #[test]
@@ -6421,6 +6470,63 @@ mod tests {
     }
 
     #[test]
+    fn write_save_applies_typed_string_edit_with_length_change() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-001.sav");
+        let output_path = dir.path().join("G1R-001-string.sav");
+        let private_payload = {
+            let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+            p.push(0);
+            p.extend_from_slice(&private_str_property("m_PlayerName", "Hero"));
+            p.extend_from_slice(&int_property("m_MaxQuick", 3));
+            p.extend_from_slice(&fstring("None"));
+            p.extend_from_slice(&0u32.to_le_bytes());
+            p
+        };
+        let seed_compressed = b"seed-compressed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot A"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let response = write_save_with_codec_backend(
+            &path,
+            &[json!({
+                "path": "private.typed.setValue",
+                "value": { "path": ["m_PlayerName"], "value": "Nameless" }
+            })],
+            false,
+            Some(&output_path),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(response["editsApplied"], 1);
+
+        // The grown payload re-parses strictly and surfaces the new value.
+        let value =
+            inspect_save_with_codec_backend(&output_path, true, Some(&backend), None).unwrap();
+        assert_eq!(value["private"]["typedParse"]["status"], "ok");
+        let strings = value["private"]["strings"].as_array().unwrap();
+        assert!(strings.iter().any(|s| s == "Nameless"));
+
+        let searched = search_typed_properties(
+            &output_path,
+            &json!({ "query": "PlayerName" }),
+            Some(&backend),
+        )
+        .unwrap();
+        let hit = &searched["results"][0];
+        assert_eq!(hit["value"], "Nameless");
+        assert_eq!(hit["editable"], true);
+    }
+
+    #[test]
     fn typed_set_value_rejects_wrong_type_and_unknown_path() {
         let mut payload = fstring("/Script/Test.Save");
         payload.push(0);
@@ -6442,6 +6548,13 @@ mod tests {
         assert!(apply_private_typed_set_value_edit_to_payload(&mut copy, &unknown).is_err());
         assert_eq!(copy, payload, "failed edits must not mutate the payload");
 
+        let string_on_int = PrivateTypedSetValueEdit {
+            path: properties::parse_path(&["m_X".to_string()]).unwrap(),
+            value: json!("oops"),
+        };
+        assert!(apply_private_typed_set_value_edit_to_payload(&mut copy, &string_on_int).is_err());
+        assert_eq!(copy, payload, "failed edits must not mutate the payload");
+
         let ok = PrivateTypedSetValueEdit {
             path: properties::parse_path(&["m_X".to_string()]).unwrap(),
             value: json!(42),
@@ -6449,6 +6562,43 @@ mod tests {
         apply_private_typed_set_value_edit_to_payload(&mut copy, &ok).unwrap();
         let root = properties::parse_private_root(&copy).unwrap();
         assert_eq!(root.properties[0].value, properties::PropertyValue::Int(42));
+    }
+
+    #[test]
+    fn typed_set_value_patches_string_with_length_change() {
+        let mut payload = fstring("/Script/Test.Save");
+        payload.push(0);
+        payload.extend_from_slice(&private_str_property("m_PlayerName", "Hero"));
+        payload.extend_from_slice(&int_property("m_Gold", 250));
+        payload.extend_from_slice(&fstring("None"));
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        let original_len = payload.len();
+
+        // Non-string value on a string target must fail without mutation.
+        let copy = payload.clone();
+        let bad = PrivateTypedSetValueEdit {
+            path: properties::parse_path(&["m_PlayerName".to_string()]).unwrap(),
+            value: json!(7),
+        };
+        assert!(apply_private_typed_set_value_edit_to_payload(&mut payload, &bad).is_err());
+        assert_eq!(payload, copy);
+
+        let edit = PrivateTypedSetValueEdit {
+            path: properties::parse_path(&["m_PlayerName".to_string()]).unwrap(),
+            value: json!("Nameless"),
+        };
+        apply_private_typed_set_value_edit_to_payload(&mut payload, &edit).unwrap();
+
+        assert_eq!(payload.len(), original_len + 4);
+        let root = properties::parse_private_root(&payload).unwrap();
+        assert_eq!(
+            root.properties[0].value,
+            properties::PropertyValue::Str("Nameless".to_string())
+        );
+        assert_eq!(
+            root.properties[1].value,
+            properties::PropertyValue::Int(250)
+        );
     }
 
     #[test]

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -3441,7 +3441,8 @@ fn parse_private_typed_set_value_edit(edit: &Edit) -> Result<PrivateTypedSetValu
 }
 
 /// Replacement value for `private.typed.setValue`: fixed-size scalars patch
-/// in place, Str/Name strings may change the payload length.
+/// in place, string-valued properties (Str/Name/Object/Enum and the
+/// enum-as-byte form of ByteProperty) may change the payload length.
 #[derive(Debug, Clone, PartialEq)]
 enum TypedSetValue {
     Scalar(properties::ScalarValue),
@@ -3489,13 +3490,30 @@ fn coerce_typed_value(
             .as_bool()
             .map(|v| scalar(ScalarValue::Bool(v)))
             .ok_or_else(|| err("a boolean")),
-        "StrProperty" | "NameProperty" => value
+        // ByteProperty has two serialized forms: a plain byte (scalar patch in
+        // place) and an enum-as-FString (string patch). Dispatch on the parsed
+        // value, not the tag type.
+        "ByteProperty" => match property.value {
+            properties::PropertyValue::Byte(_) => value
+                .as_u64()
+                .and_then(|v| u8::try_from(v).ok())
+                .map(|v| scalar(ScalarValue::Byte(v)))
+                .ok_or_else(|| err("a u8 integer")),
+            properties::PropertyValue::Enum(_) => value
+                .as_str()
+                .map(|v| TypedSetValue::Text(v.to_string()))
+                .ok_or_else(|| err("a string (this ByteProperty holds an enum name)")),
+            _ => Err(CoreError::UnsupportedEdit(
+                "private.typed.setValue does not support this ByteProperty form".to_string(),
+            )),
+        },
+        "StrProperty" | "NameProperty" | "ObjectProperty" | "EnumProperty" => value
             .as_str()
             .map(|v| TypedSetValue::Text(v.to_string()))
             .ok_or_else(|| err("a string")),
         other => Err(CoreError::UnsupportedEdit(format!(
             "private.typed.setValue does not support {other} targets \
-             (fixed-size scalars and Str/Name strings only)"
+             (fixed-size scalars and string-valued properties only)"
         ))),
     }
 }
@@ -4831,6 +4849,31 @@ mod tests {
         out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
         out.push(0);
         out.extend_from_slice(&payload);
+        out
+    }
+
+    /// ByteProperty in its enum-as-FString form.
+    fn private_byte_enum_property(name: &str, value: &str) -> Vec<u8> {
+        let payload = fstring(value);
+        let mut out = Vec::new();
+        out.extend_from_slice(&fstring(name));
+        out.extend_from_slice(&fstring("ByteProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        out.push(0);
+        out.extend_from_slice(&payload);
+        out
+    }
+
+    /// ByteProperty in its plain one-byte form.
+    fn private_byte_plain_property(name: &str, value: u8) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&fstring(name));
+        out.extend_from_slice(&fstring("ByteProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.push(0);
+        out.push(value);
         out
     }
 
@@ -6467,6 +6510,54 @@ mod tests {
         // patched payload re-parses and carries the new value
         let strings = value["private"]["strings"].as_array().unwrap();
         assert!(strings.iter().any(|s| s == "m_MaxQuick"));
+    }
+
+    #[test]
+    fn typed_set_value_dispatches_byte_property_forms() {
+        let mut payload = fstring("/Script/Test.Save");
+        payload.push(0);
+        payload.extend_from_slice(&private_byte_plain_property("m_Level", 3));
+        payload.extend_from_slice(&private_byte_enum_property("m_Rank", "ERank::Novice"));
+        payload.extend_from_slice(&fstring("None"));
+        payload.extend_from_slice(&0u32.to_le_bytes());
+
+        // Plain byte: number accepted, string rejected without mutation.
+        let copy = payload.clone();
+        let bad = PrivateTypedSetValueEdit {
+            path: properties::parse_path(&["m_Level".to_string()]).unwrap(),
+            value: json!("ERank::Master"),
+        };
+        assert!(apply_private_typed_set_value_edit_to_payload(&mut payload, &bad).is_err());
+        assert_eq!(payload, copy);
+        let edit = PrivateTypedSetValueEdit {
+            path: properties::parse_path(&["m_Level".to_string()]).unwrap(),
+            value: json!(42),
+        };
+        apply_private_typed_set_value_edit_to_payload(&mut payload, &edit).unwrap();
+
+        // Enum-as-byte: string accepted (length change), number rejected.
+        let copy = payload.clone();
+        let bad = PrivateTypedSetValueEdit {
+            path: properties::parse_path(&["m_Rank".to_string()]).unwrap(),
+            value: json!(1),
+        };
+        assert!(apply_private_typed_set_value_edit_to_payload(&mut payload, &bad).is_err());
+        assert_eq!(payload, copy);
+        let edit = PrivateTypedSetValueEdit {
+            path: properties::parse_path(&["m_Rank".to_string()]).unwrap(),
+            value: json!("ERank::Master"),
+        };
+        apply_private_typed_set_value_edit_to_payload(&mut payload, &edit).unwrap();
+
+        let root = properties::parse_private_root(&payload).unwrap();
+        assert_eq!(
+            root.properties[0].value,
+            properties::PropertyValue::Byte(42)
+        );
+        assert_eq!(
+            root.properties[1].value,
+            properties::PropertyValue::Enum("ERank::Master".to_string())
+        );
     }
 
     #[test]

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -55,6 +55,15 @@ pub struct Property {
     pub value: PropertyValue,
 }
 
+impl Property {
+    /// Absolute offset of the tag's u32 `size` field. The value payload is
+    /// always preceded by `u32 size | u8 tag_flags`, so the size field sits
+    /// five bytes before the recorded value offset.
+    pub fn size_field_offset(&self) -> usize {
+        self.value_offset - 5
+    }
+}
+
 /// Type descriptors serialized between the property type and the value header.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Descriptor {
@@ -124,10 +133,26 @@ pub struct ObjectInstance {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum StructValue {
-    Vector3 { x: f64, y: f64, z: f64 },
-    Vector3f { x: f32, y: f32, z: f32 },
-    Vector4 { x: f64, y: f64, z: f64, w: f64 },
-    Vector2 { x: f64, y: f64 },
+    Vector3 {
+        x: f64,
+        y: f64,
+        z: f64,
+    },
+    Vector3f {
+        x: f32,
+        y: f32,
+        z: f32,
+    },
+    Vector4 {
+        x: f64,
+        y: f64,
+        z: f64,
+        w: f64,
+    },
+    Vector2 {
+        x: f64,
+        y: f64,
+    },
     Guid([u8; 16]),
     DateTime(i64),
     GameplayTagContainer(Vec<String>),
@@ -139,6 +164,9 @@ pub enum StructValue {
 #[derive(Debug, Clone, PartialEq)]
 pub struct InstancedStruct {
     pub actual_type: String,
+    /// Absolute offset of the u32 `data_size` field preceding the body.
+    /// Length-changing edits inside this struct must adjust it.
+    pub data_size_offset: usize,
     pub properties: Vec<Property>,
 }
 
@@ -166,9 +194,9 @@ pub fn parse_path(segments: &[String]) -> Result<Vec<PathSeg>, CoreError> {
             if let Some(key) = raw.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
                 Ok(PathSeg::MapKey(key.to_string()))
             } else if let Some(idx) = raw.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
-                idx.parse::<usize>()
-                    .map(PathSeg::Index)
-                    .map_err(|_| CoreError::InvalidRequest(format!("invalid index segment {raw:?}")))
+                idx.parse::<usize>().map(PathSeg::Index).map_err(|_| {
+                    CoreError::InvalidRequest(format!("invalid index segment {raw:?}"))
+                })
             } else if raw.is_empty() {
                 Err(CoreError::InvalidRequest("empty path segment".to_string()))
             } else {
@@ -192,11 +220,44 @@ fn map_key_to_string(key: &PropertyValue) -> Option<String> {
     }
 }
 
+/// A resolved typed path plus the absolute offsets of every enclosing u32
+/// size field crossed on the way to the target (outermost first): the tag
+/// `size` of each ancestor property and the `data_size` of each
+/// InstancedStruct wrapper. Length-changing edits must add their byte delta
+/// to each of these fields; the target's own size field is not included.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedChain<'a> {
+    pub target: &'a Property,
+    pub enclosing_size_fields: Vec<usize>,
+}
+
 /// Resolve a path to a tagged property within a parsed tree. The target must
 /// be a `Property` (it carries the absolute value offset needed for patching).
 pub fn resolve<'a>(
     properties: &'a [Property],
     path: &[PathSeg],
+) -> Result<&'a Property, CoreError> {
+    resolve_chain(properties, path).map(|chain| chain.target)
+}
+
+/// Like [`resolve`], but also collects the enclosing size-field offsets needed
+/// to apply a length-changing patch at the target.
+pub fn resolve_chain<'a>(
+    properties: &'a [Property],
+    path: &[PathSeg],
+) -> Result<ResolvedChain<'a>, CoreError> {
+    let mut enclosing_size_fields = Vec::new();
+    let target = resolve_in_properties(properties, path, &mut enclosing_size_fields)?;
+    Ok(ResolvedChain {
+        target,
+        enclosing_size_fields,
+    })
+}
+
+fn resolve_in_properties<'a>(
+    properties: &'a [Property],
+    path: &[PathSeg],
+    sizes: &mut Vec<usize>,
 ) -> Result<&'a Property, CoreError> {
     let Some((first, rest)) = path.split_first() else {
         return Err(CoreError::InvalidRequest("empty typed path".to_string()));
@@ -213,20 +274,23 @@ pub fn resolve<'a>(
     if rest.is_empty() {
         return Ok(property);
     }
-    resolve_in_value(&property.value, rest)
+    sizes.push(property.size_field_offset());
+    resolve_in_value(&property.value, rest, sizes)
 }
 
 fn resolve_in_value<'a>(
     value: &'a PropertyValue,
     path: &[PathSeg],
+    sizes: &mut Vec<usize>,
 ) -> Result<&'a Property, CoreError> {
     let (seg, rest) = path.split_first().expect("path checked non-empty");
     match (value, seg) {
         (PropertyValue::Struct(StructValue::Properties(inner)), PathSeg::Name(_)) => {
-            resolve(inner, path)
+            resolve_in_properties(inner, path, sizes)
         }
         (PropertyValue::Struct(StructValue::Instanced(Some(instanced))), PathSeg::Name(_)) => {
-            resolve(&instanced.properties, path)
+            sizes.push(instanced.data_size_offset);
+            resolve_in_properties(&instanced.properties, path, sizes)
         }
         (PropertyValue::Map { entries, .. }, PathSeg::MapKey(wanted)) => {
             let entry = entries
@@ -238,7 +302,7 @@ fn resolve_in_value<'a>(
                     "path may not end on a map entry; address a property inside it".to_string(),
                 ));
             }
-            resolve_in_value(&entry.1, rest)
+            resolve_in_value(&entry.1, rest, sizes)
         }
         (PropertyValue::Array { elements }, PathSeg::Index(i))
         | (PropertyValue::Set { elements, .. }, PathSeg::Index(i)) => {
@@ -251,7 +315,7 @@ fn resolve_in_value<'a>(
                         .to_string(),
                 ));
             }
-            resolve_in_value(element, rest)
+            resolve_in_value(element, rest, sizes)
         }
         (PropertyValue::ObjectInstances(instances), PathSeg::Index(i)) => {
             let instance = instances
@@ -263,7 +327,7 @@ fn resolve_in_value<'a>(
                         .to_string(),
                 ));
             }
-            resolve(&instance.properties, rest)
+            resolve_in_properties(&instance.properties, rest, sizes)
         }
         (other, seg) => Err(CoreError::InvalidRequest(format!(
             "segment {seg:?} cannot descend into {}",
@@ -307,7 +371,8 @@ pub struct PropertyHit {
     pub type_name: String,
     /// Formatted current value.
     pub value_display: String,
-    /// True for fixed-size scalars that `private.typed.setValue` can patch.
+    /// True for values `private.typed.setValue` can patch: fixed-size scalars
+    /// and Str/Name strings (length-changing, size chain fixed up on write).
     pub editable: bool,
 }
 
@@ -332,7 +397,12 @@ pub fn search_properties(
         total: &mut total,
         hits: &mut hits,
     };
-    walk_search(&root.properties, &mut Vec::new(), &mut String::new(), &mut ctx);
+    walk_search(
+        &root.properties,
+        &mut Vec::new(),
+        &mut String::new(),
+        &mut ctx,
+    );
     (hits, total)
 }
 
@@ -365,6 +435,8 @@ fn scalar_editable(value: &PropertyValue) -> bool {
             | PropertyValue::Float(_)
             | PropertyValue::Double(_)
             | PropertyValue::Bool(_)
+            | PropertyValue::Str(_)
+            | PropertyValue::Name(_)
     )
 }
 
@@ -377,9 +449,10 @@ fn scalar_display(value: &PropertyValue) -> Option<String> {
         PropertyValue::Double(v) => v.to_string(),
         PropertyValue::Bool(v) => v.to_string(),
         PropertyValue::Byte(v) => v.to_string(),
-        PropertyValue::Str(s) | PropertyValue::Name(s) | PropertyValue::Object(s) | PropertyValue::Enum(s) => {
-            s.clone()
-        }
+        PropertyValue::Str(s)
+        | PropertyValue::Name(s)
+        | PropertyValue::Object(s)
+        | PropertyValue::Enum(s) => s.clone(),
         PropertyValue::SoftObject(p) => p.package_name.clone(),
         _ => return None,
     })
@@ -546,7 +619,12 @@ pub fn patch_scalar(
     property: &Property,
     value: ScalarValue,
 ) -> Result<(), CoreError> {
-    fn write(payload: &mut [u8], offset: usize, size: usize, bytes: &[u8]) -> Result<(), CoreError> {
+    fn write(
+        payload: &mut [u8],
+        offset: usize,
+        size: usize,
+        bytes: &[u8],
+    ) -> Result<(), CoreError> {
         if size != bytes.len() || offset + size > payload.len() {
             return Err(CoreError::Parse(format!(
                 "patch target out of bounds: offset {offset}, size {size}"
@@ -562,21 +640,36 @@ pub fn patch_scalar(
         ))
     };
     match (property.type_name.as_str(), value) {
-        ("IntProperty", ScalarValue::Int(v)) => {
-            write(payload, property.value_offset, property.value_size, &v.to_le_bytes())
-        }
-        ("UInt32Property", ScalarValue::UInt32(v)) => {
-            write(payload, property.value_offset, property.value_size, &v.to_le_bytes())
-        }
-        ("Int64Property", ScalarValue::Int64(v)) => {
-            write(payload, property.value_offset, property.value_size, &v.to_le_bytes())
-        }
-        ("FloatProperty", ScalarValue::Float(v)) => {
-            write(payload, property.value_offset, property.value_size, &v.to_le_bytes())
-        }
-        ("DoubleProperty", ScalarValue::Double(v)) => {
-            write(payload, property.value_offset, property.value_size, &v.to_le_bytes())
-        }
+        ("IntProperty", ScalarValue::Int(v)) => write(
+            payload,
+            property.value_offset,
+            property.value_size,
+            &v.to_le_bytes(),
+        ),
+        ("UInt32Property", ScalarValue::UInt32(v)) => write(
+            payload,
+            property.value_offset,
+            property.value_size,
+            &v.to_le_bytes(),
+        ),
+        ("Int64Property", ScalarValue::Int64(v)) => write(
+            payload,
+            property.value_offset,
+            property.value_size,
+            &v.to_le_bytes(),
+        ),
+        ("FloatProperty", ScalarValue::Float(v)) => write(
+            payload,
+            property.value_offset,
+            property.value_size,
+            &v.to_le_bytes(),
+        ),
+        ("DoubleProperty", ScalarValue::Double(v)) => write(
+            payload,
+            property.value_offset,
+            property.value_size,
+            &v.to_le_bytes(),
+        ),
         ("BoolProperty", ScalarValue::Bool(v)) => {
             // No payload; the value is tag_flags bit 0x10, one byte before the
             // recorded value offset.
@@ -585,7 +678,9 @@ pub fn patch_scalar(
                 .checked_sub(1)
                 .ok_or_else(|| CoreError::Parse("bool tag offset underflow".to_string()))?;
             if flag_offset >= payload.len() {
-                return Err(CoreError::Parse("bool tag offset out of bounds".to_string()));
+                return Err(CoreError::Parse(
+                    "bool tag offset out of bounds".to_string(),
+                ));
             }
             if v {
                 payload[flag_offset] |= TAG_FLAG_BOOL_TRUE;
@@ -596,6 +691,91 @@ pub fn patch_scalar(
         }
         _ => Err(mismatch()),
     }
+}
+
+/// Serialized FString payload for a replacement value, mirroring the formats
+/// `Reader::fstring` accepts: empty => bare zero length, ASCII => 8-bit chars
+/// with a NUL terminator, otherwise UTF-16LE with a negative character count.
+fn encode_fstring_value(value: &str) -> Vec<u8> {
+    if value.is_empty() {
+        return 0i32.to_le_bytes().to_vec();
+    }
+    if value.is_ascii() {
+        let mut out = ((value.len() + 1) as i32).to_le_bytes().to_vec();
+        out.extend_from_slice(value.as_bytes());
+        out.push(0);
+        return out;
+    }
+    let units: Vec<u16> = value.encode_utf16().collect();
+    let count = -((units.len() + 1) as i32);
+    let mut out = count.to_le_bytes().to_vec();
+    for unit in units {
+        out.extend_from_slice(&unit.to_le_bytes());
+    }
+    out.extend_from_slice(&[0, 0]);
+    out
+}
+
+/// Replace a Str/Name property's FString payload. The new bytes may differ in
+/// length: the property's own tag size and every enclosing size field in
+/// `enclosing_size_fields` (from [`resolve_chain`]) are adjusted by the byte
+/// delta. All writes are validated before the first mutation, so a failed
+/// patch leaves the payload untouched. Offsets recorded in the parsed tree
+/// are stale after a successful patch — re-parse before further edits.
+pub fn patch_string(
+    payload: &mut Vec<u8>,
+    target: &Property,
+    enclosing_size_fields: &[usize],
+    new_value: &str,
+) -> Result<(), CoreError> {
+    if target.type_name != "StrProperty" && target.type_name != "NameProperty" {
+        return Err(CoreError::InvalidRequest(format!(
+            "string value does not match property type {}",
+            target.type_name
+        )));
+    }
+    let value_end = target
+        .value_offset
+        .checked_add(target.value_size)
+        .filter(|end| *end <= payload.len())
+        .ok_or_else(|| {
+            CoreError::Parse(format!(
+                "patch target out of bounds: offset {}, size {}",
+                target.value_offset, target.value_size
+            ))
+        })?;
+    let encoded = encode_fstring_value(new_value);
+    let new_size = u32::try_from(encoded.len())
+        .map_err(|_| CoreError::InvalidRequest("replacement string too long".to_string()))?;
+    let delta = encoded.len() as i64 - target.value_size as i64;
+
+    // Compute every size-field rewrite up front; mutate only once all are valid.
+    let mut writes = Vec::with_capacity(enclosing_size_fields.len() + 1);
+    if target.value_offset < 5 {
+        return Err(CoreError::Parse("string tag offset underflow".to_string()));
+    }
+    writes.push((target.size_field_offset(), new_size));
+    for &offset in enclosing_size_fields {
+        // Enclosing headers always precede the value they wrap, so they are
+        // unaffected by the splice below.
+        if offset + 4 > target.value_offset {
+            return Err(CoreError::Parse(format!(
+                "enclosing size field at 0x{offset:x} does not precede the patch target"
+            )));
+        }
+        let old = u32::from_le_bytes(payload[offset..offset + 4].try_into().unwrap());
+        let updated = u32::try_from(i64::from(old) + delta).map_err(|_| {
+            CoreError::Parse(format!(
+                "enclosing size field at 0x{offset:x} would leave the u32 range"
+            ))
+        })?;
+        writes.push((offset, updated));
+    }
+    for (offset, value) in writes {
+        payload[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+    payload.splice(target.value_offset..value_end, encoded);
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -673,7 +853,9 @@ fn read_object(r: &mut Reader, depth: usize) -> Result<RootObject, CoreError> {
 
 pub(crate) fn read_property_list(r: &mut Reader, depth: usize) -> Result<Vec<Property>, CoreError> {
     if depth > MAX_DEPTH {
-        return Err(CoreError::Parse(format!("property nesting exceeds {MAX_DEPTH}")));
+        return Err(CoreError::Parse(format!(
+            "property nesting exceeds {MAX_DEPTH}"
+        )));
     }
     let mut out = Vec::new();
     loop {
@@ -1001,6 +1183,7 @@ fn read_struct_value(
         }
         "InstancedStruct" => {
             let actual_type = r.fstring()?;
+            let data_size_offset = r.abs_pos();
             let data_size = r.u32()? as usize;
             let body_base = r.abs_pos();
             let body = r.read(data_size)?;
@@ -1017,6 +1200,7 @@ fn read_struct_value(
             }
             Ok(StructValue::Instanced(Some(InstancedStruct {
                 actual_type,
+                data_size_offset,
                 properties,
             })))
         }
@@ -1182,7 +1366,13 @@ mod tests {
         let parsed = parse_private_root(&payload).unwrap();
         match &parsed.properties[0].value {
             PropertyValue::Struct(StructValue::GameplayTagContainer(tags)) => {
-                assert_eq!(tags, &vec!["Guild.Orc.Scout".to_string(), "Memory.Guild.Joined".to_string()]);
+                assert_eq!(
+                    tags,
+                    &vec![
+                        "Guild.Orc.Scout".to_string(),
+                        "Memory.Guild.Joined".to_string()
+                    ]
+                );
             }
             other => panic!("unexpected value {other:?}"),
         }
@@ -1209,7 +1399,10 @@ mod tests {
         match &parsed.properties[0].value {
             PropertyValue::Struct(StructValue::Properties(inner)) => {
                 assert_eq!(inner[0].name, "TagName");
-                assert_eq!(inner[0].value, PropertyValue::Name("CrimeLocation.OldCamp".into()));
+                assert_eq!(
+                    inner[0].value,
+                    PropertyValue::Name("CrimeLocation.OldCamp".into())
+                );
             }
             other => panic!("unexpected value {other:?}"),
         }
@@ -1298,7 +1491,10 @@ mod tests {
         let parsed = parse_private_root(&payload).unwrap();
 
         match &parsed.properties[0].value {
-            PropertyValue::Map { num_to_remove, entries } => {
+            PropertyValue::Map {
+                num_to_remove,
+                entries,
+            } => {
                 assert_eq!(*num_to_remove, 0);
                 assert_eq!(
                     entries[0],
@@ -1438,8 +1634,7 @@ mod tests {
         };
         for path in paths.split(';').filter(|p| !p.is_empty()) {
             let payload = std::fs::read(path).unwrap();
-            let parsed = parse_private_root(&payload)
-                .unwrap_or_else(|err| panic!("{path}: {err}"));
+            let parsed = parse_private_root(&payload).unwrap_or_else(|err| panic!("{path}: {err}"));
             assert_eq!(parsed.consumed, payload.len(), "{path}: incomplete parse");
             fn count(props: &[Property]) -> usize {
                 props
@@ -1464,6 +1659,63 @@ mod tests {
                 payload.len(),
                 parsed.properties.len(),
                 count(&parsed.properties),
+            );
+        }
+    }
+
+    /// Length-changing string patch against real payload dumps: grow the first
+    /// addressable nested string by four bytes, then prove the strict re-parse
+    /// still consumes every byte. Run manually like `real_payload_parses_byte_exact`.
+    #[test]
+    #[ignore = "needs a local payload dump (GORESAVE_PAYLOAD_BIN)"]
+    fn real_payload_string_patch_reparses_byte_exact() {
+        let Ok(paths) = std::env::var("GORESAVE_PAYLOAD_BIN") else {
+            panic!("set GORESAVE_PAYLOAD_BIN to a decompressed payload dump");
+        };
+        for path in paths.split(';').filter(|p| !p.is_empty()) {
+            let mut payload = std::fs::read(path).unwrap();
+            let parsed = parse_private_root(&payload).unwrap();
+            let (hits, _) = search_properties(&parsed, "", 0, 100_000);
+            // Deepest addressable string = longest enclosing size chain.
+            let Some(hit) = hits
+                .iter()
+                .filter(|h| {
+                    h.editable && (h.type_name == "StrProperty" || h.type_name == "NameProperty")
+                })
+                .max_by_key(|h| h.path.len())
+            else {
+                println!("{path}: no addressable string property, skipping");
+                continue;
+            };
+            let segs = parse_path(&hit.path).unwrap();
+            let chain = resolve_chain(&parsed.properties, &segs).unwrap();
+            let target = chain.target.clone();
+            let new_value = format!("{}_ABC", hit.value_display);
+            patch_string(
+                &mut payload,
+                &target,
+                &chain.enclosing_size_fields,
+                &new_value,
+            )
+            .unwrap();
+
+            let reparsed = parse_private_root(&payload)
+                .unwrap_or_else(|err| panic!("{path}: re-parse after string patch failed: {err}"));
+            assert_eq!(
+                reparsed.consumed,
+                payload.len(),
+                "{path}: incomplete re-parse"
+            );
+            let after = resolve(&reparsed.properties, &segs).unwrap();
+            let value = match &after.value {
+                PropertyValue::Str(s) | PropertyValue::Name(s) => s.clone(),
+                other => panic!("{path}: unexpected value {other:?}"),
+            };
+            assert_eq!(value, new_value);
+            println!(
+                "{path}: patched {} ({} enclosing size fields) -> {new_value:?}",
+                hit.display,
+                chain.enclosing_size_fields.len(),
             );
         }
     }
@@ -1520,13 +1772,19 @@ mod tests {
         assert_eq!(total, 1);
         assert_eq!(hits.len(), 1);
         let hit = &hits[0];
-        assert_eq!(hit.path, vec!["m_GenericData", "{ChestStates}", "m_ItemCount"]);
+        assert_eq!(
+            hit.path,
+            vec!["m_GenericData", "{ChestStates}", "m_ItemCount"]
+        );
         assert_eq!(hit.type_name, "IntProperty");
         assert_eq!(hit.value_display, "5");
         assert!(hit.editable);
         // path round-trips through resolve()
         let segs = parse_path(&hit.path).unwrap();
-        assert_eq!(resolve(&root.properties, &segs).unwrap().value, PropertyValue::Int(5));
+        assert_eq!(
+            resolve(&root.properties, &segs).unwrap().value,
+            PropertyValue::Int(5)
+        );
     }
 
     #[test]
@@ -1552,7 +1810,7 @@ mod tests {
     }
 
     #[test]
-    fn search_marks_strings_non_editable() {
+    fn search_marks_strings_editable() {
         // root class string is not a property; build a payload with a StrProperty
         let mut props = str_property("m_ProfileName", "Hero");
         props.extend_from_slice(&int_property("m_Gold", 250));
@@ -1560,9 +1818,28 @@ mod tests {
         let parsed = parse_private_root(&payload).unwrap();
         let (hits, _) = search_properties(&parsed, "m_", 0, 100);
         let name_hit = hits.iter().find(|h| h.display == "m_ProfileName").unwrap();
-        assert!(!name_hit.editable);
+        assert!(name_hit.editable);
         let gold_hit = hits.iter().find(|h| h.display == "m_Gold").unwrap();
         assert!(gold_hit.editable);
+    }
+
+    #[test]
+    fn search_keeps_container_element_strings_non_editable() {
+        // Set<NameProperty> elements surface as hits whose path ends on an
+        // `[index]` segment, which setValue cannot resolve — stay read-only.
+        let mut set_body = 0u32.to_le_bytes().to_vec();
+        set_body.extend_from_slice(&1u32.to_le_bytes());
+        set_body.extend_from_slice(&fstring("Lock_A"));
+        let mut props = tag("m_UnlockedLocks", "SetProperty");
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("NameProperty"));
+        props.extend_from_slice(&header(set_body.len() as u32, 0));
+        props.extend_from_slice(&set_body);
+        let payload = root("/Script/Test.Save", &props);
+        let parsed = parse_private_root(&payload).unwrap();
+        let (hits, _) = search_properties(&parsed, "lock", 0, 100);
+        let hit = hits.iter().find(|h| h.value_display == "Lock_A").unwrap();
+        assert!(!hit.editable);
     }
 
     #[test]
@@ -1672,5 +1949,215 @@ mod tests {
         // The recorded offset must index the WHOLE payload, not the inner body.
         let raw = &payload[inner.value_offset..inner.value_offset + inner.value_size];
         assert_eq!(i32::from_le_bytes(raw.try_into().unwrap()), 5);
+    }
+
+    /// Real-save shape with a string leaf: root → MapProperty<Str,
+    /// InstancedStruct> → { m_PlayerName: Str, m_ItemCount: Int }, plus a
+    /// root-level int after the map so a missed size-chain fixup shifts it
+    /// and breaks the strict re-parse.
+    fn nested_string_payload(player_name: &str) -> Vec<u8> {
+        let nested = {
+            let mut n = str_property("m_PlayerName", player_name);
+            n.extend_from_slice(&int_property("m_ItemCount", 5));
+            n.extend_from_slice(&fstring("None"));
+            n
+        };
+        let mut instanced = fstring("/Script/G1R.PlayerCharacter");
+        instanced.extend_from_slice(&(nested.len() as u32).to_le_bytes());
+        instanced.extend_from_slice(&nested);
+
+        let mut map_body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        map_body.extend_from_slice(&1u32.to_le_bytes()); // count
+        map_body.extend_from_slice(&fstring("CharacterStates"));
+        map_body.extend_from_slice(&instanced);
+
+        let mut props = tag("m_GenericData", "MapProperty");
+        props.extend_from_slice(&2u32.to_le_bytes());
+        props.extend_from_slice(&fstring("StrProperty"));
+        props.extend_from_slice(&0u32.to_le_bytes()); // key_flags
+        props.extend_from_slice(&fstring("StructProperty"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("InstancedStruct"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("/Script/StructUtils"));
+        props.extend_from_slice(&header(map_body.len() as u32, TAG_FLAG_NATIVE_SERIALIZE));
+        props.extend_from_slice(&map_body);
+        props.extend_from_slice(&int_property("m_AfterMap", 7));
+        root("/Script/Test.Save", &props)
+    }
+
+    fn player_name_path() -> Vec<PathSeg> {
+        parse_path(&[
+            "m_GenericData".into(),
+            "{CharacterStates}".into(),
+            "m_PlayerName".into(),
+        ])
+        .unwrap()
+    }
+
+    /// Re-parse strictly and assert the string took the new value while the
+    /// nested int and the root-level property after the map stayed intact.
+    fn assert_nested_string_patch(payload: &[u8], expected_name: &str) {
+        let reparsed = parse_private_root(payload).unwrap();
+        let name = resolve(&reparsed.properties, &player_name_path()).unwrap();
+        assert_eq!(name.value, PropertyValue::Str(expected_name.to_string()));
+        let count_path = parse_path(&[
+            "m_GenericData".into(),
+            "{CharacterStates}".into(),
+            "m_ItemCount".into(),
+        ])
+        .unwrap();
+        let count = resolve(&reparsed.properties, &count_path).unwrap();
+        assert_eq!(count.value, PropertyValue::Int(5));
+        let after = parse_path(&["m_AfterMap".into()]).unwrap();
+        let after = resolve(&reparsed.properties, &after).unwrap();
+        assert_eq!(after.value, PropertyValue::Int(7));
+    }
+
+    #[test]
+    fn resolve_chain_collects_enclosing_size_fields() {
+        let payload = nested_string_payload("Hero");
+        let parsed = parse_private_root(&payload).unwrap();
+        let chain = resolve_chain(&parsed.properties, &player_name_path()).unwrap();
+        assert_eq!(chain.target.type_name, "StrProperty");
+
+        let map_property = &parsed.properties[0];
+        let PropertyValue::Map { entries, .. } = &map_property.value else {
+            panic!("expected map");
+        };
+        let PropertyValue::Struct(StructValue::Instanced(Some(instanced))) = &entries[0].1 else {
+            panic!("expected instanced struct");
+        };
+        // Outermost first: the map tag's size, then the instanced data_size.
+        assert_eq!(
+            chain.enclosing_size_fields,
+            vec![map_property.size_field_offset(), instanced.data_size_offset]
+        );
+        // Both offsets index the size fields the parser consumed.
+        let map_size = u32::from_le_bytes(
+            payload[map_property.size_field_offset()..map_property.size_field_offset() + 4]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(map_size as usize, map_property.value_size);
+    }
+
+    #[test]
+    fn patch_string_grows_nested_string_and_fixes_size_chain() {
+        let mut payload = nested_string_payload("Hero");
+        let original_len = payload.len();
+        let parsed = parse_private_root(&payload).unwrap();
+        let chain = resolve_chain(&parsed.properties, &player_name_path()).unwrap();
+        let target = chain.target.clone();
+        patch_string(
+            &mut payload,
+            &target,
+            &chain.enclosing_size_fields,
+            "Nameless",
+        )
+        .unwrap();
+
+        assert_eq!(payload.len(), original_len + 4);
+        assert_nested_string_patch(&payload, "Nameless");
+    }
+
+    #[test]
+    fn patch_string_shrinks_nested_string_and_fixes_size_chain() {
+        let mut payload = nested_string_payload("Hero");
+        let original_len = payload.len();
+        let parsed = parse_private_root(&payload).unwrap();
+        let chain = resolve_chain(&parsed.properties, &player_name_path()).unwrap();
+        let target = chain.target.clone();
+        patch_string(&mut payload, &target, &chain.enclosing_size_fields, "Po").unwrap();
+
+        assert_eq!(payload.len(), original_len - 2);
+        assert_nested_string_patch(&payload, "Po");
+    }
+
+    #[test]
+    fn patch_string_handles_same_length_and_name_property() {
+        let nested = {
+            let mut n = tag("m_QuestTag", "NameProperty");
+            let value = fstring("Quest.A");
+            n.extend_from_slice(&header(value.len() as u32, 0));
+            n.extend_from_slice(&value);
+            n
+        };
+        let mut payload = root("/Script/Test.Save", &nested);
+        let parsed = parse_private_root(&payload).unwrap();
+        let path = parse_path(&["m_QuestTag".into()]).unwrap();
+        let chain = resolve_chain(&parsed.properties, &path).unwrap();
+        assert!(chain.enclosing_size_fields.is_empty());
+        let target = chain.target.clone();
+        patch_string(
+            &mut payload,
+            &target,
+            &chain.enclosing_size_fields,
+            "Quest.B",
+        )
+        .unwrap();
+
+        let reparsed = parse_private_root(&payload).unwrap();
+        let after = resolve(&reparsed.properties, &path).unwrap();
+        assert_eq!(after.value, PropertyValue::Name("Quest.B".to_string()));
+    }
+
+    #[test]
+    fn patch_string_writes_utf16_for_non_ascii() {
+        let mut payload = nested_string_payload("Hero");
+        let parsed = parse_private_root(&payload).unwrap();
+        let chain = resolve_chain(&parsed.properties, &player_name_path()).unwrap();
+        let target = chain.target.clone();
+        patch_string(
+            &mut payload,
+            &target,
+            &chain.enclosing_size_fields,
+            "Hörnchen",
+        )
+        .unwrap();
+
+        assert_nested_string_patch(&payload, "Hörnchen");
+        // The new payload is UTF-16: negative character count incl. terminator.
+        let reparsed = parse_private_root(&payload).unwrap();
+        let after = resolve(&reparsed.properties, &player_name_path()).unwrap();
+        let count = i32::from_le_bytes(
+            payload[after.value_offset..after.value_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(count, -9);
+        assert_eq!(after.value_size, 4 + 9 * 2);
+    }
+
+    #[test]
+    fn patch_string_supports_empty_replacement() {
+        let mut payload = nested_string_payload("Hero");
+        let parsed = parse_private_root(&payload).unwrap();
+        let chain = resolve_chain(&parsed.properties, &player_name_path()).unwrap();
+        let target = chain.target.clone();
+        patch_string(&mut payload, &target, &chain.enclosing_size_fields, "").unwrap();
+
+        assert_nested_string_patch(&payload, "");
+    }
+
+    #[test]
+    fn patch_string_rejects_non_string_target() {
+        let mut payload = nested_string_payload("Hero");
+        let original = payload.clone();
+        let parsed = parse_private_root(&payload).unwrap();
+        let path = parse_path(&[
+            "m_GenericData".into(),
+            "{CharacterStates}".into(),
+            "m_ItemCount".into(),
+        ])
+        .unwrap();
+        let chain = resolve_chain(&parsed.properties, &path).unwrap();
+        let target = chain.target.clone();
+        let err = patch_string(&mut payload, &target, &chain.enclosing_size_fields, "oops");
+        assert!(err.is_err());
+        assert_eq!(
+            payload, original,
+            "failed patches must not mutate the payload"
+        );
     }
 }

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -435,8 +435,11 @@ fn scalar_editable(value: &PropertyValue) -> bool {
             | PropertyValue::Float(_)
             | PropertyValue::Double(_)
             | PropertyValue::Bool(_)
+            | PropertyValue::Byte(_)
             | PropertyValue::Str(_)
             | PropertyValue::Name(_)
+            | PropertyValue::Object(_)
+            | PropertyValue::Enum(_)
     )
 }
 
@@ -609,6 +612,9 @@ pub enum ScalarValue {
     Float(f32),
     Double(f64),
     Bool(bool),
+    /// Plain one-byte ByteProperty only; the enum-as-FString form goes
+    /// through `patch_string`.
+    Byte(u8),
 }
 
 /// Patch a resolved property's value in place. Only fixed-size scalars are
@@ -670,6 +676,14 @@ pub fn patch_scalar(
             property.value_size,
             &v.to_le_bytes(),
         ),
+        ("ByteProperty", ScalarValue::Byte(v)) => {
+            // Only the plain one-byte form; enum-as-byte payloads are FStrings
+            // and longer than one byte, which the size check below rejects.
+            if !matches!(property.value, PropertyValue::Byte(_)) {
+                return Err(mismatch());
+            }
+            write(payload, property.value_offset, property.value_size, &[v])
+        }
         ("BoolProperty", ScalarValue::Bool(v)) => {
             // No payload; the value is tag_flags bit 0x10, one byte before the
             // recorded value offset.
@@ -716,19 +730,30 @@ fn encode_fstring_value(value: &str) -> Vec<u8> {
     out
 }
 
-/// Replace a Str/Name property's FString payload. The new bytes may differ in
-/// length: the property's own tag size and every enclosing size field in
-/// `enclosing_size_fields` (from [`resolve_chain`]) are adjusted by the byte
-/// delta. All writes are validated before the first mutation, so a failed
-/// patch leaves the payload untouched. Offsets recorded in the parsed tree
-/// are stale after a successful patch — re-parse before further edits.
+/// True when a tagged property's whole value payload is a single FString that
+/// [`patch_string`] can replace: Str/Name/Object/Enum properties, plus the
+/// enum-as-FString form of ByteProperty (the plain one-byte form is a scalar).
+pub fn string_patchable(property: &Property) -> bool {
+    match property.type_name.as_str() {
+        "StrProperty" | "NameProperty" | "ObjectProperty" | "EnumProperty" => true,
+        "ByteProperty" => matches!(property.value, PropertyValue::Enum(_)),
+        _ => false,
+    }
+}
+
+/// Replace a string-valued property's FString payload. The new bytes may
+/// differ in length: the property's own tag size and every enclosing size
+/// field in `enclosing_size_fields` (from [`resolve_chain`]) are adjusted by
+/// the byte delta. All writes are validated before the first mutation, so a
+/// failed patch leaves the payload untouched. Offsets recorded in the parsed
+/// tree are stale after a successful patch — re-parse before further edits.
 pub fn patch_string(
     payload: &mut Vec<u8>,
     target: &Property,
     enclosing_size_fields: &[usize],
     new_value: &str,
 ) -> Result<(), CoreError> {
-    if target.type_name != "StrProperty" && target.type_name != "NameProperty" {
+    if !string_patchable(target) {
         return Err(CoreError::InvalidRequest(format!(
             "string value does not match property type {}",
             target.type_name
@@ -2159,5 +2184,153 @@ mod tests {
             payload, original,
             "failed patches must not mutate the payload"
         );
+    }
+
+    /// Tagged property whose value payload is a single FString.
+    fn fstring_property(name: &str, type_name: &str, value: &str) -> Vec<u8> {
+        let payload = fstring(value);
+        let mut out = tag(name, type_name);
+        out.extend_from_slice(&header(payload.len() as u32, 0));
+        out.extend_from_slice(&payload);
+        out
+    }
+
+    fn enum_property(name: &str, enum_type: &str, value: &str) -> Vec<u8> {
+        let payload = fstring(value);
+        let mut out = tag(name, "EnumProperty");
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring(enum_type));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("/Script/Test"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("ByteProperty"));
+        out.extend_from_slice(&header(payload.len() as u32, 0));
+        out.extend_from_slice(&payload);
+        out
+    }
+
+    fn plain_byte_property(name: &str, value: u8) -> Vec<u8> {
+        let mut out = tag(name, "ByteProperty");
+        out.extend_from_slice(&header(1, 0));
+        out.push(value);
+        out
+    }
+
+    #[test]
+    fn patch_string_updates_object_and_enum_properties() {
+        let mut props = fstring_property("m_Weapon", "ObjectProperty", "/Script/G1R.ItMw_Sword");
+        props.extend_from_slice(&enum_property("m_Guild", "EGuild", "EGuild::Old"));
+        props.extend_from_slice(&int_property("m_After", 7));
+        let mut payload = root("/Script/Test.Save", &props);
+
+        for (name, new_value) in [
+            ("m_Weapon", "/Script/G1R.ItMw_Axe_TwoHanded"),
+            ("m_Guild", "EGuild::None"),
+        ] {
+            let parsed = parse_private_root(&payload).unwrap();
+            let path = parse_path(&[name.to_string()]).unwrap();
+            let chain = resolve_chain(&parsed.properties, &path).unwrap();
+            let target = chain.target.clone();
+            patch_string(
+                &mut payload,
+                &target,
+                &chain.enclosing_size_fields,
+                new_value,
+            )
+            .unwrap();
+
+            let reparsed = parse_private_root(&payload).unwrap();
+            let after = resolve(&reparsed.properties, &path).unwrap();
+            let read = match &after.value {
+                PropertyValue::Object(s) | PropertyValue::Enum(s) => s.clone(),
+                other => panic!("unexpected value {other:?}"),
+            };
+            assert_eq!(read, new_value);
+            let after_int = resolve(
+                &reparsed.properties,
+                &parse_path(&["m_After".into()]).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(after_int.value, PropertyValue::Int(7));
+        }
+    }
+
+    #[test]
+    fn patch_string_updates_enum_as_byte_property() {
+        // enum-as-byte: ByteProperty whose payload is an FString enum name
+        let mut props = fstring_property("m_Rank", "ByteProperty", "ERank::Novice");
+        props.extend_from_slice(&int_property("m_After", 7));
+        let mut payload = root("/Script/Test.Save", &props);
+
+        let parsed = parse_private_root(&payload).unwrap();
+        let path = parse_path(&["m_Rank".into()]).unwrap();
+        let chain = resolve_chain(&parsed.properties, &path).unwrap();
+        assert_eq!(
+            chain.target.value,
+            PropertyValue::Enum("ERank::Novice".into())
+        );
+        let target = chain.target.clone();
+        patch_string(
+            &mut payload,
+            &target,
+            &chain.enclosing_size_fields,
+            "ERank::Master",
+        )
+        .unwrap();
+
+        let reparsed = parse_private_root(&payload).unwrap();
+        let after = resolve(&reparsed.properties, &path).unwrap();
+        assert_eq!(after.value, PropertyValue::Enum("ERank::Master".into()));
+        let after_int = resolve(
+            &reparsed.properties,
+            &parse_path(&["m_After".into()]).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(after_int.value, PropertyValue::Int(7));
+    }
+
+    #[test]
+    fn patch_scalar_updates_plain_byte_and_rejects_enum_form() {
+        let mut props = plain_byte_property("m_Level", 3);
+        props.extend_from_slice(&fstring_property("m_Rank", "ByteProperty", "ERank::Novice"));
+        let mut payload = root("/Script/Test.Save", &props);
+
+        let parsed = parse_private_root(&payload).unwrap();
+        let level = resolve(
+            &parsed.properties,
+            &parse_path(&["m_Level".into()]).unwrap(),
+        )
+        .unwrap()
+        .clone();
+        assert_eq!(level.value, PropertyValue::Byte(3));
+        patch_scalar(&mut payload, &level, ScalarValue::Byte(42)).unwrap();
+        let reparsed = parse_private_root(&payload).unwrap();
+        assert_eq!(reparsed.properties[0].value, PropertyValue::Byte(42));
+
+        // Scalar byte write on the enum-as-byte form must be rejected.
+        let rank = resolve(
+            &reparsed.properties,
+            &parse_path(&["m_Rank".into()]).unwrap(),
+        )
+        .unwrap()
+        .clone();
+        assert!(patch_scalar(&mut payload, &rank, ScalarValue::Byte(1)).is_err());
+        // And the plain-byte form must reject a string patch.
+        assert!(patch_string(&mut payload, &level, &[], "oops").is_err());
+    }
+
+    #[test]
+    fn search_marks_object_enum_and_byte_editable() {
+        let mut props = fstring_property("m_Weapon", "ObjectProperty", "/Script/G1R.ItMw_Sword");
+        props.extend_from_slice(&enum_property("m_Guild", "EGuild", "EGuild::Old"));
+        props.extend_from_slice(&fstring_property("m_Rank", "ByteProperty", "ERank::Novice"));
+        props.extend_from_slice(&plain_byte_property("m_Level", 3));
+        let payload = root("/Script/Test.Save", &props);
+        let parsed = parse_private_root(&payload).unwrap();
+        let (hits, _) = search_properties(&parsed, "m_", 0, 100);
+        for name in ["m_Weapon", "m_Guild", "m_Rank", "m_Level"] {
+            let hit = hits.iter().find(|h| h.display == name).unwrap();
+            assert!(hit.editable, "{name} should be editable");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Extends the typed property editor (`private.typed.setValue`) to support **length-changing string edits** and the remaining string-valued property types, so almost every leaf value in a G1R save is now editable instead of read-only.

Previously only fixed-size scalars (Int/Float/Double/Bool) could be patched, because changing a value's byte length shifts every offset after it and breaks the enclosing container size fields.

## What changed

### Length-changing string edits (commit 1)
- Parser records each `InstancedStruct` `data_size` offset.
- New `resolve_chain()` collects every enclosing `u32` size field along a typed path (each ancestor property tag `size` + each `InstancedStruct` `data_size`), outermost first.
- New `patch_string()` splices the new FString payload and propagates the byte delta up the whole container chain. Non-ASCII serializes as UTF-16LE with a negative character count; empty string supported.
- All size-field writes are validated before the first mutation; at the edit layer the patch runs on a scratch copy and is adopted only after a strict re-parse proves every enclosing size was fixed up — a bug cannot corrupt the save.
- `StrProperty` / `NameProperty` become editable.

### Object / Enum / Byte properties (commit 2)
- `ObjectProperty`, `EnumProperty` and the enum-as-FString form of `ByteProperty` go through the same length-changing string patch.
- Plain one-byte `ByteProperty` becomes a fixed-size scalar patch via the new `ScalarValue::Byte`. The two Byte forms are dispatched on the parsed value, and each rejects the other kind of replacement.
- UI sends object/enum input as trimmed strings; resolves the Byte ambiguity by sending a number when the field parses as one, else raw text (core validates against the actual form).

### Still read-only (by design)
`SoftObjectProperty` (three FStrings, path semantics), `TextProperty` (opaque), native structs, and container elements (`[i]`/`{key}`-terminated paths — not resolvable by `setValue`).

## Testing
- 154/154 Rust unit tests pass (grow/shrink/same-length through Map→InstancedStruct chains, UTF-16, empty string, reject-without-mutation, Object/Enum/Byte dispatch).
- Real saves: all three G1R dumps (75–77 MB) strict-parse; new ignored test patches a real nested string through 2 enclosing size fields and re-parses byte-exact.
- `flutter analyze` clean, 41/41 Flutter tests pass, `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes binary save payload editing and length-changing string patches with container size fixups; bugs could corrupt saves despite re-parse guards, though failed patches are designed not to mutate data.
> 
> **Overview**
> **`private.typed.setValue`** no longer limits edits to fixed-size scalars. The core now accepts **string-valued** properties (Str/Name/Object/Enum and enum-as-FString **ByteProperty**) via a length-changing **`patch_string`**, and **plain one-byte ByteProperty** via in-place scalar patch. Coercion was generalized from scalars-only to **`TypedSetValue`** (scalar vs text), including Byte dispatch on the parsed form and accepting numeric JSON for all-digit enum labels.
> 
> Length-changing writes use **`resolve_chain`** to collect ancestor tag **`size`** fields and **`InstancedStruct` `data_size`** offsets, splice the new FString (ASCII or UTF-16LE), propagate the byte delta, and adopt the result only after a **strict re-parse** on a scratch buffer so a bad patch cannot corrupt the save. Typed property **search** marks the new leaf types as editable; container-element strings stay read-only.
> 
> The Flutter **All Data** panel copy and **`_coerce`** logic were updated so the UI sends verbatim Str/Name text, trimmed object/enum strings, and Byte values as a number when parseable else raw text for core validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0a177deb1ffa964593d15532241931428ed5c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->