### PR TITLE
Progression tab v2: structured editable quests, knowledge, and memory events

### DIFF
--- a/apps/goresave/lib/features/editor/domain/editor_models.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_models.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:goresave/features/editor/domain/progression_models.dart';
+
 /// One property surfaced by the typed property browser search.
 class TypedPropertyHit {
   const TypedPropertyHit({
@@ -269,7 +271,7 @@ class SaveInspection {
     this.privateTotalChunkCount,
     this.privatePlayer = const PrivatePlayerSummary(),
     this.privateInventory = const PrivateInventorySummary(),
-    this.privateProgression = const PrivateProgressionSummary(),
+    this.privateProgression = const ProgressionOverview(),
     this.privateTypedParseStatus,
     this.privateTypedPropertyCount,
     this.privateTypedMaxDepth,
@@ -327,9 +329,7 @@ class SaveInspection {
       privateTotalChunkCount: (private?['totalChunkCount'] as num?)?.toInt(),
       privatePlayer: PrivatePlayerSummary.fromJson(privatePlayer),
       privateInventory: PrivateInventorySummary.fromJson(privateInventory),
-      privateProgression: PrivateProgressionSummary.fromJson(
-        privateProgression,
-      ),
+      privateProgression: ProgressionOverview.fromJson(privateProgression),
       privateTypedParseStatus: typedParse?['status'] as String?,
       privateTypedPropertyCount: (typedParse?['propertyCount'] as num?)
           ?.toInt(),
@@ -373,7 +373,7 @@ class SaveInspection {
 
   final PrivatePlayerSummary privatePlayer;
   final PrivateInventorySummary privateInventory;
-  final PrivateProgressionSummary privateProgression;
+  final ProgressionOverview privateProgression;
 
   /// Status of the strict typed property parse of the decoded private payload
   /// ('ok', 'failed', 'skipped_preview'); null when no private decode ran.
@@ -603,58 +603,6 @@ class PrivateInventoryItem {
   final String id;
   final String path;
   final int? count;
-}
-
-class PrivateProgressionSummary {
-  const PrivateProgressionSummary({
-    this.candidateCount = 0,
-    this.candidates = const [],
-    this.gameplayTags = const [],
-    this.sections = const [],
-    this.scriptPaths = const [],
-    this.properties = const [],
-    this.writable = const [],
-  });
-
-  factory PrivateProgressionSummary.fromJson(Map<String, Object?>? json) {
-    return PrivateProgressionSummary(
-      candidateCount: (json?['candidateCount'] as num?)?.toInt() ?? 0,
-      candidates:
-          (json?['candidates'] as List?)?.whereType<String>().toList() ??
-          const [],
-      gameplayTags:
-          (json?['gameplayTags'] as List?)?.whereType<String>().toList() ??
-          const [],
-      sections:
-          (json?['sections'] as List?)?.whereType<String>().toList() ??
-          const [],
-      scriptPaths:
-          (json?['scriptPaths'] as List?)?.whereType<String>().toList() ??
-          const [],
-      properties:
-          (json?['properties'] as List?)?.whereType<String>().toList() ??
-          const [],
-      writable:
-          (json?['writable'] as List?)?.whereType<String>().toList() ??
-          const [],
-    );
-  }
-
-  final int candidateCount;
-  final List<String> candidates;
-  final List<String> gameplayTags;
-  final List<String> sections;
-  final List<String> scriptPaths;
-  final List<String> properties;
-  final List<String> writable;
-
-  bool get hasData =>
-      candidateCount > 0 ||
-      candidates.isNotEmpty ||
-      gameplayTags.isNotEmpty ||
-      sections.isNotEmpty ||
-      scriptPaths.isNotEmpty ||
-      properties.isNotEmpty;
 }
 
 class InventoryItemCountChange {

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -933,7 +933,13 @@ class EditorNotifier extends StateNotifier<EditorState> {
   Future<bool> applyMemoryEventEdit(MemoryEventEdit edit) async {
     final savePath = state.selectedPath;
     if (savePath == null) return false;
-    if (state.isLoading) return false;
+    if (state.isLoading) {
+      state = state.copyWith(
+        error:
+            'Another operation is in progress — try again when it finishes.',
+      );
+      return false;
+    }
     if (state.pendingEdits.isNotEmpty) {
       state = state.copyWith(
         error:

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -132,7 +132,11 @@ class EditorState {
 
   /// The profile id to use for filtering: the explicitly selected profile, or
   /// fall back to the scan's active profile id.
-  int? get effectiveProfileId => selectedProfileId ?? activeProfileId;
+  /// One resolution shared by the header and the save-list filter, so they
+  /// can never disagree: explicit switcher choice first, then the selected
+  /// save's own profile, then the scan's active profile id.
+  int? get effectiveProfileId =>
+      selectedProfileId ?? selectedSave?.persistentProfileId ?? activeProfileId;
 
   /// Saves to show in the sidebar. When there are fewer than 2 profiles, or
   /// no effective profile id, all saves are shown. Otherwise only saves whose
@@ -154,13 +158,9 @@ class EditorState {
   }
 
   ProfileSummary? get activeProfile {
-    // Prefer the explicitly selected profile; fall back to the selected save's
-    // own profile so a mixed-profile folder shows the profile that the selected
-    // slot belongs to; finally fall back to the scan's active profile id.
-    final targetProfileId =
-        selectedProfileId ??
-        selectedSave?.persistentProfileId ??
-        activeProfileId;
+    // Same resolution as the save-list filter (effectiveProfileId), so the
+    // header always describes the profile whose saves are listed.
+    final targetProfileId = effectiveProfileId;
     for (final profile in profiles) {
       if (profile.profileId == targetProfileId) return profile;
     }

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -114,7 +114,8 @@ class EditorState {
     // Prefer the selected save's own profile so a mixed-profile folder shows the
     // profile that the selected slot belongs to, falling back to the scan's
     // active profile id.
-    final targetProfileId = selectedSave?.persistentProfileId ?? activeProfileId;
+    final targetProfileId =
+        selectedSave?.persistentProfileId ?? activeProfileId;
     for (final profile in profiles) {
       if (profile.profileId == targetProfileId) return profile;
     }
@@ -650,10 +651,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
 
   Future<void> checkCodec() async {
     try {
-      final response = await _execute(
-        'check_codec',
-        payload: _codecPayload(),
-      );
+      final response = await _execute('check_codec', payload: _codecPayload());
       if (response['ok'] != true) {
         // Use the dedicated codec error channel so a concurrent/later refresh
         // does not wipe this message, and drop the now-stale codec status so
@@ -846,10 +844,12 @@ class EditorNotifier extends StateNotifier<EditorState> {
     int limit = 100,
   }) async {
     String? error;
-    final data = await _queryProgression(
-      {'section': 'quests', 'query': query, 'offset': offset, 'limit': limit},
-      onError: (message) => error = message,
-    );
+    final data = await _queryProgression({
+      'section': 'quests',
+      'query': query,
+      'offset': offset,
+      'limit': limit,
+    }, onError: (message) => error = message);
     if (data == null) return ProgressionQuestPage(error: error);
     return ProgressionQuestPage.fromJson(data);
   }
@@ -860,15 +860,12 @@ class EditorNotifier extends StateNotifier<EditorState> {
     int limit = 100,
   }) async {
     String? error;
-    final data = await _queryProgression(
-      {
-        'section': 'knowledge',
-        'query': query,
-        'offset': offset,
-        'limit': limit,
-      },
-      onError: (message) => error = message,
-    );
+    final data = await _queryProgression({
+      'section': 'knowledge',
+      'query': query,
+      'offset': offset,
+      'limit': limit,
+    }, onError: (message) => error = message);
     if (data == null) return KnowledgeCharactersPage(error: error);
     return KnowledgeCharactersPage.fromJson(data);
   }
@@ -880,16 +877,13 @@ class EditorNotifier extends StateNotifier<EditorState> {
     int limit = 200,
   }) async {
     String? error;
-    final data = await _queryProgression(
-      {
-        'section': 'knowledge',
-        'character': character,
-        'query': query,
-        'offset': offset,
-        'limit': limit,
-      },
-      onError: (message) => error = message,
-    );
+    final data = await _queryProgression({
+      'section': 'knowledge',
+      'character': character,
+      'query': query,
+      'offset': offset,
+      'limit': limit,
+    }, onError: (message) => error = message);
     if (data == null) return KnowledgeEntriesPage(error: error);
     return KnowledgeEntriesPage.fromJson(data);
   }
@@ -900,10 +894,12 @@ class EditorNotifier extends StateNotifier<EditorState> {
     int limit = 100,
   }) async {
     String? error;
-    final data = await _queryProgression(
-      {'section': 'events', 'query': query, 'offset': offset, 'limit': limit},
-      onError: (message) => error = message,
-    );
+    final data = await _queryProgression({
+      'section': 'events',
+      'query': query,
+      'offset': offset,
+      'limit': limit,
+    }, onError: (message) => error = message);
     if (data == null) return MemoryCharactersPage(error: error);
     return MemoryCharactersPage.fromJson(data);
   }
@@ -915,16 +911,13 @@ class EditorNotifier extends StateNotifier<EditorState> {
     int limit = 100,
   }) async {
     String? error;
-    final data = await _queryProgression(
-      {
-        'section': 'events',
-        'character': character,
-        'query': query,
-        'offset': offset,
-        'limit': limit,
-      },
-      onError: (message) => error = message,
-    );
+    final data = await _queryProgression({
+      'section': 'events',
+      'character': character,
+      'query': query,
+      'offset': offset,
+      'limit': limit,
+    }, onError: (message) => error = message);
     if (data == null) return MemoryEventsPage(error: error);
     return MemoryEventsPage.fromJson(data);
   }
@@ -937,6 +930,15 @@ class EditorNotifier extends StateNotifier<EditorState> {
     final savePath = state.selectedPath;
     if (savePath == null) return false;
     if (state.isLoading) return false;
+    if (state.pendingEdits.isNotEmpty) {
+      state = state.copyWith(
+        error:
+            'Save or reset your unsaved changes first — removing or '
+            'duplicating a memory event writes the file immediately and '
+            'would discard them.',
+      );
+      return false;
+    }
     return _runWrite(
       payload: {
         'path': savePath,
@@ -966,10 +968,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
   }
 
   Future<_BackupSnapshot?> _loadBackups(String path, int seq) async {
-    final response = await _execute(
-      'list_backups',
-      payload: {'path': path},
-    );
+    final response = await _execute('list_backups', payload: {'path': path});
     // Only the latest load applies; a superseded load must not replace the
     // fresher list with its outdated result.
     if (seq != _loadSeq) return null;

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -1064,7 +1064,10 @@ class EditorNotifier extends StateNotifier<EditorState> {
   /// intentionally not part of the pending-edit registry.
   Future<bool> applyMemoryEventEdit(MemoryEventEdit edit) async {
     final savePath = state.selectedPath;
-    if (savePath == null) return false;
+    if (savePath == null) {
+      state = state.copyWith(error: 'No save selected.');
+      return false;
+    }
     if (state.isLoading) {
       state = state.copyWith(
         error: 'Another operation is in progress — try again when it finishes.',

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -6,6 +6,7 @@ import 'package:goresave/features/editor/domain/editor_models.dart';
 import 'package:goresave/features/editor/domain/editor_settings_store.dart';
 import 'package:goresave/features/editor/domain/hero_attributes.dart';
 import 'package:goresave/features/editor/domain/pending_edits.dart';
+import 'package:goresave/features/editor/domain/progression_models.dart';
 import 'package:goresave/utils/default_paths.dart';
 import 'package:path/path.dart' as p;
 import 'package:state_notifier/state_notifier.dart';
@@ -809,6 +810,145 @@ class EditorNotifier extends StateNotifier<EditorState> {
       if (offset >= result.total || result.results.isEmpty) break;
     }
     return HeroAttributesResult(attributes: parseHeroAttributes(hits));
+  }
+
+  /// Run one progression section query. Returns the raw data map, or null
+  /// with [onError] called, so each typed loader below can build its own page
+  /// object with an inline error.
+  Future<Map<String, Object?>?> _queryProgression(
+    Map<String, Object?> params, {
+    required void Function(String message) onError,
+  }) async {
+    final path = state.selectedPath;
+    if (path == null) {
+      onError('No save selected.');
+      return null;
+    }
+    try {
+      final response = await _execute(
+        'query_progression',
+        payload: {'path': path, ...params, ..._codecPayload()},
+      );
+      if (response['ok'] != true) {
+        onError(_errorMessage(response));
+        return null;
+      }
+      return (response['data'] as Map).cast<String, Object?>();
+    } catch (error) {
+      onError('Progression query failed: $error');
+      return null;
+    }
+  }
+
+  Future<ProgressionQuestPage> loadProgressionQuests({
+    String query = '',
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {'section': 'quests', 'query': query, 'offset': offset, 'limit': limit},
+      onError: (message) => error = message,
+    );
+    if (data == null) return ProgressionQuestPage(error: error);
+    return ProgressionQuestPage.fromJson(data);
+  }
+
+  Future<KnowledgeCharactersPage> loadKnowledgeCharacters({
+    String query = '',
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {
+        'section': 'knowledge',
+        'query': query,
+        'offset': offset,
+        'limit': limit,
+      },
+      onError: (message) => error = message,
+    );
+    if (data == null) return KnowledgeCharactersPage(error: error);
+    return KnowledgeCharactersPage.fromJson(data);
+  }
+
+  Future<KnowledgeEntriesPage> loadKnowledgeEntries(
+    String character, {
+    String query = '',
+    int offset = 0,
+    int limit = 200,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {
+        'section': 'knowledge',
+        'character': character,
+        'query': query,
+        'offset': offset,
+        'limit': limit,
+      },
+      onError: (message) => error = message,
+    );
+    if (data == null) return KnowledgeEntriesPage(error: error);
+    return KnowledgeEntriesPage.fromJson(data);
+  }
+
+  Future<MemoryCharactersPage> loadMemoryCharacters({
+    String query = '',
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {'section': 'events', 'query': query, 'offset': offset, 'limit': limit},
+      onError: (message) => error = message,
+    );
+    if (data == null) return MemoryCharactersPage(error: error);
+    return MemoryCharactersPage.fromJson(data);
+  }
+
+  Future<MemoryEventsPage> loadMemoryEvents(
+    String character, {
+    String query = '',
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {
+        'section': 'events',
+        'character': character,
+        'query': query,
+        'offset': offset,
+        'limit': limit,
+      },
+      onError: (message) => error = message,
+    );
+    if (data == null) return MemoryEventsPage(error: error);
+    return MemoryEventsPage.fromJson(data);
+  }
+
+  /// Apply one structural progression edit (event remove/duplicate)
+  /// immediately, with backup. Index-addressed array edits must go one per
+  /// write round — indices shift after every structural change — so this is
+  /// intentionally not part of the pending-edit registry.
+  Future<bool> applyMemoryEventEdit(MemoryEventEdit edit) async {
+    final savePath = state.selectedPath;
+    if (savePath == null) return false;
+    if (state.isLoading) return false;
+    return _runWrite(
+      payload: {
+        'path': savePath,
+        'backup': true,
+        'edits': [edit.toEditJson()],
+        ..._codecPayload(),
+      },
+      message: (data) => _backupMessage(
+        edit.isRemove ? 'Memory event removed' : 'Memory event duplicated',
+        data,
+      ),
+    );
   }
 
   String _errorMessage(Map<String, Object?> response) {

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -58,6 +58,7 @@ class EditorState {
     this.saves = const [],
     this.profiles = const [],
     this.activeProfileId,
+    this.selectedProfileId,
     this.backups = const [],
     this.companionBackups = const [],
     this.selectedPath,
@@ -77,6 +78,11 @@ class EditorState {
   final List<SaveSlot> saves;
   final List<ProfileSummary> profiles;
   final int? activeProfileId;
+
+  /// Explicitly selected profile id. Null means no explicit selection — use
+  /// [effectiveProfileId] for the resolved value.
+  final int? selectedProfileId;
+
   final List<BackupEntry> backups;
   final List<BackupEntry> companionBackups;
   final String? selectedPath;
@@ -124,12 +130,37 @@ class EditorState {
     return null;
   }
 
+  /// The profile id to use for filtering: the explicitly selected profile, or
+  /// fall back to the scan's active profile id.
+  int? get effectiveProfileId => selectedProfileId ?? activeProfileId;
+
+  /// Saves to show in the sidebar. When there are fewer than 2 profiles, or
+  /// no effective profile id, all saves are shown. Otherwise only saves whose
+  /// [SaveSlot.persistentProfileId] matches [effectiveProfileId] are shown
+  /// (saves with a null persistentProfileId stay visible in every profile —
+  /// they cannot be attributed). The currently selected save is always kept
+  /// visible so it is never silently removed from the list mid-session.
+  List<SaveSlot> get visibleSaves {
+    final eid = effectiveProfileId;
+    if (eid == null || profiles.length < 2) return saves;
+    return saves
+        .where(
+          (s) =>
+              s.persistentProfileId == eid ||
+              s.persistentProfileId == null ||
+              s.path == selectedPath,
+        )
+        .toList();
+  }
+
   ProfileSummary? get activeProfile {
-    // Prefer the selected save's own profile so a mixed-profile folder shows the
-    // profile that the selected slot belongs to, falling back to the scan's
-    // active profile id.
+    // Prefer the explicitly selected profile; fall back to the selected save's
+    // own profile so a mixed-profile folder shows the profile that the selected
+    // slot belongs to; finally fall back to the scan's active profile id.
     final targetProfileId =
-        selectedSave?.persistentProfileId ?? activeProfileId;
+        selectedProfileId ??
+        selectedSave?.persistentProfileId ??
+        activeProfileId;
     for (final profile in profiles) {
       if (profile.profileId == targetProfileId) return profile;
     }
@@ -146,6 +177,7 @@ class EditorState {
     List<SaveSlot>? saves,
     List<ProfileSummary>? profiles,
     Object? activeProfileId = _unchanged,
+    Object? selectedProfileId = _unchanged,
     List<BackupEntry>? backups,
     List<BackupEntry>? companionBackups,
     Object? selectedPath = _unchanged,
@@ -174,6 +206,9 @@ class EditorState {
       activeProfileId: identical(activeProfileId, _unchanged)
           ? this.activeProfileId
           : activeProfileId as int?,
+      selectedProfileId: identical(selectedProfileId, _unchanged)
+          ? this.selectedProfileId
+          : selectedProfileId as int?,
       backups: clearBackups ? const [] : backups ?? this.backups,
       companionBackups: clearBackups
           ? const []
@@ -303,6 +338,68 @@ class EditorNotifier extends StateNotifier<EditorState> {
   void dismissWriteMessage() {
     if (state.lastWriteMessage != null) {
       state = state.copyWith(clearWriteMessage: true);
+    }
+  }
+
+  /// Switch the active profile filter. Pass null to clear the explicit
+  /// selection (show all profiles).
+  ///
+  /// Blocked with an error when there are unsaved edits — switching profiles
+  /// changes which saves are visible and would potentially move selection away
+  /// from the save the edits target.
+  ///
+  /// If the currently selected save is not in the new visible set, the first
+  /// visible save is selected (triggering [_inspect]); if there are none,
+  /// the selection is cleared.
+  Future<void> selectProfile(int? profileId) async {
+    if (state.pendingEdits.isNotEmpty) {
+      state = state.copyWith(
+        error:
+            'Save or reset your unsaved changes first — switching profiles '
+            'would move away from the current save.',
+      );
+      return;
+    }
+
+    // Check whether the current selection belongs to the target profile before
+    // updating state. We avoid relying on visibleSaves here so that the "keep
+    // selected save visible" exemption cannot silently keep the old save in view
+    // and prevent the selection from moving.
+    final currentSave = state.selectedSave;
+    final selectionMatchesNewProfile =
+        profileId == null ||
+        state.profiles.length < 2 ||
+        currentSave == null ||
+        currentSave.persistentProfileId == null ||
+        currentSave.persistentProfileId == profileId;
+
+    state = state.copyWith(selectedProfileId: profileId);
+
+    if (selectionMatchesNewProfile) {
+      // Current selection is compatible with the new profile — stay put.
+      return;
+    }
+
+    // Current save does not belong to the new profile — move to the first
+    // save that does. Compute candidate list without the selectedPath exemption
+    // (we have already established the current save is the wrong profile).
+    final candidates = state.saves
+        .where(
+          (s) =>
+              s.persistentProfileId == profileId ||
+              s.persistentProfileId == null,
+        )
+        .toList();
+
+    if (candidates.isNotEmpty) {
+      await _inspect(candidates.first.path);
+    } else {
+      state = state.copyWith(
+        selectedPath: null,
+        clearInspection: true,
+        clearBackups: true,
+        clearPendingEdits: true,
+      );
     }
   }
 
@@ -458,6 +555,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
       profiles: const [],
       selectedPath: null,
       activeProfileId: null,
+      selectedProfileId: null,
       clearInspection: true,
       clearBackups: true,
     );
@@ -504,16 +602,36 @@ class EditorNotifier extends StateNotifier<EditorState> {
           .map((m) => ProfileSummary.fromJson(m.cast<String, Object?>()))
           .toList();
       final activeProfileId = (data?['activeProfileId'] as num?)?.toInt();
-      final selectedPath = saves.any((save) => save.path == state.selectedPath)
-          ? state.selectedPath
-          : (saves.isNotEmpty ? saves.first.path : null);
-      // Pending edits are cleared by _inspect once the fresh inspection
-      // actually lands (so a failed re-inspect keeps them retryable); only
-      // when nothing remains selected is there no inspect to do it.
-      state = state.copyWith(
+      // Keep the explicit profile selection if that profile still exists in
+      // the new scan result, otherwise reset it to null.
+      final profileIds = profiles.map((p) => p.profileId).toSet();
+      final keptSelectedProfileId =
+          (state.selectedProfileId != null &&
+              profileIds.contains(state.selectedProfileId))
+          ? state.selectedProfileId
+          : null;
+
+      // When the explicit selection was reset, fall back to any visible save;
+      // otherwise restrict to the still-valid profile's visible saves.
+      final newState = state.copyWith(
         saves: saves,
         profiles: profiles,
         activeProfileId: activeProfileId,
+        selectedProfileId: keptSelectedProfileId,
+      );
+      // Compute visible saves with the updated state fields to find a
+      // sensible first selection path when the folder or profile changed.
+      final visibleAfterRefresh = newState.visibleSaves;
+      final selectedPath =
+          visibleAfterRefresh.any((s) => s.path == state.selectedPath)
+          ? state.selectedPath
+          : (visibleAfterRefresh.isNotEmpty
+                ? visibleAfterRefresh.first.path
+                : null);
+      // Pending edits are cleared by _inspect once the fresh inspection
+      // actually lands (so a failed re-inspect keeps them retryable); only
+      // when nothing remains selected is there no inspect to do it.
+      state = newState.copyWith(
         selectedPath: selectedPath,
         clearInspection: selectedPath == null,
         clearBackups: selectedPath == null,
@@ -949,8 +1067,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
     if (savePath == null) return false;
     if (state.isLoading) {
       state = state.copyWith(
-        error:
-            'Another operation is in progress — try again when it finishes.',
+        error: 'Another operation is in progress — try again when it finishes.',
       );
       return false;
     }

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -13,19 +13,33 @@ import 'package:state_notifier/state_notifier.dart';
 
 const _unchanged = Object();
 
-/// Sorts saves by file last-modified time, newest first. Saves whose file
-/// can't be stat'd (e.g. fake paths in tests) sink to the bottom rather than
-/// throwing, so a transient FS error never breaks the scan.
-void _sortByLastModifiedDesc(List<SaveSlot> saves) {
+/// Sorts saves by in-game playtime (highest first). Slots with null playtime
+/// sink to the bottom. Equal or both-null playtime falls back to file
+/// last-modified descending so the order is stable on files that lack
+/// persistent metadata — saves whose file can't be stat'd sink to the very
+/// bottom rather than throwing, so a transient FS error never breaks the scan.
+void _sortByPlaytimeDesc(List<SaveSlot> saves) {
   final mtime = <String, DateTime>{};
   for (final save in saves) {
     try {
       mtime[save.path] = File(save.path).lastModifiedSync();
     } catch (_) {
-      // Leave unset; treated as oldest below.
+      // Leave unset; treated as oldest in the mtime tie-break below.
     }
   }
   saves.sort((a, b) {
+    final pa = a.timePlayedSeconds;
+    final pb = b.timePlayedSeconds;
+    // Primary key: playtime descending; nulls sink to the bottom.
+    if (pa != null && pb != null) {
+      final cmp = pb.compareTo(pa);
+      if (cmp != 0) return cmp;
+    } else if (pa == null && pb != null) {
+      return 1;
+    } else if (pa != null && pb == null) {
+      return -1;
+    }
+    // Secondary key: last-modified descending (tie-break / no-metadata path).
     final ma = mtime[a.path];
     final mb = mtime[b.path];
     if (ma == null && mb == null) return 0;
@@ -483,7 +497,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
           .whereType<Map>()
           .map((m) => SaveSlot.fromJson(m.cast<String, Object?>()))
           .toList();
-      _sortByLastModifiedDesc(saves);
+      _sortByPlaytimeDesc(saves);
       final rawProfiles = (data?['profiles'] as List?) ?? const [];
       final profiles = rawProfiles
           .whereType<Map>()

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -842,6 +842,8 @@ class EditorNotifier extends StateNotifier<EditorState> {
     String query = '',
     int offset = 0,
     int limit = 100,
+    String? state,
+    String? group,
   }) async {
     String? error;
     final data = await _queryProgression({
@@ -849,6 +851,8 @@ class EditorNotifier extends StateNotifier<EditorState> {
       'query': query,
       'offset': offset,
       'limit': limit,
+      if (state != null && state.isNotEmpty) 'state': state,
+      if (group != null && group.isNotEmpty) 'group': group,
     }, onError: (message) => error = message);
     if (data == null) return ProgressionQuestPage(error: error);
     return ProgressionQuestPage.fromJson(data);

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -381,18 +381,23 @@ class EditorNotifier extends StateNotifier<EditorState> {
     }
 
     // Current save does not belong to the new profile — move to the first
-    // save that does. Compute candidate list without the selectedPath exemption
-    // (we have already established the current save is the wrong profile).
-    final candidates = state.saves
-        .where(
-          (s) =>
-              s.persistentProfileId == profileId ||
-              s.persistentProfileId == null,
-        )
-        .toList();
+    // save that does. Prefer saves attributed to the target profile; an
+    // unattributed (null persistentProfileId) save is only a fallback so it
+    // cannot shadow the profile's own saves in global sort order. The
+    // selectedPath exemption is intentionally absent (we have already
+    // established the current save is the wrong profile).
+    final attributed = state.saves.where(
+      (s) => s.persistentProfileId == profileId,
+    );
+    final unattributed = state.saves.where(
+      (s) => s.persistentProfileId == null,
+    );
+    final candidate = attributed.isNotEmpty
+        ? attributed.first
+        : (unattributed.isNotEmpty ? unattributed.first : null);
 
-    if (candidates.isNotEmpty) {
-      await _inspect(candidates.first.path);
+    if (candidate != null) {
+      await _inspect(candidate.path);
     } else {
       state = state.copyWith(
         selectedPath: null,

--- a/apps/goresave/lib/features/editor/domain/progression_models.dart
+++ b/apps/goresave/lib/features/editor/domain/progression_models.dart
@@ -86,6 +86,7 @@ class ProgressionQuestPage {
   const ProgressionQuestPage({
     this.quests = const [],
     this.stateCounts = const {},
+    this.groupCounts = const {},
     this.total = 0,
     this.offset = 0,
     this.limit = 100,
@@ -97,6 +98,10 @@ class ProgressionQuestPage {
     (json['stateCounts'] as Map?)?.forEach((key, value) {
       if (key is String && value is num) counts[key] = value.toInt();
     });
+    final gCounts = <String, int>{};
+    (json['groupCounts'] as Map?)?.forEach((key, value) {
+      if (key is String && value is num) gCounts[key] = value.toInt();
+    });
     return ProgressionQuestPage(
       quests:
           (json['quests'] as List?)
@@ -105,6 +110,7 @@ class ProgressionQuestPage {
               .toList(growable: false) ??
           const [],
       stateCounts: counts,
+      groupCounts: gCounts,
       total: (json['total'] as num?)?.toInt() ?? 0,
       offset: (json['offset'] as num?)?.toInt() ?? 0,
       limit: (json['limit'] as num?)?.toInt() ?? 100,
@@ -113,6 +119,7 @@ class ProgressionQuestPage {
 
   final List<ProgressionQuest> quests;
   final Map<String, int> stateCounts;
+  final Map<String, int> groupCounts;
   final int total;
   final int offset;
   final int limit;

--- a/apps/goresave/lib/features/editor/domain/progression_models.dart
+++ b/apps/goresave/lib/features/editor/domain/progression_models.dart
@@ -65,9 +65,9 @@ class ProgressionQuest {
       name: json['name'] as String? ?? '',
       currentState: json['currentState'] as String?,
       statePath:
-          (json['statePath'] as List?)
-              ?.whereType<String>()
-              .toList(growable: false) ??
+          (json['statePath'] as List?)?.whereType<String>().toList(
+            growable: false,
+          ) ??
           const [],
       writable: json['writable'] as bool? ?? false,
     );
@@ -149,7 +149,9 @@ class KnowledgeCharactersPage {
       characters:
           (json['characters'] as List?)
               ?.whereType<Map>()
-              .map((e) => KnowledgeCharacter.fromJson(e.cast<String, Object?>()))
+              .map(
+                (e) => KnowledgeCharacter.fromJson(e.cast<String, Object?>()),
+              )
               .toList(growable: false) ??
           const [],
       total: (json['total'] as num?)?.toInt() ?? 0,
@@ -182,14 +184,14 @@ class KnowledgeEntriesPage {
     return KnowledgeEntriesPage(
       character: json['character'] as String? ?? '',
       entries:
-          (json['entries'] as List?)
-              ?.whereType<String>()
-              .toList(growable: false) ??
+          (json['entries'] as List?)?.whereType<String>().toList(
+            growable: false,
+          ) ??
           const [],
       setPath:
-          (json['setPath'] as List?)
-              ?.whereType<String>()
-              .toList(growable: false) ??
+          (json['setPath'] as List?)?.whereType<String>().toList(
+            growable: false,
+          ) ??
           const [],
       total: (json['total'] as num?)?.toInt() ?? 0,
       offset: (json['offset'] as num?)?.toInt() ?? 0,
@@ -250,6 +252,8 @@ class MemoryCharactersPage {
   final int offset;
   final int limit;
   final String? error;
+
+  bool get hasMore => offset + characters.length < total;
 }
 
 class MemoryEvent {
@@ -269,7 +273,9 @@ class MemoryEvent {
     return MemoryEvent(
       index: (json['index'] as num?)?.toInt() ?? 0,
       tags:
-          (json['tags'] as List?)?.whereType<String>().toList(growable: false) ??
+          (json['tags'] as List?)?.whereType<String>().toList(
+            growable: false,
+          ) ??
           const [],
       magnitude: (json['magnitude'] as num?)?.toDouble(),
       timeSeconds: (json['timeSeconds'] as num?)?.toDouble(),
@@ -313,9 +319,9 @@ class MemoryEventsPage {
               .toList(growable: false) ??
           const [],
       arrayPath:
-          (json['arrayPath'] as List?)
-              ?.whereType<String>()
-              .toList(growable: false) ??
+          (json['arrayPath'] as List?)?.whereType<String>().toList(
+            growable: false,
+          ) ??
           const [],
       total: (json['total'] as num?)?.toInt() ?? 0,
       offset: (json['offset'] as num?)?.toInt() ?? 0,
@@ -352,9 +358,9 @@ class QuestStateChange {
 /// Pending knowledge add/remove → `private.typed.setAdd` / `setRemove`.
 class KnowledgeEntryEdit {
   const KnowledgeEntryEdit.add({required this.setPath, required this.entry})
-      : isAdd = true;
+    : isAdd = true;
   const KnowledgeEntryEdit.remove({required this.setPath, required this.entry})
-      : isAdd = false;
+    : isAdd = false;
 
   final List<String> setPath;
   final String entry;
@@ -373,7 +379,7 @@ class KnowledgeEntryEdit {
 /// round (indices shift after each structural change).
 class MemoryEventEdit {
   const MemoryEventEdit.remove({required this.arrayPath, required this.index})
-      : isRemove = true;
+    : isRemove = true;
   const MemoryEventEdit.duplicate({
     required this.arrayPath,
     required this.index,

--- a/apps/goresave/lib/features/editor/domain/progression_models.dart
+++ b/apps/goresave/lib/features/editor/domain/progression_models.dart
@@ -1,0 +1,394 @@
+// Models for the Progression tab: the inspect overview, paged section
+// queries (quests / knowledge / events), and the edit intents that map to
+// core write ops. All pages carry an optional [error] (set by the notifier
+// instead of throwing) so cards can render failures inline.
+
+class ProgressionOverview {
+  const ProgressionOverview({
+    this.status,
+    this.questTotal = 0,
+    this.questStates = const {},
+    this.knowledgeCharacters = 0,
+    this.knowledgeEntries = 0,
+    this.memoryCharacters = 0,
+    this.memoryEvents = 0,
+    this.writable = const [],
+  });
+
+  factory ProgressionOverview.fromJson(Map<String, Object?>? json) {
+    final states = <String, int>{};
+    (json?['questStates'] as Map?)?.forEach((key, value) {
+      if (key is String && value is num) states[key] = value.toInt();
+    });
+    return ProgressionOverview(
+      status: json?['status'] as String?,
+      questTotal: (json?['questTotal'] as num?)?.toInt() ?? 0,
+      questStates: states,
+      knowledgeCharacters: (json?['knowledgeCharacters'] as num?)?.toInt() ?? 0,
+      knowledgeEntries: (json?['knowledgeEntries'] as num?)?.toInt() ?? 0,
+      memoryCharacters: (json?['memoryCharacters'] as num?)?.toInt() ?? 0,
+      memoryEvents: (json?['memoryEvents'] as num?)?.toInt() ?? 0,
+      writable:
+          (json?['writable'] as List?)?.whereType<String>().toList() ??
+          const [],
+    );
+  }
+
+  final String? status;
+  final int questTotal;
+  final Map<String, int> questStates;
+  final int knowledgeCharacters;
+  final int knowledgeEntries;
+  final int memoryCharacters;
+  final int memoryEvents;
+  final List<String> writable;
+
+  bool get available => status == 'ok';
+}
+
+class ProgressionQuest {
+  const ProgressionQuest({
+    required this.questClass,
+    required this.id,
+    required this.group,
+    required this.name,
+    required this.statePath,
+    this.currentState,
+    this.writable = false,
+  });
+
+  factory ProgressionQuest.fromJson(Map<String, Object?> json) {
+    return ProgressionQuest(
+      questClass: json['questClass'] as String? ?? '',
+      id: json['id'] as String? ?? '',
+      group: json['group'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      currentState: json['currentState'] as String?,
+      statePath:
+          (json['statePath'] as List?)
+              ?.whereType<String>()
+              .toList(growable: false) ??
+          const [],
+      writable: json['writable'] as bool? ?? false,
+    );
+  }
+
+  final String questClass;
+  final String id;
+  final String group;
+  final String name;
+  final String? currentState;
+  final List<String> statePath;
+  final bool writable;
+}
+
+class ProgressionQuestPage {
+  const ProgressionQuestPage({
+    this.quests = const [],
+    this.stateCounts = const {},
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 100,
+    this.error,
+  });
+
+  factory ProgressionQuestPage.fromJson(Map<String, Object?> json) {
+    final counts = <String, int>{};
+    (json['stateCounts'] as Map?)?.forEach((key, value) {
+      if (key is String && value is num) counts[key] = value.toInt();
+    });
+    return ProgressionQuestPage(
+      quests:
+          (json['quests'] as List?)
+              ?.whereType<Map>()
+              .map((e) => ProgressionQuest.fromJson(e.cast<String, Object?>()))
+              .toList(growable: false) ??
+          const [],
+      stateCounts: counts,
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 100,
+    );
+  }
+
+  final List<ProgressionQuest> quests;
+  final Map<String, int> stateCounts;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+
+  bool get hasMore => offset + quests.length < total;
+}
+
+class KnowledgeCharacter {
+  const KnowledgeCharacter({required this.name, required this.entryCount});
+
+  factory KnowledgeCharacter.fromJson(Map<String, Object?> json) {
+    return KnowledgeCharacter(
+      name: json['name'] as String? ?? '',
+      entryCount: (json['entryCount'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  final String name;
+  final int entryCount;
+}
+
+class KnowledgeCharactersPage {
+  const KnowledgeCharactersPage({
+    this.characters = const [],
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 100,
+    this.error,
+  });
+
+  factory KnowledgeCharactersPage.fromJson(Map<String, Object?> json) {
+    return KnowledgeCharactersPage(
+      characters:
+          (json['characters'] as List?)
+              ?.whereType<Map>()
+              .map((e) => KnowledgeCharacter.fromJson(e.cast<String, Object?>()))
+              .toList(growable: false) ??
+          const [],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 100,
+    );
+  }
+
+  final List<KnowledgeCharacter> characters;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+
+  bool get hasMore => offset + characters.length < total;
+}
+
+class KnowledgeEntriesPage {
+  const KnowledgeEntriesPage({
+    this.character = '',
+    this.entries = const [],
+    this.setPath = const [],
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 200,
+    this.error,
+  });
+
+  factory KnowledgeEntriesPage.fromJson(Map<String, Object?> json) {
+    return KnowledgeEntriesPage(
+      character: json['character'] as String? ?? '',
+      entries:
+          (json['entries'] as List?)
+              ?.whereType<String>()
+              .toList(growable: false) ??
+          const [],
+      setPath:
+          (json['setPath'] as List?)
+              ?.whereType<String>()
+              .toList(growable: false) ??
+          const [],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 200,
+    );
+  }
+
+  final String character;
+  final List<String> entries;
+  final List<String> setPath;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+
+  bool get hasMore => offset + entries.length < total;
+}
+
+class MemoryCharacter {
+  const MemoryCharacter({required this.id, required this.eventCount});
+
+  factory MemoryCharacter.fromJson(Map<String, Object?> json) {
+    return MemoryCharacter(
+      id: json['id'] as String? ?? '',
+      eventCount: (json['eventCount'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  final String id;
+  final int eventCount;
+}
+
+class MemoryCharactersPage {
+  const MemoryCharactersPage({
+    this.characters = const [],
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 100,
+    this.error,
+  });
+
+  factory MemoryCharactersPage.fromJson(Map<String, Object?> json) {
+    return MemoryCharactersPage(
+      characters:
+          (json['characters'] as List?)
+              ?.whereType<Map>()
+              .map((e) => MemoryCharacter.fromJson(e.cast<String, Object?>()))
+              .toList(growable: false) ??
+          const [],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 100,
+    );
+  }
+
+  final List<MemoryCharacter> characters;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+}
+
+class MemoryEvent {
+  const MemoryEvent({
+    required this.index,
+    this.tags = const [],
+    this.magnitude,
+    this.timeSeconds,
+    this.durationSeconds,
+    this.instigator,
+    this.affected,
+    this.optionalClass1,
+    this.optionalClass2,
+  });
+
+  factory MemoryEvent.fromJson(Map<String, Object?> json) {
+    return MemoryEvent(
+      index: (json['index'] as num?)?.toInt() ?? 0,
+      tags:
+          (json['tags'] as List?)?.whereType<String>().toList(growable: false) ??
+          const [],
+      magnitude: (json['magnitude'] as num?)?.toDouble(),
+      timeSeconds: (json['timeSeconds'] as num?)?.toDouble(),
+      durationSeconds: (json['durationSeconds'] as num?)?.toDouble(),
+      instigator: json['instigator'] as String?,
+      affected: json['affected'] as String?,
+      optionalClass1: json['optionalClass1'] as String?,
+      optionalClass2: json['optionalClass2'] as String?,
+    );
+  }
+
+  final int index;
+  final List<String> tags;
+  final double? magnitude;
+  final double? timeSeconds;
+  final double? durationSeconds;
+  final String? instigator;
+  final String? affected;
+  final String? optionalClass1;
+  final String? optionalClass2;
+}
+
+class MemoryEventsPage {
+  const MemoryEventsPage({
+    this.character = '',
+    this.events = const [],
+    this.arrayPath = const [],
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 100,
+    this.error,
+  });
+
+  factory MemoryEventsPage.fromJson(Map<String, Object?> json) {
+    return MemoryEventsPage(
+      character: json['character'] as String? ?? '',
+      events:
+          (json['events'] as List?)
+              ?.whereType<Map>()
+              .map((e) => MemoryEvent.fromJson(e.cast<String, Object?>()))
+              .toList(growable: false) ??
+          const [],
+      arrayPath:
+          (json['arrayPath'] as List?)
+              ?.whereType<String>()
+              .toList(growable: false) ??
+          const [],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 100,
+    );
+  }
+
+  final String character;
+  final List<MemoryEvent> events;
+  final List<String> arrayPath;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+
+  bool get hasMore => offset + events.length < total;
+}
+
+/// Pending quest-state change → `private.typed.setValue`.
+class QuestStateChange {
+  const QuestStateChange({required this.statePath, required this.state});
+
+  final List<String> statePath;
+  final String state;
+
+  Map<String, Object?> toEditJson() {
+    return {
+      'path': 'private.typed.setValue',
+      'value': {'path': statePath, 'value': state},
+    };
+  }
+}
+
+/// Pending knowledge add/remove → `private.typed.setAdd` / `setRemove`.
+class KnowledgeEntryEdit {
+  const KnowledgeEntryEdit.add({required this.setPath, required this.entry})
+      : isAdd = true;
+  const KnowledgeEntryEdit.remove({required this.setPath, required this.entry})
+      : isAdd = false;
+
+  final List<String> setPath;
+  final String entry;
+  final bool isAdd;
+
+  Map<String, Object?> toEditJson() {
+    return {
+      'path': isAdd ? 'private.typed.setAdd' : 'private.typed.setRemove',
+      'value': {'path': setPath, 'value': entry},
+    };
+  }
+}
+
+/// Structural memory-event edit → `private.typed.arrayRemove` /
+/// `arrayDuplicate`. Index-addressed, so the UI applies at most one per save
+/// round (indices shift after each structural change).
+class MemoryEventEdit {
+  const MemoryEventEdit.remove({required this.arrayPath, required this.index})
+      : isRemove = true;
+  const MemoryEventEdit.duplicate({
+    required this.arrayPath,
+    required this.index,
+  }) : isRemove = false;
+
+  final List<String> arrayPath;
+  final int index;
+  final bool isRemove;
+
+  Map<String, Object?> toEditJson() {
+    return {
+      'path': isRemove
+          ? 'private.typed.arrayRemove'
+          : 'private.typed.arrayDuplicate',
+      'value': {'path': arrayPath, 'index': index},
+    };
+  }
+}

--- a/apps/goresave/lib/features/editor/domain/progression_models.dart
+++ b/apps/goresave/lib/features/editor/domain/progression_models.dart
@@ -119,6 +119,10 @@ class ProgressionQuestPage {
   final String? error;
 
   bool get hasMore => offset + quests.length < total;
+  bool get hasNext => offset + quests.length < total;
+  bool get hasPrevious => offset > 0;
+  int get pageIndex => limit == 0 ? 0 : offset ~/ limit;
+  int get pageCount => total == 0 ? 1 : (total + limit - 1) ~/ limit;
 }
 
 class KnowledgeCharacter {
@@ -167,6 +171,10 @@ class KnowledgeCharactersPage {
   final String? error;
 
   bool get hasMore => offset + characters.length < total;
+  bool get hasNext => offset + characters.length < total;
+  bool get hasPrevious => offset > 0;
+  int get pageIndex => limit == 0 ? 0 : offset ~/ limit;
+  int get pageCount => total == 0 ? 1 : (total + limit - 1) ~/ limit;
 }
 
 class KnowledgeEntriesPage {
@@ -208,6 +216,10 @@ class KnowledgeEntriesPage {
   final String? error;
 
   bool get hasMore => offset + entries.length < total;
+  bool get hasNext => offset + entries.length < total;
+  bool get hasPrevious => offset > 0;
+  int get pageIndex => limit == 0 ? 0 : offset ~/ limit;
+  int get pageCount => total == 0 ? 1 : (total + limit - 1) ~/ limit;
 }
 
 class MemoryCharacter {
@@ -254,6 +266,10 @@ class MemoryCharactersPage {
   final String? error;
 
   bool get hasMore => offset + characters.length < total;
+  bool get hasNext => offset + characters.length < total;
+  bool get hasPrevious => offset > 0;
+  int get pageIndex => limit == 0 ? 0 : offset ~/ limit;
+  int get pageCount => total == 0 ? 1 : (total + limit - 1) ~/ limit;
 }
 
 class MemoryEvent {
@@ -338,6 +354,10 @@ class MemoryEventsPage {
   final String? error;
 
   bool get hasMore => offset + events.length < total;
+  bool get hasNext => offset + events.length < total;
+  bool get hasPrevious => offset > 0;
+  int get pageIndex => limit == 0 ? 0 : offset ~/ limit;
+  int get pageCount => total == 0 ? 1 : (total + limit - 1) ~/ limit;
 }
 
 /// Pending quest-state change → `private.typed.setValue`.

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -162,7 +162,12 @@ class _SaveSidebar extends StatelessWidget {
       ),
       child: Column(
         children: [
-          _ProfileHeader(profile: state.activeProfile, saveCount: saves.length),
+          _ProfileHeader(
+            profile: state.activeProfile,
+            saveCount: saves.length,
+            notifier: notifier,
+            isLoading: state.isLoading,
+          ),
           Expanded(
             child: saves.isEmpty
                 ? const Center(
@@ -200,10 +205,17 @@ class _SaveSidebar extends StatelessWidget {
 }
 
 class _ProfileHeader extends StatelessWidget {
-  const _ProfileHeader({required this.profile, required this.saveCount});
+  const _ProfileHeader({
+    required this.profile,
+    required this.saveCount,
+    required this.notifier,
+    required this.isLoading,
+  });
 
   final ProfileSummary? profile;
   final int saveCount;
+  final EditorNotifier notifier;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -217,7 +229,7 @@ class _ProfileHeader extends StatelessWidget {
       // height + 2 indicator weight = 74, measured) so the header's bottom
       // edge lines up with the tab bar's.
       height: 74,
-      padding: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.only(left: 16, right: 4),
       alignment: Alignment.centerLeft,
       decoration: BoxDecoration(
         color: scheme.surfaceContainerLowest,
@@ -257,6 +269,13 @@ class _ProfileHeader extends StatelessWidget {
                 ),
               ],
             ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Rescan save folder',
+            visualDensity: VisualDensity.compact,
+            iconSize: 20,
+            onPressed: isLoading ? null : notifier.refresh,
           ),
         ],
       ),

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -13,6 +13,7 @@ import 'package:goresave/features/editor/domain/pending_edits.dart';
 import 'package:goresave/providers/data_providers.dart';
 import 'package:intl/intl.dart';
 import 'hero_stats_card.dart';
+import 'progression_panel.dart';
 
 final _bytes = NumberFormat.decimalPattern();
 
@@ -592,9 +593,13 @@ class _EditorWorkspace extends StatelessWidget {
                     ),
                   ),
                   _KeepAliveTab(
-                    child: _ProgressionPanel(
+                    child: ProgressionPanel(
                       inspection: inspection,
                       notifier: notifier,
+                      editable:
+                          inspection.privateEditable &&
+                          inspection.privateTypedVerified &&
+                          state.codecCompressReady,
                     ),
                   ),
                   _KeepAliveTab(
@@ -1409,201 +1414,6 @@ class _InventoryPanel extends StatelessWidget {
   }
 }
 
-class _ProgressionPanel extends StatelessWidget {
-  const _ProgressionPanel({required this.inspection, required this.notifier});
-
-  final SaveInspection inspection;
-  final EditorNotifier notifier;
-
-  @override
-  Widget build(BuildContext context) {
-    if (!inspection.privateDecoded) {
-      return const _MessagePane(
-        icon: Icons.flag_outlined,
-        title: 'Progression',
-        body:
-            'Progression data needs decoded private payload data from the G1R codec host.',
-      );
-    }
-    return ListView(
-      padding: const EdgeInsets.all(20),
-      children: [
-        if (inspection.privateProgression.hasData)
-          _PrivateProgressionSummaryCard(
-            progression: inspection.privateProgression,
-          )
-        else
-          const _MessagePane(
-            icon: Icons.flag_outlined,
-            title: 'Progression',
-            body:
-                'No progression markers found in the decoded private payload.',
-          ),
-      ],
-    );
-  }
-}
-
-class _PrivateProgressionSummaryCard extends StatefulWidget {
-  const _PrivateProgressionSummaryCard({required this.progression});
-
-  final PrivateProgressionSummary progression;
-
-  @override
-  State<_PrivateProgressionSummaryCard> createState() =>
-      _PrivateProgressionSummaryCardState();
-}
-
-class _PrivateProgressionSummaryCardState
-    extends State<_PrivateProgressionSummaryCard> {
-  String _query = '';
-
-  @override
-  Widget build(BuildContext context) {
-    final progression = widget.progression;
-    final query = _query.trim().toLowerCase();
-    final candidates = progression.candidates
-        .where((value) => query.isEmpty || value.toLowerCase().contains(query))
-        .take(160)
-        .toList();
-    final candidateSet = candidates.toSet();
-    final tags = progression.gameplayTags
-        .where(
-          (value) =>
-              (query.isEmpty || value.toLowerCase().contains(query)) &&
-              !candidateSet.contains(value),
-        )
-        .take(160)
-        .toList();
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.flag_outlined),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'Progression summary',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                _SummaryMetric(
-                  label: 'Candidates',
-                  value: progression.candidateCount.toString(),
-                ),
-                _SummaryMetric(
-                  label: 'Gameplay tags',
-                  value: progression.gameplayTags.length.toString(),
-                ),
-                _SummaryMetric(
-                  label: 'Sections',
-                  value: progression.sections.length.toString(),
-                ),
-                _SummaryMetric(
-                  label: 'Properties',
-                  value: progression.properties.length.toString(),
-                ),
-                _SummaryMetric(
-                  label: 'Scripts',
-                  value: progression.scriptPaths.length.toString(),
-                ),
-              ],
-            ),
-            if (progression.sections.isNotEmpty) ...[
-              const SizedBox(height: 16),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: progression.sections
-                    .map((value) => Chip(label: Text(value, maxLines: 1)))
-                    .toList(),
-              ),
-            ],
-            const SizedBox(height: 16),
-            TextField(
-              decoration: const InputDecoration(
-                labelText: 'Filter progression',
-                prefixIcon: Icon(Icons.search),
-              ),
-              onChanged: (value) => setState(() => _query = value),
-            ),
-            if (candidates.isNotEmpty) ...[
-              const SizedBox(height: 16),
-              Text(
-                'Progression markers',
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-              const SizedBox(height: 8),
-              _StringList(values: candidates, icon: Icons.flag_outlined),
-            ],
-            if (tags.isNotEmpty) ...[
-              const SizedBox(height: 16),
-              Text(
-                'Gameplay tags',
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-              const SizedBox(height: 8),
-              _StringList(values: tags, icon: Icons.sell_outlined),
-            ],
-            if (progression.scriptPaths.isNotEmpty) ...[
-              const SizedBox(height: 16),
-              Text(
-                'Progression scripts',
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-              const SizedBox(height: 8),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: progression.scriptPaths
-                    .take(8)
-                    .map((value) => Chip(label: Text(value, maxLines: 1)))
-                    .toList(),
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _StringList extends StatelessWidget {
-  const _StringList({required this.values, required this.icon});
-
-  final List<String> values;
-  final IconData icon;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      height: 220,
-      child: ListView.separated(
-        itemCount: values.length,
-        separatorBuilder: (_, _) => const Divider(height: 1),
-        itemBuilder: (context, index) {
-          return ListTile(
-            dense: true,
-            leading: Icon(icon),
-            title: SelectableText(values[index], maxLines: 1),
-          );
-        },
-      ),
-    );
-  }
-}
-
 class _PrivateInventorySummaryCard extends StatefulWidget {
   const _PrivateInventorySummaryCard({
     required this.inventory,
@@ -2396,39 +2206,6 @@ String _formatAttributeValue(double? value) {
   // a lossy rounding (0.125 → 0.13) would silently corrupt untouched axes
   // the moment any sibling field changes. Round-trip or full precision.
   return double.tryParse(rounded) == value ? rounded : value.toString();
-}
-
-class _SummaryMetric extends StatelessWidget {
-  const _SummaryMetric({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 120,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-          Text(
-            value,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-        ],
-      ),
-    );
-  }
 }
 
 /// Generic typed property browser: search every property in the decoded

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -275,11 +275,41 @@ class _ProfileHeader extends StatelessWidget {
             tooltip: 'Rescan save folder',
             visualDensity: VisualDensity.compact,
             iconSize: 20,
-            onPressed: isLoading ? null : notifier.refresh,
+            onPressed: isLoading ? null : () => _confirmRefresh(context),
           ),
         ],
       ),
     );
+  }
+
+  /// Rescanning re-inspects the selected slot, which clears the global
+  /// pending-edit registry — never silently discard unsaved drafts.
+  Future<void> _confirmRefresh(BuildContext context) async {
+    final pendingCount = notifier.pendingEditCount;
+    if (pendingCount > 0) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Discard unsaved changes?'),
+          content: Text(
+            'Rescanning reloads every save and discards your $pendingCount '
+            'unsaved change${pendingCount == 1 ? '' : 's'}.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Discard and rescan'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) return;
+    }
+    await notifier.refresh();
   }
 }
 
@@ -519,9 +549,7 @@ class _EditorWorkspace extends StatelessWidget {
                     child: FilledButton.icon(
                       icon: const Icon(Icons.save_outlined),
                       label: Text(
-                        pendingCount == 0
-                            ? 'Save'
-                            : 'Save ($pendingCount)',
+                        pendingCount == 0 ? 'Save' : 'Save ($pendingCount)',
                       ),
                       onPressed: pendingCount > 0 && !state.isLoading
                           ? notifier.saveAllPending
@@ -599,7 +627,8 @@ class _EditorWorkspace extends StatelessWidget {
                       // codec host to be compress-ready (auto-trusted or verified
                       // this session), not just decode-ready.
                       editable:
-                          inspection.privateEditable && state.codecCompressReady,
+                          inspection.privateEditable &&
+                          state.codecCompressReady,
                       lockedBody:
                           'Private player edits need a verified G1R codec host.',
                     ),
@@ -629,7 +658,8 @@ class _EditorWorkspace extends StatelessWidget {
                       // full private decode (not a preview) plus a compress-ready
                       // codec, matching the Player and Inventory gating.
                       editable:
-                          inspection.privateEditable && state.codecCompressReady,
+                          inspection.privateEditable &&
+                          state.codecCompressReady,
                     ),
                   ),
                   _KeepAliveTab(
@@ -777,9 +807,8 @@ class _OverviewInspectionJsonState extends State<_OverviewInspectionJson> {
                   IconButton(
                     tooltip: 'Copy',
                     icon: const Icon(Icons.copy),
-                    onPressed: () => Clipboard.setData(
-                      ClipboardData(text: _getJson()),
-                    ),
+                    onPressed: () =>
+                        Clipboard.setData(ClipboardData(text: _getJson())),
                   ),
                 ],
               ),
@@ -1291,10 +1320,7 @@ class _PrivatePanel extends StatelessWidget {
                       for (final edit in edits)
                         {
                           'path': 'private.typed.setValue',
-                          'value': {
-                            'path': edit.path,
-                            'value': edit.value,
-                          },
+                          'value': {'path': edit.path, 'value': edit.value},
                         },
                     ],
                   ),
@@ -1674,10 +1700,7 @@ class _InventoryItemCountEditorState extends State<_InventoryItemCountEditor> {
         controller: _controller,
         keyboardType: TextInputType.number,
         onChanged: _onCountTextChanged,
-        decoration: InputDecoration(
-          labelText: 'Count',
-          errorText: _error,
-        ),
+        decoration: InputDecoration(labelText: 'Count', errorText: _error),
       ),
     );
   }
@@ -1956,11 +1979,7 @@ class _PrivatePlayerTransformEditorState
           {
             'path': 'private.player.setTransform',
             'value': {
-              'location': {
-                'x': locationX,
-                'y': locationY,
-                'z': locationZ,
-              },
+              'location': {'x': locationX, 'y': locationY, 'z': locationZ},
               'rotation': {
                 'pitch': rotationPitch,
                 'yaw': rotationYaw,
@@ -2606,8 +2625,7 @@ class _TypedPropertyRowState extends State<_TypedPropertyRow> {
     // Re-seed when the reloadKey identity changes (e.g. after Reset/refresh
     // that produces a new inspection — same canonical value, draft must go).
     final newKey = widget.reloadKey;
-    final keyChanged =
-        newKey != null && !identical(newKey, _lastReloadKey);
+    final keyChanged = newKey != null && !identical(newKey, _lastReloadKey);
     if (keyChanged) {
       _lastReloadKey = newKey;
     }

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -141,21 +141,9 @@ class _SaveSidebar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Scope the list to the active profile so the list, the header total, and
-    // the profile-scoped Quick/Auto counts all agree in a multi-profile folder.
-    final activeProfileId = state.activeProfile?.profileId;
-    final saves = activeProfileId == null
-        ? state.saves
-        : state.saves
-              .where(
-                (s) =>
-                    // Keep this profile's saves, plus saves with unknown profile
-                    // metadata, and never hide the currently selected save.
-                    s.persistentProfileId == activeProfileId ||
-                    s.persistentProfileId == null ||
-                    s.path == state.selectedPath,
-              )
-              .toList();
+    // Use the notifier-computed visible saves so the list, header count, and
+    // Quick/Auto stats all agree.
+    final saves = state.visibleSaves;
     return DecoratedBox(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainerLow,
@@ -164,6 +152,7 @@ class _SaveSidebar extends StatelessWidget {
         children: [
           _ProfileHeader(
             profile: state.activeProfile,
+            profiles: state.profiles,
             saveCount: saves.length,
             notifier: notifier,
             isLoading: state.isLoading,
@@ -207,12 +196,14 @@ class _SaveSidebar extends StatelessWidget {
 class _ProfileHeader extends StatelessWidget {
   const _ProfileHeader({
     required this.profile,
+    required this.profiles,
     required this.saveCount,
     required this.notifier,
     required this.isLoading,
   });
 
   final ProfileSummary? profile;
+  final List<ProfileSummary> profiles;
   final int saveCount;
   final EditorNotifier notifier;
   final bool isLoading;
@@ -223,6 +214,7 @@ class _ProfileHeader extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     final quickCount = profile?.quickSaveSlots.length ?? 0;
     final autoCount = profile?.autoSaveSlots.length ?? 0;
+    final multiProfile = profiles.length > 1;
     return Container(
       width: double.infinity,
       // Match the icon+text TabBar row in the workspace next door (72 tab
@@ -252,12 +244,20 @@ class _ProfileHeader extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  profile?.displayName ?? 'Profile',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: textTheme.titleMedium,
-                ),
+                if (multiProfile)
+                  _ProfileSwitcher(
+                    profile: profile,
+                    profiles: profiles,
+                    notifier: notifier,
+                    isLoading: isLoading,
+                  )
+                else
+                  Text(
+                    profile?.displayName ?? 'Profile',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: textTheme.titleMedium,
+                  ),
                 const SizedBox(height: 2),
                 Text(
                   '${_formatCount(saveCount, 'save')} | Quick $quickCount | Auto $autoCount',
@@ -310,6 +310,73 @@ class _ProfileHeader extends StatelessWidget {
       if (confirmed != true) return;
     }
     await notifier.refresh();
+  }
+}
+
+/// Profile name shown as a [PopupMenuButton] when multiple profiles exist.
+/// Selecting a profile calls [EditorNotifier.selectProfile].
+class _ProfileSwitcher extends StatelessWidget {
+  const _ProfileSwitcher({
+    required this.profile,
+    required this.profiles,
+    required this.notifier,
+    required this.isLoading,
+  });
+
+  final ProfileSummary? profile;
+  final List<ProfileSummary> profiles;
+  final EditorNotifier notifier;
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final scheme = Theme.of(context).colorScheme;
+    final currentId = profile?.profileId;
+    return PopupMenuButton<int>(
+      tooltip: 'Switch profile',
+      enabled: !isLoading,
+      onSelected: (id) => notifier.selectProfile(id),
+      itemBuilder: (context) => [
+        for (final p in profiles)
+          PopupMenuItem<int>(
+            value: p.profileId,
+            child: Row(
+              children: [
+                if (p.profileId == currentId)
+                  Icon(Icons.check, size: 18, color: scheme.primary)
+                else
+                  const SizedBox(width: 18),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '${p.displayName} (${p.savedSlots.length} saves)',
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Text(
+              profile?.displayName ?? 'Profile',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: textTheme.titleMedium,
+            ),
+          ),
+          Icon(
+            Icons.arrow_drop_down,
+            size: 18,
+            color: isLoading ? scheme.onSurfaceVariant : scheme.primary,
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -1,0 +1,986 @@
+import 'package:flutter/material.dart';
+
+import '../domain/editor_models.dart';
+import '../domain/editor_notifier.dart';
+import '../domain/pending_edits.dart';
+import '../domain/progression_models.dart';
+
+/// All five EQuestState values, in dropdown order.
+const questStates = <String>[
+  'EQuestState::None',
+  'EQuestState::Available',
+  'EQuestState::Running',
+  'EQuestState::Succeeded',
+  'EQuestState::Failed',
+];
+
+String shortStateLabel(String state) {
+  final idx = state.lastIndexOf('::');
+  return idx < 0 ? state : state.substring(idx + 2);
+}
+
+/// Progression tab: structured quests / dialog knowledge / memory events.
+/// Data loads lazily per card through the notifier's query_progression
+/// wrappers. [reloadKey] identifies the inspected save (sha1); when it
+/// changes, cards drop local state and reload.
+class ProgressionPanel extends StatelessWidget {
+  const ProgressionPanel({
+    super.key,
+    required this.inspection,
+    required this.notifier,
+    required this.editable,
+  });
+
+  final SaveInspection inspection;
+  final EditorNotifier notifier;
+  final bool editable;
+
+  @override
+  Widget build(BuildContext context) {
+    final overview = inspection.privateProgression;
+    if (!inspection.privateDecoded) {
+      return const _MessagePane(
+        icon: Icons.flag_outlined,
+        title: 'Progression',
+        body:
+            'Progression data needs decoded private payload data from the G1R codec host.',
+      );
+    }
+    if (!overview.available) {
+      return const _MessagePane(
+        icon: Icons.flag_outlined,
+        title: 'Progression',
+        body:
+            'Structured progression data needs a fully decoded save with a '
+            'verified typed parse.',
+      );
+    }
+    final reloadKey = inspection.sha1;
+    return ListView(
+      padding: const EdgeInsets.all(20),
+      children: [
+        _OverviewCard(overview: overview),
+        const SizedBox(height: 16),
+        _QuestsCard(
+          notifier: notifier,
+          editable: editable,
+          reloadKey: reloadKey,
+        ),
+        const SizedBox(height: 16),
+        _KnowledgeCard(
+          notifier: notifier,
+          editable: editable,
+          reloadKey: reloadKey,
+        ),
+        const SizedBox(height: 16),
+        _EventsCard(
+          notifier: notifier,
+          editable: editable,
+          reloadKey: reloadKey,
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Overview card (stateless)
+// ---------------------------------------------------------------------------
+
+class _OverviewCard extends StatelessWidget {
+  const _OverviewCard({required this.overview});
+
+  final ProgressionOverview overview;
+
+  @override
+  Widget build(BuildContext context) {
+    final states = overview.questStates;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.flag_outlined),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Progression summary',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _SummaryMetric(
+                  label: 'Quests total',
+                  value: overview.questTotal.toString(),
+                ),
+                for (final entry in states.entries)
+                  _SummaryMetric(
+                    label: entry.key,
+                    value: entry.value.toString(),
+                  ),
+                _SummaryMetric(
+                  label: 'Knowledge NPCs',
+                  value: overview.knowledgeCharacters.toString(),
+                ),
+                _SummaryMetric(
+                  label: 'Knowledge entries',
+                  value: overview.knowledgeEntries.toString(),
+                ),
+                _SummaryMetric(
+                  label: 'Memory characters',
+                  value: overview.memoryCharacters.toString(),
+                ),
+                _SummaryMetric(
+                  label: 'Memory events',
+                  value: overview.memoryEvents.toString(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Quests card (stateful, pending-edit pattern)
+// ---------------------------------------------------------------------------
+
+class _QuestsCard extends StatefulWidget {
+  const _QuestsCard({
+    required this.notifier,
+    required this.editable,
+    required this.reloadKey,
+  });
+
+  final EditorNotifier notifier;
+  final bool editable;
+  final Object reloadKey;
+
+  @override
+  State<_QuestsCard> createState() => _QuestsCardState();
+}
+
+class _QuestsCardState extends State<_QuestsCard> {
+  final TextEditingController _search = TextEditingController();
+  ProgressionQuestPage _page = const ProgressionQuestPage();
+  final List<ProgressionQuest> _quests = [];
+  final Map<String, QuestStateChange> _pending = {};
+  bool _loading = false;
+  int _reloadEpoch = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _reload();
+  }
+
+  @override
+  void didUpdateWidget(covariant _QuestsCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.reloadKey != oldWidget.reloadKey) {
+      _pending.clear();
+      _reload();
+    }
+  }
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  Future<void> _reload({bool append = false}) async {
+    final epoch = ++_reloadEpoch;
+    setState(() => _loading = true);
+    final page = await widget.notifier.loadProgressionQuests(
+      query: _search.text.trim(),
+      offset: append ? _quests.length : 0,
+    );
+    if (!mounted || epoch != _reloadEpoch) return;
+    setState(() {
+      _loading = false;
+      _page = page;
+      if (!append) _quests.clear();
+      _quests.addAll(page.quests);
+    });
+  }
+
+  void _pushPending() {
+    if (_pending.isEmpty) {
+      widget.notifier.clearPendingEdit('progression.quests');
+    } else {
+      widget.notifier.setPendingEdit(
+        'progression.quests',
+        PendingSaveEdit(
+          edits: _pending.values.map((c) => c.toEditJson()).toList(),
+        ),
+      );
+    }
+  }
+
+  void _setQuestState(ProgressionQuest quest, String? state) {
+    setState(() {
+      if (state == null || state == quest.currentState) {
+        _pending.remove(quest.questClass);
+      } else {
+        _pending[quest.questClass] = QuestStateChange(
+          statePath: quest.statePath,
+          state: state,
+        );
+      }
+    });
+    _pushPending();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.flag_outlined),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Quests',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                if (widget.editable && _pending.isNotEmpty)
+                  Tooltip(
+                    message: 'Reset quest changes',
+                    child: IconButton(
+                      icon: const Icon(Icons.undo_outlined),
+                      onPressed: () {
+                        setState(_pending.clear);
+                        widget.notifier.clearPendingEdit('progression.quests');
+                      },
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _search,
+              decoration: const InputDecoration(
+                labelText: 'Search quests',
+                prefixIcon: Icon(Icons.search),
+              ),
+              onSubmitted: (_) => _reload(),
+            ),
+            if (_page.error != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                _page.error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ],
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 360,
+              child: _loading && _quests.isEmpty
+                  ? const Center(child: CircularProgressIndicator())
+                  : ListView.separated(
+                      itemCount: _quests.length + (_page.hasMore ? 1 : 0),
+                      separatorBuilder: (_, _) => const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        if (index >= _quests.length) {
+                          return TextButton(
+                            onPressed: _loading
+                                ? null
+                                : () => _reload(append: true),
+                            child: Text(
+                              'Load more (${_quests.length} of ${_page.total})',
+                            ),
+                          );
+                        }
+                        final quest = _quests[index];
+                        final pendingState = _pending[quest.questClass]?.state;
+                        final effectiveState =
+                            pendingState ?? quest.currentState;
+                        // Guard: only show dropdown if the current value is a
+                        // known questStates entry; otherwise fall back to text.
+                        final inKnownStates =
+                            effectiveState != null &&
+                            questStates.contains(effectiveState);
+                        return ListTile(
+                          dense: true,
+                          leading: const Icon(Icons.flag_outlined),
+                          title: SelectableText(
+                            quest.name.isEmpty ? quest.id : quest.name,
+                            maxLines: 1,
+                          ),
+                          subtitle: SelectableText(quest.group, maxLines: 1),
+                          trailing:
+                              widget.editable && quest.writable && inKnownStates
+                              ? DropdownButton<String>(
+                                  value: effectiveState,
+                                  underline: const SizedBox.shrink(),
+                                  items: questStates
+                                      .map(
+                                        (s) => DropdownMenuItem(
+                                          value: s,
+                                          child: Text(shortStateLabel(s)),
+                                        ),
+                                      )
+                                      .toList(),
+                                  onChanged: (s) => _setQuestState(quest, s),
+                                )
+                              : Text(
+                                  shortStateLabel(
+                                    quest.currentState ?? 'unknown',
+                                  ),
+                                ),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge card (stateful, pending-edit pattern)
+// ---------------------------------------------------------------------------
+
+class _KnowledgeCard extends StatefulWidget {
+  const _KnowledgeCard({
+    required this.notifier,
+    required this.editable,
+    required this.reloadKey,
+  });
+
+  final EditorNotifier notifier;
+  final bool editable;
+  final Object reloadKey;
+
+  @override
+  State<_KnowledgeCard> createState() => _KnowledgeCardState();
+}
+
+class _KnowledgeCardState extends State<_KnowledgeCard> {
+  KnowledgeCharactersPage _characters = const KnowledgeCharactersPage();
+  String? _selectedCharacter;
+  KnowledgeEntriesPage _entries = const KnowledgeEntriesPage();
+  final Map<String, KnowledgeEntryEdit> _pending = {};
+  final TextEditingController _addController = TextEditingController();
+  bool _loadingCharacters = false;
+  bool _loadingEntries = false;
+  int _reloadEpoch = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCharacters();
+  }
+
+  @override
+  void didUpdateWidget(covariant _KnowledgeCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.reloadKey != oldWidget.reloadKey) {
+      _pending.clear();
+      _selectedCharacter = null;
+      _entries = const KnowledgeEntriesPage();
+      _loadCharacters();
+    }
+  }
+
+  @override
+  void dispose() {
+    _addController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadCharacters() async {
+    final epoch = ++_reloadEpoch;
+    setState(() => _loadingCharacters = true);
+    final page = await widget.notifier.loadKnowledgeCharacters();
+    if (!mounted || epoch != _reloadEpoch) return;
+    setState(() {
+      _loadingCharacters = false;
+      _characters = page;
+    });
+  }
+
+  Future<void> _selectCharacter(String name) async {
+    final epoch = ++_reloadEpoch;
+    setState(() {
+      _selectedCharacter = name;
+      _loadingEntries = true;
+    });
+    final page = await widget.notifier.loadKnowledgeEntries(name);
+    if (!mounted || epoch != _reloadEpoch) return;
+    setState(() {
+      _loadingEntries = false;
+      _entries = page;
+    });
+  }
+
+  void _pushPending() {
+    if (_pending.isEmpty) {
+      widget.notifier.clearPendingEdit('progression.knowledge');
+    } else {
+      widget.notifier.setPendingEdit(
+        'progression.knowledge',
+        PendingSaveEdit(
+          edits: _pending.values.map((e) => e.toEditJson()).toList(),
+        ),
+      );
+    }
+  }
+
+  String _pendingKey(String character, String entry) => '$character\t$entry';
+
+  void _removeEntry(String entry) {
+    final key = _pendingKey(_selectedCharacter!, entry);
+    setState(() {
+      if (_pending.containsKey(key)) {
+        // Was a pending-add — undo it
+        _pending.remove(key);
+      } else {
+        _pending[key] = KnowledgeEntryEdit.remove(
+          setPath: _entries.setPath,
+          entry: entry,
+        );
+      }
+    });
+    _pushPending();
+  }
+
+  void _addEntry(String entry) {
+    final trimmed = entry.trim();
+    if (trimmed.isEmpty) return;
+    if (_entries.entries.contains(trimmed)) return;
+    final key = _pendingKey(_selectedCharacter!, trimmed);
+    if (_pending.containsKey(key)) return; // already pending
+    setState(() {
+      _pending[key] = KnowledgeEntryEdit.add(
+        setPath: _entries.setPath,
+        entry: trimmed,
+      );
+      _addController.clear();
+    });
+    _pushPending();
+  }
+
+  void _undoAdd(String entry) {
+    final key = _pendingKey(_selectedCharacter!, entry);
+    setState(() => _pending.remove(key));
+    _pushPending();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final character = _selectedCharacter;
+
+    // Compute sets for rendering
+    final removedEntries = <String>{};
+    final addedEntries = <String>[];
+    if (character != null) {
+      for (final edit in _pending.values) {
+        if (!edit.isAdd) removedEntries.add(edit.entry);
+        if (edit.isAdd) addedEntries.add(edit.entry);
+      }
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.chat_bubble_outline),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Dialog Knowledge',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                if (widget.editable && _pending.isNotEmpty)
+                  Tooltip(
+                    message: 'Reset knowledge changes',
+                    child: IconButton(
+                      icon: const Icon(Icons.undo_outlined),
+                      onPressed: () {
+                        setState(_pending.clear);
+                        widget.notifier.clearPendingEdit(
+                          'progression.knowledge',
+                        );
+                      },
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            if (_characters.error != null) ...[
+              Text(_characters.error!, style: TextStyle(color: scheme.error)),
+              const SizedBox(height: 8),
+            ],
+            // Character list (height-capped)
+            SizedBox(
+              height: 200,
+              child: _loadingCharacters
+                  ? const Center(child: CircularProgressIndicator())
+                  : ListView.separated(
+                      itemCount: _characters.characters.length,
+                      separatorBuilder: (_, _) => const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        final c = _characters.characters[index];
+                        final isSelected = c.name == character;
+                        return ListTile(
+                          dense: true,
+                          selected: isSelected,
+                          title: Text('${c.name} (${c.entryCount})'),
+                          onTap: () => _selectCharacter(c.name),
+                        );
+                      },
+                    ),
+            ),
+            if (character != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                'Entries for $character',
+                style: Theme.of(context).textTheme.labelLarge,
+              ),
+              const SizedBox(height: 8),
+              if (_entries.error != null)
+                Text(_entries.error!, style: TextStyle(color: scheme.error)),
+              if (_loadingEntries)
+                const Center(child: CircularProgressIndicator())
+              else
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: [
+                    // Existing entries
+                    for (final entry in _entries.entries)
+                      if (removedEntries.contains(entry))
+                        Chip(
+                          label: Text(
+                            entry,
+                            style: const TextStyle(
+                              decoration: TextDecoration.lineThrough,
+                            ),
+                          ),
+                          deleteIcon: const Icon(Icons.undo, size: 16),
+                          onDeleted: widget.editable
+                              ? () => _removeEntry(entry)
+                              : null,
+                        )
+                      else
+                        Chip(
+                          label: Text(entry),
+                          onDeleted: widget.editable
+                              ? () => _removeEntry(entry)
+                              : null,
+                        ),
+                    // Pending adds
+                    for (final entry in addedEntries)
+                      Chip(
+                        backgroundColor: scheme.tertiaryContainer,
+                        label: Text(
+                          entry,
+                          style: TextStyle(color: scheme.onTertiaryContainer),
+                        ),
+                        deleteIcon: const Icon(Icons.undo, size: 16),
+                        onDeleted: widget.editable
+                            ? () => _undoAdd(entry)
+                            : null,
+                      ),
+                  ],
+                ),
+              if (widget.editable) ...[
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: _addController,
+                        decoration: const InputDecoration(
+                          labelText: 'Add knowledge entry',
+                          isDense: true,
+                        ),
+                        onSubmitted: _addEntry,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    IconButton(
+                      icon: const Icon(Icons.add),
+                      tooltip: 'Add',
+                      onPressed: () => _addEntry(_addController.text),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Events card (stateful, immediate-write pattern)
+// ---------------------------------------------------------------------------
+
+class _EventsCard extends StatefulWidget {
+  const _EventsCard({
+    required this.notifier,
+    required this.editable,
+    required this.reloadKey,
+  });
+
+  final EditorNotifier notifier;
+  final bool editable;
+  final Object reloadKey;
+
+  @override
+  State<_EventsCard> createState() => _EventsCardState();
+}
+
+class _EventsCardState extends State<_EventsCard> {
+  MemoryCharactersPage _characters = const MemoryCharactersPage();
+  String? _selectedCharacter;
+  MemoryEventsPage _events = const MemoryEventsPage();
+  bool _loadingCharacters = false;
+  bool _loadingEvents = false;
+  int _reloadEpoch = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCharacters();
+  }
+
+  @override
+  void didUpdateWidget(covariant _EventsCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.reloadKey != oldWidget.reloadKey) {
+      _selectedCharacter = null;
+      _events = const MemoryEventsPage();
+      _loadCharacters();
+    }
+  }
+
+  Future<void> _loadCharacters() async {
+    final epoch = ++_reloadEpoch;
+    setState(() => _loadingCharacters = true);
+    final page = await widget.notifier.loadMemoryCharacters();
+    if (!mounted || epoch != _reloadEpoch) return;
+    setState(() {
+      _loadingCharacters = false;
+      _characters = page;
+    });
+  }
+
+  Future<void> _selectCharacter(String id) async {
+    final epoch = ++_reloadEpoch;
+    setState(() {
+      _selectedCharacter = id;
+      _loadingEvents = true;
+    });
+    final page = await widget.notifier.loadMemoryEvents(id);
+    if (!mounted || epoch != _reloadEpoch) return;
+    setState(() {
+      _loadingEvents = false;
+      _events = page;
+    });
+  }
+
+  Future<void> _loadMoreEvents() async {
+    final character = _selectedCharacter;
+    if (character == null) return;
+    final epoch = ++_reloadEpoch;
+    setState(() => _loadingEvents = true);
+    final page = await widget.notifier.loadMemoryEvents(
+      character,
+      offset: _events.events.length,
+    );
+    if (!mounted || epoch != _reloadEpoch) return;
+    setState(() {
+      _loadingEvents = false;
+      _events = MemoryEventsPage(
+        character: page.character,
+        events: [..._events.events, ...page.events],
+        arrayPath: page.arrayPath,
+        total: page.total,
+        offset: page.offset,
+        limit: page.limit,
+        error: page.error,
+      );
+    });
+  }
+
+  Future<void> _confirmAndApply(
+    BuildContext context,
+    MemoryEventEdit edit,
+    String title,
+    String message,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Confirm'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    if (!mounted) return;
+    await widget.notifier.applyMemoryEventEdit(edit);
+    // On success the notifier refreshes inspection → reloadKey changes →
+    // didUpdateWidget fires and reloads this card automatically.
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final character = _selectedCharacter;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.memory_outlined),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Memory Events',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            if (_characters.error != null) ...[
+              Text(_characters.error!, style: TextStyle(color: scheme.error)),
+              const SizedBox(height: 8),
+            ],
+            // Character list (height-capped)
+            SizedBox(
+              height: 200,
+              child: _loadingCharacters
+                  ? const Center(child: CircularProgressIndicator())
+                  : ListView.separated(
+                      itemCount: _characters.characters.length,
+                      separatorBuilder: (_, _) => const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        final c = _characters.characters[index];
+                        final isSelected = c.id == character;
+                        return ListTile(
+                          dense: true,
+                          selected: isSelected,
+                          title: Text('${c.id} (${c.eventCount})'),
+                          onTap: () => _selectCharacter(c.id),
+                        );
+                      },
+                    ),
+            ),
+            if (character != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                'Events for $character',
+                style: Theme.of(context).textTheme.labelLarge,
+              ),
+              const SizedBox(height: 8),
+              if (_events.error != null)
+                Text(_events.error!, style: TextStyle(color: scheme.error)),
+              SizedBox(
+                height: 360,
+                child: _loadingEvents && _events.events.isEmpty
+                    ? const Center(child: CircularProgressIndicator())
+                    : ListView.separated(
+                        itemCount:
+                            _events.events.length + (_events.hasMore ? 1 : 0),
+                        separatorBuilder: (_, _) => const Divider(height: 1),
+                        itemBuilder: (context, index) {
+                          if (index >= _events.events.length) {
+                            return TextButton(
+                              onPressed: _loadingEvents
+                                  ? null
+                                  : _loadMoreEvents,
+                              child: Text(
+                                'Load more (${_events.events.length} of ${_events.total})',
+                              ),
+                            );
+                          }
+                          final event = _events.events[index];
+                          final tagLabel = event.tags.isEmpty
+                              ? '(no tags)'
+                              : event.tags.join(', ');
+                          final timeStr = event.timeSeconds != null
+                              ? event.timeSeconds!.toStringAsFixed(0)
+                              : '?';
+                          final affected = event.affected ?? '';
+                          return ListTile(
+                            dense: true,
+                            title: SelectableText(tagLabel, maxLines: 1),
+                            subtitle: SelectableText(
+                              't=${timeStr}s  $affected',
+                              maxLines: 1,
+                            ),
+                            trailing: widget.editable
+                                ? Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      IconButton(
+                                        icon: const Icon(
+                                          Icons.delete_outline,
+                                          size: 20,
+                                        ),
+                                        tooltip: 'Remove event',
+                                        onPressed: () => _confirmAndApply(
+                                          context,
+                                          MemoryEventEdit.remove(
+                                            arrayPath: _events.arrayPath,
+                                            index: event.index,
+                                          ),
+                                          'Remove memory event?',
+                                          'Remove this memory event? '
+                                              'A backup is written first.',
+                                        ),
+                                      ),
+                                      IconButton(
+                                        icon: const Icon(
+                                          Icons.copy_outlined,
+                                          size: 20,
+                                        ),
+                                        tooltip: 'Duplicate event',
+                                        onPressed: () => _confirmAndApply(
+                                          context,
+                                          MemoryEventEdit.duplicate(
+                                            arrayPath: _events.arrayPath,
+                                            index: event.index,
+                                          ),
+                                          'Duplicate memory event?',
+                                          'Duplicate this memory event? '
+                                              'A backup is written first.',
+                                        ),
+                                      ),
+                                    ],
+                                  )
+                                : null,
+                          );
+                        },
+                      ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local private helpers (duplicated from editor_page.dart)
+// ---------------------------------------------------------------------------
+
+class _MessagePane extends StatelessWidget {
+  const _MessagePane({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
+        child: Card(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  icon,
+                  size: 48,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(height: 12),
+                Text(title, style: Theme.of(context).textTheme.titleLarge),
+                const SizedBox(height: 8),
+                Text(body, textAlign: TextAlign.center),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryMetric extends StatelessWidget {
+  const _SummaryMetric({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 120,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -125,23 +125,27 @@ class _ProgressionPanelState extends State<ProgressionPanel> {
           const SizedBox(width: 16),
           // Detail area — fills remaining width and full height
           Expanded(
+            // Keys are stable on purpose: a key derived from reloadKey would
+            // remount the detail on every fresh inspection, disposing state
+            // and bypassing the didUpdateWidget logic that preserves the
+            // selected character across save-triggered reloads.
             child: switch (_selected) {
               _ProgSection.quests => _QuestsDetail(
-                key: ValueKey(('quests', reloadKey)),
+                key: const ValueKey('quests'),
                 notifier: widget.notifier,
                 editable: widget.editable,
                 reloadKey: reloadKey,
                 theme: theme,
               ),
               _ProgSection.knowledge => _KnowledgeDetail(
-                key: ValueKey(('knowledge', reloadKey)),
+                key: const ValueKey('knowledge'),
                 notifier: widget.notifier,
                 editable: widget.editable,
                 reloadKey: reloadKey,
                 theme: theme,
               ),
               _ProgSection.events => _EventsDetail(
-                key: ValueKey(('events', reloadKey)),
+                key: const ValueKey('events'),
                 notifier: widget.notifier,
                 editable: widget.editable,
                 reloadKey: reloadKey,
@@ -329,7 +333,7 @@ class _QuestsDetail extends StatefulWidget {
 
   final EditorNotifier notifier;
   final bool editable;
-  final Object reloadKey;
+  final SaveInspection reloadKey;
   final ThemeData theme;
 
   @override
@@ -584,7 +588,7 @@ class _KnowledgeDetail extends StatefulWidget {
 
   final EditorNotifier notifier;
   final bool editable;
-  final Object reloadKey;
+  final SaveInspection reloadKey;
   final ThemeData theme;
 
   @override
@@ -624,7 +628,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
   void didUpdateWidget(covariant _KnowledgeDetail oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.reloadKey != oldWidget.reloadKey) {
-      // Pending edits belong to the old save — always clear them.
+      // Pending edits belong to the old inspection — always clear them.
       _pending.clear();
       // Invalidate both loaders so any in-flight call for the old reloadKey
       // is treated as stale and exits without touching flags.
@@ -632,10 +636,12 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
       _entriesEpoch++;
       _characterSearch.clear();
       _activeCharQuery = '';
+      // A different save file means a different character set: drop the
+      // selection. A same-file refresh (post-save reload) preserves it.
+      if (widget.reloadKey.path != oldWidget.reloadKey.path) {
+        _selectedCharacter = null;
+      }
       _loadCharacters(offset: 0);
-      // Issue 3 fix (consistency): preserve the previously selected character
-      // so the entries pane does not drop to null on save-triggered reloads.
-      // Pending edits are cleared above so we just re-load the entries fresh.
       if (_selectedCharacter != null) {
         _selectCharacter(_selectedCharacter!);
       } else {
@@ -1188,7 +1194,7 @@ class _EventsDetail extends StatefulWidget {
 
   final EditorNotifier notifier;
   final bool editable;
-  final Object reloadKey;
+  final SaveInspection reloadKey;
   final ThemeData theme;
 
   @override
@@ -1222,17 +1228,21 @@ class _EventsDetailState extends State<_EventsDetail> {
   void didUpdateWidget(covariant _EventsDetail oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.reloadKey != oldWidget.reloadKey) {
-      // Issue 3 fix: preserve the previously selected character so the right
-      // pane does not fall back to "Select a character" after an event edit.
       // Invalidate both loaders so any in-flight call for the old reloadKey
       // is treated as stale and exits without touching flags.
       _charsEpoch++;
       _eventsEpoch++;
       _characterSearch.clear();
       _activeCharQuery = '';
+      // A different save file means a different character set: drop the
+      // selection. A same-file refresh (post-event-edit reload) preserves it
+      // so the right pane does not fall back to "Select a character".
+      if (widget.reloadKey.path != oldWidget.reloadKey.path) {
+        _selectedCharacter = null;
+      }
       _loadCharacters(offset: 0);
-      // If a character was selected, re-trigger its events load (page reset to
-      // 0 is fine). If it has since been deleted the existing error rendering
+      // Re-trigger the preserved character's events load (page reset to 0 is
+      // fine). If it has since been deleted the existing error rendering
       // will handle it.
       if (_selectedCharacter != null) {
         _selectCharacter(_selectedCharacter!);

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -19,12 +19,14 @@ String shortStateLabel(String state) {
   return idx < 0 ? state : state.substring(idx + 2);
 }
 
+/// Sidebar section entries for the Progression tab.
+enum _ProgSection { quests, knowledge, events }
+
 /// Progression tab: structured quests / dialog knowledge / memory events.
-/// Data loads lazily per card through the notifier's query_progression
-/// wrappers. [reloadKey] is the [SaveInspection] instance itself; identity
-/// comparison means every fresh inspection (even of the same file) clears
-/// local pending state and reloads, matching the inventory card semantics.
-class ProgressionPanel extends StatelessWidget {
+/// Full-height sidebar layout (no outer scroll). [reloadKey] is the
+/// [SaveInspection] instance itself; identity comparison means every fresh
+/// inspection clears local pending state and reloads.
+class ProgressionPanel extends StatefulWidget {
   const ProgressionPanel({
     super.key,
     required this.inspection,
@@ -37,9 +39,17 @@ class ProgressionPanel extends StatelessWidget {
   final bool editable;
 
   @override
+  State<ProgressionPanel> createState() => _ProgressionPanelState();
+}
+
+class _ProgressionPanelState extends State<ProgressionPanel> {
+  // Keep selected section across save-triggered reloads (identity comparison
+  // on reloadKey, not path comparison, so same pattern as hero_stats_card).
+  _ProgSection _selected = _ProgSection.quests;
+
+  @override
   Widget build(BuildContext context) {
-    final overview = inspection.privateProgression;
-    if (!inspection.privateDecoded) {
+    if (!widget.inspection.privateDecoded) {
       return const _MessagePane(
         icon: Icons.flag_outlined,
         title: 'Progression',
@@ -47,7 +57,7 @@ class ProgressionPanel extends StatelessWidget {
             'Progression data needs decoded private payload data from the G1R codec host.',
       );
     }
-    if (!overview.available) {
+    if (!widget.inspection.privateProgression.available) {
       return const _MessagePane(
         icon: Icons.flag_outlined,
         title: 'Progression',
@@ -56,97 +66,134 @@ class ProgressionPanel extends StatelessWidget {
             'verified typed parse.',
       );
     }
-    final reloadKey = inspection;
-    return ListView(
+
+    final reloadKey = widget.inspection;
+    final theme = Theme.of(context);
+
+    return Padding(
       padding: const EdgeInsets.all(20),
-      children: [
-        _OverviewCard(overview: overview),
-        const SizedBox(height: 16),
-        _QuestsCard(
-          notifier: notifier,
-          editable: editable,
-          reloadKey: reloadKey,
-        ),
-        const SizedBox(height: 16),
-        _KnowledgeCard(
-          notifier: notifier,
-          editable: editable,
-          reloadKey: reloadKey,
-        ),
-        const SizedBox(height: 16),
-        _EventsCard(
-          notifier: notifier,
-          editable: editable,
-          reloadKey: reloadKey,
-        ),
-      ],
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Slim left sidebar
+          SizedBox(
+            width: 140,
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _SidebarTile(
+                      icon: Icons.flag_outlined,
+                      label: 'Quests',
+                      selected: _selected == _ProgSection.quests,
+                      onTap: () =>
+                          setState(() => _selected = _ProgSection.quests),
+                    ),
+                    _SidebarTile(
+                      icon: Icons.school_outlined,
+                      label: 'Knowledge',
+                      selected: _selected == _ProgSection.knowledge,
+                      onTap: () =>
+                          setState(() => _selected = _ProgSection.knowledge),
+                    ),
+                    _SidebarTile(
+                      icon: Icons.history_outlined,
+                      label: 'Events',
+                      selected: _selected == _ProgSection.events,
+                      onTap: () =>
+                          setState(() => _selected = _ProgSection.events),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          // Detail area — fills remaining width and full height
+          Expanded(
+            child: switch (_selected) {
+              _ProgSection.quests => _QuestsDetail(
+                key: ValueKey(('quests', reloadKey)),
+                notifier: widget.notifier,
+                editable: widget.editable,
+                reloadKey: reloadKey,
+                theme: theme,
+              ),
+              _ProgSection.knowledge => _KnowledgeDetail(
+                key: ValueKey(('knowledge', reloadKey)),
+                notifier: widget.notifier,
+                editable: widget.editable,
+                reloadKey: reloadKey,
+                theme: theme,
+              ),
+              _ProgSection.events => _EventsDetail(
+                key: ValueKey(('events', reloadKey)),
+                notifier: widget.notifier,
+                editable: widget.editable,
+                reloadKey: reloadKey,
+                theme: theme,
+              ),
+            },
+          ),
+        ],
+      ),
     );
   }
 }
 
 // ---------------------------------------------------------------------------
-// Overview card (stateless)
+// Sidebar tile
 // ---------------------------------------------------------------------------
 
-class _OverviewCard extends StatelessWidget {
-  const _OverviewCard({required this.overview});
+class _SidebarTile extends StatelessWidget {
+  const _SidebarTile({
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
 
-  final ProgressionOverview overview;
+  final IconData icon;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    final states = overview.questStates;
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(Icons.flag_outlined),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'Progression summary',
-                    style: Theme.of(context).textTheme.titleMedium,
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: selected ? scheme.secondaryContainer : Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 12),
+          child: Row(
+            children: [
+              Icon(
+                icon,
+                size: 18,
+                color: selected
+                    ? scheme.onSecondaryContainer
+                    : scheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 8),
+              Flexible(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+                    color: selected
+                        ? scheme.onSecondaryContainer
+                        : scheme.onSurface,
                   ),
+                  overflow: TextOverflow.ellipsis,
                 ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                _SummaryMetric(
-                  label: 'Quests total',
-                  value: overview.questTotal.toString(),
-                ),
-                for (final entry in states.entries)
-                  _SummaryMetric(
-                    label: entry.key,
-                    value: entry.value.toString(),
-                  ),
-                _SummaryMetric(
-                  label: 'Knowledge NPCs',
-                  value: overview.knowledgeCharacters.toString(),
-                ),
-                _SummaryMetric(
-                  label: 'Knowledge entries',
-                  value: overview.knowledgeEntries.toString(),
-                ),
-                _SummaryMetric(
-                  label: 'Memory characters',
-                  value: overview.memoryCharacters.toString(),
-                ),
-                _SummaryMetric(
-                  label: 'Memory events',
-                  value: overview.memoryEvents.toString(),
-                ),
-              ],
-            ),
-          ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -154,44 +201,153 @@ class _OverviewCard extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
-// Quests card (stateful, pending-edit pattern)
+// Shared pagination bar widget
 // ---------------------------------------------------------------------------
 
-class _QuestsCard extends StatefulWidget {
-  const _QuestsCard({
+class _PaginationBar extends StatelessWidget {
+  const _PaginationBar({
+    required this.offset,
+    required this.count,
+    required this.total,
+    required this.pageSize,
+    required this.busy,
+    required this.onPage,
+    required this.onPageSize,
+  });
+
+  static const _pageSizes = [25, 50, 100, 250, 500];
+
+  final int offset;
+  final int count;
+  final int total;
+  final int pageSize;
+  final bool busy;
+  final void Function(int newOffset) onPage;
+  final void Function(int newPageSize) onPageSize;
+
+  int get _pageIndex => pageSize == 0 ? 0 : offset ~/ pageSize;
+  int get _pageCount => total == 0 ? 1 : (total + pageSize - 1) ~/ pageSize;
+  bool get _hasPrevious => offset > 0;
+  bool get _hasNext => offset + count < total;
+
+  @override
+  Widget build(BuildContext context) {
+    if (total == 0) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    final muted = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+    final first = total == 0 ? 0 : offset + 1;
+    final last = offset + count;
+    final effectivePageSize = _pageSizes.contains(pageSize)
+        ? pageSize
+        : _pageSizes.reduce(
+            (a, b) => (a - pageSize).abs() < (b - pageSize).abs() ? a : b,
+          );
+    return Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      spacing: 0,
+      runSpacing: 4,
+      children: [
+        IconButton(
+          tooltip: 'First page',
+          visualDensity: VisualDensity.compact,
+          icon: const Icon(Icons.first_page),
+          onPressed: busy || !_hasPrevious ? null : () => onPage(0),
+        ),
+        IconButton(
+          tooltip: 'Previous page',
+          visualDensity: VisualDensity.compact,
+          icon: const Icon(Icons.chevron_left),
+          onPressed: busy || !_hasPrevious
+              ? null
+              : () => onPage((_pageIndex - 1) * pageSize),
+        ),
+        IconButton(
+          tooltip: 'Next page',
+          visualDensity: VisualDensity.compact,
+          icon: const Icon(Icons.chevron_right),
+          onPressed: busy || !_hasNext
+              ? null
+              : () => onPage((_pageIndex + 1) * pageSize),
+        ),
+        IconButton(
+          tooltip: 'Last page',
+          visualDensity: VisualDensity.compact,
+          icon: const Icon(Icons.last_page),
+          onPressed: busy || !_hasNext
+              ? null
+              : () => onPage((_pageCount - 1) * pageSize),
+        ),
+        const SizedBox(width: 4),
+        Text('Page ${_pageIndex + 1} / $_pageCount', style: muted),
+        const SizedBox(width: 8),
+        Text('$first–$last of $total', style: muted),
+        const SizedBox(width: 8),
+        Text('Per page:', style: muted),
+        DropdownButton<int>(
+          value: effectivePageSize,
+          isDense: true,
+          underline: const SizedBox.shrink(),
+          onChanged: busy ? null : (v) => v != null ? onPageSize(v) : null,
+          items: [
+            for (final sz in _pageSizes)
+              DropdownMenuItem(value: sz, child: Text('$sz')),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Quests detail (stateful, pending-edit pattern)
+// ---------------------------------------------------------------------------
+
+class _QuestsDetail extends StatefulWidget {
+  const _QuestsDetail({
+    super.key,
     required this.notifier,
     required this.editable,
     required this.reloadKey,
+    required this.theme,
   });
 
   final EditorNotifier notifier;
   final bool editable;
   final Object reloadKey;
+  final ThemeData theme;
 
   @override
-  State<_QuestsCard> createState() => _QuestsCardState();
+  State<_QuestsDetail> createState() => _QuestsDetailState();
 }
 
-class _QuestsCardState extends State<_QuestsCard> {
+class _QuestsDetailState extends State<_QuestsDetail> {
+  static const _defaultPageSize = 50;
+
   final TextEditingController _search = TextEditingController();
   ProgressionQuestPage _page = const ProgressionQuestPage();
-  final List<ProgressionQuest> _quests = [];
   final Map<String, QuestStateChange> _pending = {};
   bool _loading = false;
+  bool _searching = false;
   int _reloadEpoch = 0;
+  int _pageSize = _defaultPageSize;
+  String _activeQuery = '';
 
   @override
   void initState() {
     super.initState();
-    _reload();
+    _reload(offset: 0);
   }
 
   @override
-  void didUpdateWidget(covariant _QuestsCard oldWidget) {
+  void didUpdateWidget(covariant _QuestsDetail oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.reloadKey != oldWidget.reloadKey) {
       _pending.clear();
-      _reload();
+      _search.clear();
+      _activeQuery = '';
+      _reload(offset: 0);
     }
   }
 
@@ -201,20 +357,31 @@ class _QuestsCardState extends State<_QuestsCard> {
     super.dispose();
   }
 
-  Future<void> _reload({bool append = false}) async {
+  Future<void> _reload({required int offset, bool newQuery = false}) async {
+    if (newQuery) _activeQuery = _search.text.trim();
     final epoch = ++_reloadEpoch;
-    setState(() => _loading = true);
+    setState(() {
+      _loading = true;
+      if (newQuery) _searching = true;
+    });
     final page = await widget.notifier.loadProgressionQuests(
-      query: _search.text.trim(),
-      offset: append ? _quests.length : 0,
+      query: _activeQuery,
+      offset: offset,
+      limit: _pageSize,
     );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loading = false;
+      _searching = false;
       _page = page;
-      if (!append) _quests.clear();
-      _quests.addAll(page.quests);
     });
+  }
+
+  void _goToPage(int newOffset) => _reload(offset: newOffset);
+
+  void _setPageSize(int size) {
+    setState(() => _pageSize = size);
+    _reload(offset: 0);
   }
 
   void _pushPending() {
@@ -246,20 +413,22 @@ class _QuestsCardState extends State<_QuestsCard> {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = widget.theme.colorScheme;
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            // Header row
             Row(
               children: [
-                const Icon(Icons.flag_outlined),
+                Icon(Icons.flag_outlined, color: scheme.primary),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     'Quests',
-                    style: Theme.of(context).textTheme.titleMedium,
+                    style: widget.theme.textTheme.titleMedium,
                   ),
                 ),
                 if (widget.editable && _pending.isNotEmpty)
@@ -275,47 +444,56 @@ class _QuestsCardState extends State<_QuestsCard> {
                   ),
               ],
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: 8),
+            // Search field with in-flight spinner
             TextField(
               controller: _search,
-              decoration: const InputDecoration(
+              decoration: InputDecoration(
                 labelText: 'Search quests',
-                prefixIcon: Icon(Icons.search),
+                prefixIcon: const Icon(Icons.search),
+                suffixIcon: _searching
+                    ? const Padding(
+                        padding: EdgeInsets.all(12),
+                        child: SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      )
+                    : IconButton(
+                        icon: const Icon(Icons.arrow_forward),
+                        onPressed: () => _reload(offset: 0, newQuery: true),
+                      ),
               ),
-              onSubmitted: (_) => _reload(),
+              onSubmitted: (_) => _reload(offset: 0, newQuery: true),
             ),
             if (_page.error != null) ...[
-              const SizedBox(height: 12),
-              Text(
-                _page.error!,
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
-              ),
+              const SizedBox(height: 8),
+              Text(_page.error!, style: TextStyle(color: scheme.error)),
             ],
             const SizedBox(height: 8),
-            SizedBox(
-              height: 360,
-              child: _loading && _quests.isEmpty
+            _PaginationBar(
+              offset: _page.offset,
+              count: _page.quests.length,
+              total: _page.total,
+              pageSize: _pageSize,
+              busy: _loading,
+              onPage: _goToPage,
+              onPageSize: _setPageSize,
+            ),
+            const SizedBox(height: 4),
+            // Quest list — the only scrollable, fills remaining height
+            Expanded(
+              child: _loading && _page.quests.isEmpty
                   ? const Center(child: CircularProgressIndicator())
                   : ListView.separated(
-                      itemCount: _quests.length + (_page.hasMore ? 1 : 0),
+                      itemCount: _page.quests.length,
                       separatorBuilder: (_, _) => const Divider(height: 1),
                       itemBuilder: (context, index) {
-                        if (index >= _quests.length) {
-                          return TextButton(
-                            onPressed: _loading
-                                ? null
-                                : () => _reload(append: true),
-                            child: Text(
-                              'Load more (${_quests.length} of ${_page.total})',
-                            ),
-                          );
-                        }
-                        final quest = _quests[index];
+                        final quest = _page.quests[index];
                         final pendingState = _pending[quest.questClass]?.state;
                         final effectiveState =
                             pendingState ?? quest.currentState;
-                        // Guard: only show dropdown if the current value is a
-                        // known questStates entry; otherwise fall back to text.
                         final inKnownStates =
                             effectiveState != null &&
                             questStates.contains(effectiveState);
@@ -359,25 +537,30 @@ class _QuestsCardState extends State<_QuestsCard> {
 }
 
 // ---------------------------------------------------------------------------
-// Knowledge card (stateful, pending-edit pattern)
+// Knowledge detail — two-pane: NPC list left, entries right
 // ---------------------------------------------------------------------------
 
-class _KnowledgeCard extends StatefulWidget {
-  const _KnowledgeCard({
+class _KnowledgeDetail extends StatefulWidget {
+  const _KnowledgeDetail({
+    super.key,
     required this.notifier,
     required this.editable,
     required this.reloadKey,
+    required this.theme,
   });
 
   final EditorNotifier notifier;
   final bool editable;
   final Object reloadKey;
+  final ThemeData theme;
 
   @override
-  State<_KnowledgeCard> createState() => _KnowledgeCardState();
+  State<_KnowledgeDetail> createState() => _KnowledgeDetailState();
 }
 
-class _KnowledgeCardState extends State<_KnowledgeCard> {
+class _KnowledgeDetailState extends State<_KnowledgeDetail> {
+  static const _defaultPageSize = 50;
+
   final TextEditingController _characterSearch = TextEditingController();
   KnowledgeCharactersPage _characters = const KnowledgeCharactersPage();
   String? _selectedCharacter;
@@ -385,24 +568,29 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
   final Map<String, KnowledgeEntryEdit> _pending = {};
   final TextEditingController _addController = TextEditingController();
   bool _loadingCharacters = false;
+  bool _searchingCharacters = false;
   bool _loadingEntries = false;
   int _reloadEpoch = 0;
+  int _charPageSize = _defaultPageSize;
+  int _entryPageSize = _defaultPageSize;
+  String _activeCharQuery = '';
 
   @override
   void initState() {
     super.initState();
-    _loadCharacters();
+    _loadCharacters(offset: 0);
   }
 
   @override
-  void didUpdateWidget(covariant _KnowledgeCard oldWidget) {
+  void didUpdateWidget(covariant _KnowledgeDetail oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.reloadKey != oldWidget.reloadKey) {
       _pending.clear();
       _selectedCharacter = null;
       _entries = const KnowledgeEntriesPage();
       _characterSearch.clear();
-      _loadCharacters();
+      _activeCharQuery = '';
+      _loadCharacters(offset: 0);
     }
   }
 
@@ -413,27 +601,26 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
     super.dispose();
   }
 
-  Future<void> _loadCharacters({bool append = false}) async {
+  Future<void> _loadCharacters({
+    required int offset,
+    bool newQuery = false,
+  }) async {
+    if (newQuery) _activeCharQuery = _characterSearch.text.trim();
     final epoch = ++_reloadEpoch;
-    setState(() => _loadingCharacters = true);
+    setState(() {
+      _loadingCharacters = true;
+      if (newQuery) _searchingCharacters = true;
+    });
     final page = await widget.notifier.loadKnowledgeCharacters(
-      query: _characterSearch.text.trim(),
-      offset: append ? _characters.characters.length : 0,
+      query: _activeCharQuery,
+      offset: offset,
+      limit: _charPageSize,
     );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loadingCharacters = false;
-      if (!append) {
-        _characters = page;
-      } else {
-        _characters = KnowledgeCharactersPage(
-          characters: [..._characters.characters, ...page.characters],
-          total: page.total,
-          offset: page.offset,
-          limit: page.limit,
-          error: page.error,
-        );
-      }
+      _searchingCharacters = false;
+      _characters = page;
     });
   }
 
@@ -444,7 +631,11 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
       _loadingEntries = true;
       _entries = const KnowledgeEntriesPage();
     });
-    final page = await widget.notifier.loadKnowledgeEntries(name);
+    final page = await widget.notifier.loadKnowledgeEntries(
+      name,
+      offset: 0,
+      limit: _entryPageSize,
+    );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loadingEntries = false;
@@ -452,28 +643,26 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
     });
   }
 
-  Future<void> _loadMoreEntries() async {
+  Future<void> _loadEntries({required int offset}) async {
     final character = _selectedCharacter;
     if (character == null) return;
     final epoch = ++_reloadEpoch;
     setState(() => _loadingEntries = true);
     final page = await widget.notifier.loadKnowledgeEntries(
       character,
-      offset: _entries.entries.length,
+      offset: offset,
+      limit: _entryPageSize,
     );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loadingEntries = false;
-      _entries = KnowledgeEntriesPage(
-        character: page.character,
-        entries: [..._entries.entries, ...page.entries],
-        setPath: page.setPath,
-        total: page.total,
-        offset: page.offset,
-        limit: page.limit,
-        error: page.error,
-      );
+      _entries = page;
     });
+  }
+
+  void _setEntryPageSize(int size) {
+    setState(() => _entryPageSize = size);
+    _loadEntries(offset: 0);
   }
 
   void _pushPending() {
@@ -495,7 +684,6 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
     final key = _pendingKey(_selectedCharacter!, entry);
     setState(() {
       if (_pending.containsKey(key)) {
-        // Was a pending-add — undo it
         _pending.remove(key);
       } else {
         _pending[key] = KnowledgeEntryEdit.remove(
@@ -512,7 +700,7 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
     if (trimmed.isEmpty) return;
     if (_entries.entries.contains(trimmed)) return;
     final key = _pendingKey(_selectedCharacter!, trimmed);
-    if (_pending.containsKey(key)) return; // already pending
+    if (_pending.containsKey(key)) return;
     setState(() {
       _pending[key] = KnowledgeEntryEdit.add(
         setPath: _entries.setPath,
@@ -531,19 +719,18 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
+    final scheme = widget.theme.colorScheme;
     final character = _selectedCharacter;
 
     // Compute sets for rendering — only include edits for the selected NPC.
-    // Keys are '$character\t$entry' so we filter by prefix.
     final removedEntries = <String>{};
     final addedEntries = <String>[];
     if (character != null) {
       final prefix = '$character\t';
-      for (final entry in _pending.entries) {
-        if (!entry.key.startsWith(prefix)) continue;
-        if (!entry.value.isAdd) removedEntries.add(entry.value.entry);
-        if (entry.value.isAdd) addedEntries.add(entry.value.entry);
+      for (final e in _pending.entries) {
+        if (!e.key.startsWith(prefix)) continue;
+        if (!e.value.isAdd) removedEntries.add(e.value.entry);
+        if (e.value.isAdd) addedEntries.add(e.value.entry);
       }
     }
 
@@ -551,16 +738,17 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            // Header
             Row(
               children: [
-                const Icon(Icons.chat_bubble_outline),
+                Icon(Icons.school_outlined, color: scheme.primary),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     'Dialog Knowledge',
-                    style: Theme.of(context).textTheme.titleMedium,
+                    style: widget.theme.textTheme.titleMedium,
                   ),
                 ),
                 if (widget.editable && _pending.isNotEmpty)
@@ -578,140 +766,245 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
                   ),
               ],
             ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: _characterSearch,
-              decoration: const InputDecoration(
-                labelText: 'Search NPCs',
-                prefixIcon: Icon(Icons.search),
-              ),
-              onSubmitted: (_) => _loadCharacters(),
-            ),
-            if (_characters.error != null) ...[
-              const SizedBox(height: 8),
-              Text(_characters.error!, style: TextStyle(color: scheme.error)),
-            ],
             const SizedBox(height: 8),
-            // Character list (height-capped)
-            SizedBox(
-              height: 200,
-              child: _loadingCharacters && _characters.characters.isEmpty
-                  ? const Center(child: CircularProgressIndicator())
-                  : ListView.separated(
-                      itemCount:
-                          _characters.characters.length +
-                          (_characters.hasMore ? 1 : 0),
-                      separatorBuilder: (_, _) => const Divider(height: 1),
-                      itemBuilder: (context, index) {
-                        if (index >= _characters.characters.length) {
-                          return TextButton(
-                            onPressed: _loadingCharacters
-                                ? null
-                                : () => _loadCharacters(append: true),
-                            child: Text(
-                              'Load more (${_characters.characters.length}'
-                              ' of ${_characters.total})',
-                            ),
-                          );
-                        }
-                        final c = _characters.characters[index];
-                        final isSelected = c.name == character;
-                        return ListTile(
-                          dense: true,
-                          selected: isSelected,
-                          title: Text('${c.name} (${c.entryCount})'),
-                          onTap: () => _selectCharacter(c.name),
-                        );
-                      },
+            // Two-pane row: characters left, entries right
+            Expanded(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Left pane: NPC search + pagination + list
+                  SizedBox(
+                    width: 280,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        TextField(
+                          controller: _characterSearch,
+                          decoration: InputDecoration(
+                            labelText: 'Search NPCs',
+                            isDense: true,
+                            prefixIcon: const Icon(Icons.search, size: 18),
+                            suffixIcon: _searchingCharacters
+                                ? const Padding(
+                                    padding: EdgeInsets.all(10),
+                                    child: SizedBox(
+                                      width: 16,
+                                      height: 16,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    ),
+                                  )
+                                : IconButton(
+                                    icon: const Icon(
+                                      Icons.arrow_forward,
+                                      size: 18,
+                                    ),
+                                    onPressed: () => _loadCharacters(
+                                      offset: 0,
+                                      newQuery: true,
+                                    ),
+                                  ),
+                          ),
+                          onSubmitted: (_) =>
+                              _loadCharacters(offset: 0, newQuery: true),
+                        ),
+                        if (_characters.error != null) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            _characters.error!,
+                            style: TextStyle(color: scheme.error, fontSize: 12),
+                          ),
+                        ],
+                        const SizedBox(height: 4),
+                        _PaginationBar(
+                          offset: _characters.offset,
+                          count: _characters.characters.length,
+                          total: _characters.total,
+                          pageSize: _charPageSize,
+                          busy: _loadingCharacters,
+                          onPage: (o) => _loadCharacters(offset: o),
+                          onPageSize: (s) {
+                            setState(() => _charPageSize = s);
+                            _loadCharacters(offset: 0);
+                          },
+                        ),
+                        const SizedBox(height: 4),
+                        Expanded(
+                          child:
+                              _loadingCharacters &&
+                                  _characters.characters.isEmpty
+                              ? const Center(child: CircularProgressIndicator())
+                              : ListView.separated(
+                                  itemCount: _characters.characters.length,
+                                  separatorBuilder: (_, _) =>
+                                      const Divider(height: 1),
+                                  itemBuilder: (context, index) {
+                                    final c = _characters.characters[index];
+                                    final isSelected = c.name == character;
+                                    return ListTile(
+                                      dense: true,
+                                      selected: isSelected,
+                                      title: Text(
+                                        '${c.name} (${c.entryCount})',
+                                      ),
+                                      onTap: () => _selectCharacter(c.name),
+                                    );
+                                  },
+                                ),
+                        ),
+                      ],
                     ),
-            ),
-            if (character != null) ...[
-              const SizedBox(height: 12),
-              Text(
-                'Entries for $character',
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-              const SizedBox(height: 8),
-              if (_entries.error != null)
-                Text(_entries.error!, style: TextStyle(color: scheme.error)),
-              if (_loadingEntries && _entries.entries.isEmpty)
-                const Center(child: CircularProgressIndicator())
-              else
-                Wrap(
-                  spacing: 6,
-                  runSpacing: 6,
-                  children: [
-                    // Existing entries
-                    for (final entry in _entries.entries)
-                      if (removedEntries.contains(entry))
-                        Chip(
-                          label: Text(
-                            entry,
-                            style: const TextStyle(
-                              decoration: TextDecoration.lineThrough,
+                  ),
+                  const SizedBox(width: 12),
+                  const VerticalDivider(width: 1),
+                  const SizedBox(width: 12),
+                  // Right pane: header + add field + pagination + entries list
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(
+                          character != null
+                              ? 'Entries — $character'
+                              : 'Select an NPC to see entries',
+                          style: widget.theme.textTheme.labelLarge,
+                        ),
+                        if (character != null) ...[
+                          const SizedBox(height: 6),
+                          if (widget.editable)
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: TextField(
+                                    controller: _addController,
+                                    decoration: const InputDecoration(
+                                      labelText: 'Add knowledge entry',
+                                      isDense: true,
+                                    ),
+                                    onSubmitted: _addEntry,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                IconButton(
+                                  icon: const Icon(Icons.add),
+                                  tooltip: 'Add',
+                                  onPressed: () =>
+                                      _addEntry(_addController.text),
+                                ),
+                              ],
+                            ),
+                          if (_entries.error != null)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: Text(
+                                _entries.error!,
+                                style: TextStyle(color: scheme.error),
+                              ),
+                            ),
+                          const SizedBox(height: 4),
+                          _PaginationBar(
+                            offset: _entries.offset,
+                            count: _entries.entries.length,
+                            total: _entries.total,
+                            pageSize: _entryPageSize,
+                            busy: _loadingEntries,
+                            onPage: (o) => _loadEntries(offset: o),
+                            onPageSize: _setEntryPageSize,
+                          ),
+                          const SizedBox(height: 4),
+                          // Entries list — only scrollable in this pane
+                          Expanded(
+                            child: _loadingEntries && _entries.entries.isEmpty
+                                ? const Center(
+                                    child: CircularProgressIndicator(),
+                                  )
+                                : ListView.separated(
+                                    itemCount:
+                                        addedEntries.length +
+                                        _entries.entries.length,
+                                    separatorBuilder: (_, _) =>
+                                        const Divider(height: 1),
+                                    itemBuilder: (context, index) {
+                                      // Pending-add tiles at the top
+                                      if (index < addedEntries.length) {
+                                        final entry = addedEntries[index];
+                                        return ListTile(
+                                          dense: true,
+                                          tileColor: scheme.tertiaryContainer
+                                              .withValues(alpha: 0.4),
+                                          title: Text(
+                                            entry,
+                                            style: TextStyle(
+                                              color: scheme.onTertiaryContainer,
+                                            ),
+                                          ),
+                                          trailing: widget.editable
+                                              ? IconButton(
+                                                  icon: const Icon(
+                                                    Icons.undo,
+                                                    size: 18,
+                                                  ),
+                                                  tooltip: 'Undo add',
+                                                  onPressed: () =>
+                                                      _undoAdd(entry),
+                                                )
+                                              : null,
+                                        );
+                                      }
+                                      final entry = _entries
+                                          .entries[index - addedEntries.length];
+                                      final isRemoved = removedEntries.contains(
+                                        entry,
+                                      );
+                                      return ListTile(
+                                        dense: true,
+                                        title: Text(
+                                          entry,
+                                          style: isRemoved
+                                              ? const TextStyle(
+                                                  decoration: TextDecoration
+                                                      .lineThrough,
+                                                )
+                                              : null,
+                                        ),
+                                        trailing: widget.editable
+                                            ? IconButton(
+                                                icon: Icon(
+                                                  isRemoved
+                                                      ? Icons.undo
+                                                      : Icons.delete_outline,
+                                                  size: 18,
+                                                ),
+                                                tooltip: isRemoved
+                                                    ? 'Undo remove'
+                                                    : 'Remove entry',
+                                                onPressed: () =>
+                                                    _removeEntry(entry),
+                                              )
+                                            : null,
+                                      );
+                                    },
+                                  ),
+                          ),
+                        ],
+                        if (character == null)
+                          Expanded(
+                            child: Center(
+                              child: Text(
+                                'Select an NPC from the list',
+                                style: TextStyle(
+                                  color: scheme.onSurfaceVariant,
+                                ),
+                              ),
                             ),
                           ),
-                          deleteIcon: const Icon(Icons.undo, size: 16),
-                          onDeleted: widget.editable
-                              ? () => _removeEntry(entry)
-                              : null,
-                        )
-                      else
-                        Chip(
-                          label: Text(entry),
-                          onDeleted: widget.editable
-                              ? () => _removeEntry(entry)
-                              : null,
-                        ),
-                    // Pending adds
-                    for (final entry in addedEntries)
-                      Chip(
-                        backgroundColor: scheme.tertiaryContainer,
-                        label: Text(
-                          entry,
-                          style: TextStyle(color: scheme.onTertiaryContainer),
-                        ),
-                        deleteIcon: const Icon(Icons.undo, size: 16),
-                        onDeleted: widget.editable
-                            ? () => _undoAdd(entry)
-                            : null,
-                      ),
-                  ],
-                ),
-              if (_entries.hasMore) ...[
-                const SizedBox(height: 8),
-                TextButton(
-                  onPressed: _loadingEntries ? null : _loadMoreEntries,
-                  child: Text(
-                    'Load more (${_entries.entries.length}'
-                    ' of ${_entries.total})',
+                      ],
+                    ),
                   ),
-                ),
-              ],
-              if (widget.editable) ...[
-                const SizedBox(height: 12),
-                Row(
-                  children: [
-                    Expanded(
-                      child: TextField(
-                        controller: _addController,
-                        decoration: const InputDecoration(
-                          labelText: 'Add knowledge entry',
-                          isDense: true,
-                        ),
-                        onSubmitted: _addEntry,
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    IconButton(
-                      icon: const Icon(Icons.add),
-                      tooltip: 'Add',
-                      onPressed: () => _addEntry(_addController.text),
-                    ),
-                  ],
-                ),
-              ],
-            ],
+                ],
+              ),
+            ),
           ],
         ),
       ),
@@ -720,47 +1013,57 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
 }
 
 // ---------------------------------------------------------------------------
-// Events card (stateful, immediate-write pattern)
+// Events detail — two-pane: character list left, events right
 // ---------------------------------------------------------------------------
 
-class _EventsCard extends StatefulWidget {
-  const _EventsCard({
+class _EventsDetail extends StatefulWidget {
+  const _EventsDetail({
+    super.key,
     required this.notifier,
     required this.editable,
     required this.reloadKey,
+    required this.theme,
   });
 
   final EditorNotifier notifier;
   final bool editable;
   final Object reloadKey;
+  final ThemeData theme;
 
   @override
-  State<_EventsCard> createState() => _EventsCardState();
+  State<_EventsDetail> createState() => _EventsDetailState();
 }
 
-class _EventsCardState extends State<_EventsCard> {
+class _EventsDetailState extends State<_EventsDetail> {
+  static const _defaultPageSize = 50;
+
   final TextEditingController _characterSearch = TextEditingController();
   MemoryCharactersPage _characters = const MemoryCharactersPage();
   String? _selectedCharacter;
   MemoryEventsPage _events = const MemoryEventsPage();
   bool _loadingCharacters = false;
+  bool _searchingCharacters = false;
   bool _loadingEvents = false;
   int _reloadEpoch = 0;
+  int _charPageSize = _defaultPageSize;
+  int _eventPageSize = _defaultPageSize;
+  String _activeCharQuery = '';
 
   @override
   void initState() {
     super.initState();
-    _loadCharacters();
+    _loadCharacters(offset: 0);
   }
 
   @override
-  void didUpdateWidget(covariant _EventsCard oldWidget) {
+  void didUpdateWidget(covariant _EventsDetail oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.reloadKey != oldWidget.reloadKey) {
       _selectedCharacter = null;
       _events = const MemoryEventsPage();
       _characterSearch.clear();
-      _loadCharacters();
+      _activeCharQuery = '';
+      _loadCharacters(offset: 0);
     }
   }
 
@@ -770,27 +1073,26 @@ class _EventsCardState extends State<_EventsCard> {
     super.dispose();
   }
 
-  Future<void> _loadCharacters({bool append = false}) async {
+  Future<void> _loadCharacters({
+    required int offset,
+    bool newQuery = false,
+  }) async {
+    if (newQuery) _activeCharQuery = _characterSearch.text.trim();
     final epoch = ++_reloadEpoch;
-    setState(() => _loadingCharacters = true);
+    setState(() {
+      _loadingCharacters = true;
+      if (newQuery) _searchingCharacters = true;
+    });
     final page = await widget.notifier.loadMemoryCharacters(
-      query: _characterSearch.text.trim(),
-      offset: append ? _characters.characters.length : 0,
+      query: _activeCharQuery,
+      offset: offset,
+      limit: _charPageSize,
     );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loadingCharacters = false;
-      if (!append) {
-        _characters = page;
-      } else {
-        _characters = MemoryCharactersPage(
-          characters: [..._characters.characters, ...page.characters],
-          total: page.total,
-          offset: page.offset,
-          limit: page.limit,
-          error: page.error,
-        );
-      }
+      _searchingCharacters = false;
+      _characters = page;
     });
   }
 
@@ -801,7 +1103,11 @@ class _EventsCardState extends State<_EventsCard> {
       _loadingEvents = true;
       _events = const MemoryEventsPage(); // clear stale page immediately
     });
-    final page = await widget.notifier.loadMemoryEvents(id);
+    final page = await widget.notifier.loadMemoryEvents(
+      id,
+      offset: 0,
+      limit: _eventPageSize,
+    );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loadingEvents = false;
@@ -809,28 +1115,26 @@ class _EventsCardState extends State<_EventsCard> {
     });
   }
 
-  Future<void> _loadMoreEvents() async {
+  Future<void> _loadEvents({required int offset}) async {
     final character = _selectedCharacter;
     if (character == null) return;
     final epoch = ++_reloadEpoch;
     setState(() => _loadingEvents = true);
     final page = await widget.notifier.loadMemoryEvents(
       character,
-      offset: _events.events.length,
+      offset: offset,
+      limit: _eventPageSize,
     );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loadingEvents = false;
-      _events = MemoryEventsPage(
-        character: page.character,
-        events: [..._events.events, ...page.events],
-        arrayPath: page.arrayPath,
-        total: page.total,
-        offset: page.offset,
-        limit: page.limit,
-        error: page.error,
-      );
+      _events = page;
     });
+  }
+
+  void _setEventPageSize(int size) {
+    setState(() => _eventPageSize = size);
+    _loadEvents(offset: 0);
   }
 
   Future<void> _confirmAndApply(
@@ -860,172 +1164,257 @@ class _EventsCardState extends State<_EventsCard> {
     if (!mounted) return;
     await widget.notifier.applyMemoryEventEdit(edit);
     // On success the notifier refreshes inspection → reloadKey changes →
-    // didUpdateWidget fires and reloads this card automatically.
+    // didUpdateWidget fires and reloads this detail automatically.
   }
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
+    final scheme = widget.theme.colorScheme;
     final character = _selectedCharacter;
 
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            // Header
             Row(
               children: [
-                const Icon(Icons.memory_outlined),
+                Icon(Icons.history_outlined, color: scheme.primary),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     'Memory Events',
-                    style: Theme.of(context).textTheme.titleMedium,
+                    style: widget.theme.textTheme.titleMedium,
                   ),
                 ),
               ],
             ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: _characterSearch,
-              decoration: const InputDecoration(
-                labelText: 'Search characters',
-                prefixIcon: Icon(Icons.search),
-              ),
-              onSubmitted: (_) => _loadCharacters(),
-            ),
-            if (_characters.error != null) ...[
-              const SizedBox(height: 8),
-              Text(_characters.error!, style: TextStyle(color: scheme.error)),
-            ],
             const SizedBox(height: 8),
-            // Character list (height-capped)
-            SizedBox(
-              height: 200,
-              child: _loadingCharacters && _characters.characters.isEmpty
-                  ? const Center(child: CircularProgressIndicator())
-                  : ListView.separated(
-                      itemCount:
-                          _characters.characters.length +
-                          (_characters.hasMore ? 1 : 0),
-                      separatorBuilder: (_, _) => const Divider(height: 1),
-                      itemBuilder: (context, index) {
-                        if (index >= _characters.characters.length) {
-                          return TextButton(
-                            onPressed: _loadingCharacters
-                                ? null
-                                : () => _loadCharacters(append: true),
-                            child: Text(
-                              'Load more (${_characters.characters.length}'
-                              ' of ${_characters.total})',
-                            ),
-                          );
-                        }
-                        final c = _characters.characters[index];
-                        final isSelected = c.id == character;
-                        return ListTile(
-                          dense: true,
-                          selected: isSelected,
-                          title: Text('${c.id} (${c.eventCount})'),
-                          onTap: () => _selectCharacter(c.id),
-                        );
-                      },
-                    ),
-            ),
-            if (character != null) ...[
-              const SizedBox(height: 12),
-              Text(
-                'Events for $character',
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-              const SizedBox(height: 8),
-              if (_events.error != null)
-                Text(_events.error!, style: TextStyle(color: scheme.error)),
-              SizedBox(
-                height: 360,
-                child: _loadingEvents && _events.events.isEmpty
-                    ? const Center(child: CircularProgressIndicator())
-                    : ListView.separated(
-                        itemCount:
-                            _events.events.length + (_events.hasMore ? 1 : 0),
-                        separatorBuilder: (_, _) => const Divider(height: 1),
-                        itemBuilder: (context, index) {
-                          if (index >= _events.events.length) {
-                            return TextButton(
-                              onPressed: _loadingEvents
-                                  ? null
-                                  : _loadMoreEvents,
-                              child: Text(
-                                'Load more (${_events.events.length} of ${_events.total})',
-                              ),
-                            );
-                          }
-                          final event = _events.events[index];
-                          final tagLabel = event.tags.isEmpty
-                              ? '(no tags)'
-                              : event.tags.join(', ');
-                          final timeStr = event.timeSeconds != null
-                              ? event.timeSeconds!.toStringAsFixed(0)
-                              : '?';
-                          final affected = event.affected ?? '';
-                          return ListTile(
-                            dense: true,
-                            title: SelectableText(tagLabel, maxLines: 1),
-                            subtitle: SelectableText(
-                              't=${timeStr}s  $affected',
-                              maxLines: 1,
-                            ),
-                            trailing: widget.editable
-                                ? Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      IconButton(
-                                        icon: const Icon(
-                                          Icons.delete_outline,
-                                          size: 20,
-                                        ),
-                                        tooltip: 'Remove event',
-                                        onPressed: _loadingEvents
-                                            ? null
-                                            : () => _confirmAndApply(
-                                                context,
-                                                MemoryEventEdit.remove(
-                                                  arrayPath: _events.arrayPath,
-                                                  index: event.index,
-                                                ),
-                                                'Remove memory event?',
-                                                'Remove this memory event? '
-                                                    'A backup is written first.',
-                                              ),
+            // Two-pane row: characters left, events right
+            Expanded(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Left pane: character search + pagination + list
+                  SizedBox(
+                    width: 280,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        TextField(
+                          controller: _characterSearch,
+                          decoration: InputDecoration(
+                            labelText: 'Search characters',
+                            isDense: true,
+                            prefixIcon: const Icon(Icons.search, size: 18),
+                            suffixIcon: _searchingCharacters
+                                ? const Padding(
+                                    padding: EdgeInsets.all(10),
+                                    child: SizedBox(
+                                      width: 16,
+                                      height: 16,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
                                       ),
-                                      IconButton(
-                                        icon: const Icon(
-                                          Icons.copy_outlined,
-                                          size: 20,
-                                        ),
-                                        tooltip: 'Duplicate event',
-                                        onPressed: _loadingEvents
-                                            ? null
-                                            : () => _confirmAndApply(
-                                                context,
-                                                MemoryEventEdit.duplicate(
-                                                  arrayPath: _events.arrayPath,
-                                                  index: event.index,
-                                                ),
-                                                'Duplicate memory event?',
-                                                'Duplicate this memory event? '
-                                                    'A backup is written first.',
-                                              ),
-                                      ),
-                                    ],
+                                    ),
                                   )
-                                : null,
-                          );
-                        },
-                      ),
+                                : IconButton(
+                                    icon: const Icon(
+                                      Icons.arrow_forward,
+                                      size: 18,
+                                    ),
+                                    onPressed: () => _loadCharacters(
+                                      offset: 0,
+                                      newQuery: true,
+                                    ),
+                                  ),
+                          ),
+                          onSubmitted: (_) =>
+                              _loadCharacters(offset: 0, newQuery: true),
+                        ),
+                        if (_characters.error != null) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            _characters.error!,
+                            style: TextStyle(color: scheme.error, fontSize: 12),
+                          ),
+                        ],
+                        const SizedBox(height: 4),
+                        _PaginationBar(
+                          offset: _characters.offset,
+                          count: _characters.characters.length,
+                          total: _characters.total,
+                          pageSize: _charPageSize,
+                          busy: _loadingCharacters,
+                          onPage: (o) => _loadCharacters(offset: o),
+                          onPageSize: (s) {
+                            setState(() => _charPageSize = s);
+                            _loadCharacters(offset: 0);
+                          },
+                        ),
+                        const SizedBox(height: 4),
+                        Expanded(
+                          child:
+                              _loadingCharacters &&
+                                  _characters.characters.isEmpty
+                              ? const Center(child: CircularProgressIndicator())
+                              : ListView.separated(
+                                  itemCount: _characters.characters.length,
+                                  separatorBuilder: (_, _) =>
+                                      const Divider(height: 1),
+                                  itemBuilder: (context, index) {
+                                    final c = _characters.characters[index];
+                                    final isSelected = c.id == character;
+                                    return ListTile(
+                                      dense: true,
+                                      selected: isSelected,
+                                      title: Text('${c.id} (${c.eventCount})'),
+                                      onTap: () => _selectCharacter(c.id),
+                                    );
+                                  },
+                                ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  const VerticalDivider(width: 1),
+                  const SizedBox(width: 12),
+                  // Right pane: header + pagination + events list
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(
+                          character != null
+                              ? 'Events — $character'
+                              : 'Select a character to see events',
+                          style: widget.theme.textTheme.labelLarge,
+                        ),
+                        if (character != null) ...[
+                          if (_events.error != null)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: Text(
+                                _events.error!,
+                                style: TextStyle(color: scheme.error),
+                              ),
+                            ),
+                          const SizedBox(height: 4),
+                          _PaginationBar(
+                            offset: _events.offset,
+                            count: _events.events.length,
+                            total: _events.total,
+                            pageSize: _eventPageSize,
+                            busy: _loadingEvents,
+                            onPage: (o) => _loadEvents(offset: o),
+                            onPageSize: _setEventPageSize,
+                          ),
+                          const SizedBox(height: 4),
+                          // Events list — only scrollable in this pane
+                          Expanded(
+                            child: _loadingEvents && _events.events.isEmpty
+                                ? const Center(
+                                    child: CircularProgressIndicator(),
+                                  )
+                                : ListView.separated(
+                                    itemCount: _events.events.length,
+                                    separatorBuilder: (_, _) =>
+                                        const Divider(height: 1),
+                                    itemBuilder: (context, index) {
+                                      final event = _events.events[index];
+                                      final tagLabel = event.tags.isEmpty
+                                          ? '(no tags)'
+                                          : event.tags.join(', ');
+                                      final timeStr = event.timeSeconds != null
+                                          ? event.timeSeconds!.toStringAsFixed(
+                                              0,
+                                            )
+                                          : '?';
+                                      final affected = event.affected ?? '';
+                                      return ListTile(
+                                        dense: true,
+                                        title: SelectableText(
+                                          tagLabel,
+                                          maxLines: 1,
+                                        ),
+                                        subtitle: SelectableText(
+                                          't=${timeStr}s  $affected',
+                                          maxLines: 1,
+                                        ),
+                                        trailing: widget.editable
+                                            ? Row(
+                                                mainAxisSize: MainAxisSize.min,
+                                                children: [
+                                                  IconButton(
+                                                    icon: const Icon(
+                                                      Icons.delete_outline,
+                                                      size: 20,
+                                                    ),
+                                                    tooltip: 'Remove event',
+                                                    onPressed: _loadingEvents
+                                                        ? null
+                                                        : () => _confirmAndApply(
+                                                            context,
+                                                            MemoryEventEdit.remove(
+                                                              arrayPath: _events
+                                                                  .arrayPath,
+                                                              index:
+                                                                  event.index,
+                                                            ),
+                                                            'Remove memory event?',
+                                                            'Remove this memory event? '
+                                                                'A backup is written first.',
+                                                          ),
+                                                  ),
+                                                  IconButton(
+                                                    icon: const Icon(
+                                                      Icons.copy_outlined,
+                                                      size: 20,
+                                                    ),
+                                                    tooltip: 'Duplicate event',
+                                                    onPressed: _loadingEvents
+                                                        ? null
+                                                        : () => _confirmAndApply(
+                                                            context,
+                                                            MemoryEventEdit.duplicate(
+                                                              arrayPath: _events
+                                                                  .arrayPath,
+                                                              index:
+                                                                  event.index,
+                                                            ),
+                                                            'Duplicate memory event?',
+                                                            'Duplicate this memory event? '
+                                                                'A backup is written first.',
+                                                          ),
+                                                  ),
+                                                ],
+                                              )
+                                            : null,
+                                      );
+                                    },
+                                  ),
+                          ),
+                        ],
+                        if (character == null)
+                          Expanded(
+                            child: Center(
+                              child: Text(
+                                'Select a character from the list',
+                                style: TextStyle(
+                                  color: scheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ],
         ),
       ),
@@ -1034,7 +1423,7 @@ class _EventsCardState extends State<_EventsCard> {
 }
 
 // ---------------------------------------------------------------------------
-// Local private helpers (duplicated from editor_page.dart)
+// _MessagePane (local helper, duplicated from editor_page.dart pattern)
 // ---------------------------------------------------------------------------
 
 class _MessagePane extends StatelessWidget {
@@ -1072,39 +1461,6 @@ class _MessagePane extends StatelessWidget {
             ),
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _SummaryMetric extends StatelessWidget {
-  const _SummaryMetric({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 120,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-          Text(
-            value,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-        ],
       ),
     );
   }

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -21,8 +21,9 @@ String shortStateLabel(String state) {
 
 /// Progression tab: structured quests / dialog knowledge / memory events.
 /// Data loads lazily per card through the notifier's query_progression
-/// wrappers. [reloadKey] identifies the inspected save (sha1); when it
-/// changes, cards drop local state and reload.
+/// wrappers. [reloadKey] is the [SaveInspection] instance itself; identity
+/// comparison means every fresh inspection (even of the same file) clears
+/// local pending state and reloads, matching the inventory card semantics.
 class ProgressionPanel extends StatelessWidget {
   const ProgressionPanel({
     super.key,
@@ -55,7 +56,7 @@ class ProgressionPanel extends StatelessWidget {
             'verified typed parse.',
       );
     }
-    final reloadKey = inspection.sha1;
+    final reloadKey = inspection;
     return ListView(
       padding: const EdgeInsets.all(20),
       children: [
@@ -533,13 +534,16 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
     final scheme = Theme.of(context).colorScheme;
     final character = _selectedCharacter;
 
-    // Compute sets for rendering
+    // Compute sets for rendering — only include edits for the selected NPC.
+    // Keys are '$character\t$entry' so we filter by prefix.
     final removedEntries = <String>{};
     final addedEntries = <String>[];
     if (character != null) {
-      for (final edit in _pending.values) {
-        if (!edit.isAdd) removedEntries.add(edit.entry);
-        if (edit.isAdd) addedEntries.add(edit.entry);
+      final prefix = '$character\t';
+      for (final entry in _pending.entries) {
+        if (!entry.key.startsWith(prefix)) continue;
+        if (!entry.value.isAdd) removedEntries.add(entry.value.entry);
+        if (entry.value.isAdd) addedEntries.add(entry.value.entry);
       }
     }
 

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -799,6 +799,7 @@ class _EventsCardState extends State<_EventsCard> {
     setState(() {
       _selectedCharacter = id;
       _loadingEvents = true;
+      _events = const MemoryEventsPage(); // clear stale page immediately
     });
     final page = await widget.notifier.loadMemoryEvents(id);
     if (!mounted || epoch != _reloadEpoch) return;
@@ -985,16 +986,18 @@ class _EventsCardState extends State<_EventsCard> {
                                           size: 20,
                                         ),
                                         tooltip: 'Remove event',
-                                        onPressed: () => _confirmAndApply(
-                                          context,
-                                          MemoryEventEdit.remove(
-                                            arrayPath: _events.arrayPath,
-                                            index: event.index,
-                                          ),
-                                          'Remove memory event?',
-                                          'Remove this memory event? '
-                                              'A backup is written first.',
-                                        ),
+                                        onPressed: _loadingEvents
+                                            ? null
+                                            : () => _confirmAndApply(
+                                                context,
+                                                MemoryEventEdit.remove(
+                                                  arrayPath: _events.arrayPath,
+                                                  index: event.index,
+                                                ),
+                                                'Remove memory event?',
+                                                'Remove this memory event? '
+                                                    'A backup is written first.',
+                                              ),
                                       ),
                                       IconButton(
                                         icon: const Icon(
@@ -1002,16 +1005,18 @@ class _EventsCardState extends State<_EventsCard> {
                                           size: 20,
                                         ),
                                         tooltip: 'Duplicate event',
-                                        onPressed: () => _confirmAndApply(
-                                          context,
-                                          MemoryEventEdit.duplicate(
-                                            arrayPath: _events.arrayPath,
-                                            index: event.index,
-                                          ),
-                                          'Duplicate memory event?',
-                                          'Duplicate this memory event? '
-                                              'A backup is written first.',
-                                        ),
+                                        onPressed: _loadingEvents
+                                            ? null
+                                            : () => _confirmAndApply(
+                                                context,
+                                                MemoryEventEdit.duplicate(
+                                                  arrayPath: _events.arrayPath,
+                                                  index: event.index,
+                                                ),
+                                                'Duplicate memory event?',
+                                                'Duplicate this memory event? '
+                                                    'A backup is written first.',
+                                              ),
                                       ),
                                     ],
                                   )

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -875,13 +875,15 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
     final character = _selectedCharacter;
 
     // Compute sets for rendering — only include edits for the selected NPC.
+    // removedEntries holds lower-cased values to match the case-folded
+    // pending keys: lookups against displayed entries fold too.
     final removedEntries = <String>{};
     final addedEntries = <String>[];
     if (character != null) {
       final prefix = '$character\t';
       for (final e in _pending.entries) {
         if (!e.key.startsWith(prefix)) continue;
-        if (!e.value.isAdd) removedEntries.add(e.value.entry);
+        if (!e.value.isAdd) removedEntries.add(e.value.entry.toLowerCase());
         if (e.value.isAdd) addedEntries.add(e.value.entry);
       }
     }
@@ -1150,7 +1152,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
                                     itemBuilder: (context, index) {
                                       final entry = _entries.entries[index];
                                       final isRemoved = removedEntries.contains(
-                                        entry,
+                                        entry.toLowerCase(),
                                       );
                                       return ListTile(
                                         dense: true,

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -294,6 +294,7 @@ class _PaginationBar extends StatelessWidget {
         Text('$first–$last of $total', style: muted),
         const SizedBox(width: 8),
         Text('Per page:', style: muted),
+        const SizedBox(width: 6),
         DropdownButton<int>(
           value: effectivePageSize,
           isDense: true,
@@ -338,7 +339,6 @@ class _QuestsDetailState extends State<_QuestsDetail> {
   ProgressionQuestPage _page = const ProgressionQuestPage();
   final Map<String, QuestStateChange> _pending = {};
   bool _loading = false;
-  bool _searching = false;
   int _reloadEpoch = 0;
   int _pageSize = _defaultPageSize;
   String _activeQuery = '';
@@ -373,10 +373,7 @@ class _QuestsDetailState extends State<_QuestsDetail> {
   Future<void> _reload({required int offset, bool newQuery = false}) async {
     if (newQuery) _activeQuery = _search.text.trim();
     final epoch = ++_reloadEpoch;
-    setState(() {
-      _loading = true;
-      if (newQuery) _searching = true;
-    });
+    setState(() => _loading = true);
     final page = await widget.notifier.loadProgressionQuests(
       query: _activeQuery,
       offset: offset,
@@ -387,7 +384,6 @@ class _QuestsDetailState extends State<_QuestsDetail> {
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loading = false;
-      _searching = false;
       _page = page;
     });
   }
@@ -466,7 +462,7 @@ class _QuestsDetailState extends State<_QuestsDetail> {
               decoration: InputDecoration(
                 labelText: 'Search quests',
                 prefixIcon: const Icon(Icons.search),
-                suffixIcon: _searching
+                suffixIcon: _loading
                     ? const Padding(
                         padding: EdgeInsets.all(12),
                         child: SizedBox(
@@ -492,6 +488,7 @@ class _QuestsDetailState extends State<_QuestsDetail> {
               page: _page,
               stateFilter: _stateFilter,
               groupFilter: _groupFilter,
+              busy: _loading,
               onStateChanged: (label) {
                 setState(() {
                   _stateFilter = (_stateFilter == label) ? null : label;
@@ -1463,6 +1460,7 @@ class _QuestFilterRow extends StatelessWidget {
     required this.page,
     required this.stateFilter,
     required this.groupFilter,
+    required this.busy,
     required this.onStateChanged,
     required this.onGroupChanged,
   });
@@ -1470,25 +1468,47 @@ class _QuestFilterRow extends StatelessWidget {
   final ProgressionQuestPage page;
   final String? stateFilter;
   final String? groupFilter;
+  final bool busy;
   final void Function(String label) onStateChanged;
   final void Function(String? group) onGroupChanged;
 
   @override
   Widget build(BuildContext context) {
-    // Status FilterChips — only show labels with count > 0.
+    // Status FilterChips — show labels with count > 0 OR currently selected
+    // (so a selected chip whose count dropped to 0 stays visible for deselect).
     final chips = [
       for (final label in _filterStateLabels)
-        if ((page.stateCounts[label] ?? 0) > 0)
+        if ((page.stateCounts[label] ?? 0) > 0 || stateFilter == label)
           FilterChip(
-            label: Text('$label ${page.stateCounts[label]}'),
+            label: Text(
+              stateFilter == label && (page.stateCounts[label] ?? 0) == 0
+                  ? '$label 0'
+                  : '$label ${page.stateCounts[label] ?? 0}',
+            ),
             selected: stateFilter == label,
-            onSelected: (_) => onStateChanged(label),
+            onSelected: busy ? null : (_) => onStateChanged(label),
             visualDensity: VisualDensity.compact,
           ),
     ];
 
     // Group dropdown entries sorted by name.
+    // Always include the currently selected group even if its count is now 0
+    // (prevents DropdownButton crash on value not in items).
     final sortedGroups = page.groupCounts.keys.toList()..sort();
+    final groupItems = <DropdownMenuItem<String?>>[
+      const DropdownMenuItem<String?>(value: null, child: Text('All groups')),
+      for (final g in sortedGroups)
+        DropdownMenuItem<String?>(
+          value: g,
+          child: Text('$g (${page.groupCounts[g]})'),
+        ),
+      // Ensure selected group is present even when its count is 0.
+      if (groupFilter != null && !page.groupCounts.containsKey(groupFilter))
+        DropdownMenuItem<String?>(
+          value: groupFilter,
+          child: Text('$groupFilter (0)'),
+        ),
+    ];
 
     return Wrap(
       spacing: 6,
@@ -1501,18 +1521,8 @@ class _QuestFilterRow extends StatelessWidget {
           isDense: true,
           underline: const SizedBox.shrink(),
           hint: const Text('All groups'),
-          onChanged: onGroupChanged,
-          items: [
-            const DropdownMenuItem<String?>(
-              value: null,
-              child: Text('All groups'),
-            ),
-            for (final g in sortedGroups)
-              DropdownMenuItem<String?>(
-                value: g,
-                child: Text('$g (${page.groupCounts[g]})'),
-              ),
-          ],
+          onChanged: busy ? null : onGroupChanged,
+          items: groupItems,
         ),
       ],
     );

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -123,35 +123,49 @@ class _ProgressionPanelState extends State<ProgressionPanel> {
             ),
           ),
           const SizedBox(width: 16),
-          // Detail area — fills remaining width and full height
+          // Detail area — fills remaining width and full height.
+          // Every section stays mounted (Offstage, same pattern as
+          // hero_stats_card): a detail's local `_pending` map backs entries in
+          // the global pending-edit registry, so disposing it on a section
+          // switch would hide queued edits that Save still writes. Keys are
+          // stable on purpose: a key derived from reloadKey would remount the
+          // detail on every fresh inspection, disposing state and bypassing
+          // the didUpdateWidget logic that preserves the selected character.
           Expanded(
-            // Keys are stable on purpose: a key derived from reloadKey would
-            // remount the detail on every fresh inspection, disposing state
-            // and bypassing the didUpdateWidget logic that preserves the
-            // selected character across save-triggered reloads.
-            child: switch (_selected) {
-              _ProgSection.quests => _QuestsDetail(
-                key: const ValueKey('quests'),
-                notifier: widget.notifier,
-                editable: widget.editable,
-                reloadKey: reloadKey,
-                theme: theme,
-              ),
-              _ProgSection.knowledge => _KnowledgeDetail(
-                key: const ValueKey('knowledge'),
-                notifier: widget.notifier,
-                editable: widget.editable,
-                reloadKey: reloadKey,
-                theme: theme,
-              ),
-              _ProgSection.events => _EventsDetail(
-                key: const ValueKey('events'),
-                notifier: widget.notifier,
-                editable: widget.editable,
-                reloadKey: reloadKey,
-                theme: theme,
-              ),
-            },
+            child: Stack(
+              children: [
+                Offstage(
+                  offstage: _selected != _ProgSection.quests,
+                  child: _QuestsDetail(
+                    key: const ValueKey('quests'),
+                    notifier: widget.notifier,
+                    editable: widget.editable,
+                    reloadKey: reloadKey,
+                    theme: theme,
+                  ),
+                ),
+                Offstage(
+                  offstage: _selected != _ProgSection.knowledge,
+                  child: _KnowledgeDetail(
+                    key: const ValueKey('knowledge'),
+                    notifier: widget.notifier,
+                    editable: widget.editable,
+                    reloadKey: reloadKey,
+                    theme: theme,
+                  ),
+                ),
+                Offstage(
+                  offstage: _selected != _ProgSection.events,
+                  child: _EventsDetail(
+                    key: const ValueKey('events'),
+                    notifier: widget.notifier,
+                    editable: widget.editable,
+                    reloadKey: reloadKey,
+                    theme: theme,
+                  ),
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -758,13 +758,21 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
     final trimmed = entry.trim();
     if (trimmed.isEmpty) return;
     // Fast path: already on the current page.
-    if (_entries.entries.contains(trimmed)) {
+    // UE Names compare case-insensitively, so case-variants are duplicates.
+    final trimmedLower = trimmed.toLowerCase();
+    if (_entries.entries.any((e) => e.toLowerCase() == trimmedLower)) {
       setState(() => _addError = 'Already exists for this character.');
       return;
     }
     final character = _selectedCharacter!;
     final key = _pendingKey(character, trimmed);
-    // Already in pending adds/removes.
+    // Already in pending adds/removes (case-insensitive on the entry part).
+    final pendingPrefix = '$character\t'.toLowerCase();
+    if (_pending.keys.any(
+      (k) => k.toLowerCase() == '$pendingPrefix$trimmedLower',
+    )) {
+      return;
+    }
     if (_pending.containsKey(key)) return;
 
     // Issue B: cross-page duplicate check via a server query.
@@ -796,7 +804,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
           checkError = checkPage.error;
           break;
         }
-        if (checkPage.entries.any((e) => e == trimmed)) {
+        if (checkPage.entries.any((e) => e.toLowerCase() == trimmedLower)) {
           exists = true;
           break;
         }

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -738,6 +738,8 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
   String _pendingKey(String character, String entry) => '$character\t$entry';
 
   void _removeEntry(String entry) {
+    // Same guard as _addEntry: never queue an edit with an unloaded path.
+    if (_entries.setPath.isEmpty) return;
     final key = _pendingKey(_selectedCharacter!, entry);
     setState(() {
       if (_pending.containsKey(key)) {
@@ -768,12 +770,13 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
     final key = _pendingKey(character, trimmed);
     // Already in pending adds/removes (case-insensitive on the entry part).
     final pendingPrefix = '$character\t'.toLowerCase();
-    if (_pending.keys.any(
-      (k) => k.toLowerCase() == '$pendingPrefix$trimmedLower',
-    )) {
+    if (_pending.containsKey(key) ||
+        _pending.keys.any(
+          (k) => k.toLowerCase() == '$pendingPrefix$trimmedLower',
+        )) {
+      setState(() => _addError = 'Already in pending changes.');
       return;
     }
-    if (_pending.containsKey(key)) return;
 
     // Issue B: cross-page duplicate check via a server query.
     final checkCharacter = character;

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -84,14 +84,17 @@ class _ProgressionPanelState extends State<ProgressionPanel> {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          // Slim left sidebar
+          // Left sidebar: same style as the Player tab (hero_stats_card).
           SizedBox(
-            width: 140,
-            child: Card(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
+            width: 200,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerLow,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(vertical: 6),
                 child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     _SidebarTile(
                       icon: Icons.flag_outlined,
@@ -119,7 +122,7 @@ class _ProgressionPanelState extends State<ProgressionPanel> {
               ),
             ),
           ),
-          const SizedBox(width: 12),
+          const SizedBox(width: 16),
           // Detail area — fills remaining width and full height
           Expanded(
             child: switch (_selected) {
@@ -172,36 +175,37 @@ class _SidebarTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    return Material(
-      color: selected ? scheme.secondaryContainer : Colors.transparent,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 12),
-          child: Row(
-            children: [
-              Icon(
-                icon,
-                size: 18,
-                color: selected
-                    ? scheme.onSecondaryContainer
-                    : scheme.onSurfaceVariant,
-              ),
-              const SizedBox(width: 8),
-              Flexible(
-                child: Text(
-                  label,
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
-                    color: selected
-                        ? scheme.onSecondaryContainer
-                        : scheme.onSurface,
-                  ),
-                  overflow: TextOverflow.ellipsis,
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      child: Material(
+        color: selected ? scheme.primaryContainer : Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+            child: Row(
+              children: [
+                Icon(
+                  icon,
+                  size: 18,
+                  color: selected ? scheme.primary : scheme.onSurfaceVariant,
                 ),
-              ),
-            ],
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: selected ? scheme.primary : scheme.onSurface,
+                      fontWeight: selected ? FontWeight.w600 : null,
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -14,6 +14,15 @@ const questStates = <String>[
   'EQuestState::Failed',
 ];
 
+/// Short state labels shown in filter chips, in display order.
+const _filterStateLabels = <String>[
+  'Available',
+  'Running',
+  'Succeeded',
+  'Failed',
+  'None',
+];
+
 String shortStateLabel(String state) {
   final idx = state.lastIndexOf('::');
   return idx < 0 ? state : state.substring(idx + 2);
@@ -333,6 +342,8 @@ class _QuestsDetailState extends State<_QuestsDetail> {
   int _reloadEpoch = 0;
   int _pageSize = _defaultPageSize;
   String _activeQuery = '';
+  String? _stateFilter;
+  String? _groupFilter;
 
   @override
   void initState() {
@@ -347,6 +358,8 @@ class _QuestsDetailState extends State<_QuestsDetail> {
       _pending.clear();
       _search.clear();
       _activeQuery = '';
+      _stateFilter = null;
+      _groupFilter = null;
       _reload(offset: 0);
     }
   }
@@ -368,6 +381,8 @@ class _QuestsDetailState extends State<_QuestsDetail> {
       query: _activeQuery,
       offset: offset,
       limit: _pageSize,
+      state: _stateFilter,
+      group: _groupFilter,
     );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
@@ -472,6 +487,23 @@ class _QuestsDetailState extends State<_QuestsDetail> {
               Text(_page.error!, style: TextStyle(color: scheme.error)),
             ],
             const SizedBox(height: 8),
+            // Filter row: status chips + group dropdown
+            _QuestFilterRow(
+              page: _page,
+              stateFilter: _stateFilter,
+              groupFilter: _groupFilter,
+              onStateChanged: (label) {
+                setState(() {
+                  _stateFilter = (_stateFilter == label) ? null : label;
+                });
+                _reload(offset: 0);
+              },
+              onGroupChanged: (group) {
+                setState(() => _groupFilter = group);
+                _reload(offset: 0);
+              },
+            ),
+            const SizedBox(height: 4),
             _PaginationBar(
               offset: _page.offset,
               count: _page.quests.length,
@@ -1418,6 +1450,71 @@ class _EventsDetailState extends State<_EventsDetail> {
           ],
         ),
       ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Quest filter row: status chips + group dropdown
+// ---------------------------------------------------------------------------
+
+class _QuestFilterRow extends StatelessWidget {
+  const _QuestFilterRow({
+    required this.page,
+    required this.stateFilter,
+    required this.groupFilter,
+    required this.onStateChanged,
+    required this.onGroupChanged,
+  });
+
+  final ProgressionQuestPage page;
+  final String? stateFilter;
+  final String? groupFilter;
+  final void Function(String label) onStateChanged;
+  final void Function(String? group) onGroupChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    // Status FilterChips — only show labels with count > 0.
+    final chips = [
+      for (final label in _filterStateLabels)
+        if ((page.stateCounts[label] ?? 0) > 0)
+          FilterChip(
+            label: Text('$label ${page.stateCounts[label]}'),
+            selected: stateFilter == label,
+            onSelected: (_) => onStateChanged(label),
+            visualDensity: VisualDensity.compact,
+          ),
+    ];
+
+    // Group dropdown entries sorted by name.
+    final sortedGroups = page.groupCounts.keys.toList()..sort();
+
+    return Wrap(
+      spacing: 6,
+      runSpacing: 4,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        ...chips,
+        DropdownButton<String?>(
+          value: groupFilter,
+          isDense: true,
+          underline: const SizedBox.shrink(),
+          hint: const Text('All groups'),
+          onChanged: onGroupChanged,
+          items: [
+            const DropdownMenuItem<String?>(
+              value: null,
+              child: Text('All groups'),
+            ),
+            for (final g in sortedGroups)
+              DropdownMenuItem<String?>(
+                value: g,
+                child: Text('$g (${page.groupCounts[g]})'),
+              ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -752,7 +752,10 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
     final trimmed = entry.trim();
     if (trimmed.isEmpty) return;
     // Fast path: already on the current page.
-    if (_entries.entries.contains(trimmed)) return;
+    if (_entries.entries.contains(trimmed)) {
+      setState(() => _addError = 'Already exists for this character.');
+      return;
+    }
     final character = _selectedCharacter!;
     final key = _pendingKey(character, trimmed);
     // Already in pending adds/removes.
@@ -765,28 +768,55 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
       _checkingDuplicate = true;
       _addError = null;
     });
-    KnowledgeEntriesPage checkPage;
+    // The core query is a lowercase-contains filter, so an exact match can
+    // sit on any page of the match set — page through ALL matches.
+    var exists = false;
+    String? checkError;
     try {
-      checkPage = await widget.notifier.loadKnowledgeEntries(
-        checkCharacter,
-        query: trimmed,
-        limit: 50,
-      );
+      var offset = 0;
+      while (true) {
+        final checkPage = await widget.notifier.loadKnowledgeEntries(
+          checkCharacter,
+          query: trimmed,
+          limit: 200,
+          offset: offset,
+        );
+        if (!mounted ||
+            _selectedCharacter != checkCharacter ||
+            _entriesEpoch != checkEpoch) {
+          return;
+        }
+        if (checkPage.error != null) {
+          checkError = checkPage.error;
+          break;
+        }
+        if (checkPage.entries.any((e) => e == trimmed)) {
+          exists = true;
+          break;
+        }
+        offset += checkPage.entries.length;
+        if (checkPage.entries.isEmpty || offset >= checkPage.total) break;
+      }
     } finally {
-      // Issue 1 fix: clear the lock on every exit path (unmount, stale, error).
+      // Clear the lock on every exit path (unmount, stale, error).
       if (mounted) setState(() => _checkingDuplicate = false);
     }
-    if (!mounted || _selectedCharacter != checkCharacter || _entriesEpoch != checkEpoch) return;
-    // Issue 2 fix: a failed query must NOT fall through to a pending add.
-    if (checkPage.error != null) {
+    if (!mounted ||
+        _selectedCharacter != checkCharacter ||
+        _entriesEpoch != checkEpoch) {
+      return;
+    }
+    // A failed query must NOT fall through to a pending add.
+    if (checkError != null) {
       setState(() {
-        _addError =
-            'Duplicate check failed — try again: ${checkPage.error}';
+        _addError = 'Duplicate check failed — try again: $checkError';
       });
       return;
     }
-    // The core query is a lowercase-contains filter; verify exact equality.
-    if (checkPage.entries.any((e) => e == trimmed)) return;
+    if (exists) {
+      setState(() => _addError = 'Already exists for this character.');
+      return;
+    }
 
     setState(() {
       _pending[key] = KnowledgeEntryEdit.add(
@@ -963,50 +993,53 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
                           if (widget.editable) ...[
                             // Issue C: disabled while entries are loading or
                             // the set path is not yet known.
-                            Builder(builder: (context) {
-                              final addDisabled =
-                                  _loadingEntries ||
-                                  _entries.setPath.isEmpty ||
-                                  _checkingDuplicate;
-                              return Row(
-                                children: [
-                                  Expanded(
-                                    child: TextField(
-                                      controller: _addController,
-                                      enabled: !addDisabled,
-                                      decoration: const InputDecoration(
-                                        labelText: 'Add knowledge entry',
-                                        isDense: true,
-                                      ),
-                                      onSubmitted: addDisabled
-                                          ? null
-                                          : (v) => _addEntry(v),
-                                    ),
-                                  ),
-                                  const SizedBox(width: 8),
-                                  // Issue B: spinner during cross-page check.
-                                  _checkingDuplicate
-                                      ? const Padding(
-                                          padding: EdgeInsets.all(12),
-                                          child: SizedBox(
-                                            width: 16,
-                                            height: 16,
-                                            child: CircularProgressIndicator(
-                                              strokeWidth: 2,
-                                            ),
-                                          ),
-                                        )
-                                      : IconButton(
-                                          icon: const Icon(Icons.add),
-                                          tooltip: 'Add',
-                                          onPressed: addDisabled
-                                              ? null
-                                              : () =>
-                                                    _addEntry(_addController.text),
+                            Builder(
+                              builder: (context) {
+                                final addDisabled =
+                                    _loadingEntries ||
+                                    _entries.setPath.isEmpty ||
+                                    _checkingDuplicate;
+                                return Row(
+                                  children: [
+                                    Expanded(
+                                      child: TextField(
+                                        controller: _addController,
+                                        enabled: !addDisabled,
+                                        decoration: const InputDecoration(
+                                          labelText: 'Add knowledge entry',
+                                          isDense: true,
                                         ),
-                                ],
-                              );
-                            }),
+                                        onSubmitted: addDisabled
+                                            ? null
+                                            : (v) => _addEntry(v),
+                                      ),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    // Issue B: spinner during cross-page check.
+                                    _checkingDuplicate
+                                        ? const Padding(
+                                            padding: EdgeInsets.all(12),
+                                            child: SizedBox(
+                                              width: 16,
+                                              height: 16,
+                                              child: CircularProgressIndicator(
+                                                strokeWidth: 2,
+                                              ),
+                                            ),
+                                          )
+                                        : IconButton(
+                                            icon: const Icon(Icons.add),
+                                            tooltip: 'Add',
+                                            onPressed: addDisabled
+                                                ? null
+                                                : () => _addEntry(
+                                                    _addController.text,
+                                                  ),
+                                          ),
+                                  ],
+                                );
+                              },
+                            ),
                           ],
                           if (_entries.error != null)
                             Padding(
@@ -1044,9 +1077,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
                               child: Text(
                                 'Pending adds (${addedEntries.length})',
                                 style: widget.theme.textTheme.labelSmall
-                                    ?.copyWith(
-                                      color: scheme.onSurfaceVariant,
-                                    ),
+                                    ?.copyWith(color: scheme.onSurfaceVariant),
                               ),
                             ),
                             for (final entry in addedEntries)

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -377,6 +377,7 @@ class _KnowledgeCard extends StatefulWidget {
 }
 
 class _KnowledgeCardState extends State<_KnowledgeCard> {
+  final TextEditingController _characterSearch = TextEditingController();
   KnowledgeCharactersPage _characters = const KnowledgeCharactersPage();
   String? _selectedCharacter;
   KnowledgeEntriesPage _entries = const KnowledgeEntriesPage();
@@ -399,24 +400,39 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
       _pending.clear();
       _selectedCharacter = null;
       _entries = const KnowledgeEntriesPage();
+      _characterSearch.clear();
       _loadCharacters();
     }
   }
 
   @override
   void dispose() {
+    _characterSearch.dispose();
     _addController.dispose();
     super.dispose();
   }
 
-  Future<void> _loadCharacters() async {
+  Future<void> _loadCharacters({bool append = false}) async {
     final epoch = ++_reloadEpoch;
     setState(() => _loadingCharacters = true);
-    final page = await widget.notifier.loadKnowledgeCharacters();
+    final page = await widget.notifier.loadKnowledgeCharacters(
+      query: _characterSearch.text.trim(),
+      offset: append ? _characters.characters.length : 0,
+    );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loadingCharacters = false;
-      _characters = page;
+      if (!append) {
+        _characters = page;
+      } else {
+        _characters = KnowledgeCharactersPage(
+          characters: [..._characters.characters, ...page.characters],
+          total: page.total,
+          offset: page.offset,
+          limit: page.limit,
+          error: page.error,
+        );
+      }
     });
   }
 
@@ -425,12 +441,37 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
     setState(() {
       _selectedCharacter = name;
       _loadingEntries = true;
+      _entries = const KnowledgeEntriesPage();
     });
     final page = await widget.notifier.loadKnowledgeEntries(name);
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loadingEntries = false;
       _entries = page;
+    });
+  }
+
+  Future<void> _loadMoreEntries() async {
+    final character = _selectedCharacter;
+    if (character == null) return;
+    final epoch = ++_reloadEpoch;
+    setState(() => _loadingEntries = true);
+    final page = await widget.notifier.loadKnowledgeEntries(
+      character,
+      offset: _entries.entries.length,
+    );
+    if (!mounted || epoch != _reloadEpoch) return;
+    setState(() {
+      _loadingEntries = false;
+      _entries = KnowledgeEntriesPage(
+        character: page.character,
+        entries: [..._entries.entries, ...page.entries],
+        setPath: page.setPath,
+        total: page.total,
+        offset: page.offset,
+        limit: page.limit,
+        error: page.error,
+      );
     });
   }
 
@@ -534,19 +575,41 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
               ],
             ),
             const SizedBox(height: 12),
+            TextField(
+              controller: _characterSearch,
+              decoration: const InputDecoration(
+                labelText: 'Search NPCs',
+                prefixIcon: Icon(Icons.search),
+              ),
+              onSubmitted: (_) => _loadCharacters(),
+            ),
             if (_characters.error != null) ...[
-              Text(_characters.error!, style: TextStyle(color: scheme.error)),
               const SizedBox(height: 8),
+              Text(_characters.error!, style: TextStyle(color: scheme.error)),
             ],
+            const SizedBox(height: 8),
             // Character list (height-capped)
             SizedBox(
               height: 200,
-              child: _loadingCharacters
+              child: _loadingCharacters && _characters.characters.isEmpty
                   ? const Center(child: CircularProgressIndicator())
                   : ListView.separated(
-                      itemCount: _characters.characters.length,
+                      itemCount:
+                          _characters.characters.length +
+                          (_characters.hasMore ? 1 : 0),
                       separatorBuilder: (_, _) => const Divider(height: 1),
                       itemBuilder: (context, index) {
+                        if (index >= _characters.characters.length) {
+                          return TextButton(
+                            onPressed: _loadingCharacters
+                                ? null
+                                : () => _loadCharacters(append: true),
+                            child: Text(
+                              'Load more (${_characters.characters.length}'
+                              ' of ${_characters.total})',
+                            ),
+                          );
+                        }
                         final c = _characters.characters[index];
                         final isSelected = c.name == character;
                         return ListTile(
@@ -567,7 +630,7 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
               const SizedBox(height: 8),
               if (_entries.error != null)
                 Text(_entries.error!, style: TextStyle(color: scheme.error)),
-              if (_loadingEntries)
+              if (_loadingEntries && _entries.entries.isEmpty)
                 const Center(child: CircularProgressIndicator())
               else
                 Wrap(
@@ -611,6 +674,16 @@ class _KnowledgeCardState extends State<_KnowledgeCard> {
                       ),
                   ],
                 ),
+              if (_entries.hasMore) ...[
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: _loadingEntries ? null : _loadMoreEntries,
+                  child: Text(
+                    'Load more (${_entries.entries.length}'
+                    ' of ${_entries.total})',
+                  ),
+                ),
+              ],
               if (widget.editable) ...[
                 const SizedBox(height: 12),
                 Row(
@@ -662,6 +735,7 @@ class _EventsCard extends StatefulWidget {
 }
 
 class _EventsCardState extends State<_EventsCard> {
+  final TextEditingController _characterSearch = TextEditingController();
   MemoryCharactersPage _characters = const MemoryCharactersPage();
   String? _selectedCharacter;
   MemoryEventsPage _events = const MemoryEventsPage();
@@ -681,18 +755,38 @@ class _EventsCardState extends State<_EventsCard> {
     if (widget.reloadKey != oldWidget.reloadKey) {
       _selectedCharacter = null;
       _events = const MemoryEventsPage();
+      _characterSearch.clear();
       _loadCharacters();
     }
   }
 
-  Future<void> _loadCharacters() async {
+  @override
+  void dispose() {
+    _characterSearch.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadCharacters({bool append = false}) async {
     final epoch = ++_reloadEpoch;
     setState(() => _loadingCharacters = true);
-    final page = await widget.notifier.loadMemoryCharacters();
+    final page = await widget.notifier.loadMemoryCharacters(
+      query: _characterSearch.text.trim(),
+      offset: append ? _characters.characters.length : 0,
+    );
     if (!mounted || epoch != _reloadEpoch) return;
     setState(() {
       _loadingCharacters = false;
-      _characters = page;
+      if (!append) {
+        _characters = page;
+      } else {
+        _characters = MemoryCharactersPage(
+          characters: [..._characters.characters, ...page.characters],
+          total: page.total,
+          offset: page.offset,
+          limit: page.limit,
+          error: page.error,
+        );
+      }
     });
   }
 
@@ -788,19 +882,41 @@ class _EventsCardState extends State<_EventsCard> {
               ],
             ),
             const SizedBox(height: 12),
+            TextField(
+              controller: _characterSearch,
+              decoration: const InputDecoration(
+                labelText: 'Search characters',
+                prefixIcon: Icon(Icons.search),
+              ),
+              onSubmitted: (_) => _loadCharacters(),
+            ),
             if (_characters.error != null) ...[
-              Text(_characters.error!, style: TextStyle(color: scheme.error)),
               const SizedBox(height: 8),
+              Text(_characters.error!, style: TextStyle(color: scheme.error)),
             ],
+            const SizedBox(height: 8),
             // Character list (height-capped)
             SizedBox(
               height: 200,
-              child: _loadingCharacters
+              child: _loadingCharacters && _characters.characters.isEmpty
                   ? const Center(child: CircularProgressIndicator())
                   : ListView.separated(
-                      itemCount: _characters.characters.length,
+                      itemCount:
+                          _characters.characters.length +
+                          (_characters.hasMore ? 1 : 0),
                       separatorBuilder: (_, _) => const Divider(height: 1),
                       itemBuilder: (context, index) {
+                        if (index >= _characters.characters.length) {
+                          return TextButton(
+                            onPressed: _loadingCharacters
+                                ? null
+                                : () => _loadCharacters(append: true),
+                            child: Text(
+                              'Load more (${_characters.characters.length}'
+                              ' of ${_characters.total})',
+                            ),
+                          );
+                        }
                         final c = _characters.characters[index];
                         final isSelected = c.id == character;
                         return ListTile(

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -603,10 +603,14 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
   bool _loadingCharacters = false;
   bool _searchingCharacters = false;
   bool _loadingEntries = false;
-  int _reloadEpoch = 0;
+  // Per-loader epochs so a stale characters load never races an entries load.
+  int _charsEpoch = 0;
+  int _entriesEpoch = 0;
   int _charPageSize = _defaultPageSize;
   int _entryPageSize = _defaultPageSize;
   String _activeCharQuery = '';
+  // Used during the cross-page duplicate check in _addEntry.
+  bool _checkingDuplicate = false;
 
   @override
   void initState() {
@@ -623,6 +627,10 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
       _entries = const KnowledgeEntriesPage();
       _characterSearch.clear();
       _activeCharQuery = '';
+      // Invalidate both loaders so any in-flight call for the old reloadKey
+      // is treated as stale and exits without touching flags.
+      _charsEpoch++;
+      _entriesEpoch++;
       _loadCharacters(offset: 0);
     }
   }
@@ -639,7 +647,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
     bool newQuery = false,
   }) async {
     if (newQuery) _activeCharQuery = _characterSearch.text.trim();
-    final epoch = ++_reloadEpoch;
+    final epoch = ++_charsEpoch;
     setState(() {
       _loadingCharacters = true;
       if (newQuery) _searchingCharacters = true;
@@ -649,7 +657,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
       offset: offset,
       limit: _charPageSize,
     );
-    if (!mounted || epoch != _reloadEpoch) return;
+    if (!mounted || epoch != _charsEpoch) return;
     setState(() {
       _loadingCharacters = false;
       _searchingCharacters = false;
@@ -658,7 +666,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
   }
 
   Future<void> _selectCharacter(String name) async {
-    final epoch = ++_reloadEpoch;
+    final epoch = ++_entriesEpoch;
     setState(() {
       _selectedCharacter = name;
       _loadingEntries = true;
@@ -669,7 +677,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
       offset: 0,
       limit: _entryPageSize,
     );
-    if (!mounted || epoch != _reloadEpoch) return;
+    if (!mounted || epoch != _entriesEpoch) return;
     setState(() {
       _loadingEntries = false;
       _entries = page;
@@ -679,14 +687,14 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
   Future<void> _loadEntries({required int offset}) async {
     final character = _selectedCharacter;
     if (character == null) return;
-    final epoch = ++_reloadEpoch;
+    final epoch = ++_entriesEpoch;
     setState(() => _loadingEntries = true);
     final page = await widget.notifier.loadKnowledgeEntries(
       character,
       offset: offset,
       limit: _entryPageSize,
     );
-    if (!mounted || epoch != _reloadEpoch) return;
+    if (!mounted || epoch != _entriesEpoch) return;
     setState(() {
       _loadingEntries = false;
       _entries = page;
@@ -728,12 +736,32 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
     _pushPending();
   }
 
-  void _addEntry(String entry) {
+  Future<void> _addEntry(String entry) async {
+    // Issue C: defense-in-depth guard — setPath not yet loaded → reject.
+    if (_entries.setPath.isEmpty) return;
     final trimmed = entry.trim();
     if (trimmed.isEmpty) return;
+    // Fast path: already on the current page.
     if (_entries.entries.contains(trimmed)) return;
-    final key = _pendingKey(_selectedCharacter!, trimmed);
+    final character = _selectedCharacter!;
+    final key = _pendingKey(character, trimmed);
+    // Already in pending adds/removes.
     if (_pending.containsKey(key)) return;
+
+    // Issue B: cross-page duplicate check via a server query.
+    final checkCharacter = character;
+    final checkEpoch = _entriesEpoch;
+    setState(() => _checkingDuplicate = true);
+    final checkPage = await widget.notifier.loadKnowledgeEntries(
+      checkCharacter,
+      query: trimmed,
+      limit: 50,
+    );
+    if (!mounted || _selectedCharacter != checkCharacter || _entriesEpoch != checkEpoch) return;
+    setState(() => _checkingDuplicate = false);
+    // The core query is a lowercase-contains filter; verify exact equality.
+    if (checkPage.entries.any((e) => e == trimmed)) return;
+
     setState(() {
       _pending[key] = KnowledgeEntryEdit.add(
         setPath: _entries.setPath,
@@ -905,28 +933,54 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
                         ),
                         if (character != null) ...[
                           const SizedBox(height: 6),
-                          if (widget.editable)
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: TextField(
-                                    controller: _addController,
-                                    decoration: const InputDecoration(
-                                      labelText: 'Add knowledge entry',
-                                      isDense: true,
+                          if (widget.editable) ...[
+                            // Issue C: disabled while entries are loading or
+                            // the set path is not yet known.
+                            Builder(builder: (context) {
+                              final addDisabled =
+                                  _loadingEntries ||
+                                  _entries.setPath.isEmpty ||
+                                  _checkingDuplicate;
+                              return Row(
+                                children: [
+                                  Expanded(
+                                    child: TextField(
+                                      controller: _addController,
+                                      enabled: !addDisabled,
+                                      decoration: const InputDecoration(
+                                        labelText: 'Add knowledge entry',
+                                        isDense: true,
+                                      ),
+                                      onSubmitted: addDisabled
+                                          ? null
+                                          : (v) => _addEntry(v),
                                     ),
-                                    onSubmitted: _addEntry,
                                   ),
-                                ),
-                                const SizedBox(width: 8),
-                                IconButton(
-                                  icon: const Icon(Icons.add),
-                                  tooltip: 'Add',
-                                  onPressed: () =>
-                                      _addEntry(_addController.text),
-                                ),
-                              ],
-                            ),
+                                  const SizedBox(width: 8),
+                                  // Issue B: spinner during cross-page check.
+                                  _checkingDuplicate
+                                      ? const Padding(
+                                          padding: EdgeInsets.all(12),
+                                          child: SizedBox(
+                                            width: 16,
+                                            height: 16,
+                                            child: CircularProgressIndicator(
+                                              strokeWidth: 2,
+                                            ),
+                                          ),
+                                        )
+                                      : IconButton(
+                                          icon: const Icon(Icons.add),
+                                          tooltip: 'Add',
+                                          onPressed: addDisabled
+                                              ? null
+                                              : () =>
+                                                    _addEntry(_addController.text),
+                                        ),
+                                ],
+                              );
+                            }),
+                          ],
                           if (_entries.error != null)
                             Padding(
                               padding: const EdgeInsets.only(top: 4),
@@ -946,47 +1000,55 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
                             onPageSize: _setEntryPageSize,
                           ),
                           const SizedBox(height: 4),
-                          // Entries list — only scrollable in this pane
+                          // Issue E: pending adds in a separate labeled block
+                          // so the pagination bar unambiguously refers to the
+                          // saved entries below.
+                          if (addedEntries.isNotEmpty) ...[
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 4),
+                              child: Text(
+                                'Pending adds (${addedEntries.length})',
+                                style: widget.theme.textTheme.labelSmall
+                                    ?.copyWith(
+                                      color: scheme.onSurfaceVariant,
+                                    ),
+                              ),
+                            ),
+                            for (final entry in addedEntries)
+                              ListTile(
+                                dense: true,
+                                tileColor: scheme.tertiaryContainer.withValues(
+                                  alpha: 0.4,
+                                ),
+                                title: Text(
+                                  entry,
+                                  style: TextStyle(
+                                    color: scheme.onTertiaryContainer,
+                                  ),
+                                ),
+                                trailing: widget.editable
+                                    ? IconButton(
+                                        icon: const Icon(Icons.undo, size: 18),
+                                        tooltip: 'Undo add',
+                                        onPressed: () => _undoAdd(entry),
+                                      )
+                                    : null,
+                              ),
+                            const Divider(height: 8),
+                          ],
+                          // Saved entries list — the only scrollable in this
+                          // pane; pagination bar above refers only to this.
                           Expanded(
                             child: _loadingEntries && _entries.entries.isEmpty
                                 ? const Center(
                                     child: CircularProgressIndicator(),
                                   )
                                 : ListView.separated(
-                                    itemCount:
-                                        addedEntries.length +
-                                        _entries.entries.length,
+                                    itemCount: _entries.entries.length,
                                     separatorBuilder: (_, _) =>
                                         const Divider(height: 1),
                                     itemBuilder: (context, index) {
-                                      // Pending-add tiles at the top
-                                      if (index < addedEntries.length) {
-                                        final entry = addedEntries[index];
-                                        return ListTile(
-                                          dense: true,
-                                          tileColor: scheme.tertiaryContainer
-                                              .withValues(alpha: 0.4),
-                                          title: Text(
-                                            entry,
-                                            style: TextStyle(
-                                              color: scheme.onTertiaryContainer,
-                                            ),
-                                          ),
-                                          trailing: widget.editable
-                                              ? IconButton(
-                                                  icon: const Icon(
-                                                    Icons.undo,
-                                                    size: 18,
-                                                  ),
-                                                  tooltip: 'Undo add',
-                                                  onPressed: () =>
-                                                      _undoAdd(entry),
-                                                )
-                                              : null,
-                                        );
-                                      }
-                                      final entry = _entries
-                                          .entries[index - addedEntries.length];
+                                      final entry = _entries.entries[index];
                                       final isRemoved = removedEntries.contains(
                                         entry,
                                       );
@@ -1077,7 +1139,9 @@ class _EventsDetailState extends State<_EventsDetail> {
   bool _loadingCharacters = false;
   bool _searchingCharacters = false;
   bool _loadingEvents = false;
-  int _reloadEpoch = 0;
+  // Per-loader epochs so a stale characters load never races an events load.
+  int _charsEpoch = 0;
+  int _eventsEpoch = 0;
   int _charPageSize = _defaultPageSize;
   int _eventPageSize = _defaultPageSize;
   String _activeCharQuery = '';
@@ -1096,6 +1160,10 @@ class _EventsDetailState extends State<_EventsDetail> {
       _events = const MemoryEventsPage();
       _characterSearch.clear();
       _activeCharQuery = '';
+      // Invalidate both loaders so any in-flight call for the old reloadKey
+      // is treated as stale and exits without touching flags.
+      _charsEpoch++;
+      _eventsEpoch++;
       _loadCharacters(offset: 0);
     }
   }
@@ -1111,7 +1179,7 @@ class _EventsDetailState extends State<_EventsDetail> {
     bool newQuery = false,
   }) async {
     if (newQuery) _activeCharQuery = _characterSearch.text.trim();
-    final epoch = ++_reloadEpoch;
+    final epoch = ++_charsEpoch;
     setState(() {
       _loadingCharacters = true;
       if (newQuery) _searchingCharacters = true;
@@ -1121,7 +1189,7 @@ class _EventsDetailState extends State<_EventsDetail> {
       offset: offset,
       limit: _charPageSize,
     );
-    if (!mounted || epoch != _reloadEpoch) return;
+    if (!mounted || epoch != _charsEpoch) return;
     setState(() {
       _loadingCharacters = false;
       _searchingCharacters = false;
@@ -1130,7 +1198,7 @@ class _EventsDetailState extends State<_EventsDetail> {
   }
 
   Future<void> _selectCharacter(String id) async {
-    final epoch = ++_reloadEpoch;
+    final epoch = ++_eventsEpoch;
     setState(() {
       _selectedCharacter = id;
       _loadingEvents = true;
@@ -1141,7 +1209,7 @@ class _EventsDetailState extends State<_EventsDetail> {
       offset: 0,
       limit: _eventPageSize,
     );
-    if (!mounted || epoch != _reloadEpoch) return;
+    if (!mounted || epoch != _eventsEpoch) return;
     setState(() {
       _loadingEvents = false;
       _events = page;
@@ -1151,14 +1219,14 @@ class _EventsDetailState extends State<_EventsDetail> {
   Future<void> _loadEvents({required int offset}) async {
     final character = _selectedCharacter;
     if (character == null) return;
-    final epoch = ++_reloadEpoch;
+    final epoch = ++_eventsEpoch;
     setState(() => _loadingEvents = true);
     final page = await widget.notifier.loadMemoryEvents(
       character,
       offset: offset,
       limit: _eventPageSize,
     );
-    if (!mounted || epoch != _reloadEpoch) return;
+    if (!mounted || epoch != _eventsEpoch) return;
     setState(() {
       _loadingEvents = false;
       _events = page;

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -749,7 +749,13 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
     }
   }
 
-  String _pendingKey(String character, String entry) => '$character\t$entry';
+  /// UE Names compare case-insensitively, so the entry part of the pending
+  /// key is folded to lower case: an add and a remove that differ only in
+  /// casing address the same logical entry and toggle instead of coexisting
+  /// as conflicting setAdd + setRemove ops. The queued edit itself keeps the
+  /// caller's original casing.
+  String _pendingKey(String character, String entry) =>
+      '$character\t${entry.toLowerCase()}';
 
   void _removeEntry(String entry) {
     // Same guard as _addEntry: never queue an edit with an unloaded path.
@@ -781,13 +787,10 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
       return;
     }
     final character = _selectedCharacter!;
+    // _pendingKey folds the entry to lower case, so this single lookup is
+    // already case-insensitive.
     final key = _pendingKey(character, trimmed);
-    // Already in pending adds/removes (case-insensitive on the entry part).
-    final pendingPrefix = '$character\t'.toLowerCase();
-    if (_pending.containsKey(key) ||
-        _pending.keys.any(
-          (k) => k.toLowerCase() == '$pendingPrefix$trimmedLower',
-        )) {
+    if (_pending.containsKey(key)) {
       setState(() => _addError = 'Already in pending changes.');
       return;
     }

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -611,6 +611,8 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
   String _activeCharQuery = '';
   // Used during the cross-page duplicate check in _addEntry.
   bool _checkingDuplicate = false;
+  // Error text shown beneath the add field (duplicate-check failure, etc.).
+  String? _addError;
 
   @override
   void initState() {
@@ -622,16 +624,23 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
   void didUpdateWidget(covariant _KnowledgeDetail oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.reloadKey != oldWidget.reloadKey) {
+      // Pending edits belong to the old save — always clear them.
       _pending.clear();
-      _selectedCharacter = null;
-      _entries = const KnowledgeEntriesPage();
-      _characterSearch.clear();
-      _activeCharQuery = '';
       // Invalidate both loaders so any in-flight call for the old reloadKey
       // is treated as stale and exits without touching flags.
       _charsEpoch++;
       _entriesEpoch++;
+      _characterSearch.clear();
+      _activeCharQuery = '';
       _loadCharacters(offset: 0);
+      // Issue 3 fix (consistency): preserve the previously selected character
+      // so the entries pane does not drop to null on save-triggered reloads.
+      // Pending edits are cleared above so we just re-load the entries fresh.
+      if (_selectedCharacter != null) {
+        _selectCharacter(_selectedCharacter!);
+      } else {
+        _entries = const KnowledgeEntriesPage();
+      }
     }
   }
 
@@ -671,6 +680,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
       _selectedCharacter = name;
       _loadingEntries = true;
       _entries = const KnowledgeEntriesPage();
+      _addError = null;
     });
     final page = await widget.notifier.loadKnowledgeEntries(
       name,
@@ -751,14 +761,30 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
     // Issue B: cross-page duplicate check via a server query.
     final checkCharacter = character;
     final checkEpoch = _entriesEpoch;
-    setState(() => _checkingDuplicate = true);
-    final checkPage = await widget.notifier.loadKnowledgeEntries(
-      checkCharacter,
-      query: trimmed,
-      limit: 50,
-    );
+    setState(() {
+      _checkingDuplicate = true;
+      _addError = null;
+    });
+    KnowledgeEntriesPage checkPage;
+    try {
+      checkPage = await widget.notifier.loadKnowledgeEntries(
+        checkCharacter,
+        query: trimmed,
+        limit: 50,
+      );
+    } finally {
+      // Issue 1 fix: clear the lock on every exit path (unmount, stale, error).
+      if (mounted) setState(() => _checkingDuplicate = false);
+    }
     if (!mounted || _selectedCharacter != checkCharacter || _entriesEpoch != checkEpoch) return;
-    setState(() => _checkingDuplicate = false);
+    // Issue 2 fix: a failed query must NOT fall through to a pending add.
+    if (checkPage.error != null) {
+      setState(() {
+        _addError =
+            'Duplicate check failed — try again: ${checkPage.error}';
+      });
+      return;
+    }
     // The core query is a lowercase-contains filter; verify exact equality.
     if (checkPage.entries.any((e) => e == trimmed)) return;
 
@@ -768,6 +794,7 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
         entry: trimmed,
       );
       _addController.clear();
+      _addError = null;
     });
     _pushPending();
   }
@@ -989,6 +1016,14 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
                                 style: TextStyle(color: scheme.error),
                               ),
                             ),
+                          if (_addError != null)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: Text(
+                                _addError!,
+                                style: TextStyle(color: scheme.error),
+                              ),
+                            ),
                           const SizedBox(height: 4),
                           _PaginationBar(
                             offset: _entries.offset,
@@ -1156,15 +1191,23 @@ class _EventsDetailState extends State<_EventsDetail> {
   void didUpdateWidget(covariant _EventsDetail oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.reloadKey != oldWidget.reloadKey) {
-      _selectedCharacter = null;
-      _events = const MemoryEventsPage();
-      _characterSearch.clear();
-      _activeCharQuery = '';
+      // Issue 3 fix: preserve the previously selected character so the right
+      // pane does not fall back to "Select a character" after an event edit.
       // Invalidate both loaders so any in-flight call for the old reloadKey
       // is treated as stale and exits without touching flags.
       _charsEpoch++;
       _eventsEpoch++;
+      _characterSearch.clear();
+      _activeCharQuery = '';
       _loadCharacters(offset: 0);
+      // If a character was selected, re-trigger its events load (page reset to
+      // 0 is fine). If it has since been deleted the existing error rendering
+      // will handle it.
+      if (_selectedCharacter != null) {
+        _selectCharacter(_selectedCharacter!);
+      } else {
+        _events = const MemoryEventsPage();
+      }
     }
   }
 

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -1034,6 +1034,219 @@ void main() {
       expect(notifier.state.pendingEdits.containsKey('x'), isTrue);
     },
   );
+
+  // ---------------------------------------------------------------------------
+  // Profile switcher (selectProfile)
+  // ---------------------------------------------------------------------------
+
+  test(
+    'selectProfile filters visibleSaves and moves selection to that profile',
+    () async {
+      // Two profiles: profile 0 has G1R-001, profile 1 has G1R-002.
+      final core = _RecordingCoreService(
+        scanData: {
+          'saves': [
+            {
+              'path': r'C:\tmp\saves\G1R-001.sav',
+              'slot': 'G1R-001',
+              'format': 'GSAV',
+              'fileSize': 100,
+              'sha1': 'a',
+              'status': 'ok',
+              'playerSaveName': 'Save A',
+              'persistentProfileId': 0,
+            },
+            {
+              'path': r'C:\tmp\saves\G1R-002.sav',
+              'slot': 'G1R-002',
+              'format': 'GSAV',
+              'fileSize': 100,
+              'sha1': 'b',
+              'status': 'ok',
+              'playerSaveName': 'Save B',
+              'persistentProfileId': 1,
+            },
+          ],
+          'profiles': [
+            {
+              'profileId': 0,
+              'profileName': '0',
+              'quickSaveSlots': <String>[],
+              'autoSaveSlots': <String>[],
+              'savedSlots': ['G1R-001'],
+            },
+            {
+              'profileId': 1,
+              'profileName': '1',
+              'quickSaveSlots': <String>[],
+              'autoSaveSlots': <String>[],
+              'savedSlots': ['G1R-002'],
+            },
+          ],
+          'activeProfileId': 0,
+        },
+      );
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await pumpEventQueue();
+
+      // Initial selection should be profile 0's save (first after sort).
+      // Both profiles exist so visibleSaves should only show profile 0 saves.
+      expect(notifier.state.profiles.length, 2);
+      expect(
+        notifier.state.visibleSaves.map((s) => s.slot),
+        contains('G1R-001'),
+      );
+      expect(
+        notifier.state.visibleSaves.map((s) => s.slot),
+        isNot(contains('G1R-002')),
+      );
+
+      // Switch to profile 1.
+      await notifier.selectProfile(1);
+
+      // visibleSaves should now only show profile 1's save.
+      expect(
+        notifier.state.visibleSaves.map((s) => s.slot),
+        contains('G1R-002'),
+      );
+      expect(
+        notifier.state.visibleSaves.map((s) => s.slot),
+        isNot(contains('G1R-001')),
+      );
+      // Selection moved to profile 1's save.
+      expect(notifier.state.selectedPath, r'C:\tmp\saves\G1R-002.sav');
+    },
+  );
+
+  test(
+    'selectProfile with pending edits is blocked and sets an error',
+    () async {
+      final core = _RecordingCoreService(
+        scanData: {
+          'saves': [
+            {
+              'path': r'C:\tmp\saves\G1R-001.sav',
+              'slot': 'G1R-001',
+              'format': 'GSAV',
+              'fileSize': 100,
+              'sha1': 'a',
+              'status': 'ok',
+              'playerSaveName': 'Save A',
+              'persistentProfileId': 0,
+            },
+            {
+              'path': r'C:\tmp\saves\G1R-002.sav',
+              'slot': 'G1R-002',
+              'format': 'GSAV',
+              'fileSize': 100,
+              'sha1': 'b',
+              'status': 'ok',
+              'playerSaveName': 'Save B',
+              'persistentProfileId': 1,
+            },
+          ],
+          'profiles': [
+            {
+              'profileId': 0,
+              'profileName': '0',
+              'quickSaveSlots': <String>[],
+              'autoSaveSlots': <String>[],
+              'savedSlots': ['G1R-001'],
+            },
+            {
+              'profileId': 1,
+              'profileName': '1',
+              'quickSaveSlots': <String>[],
+              'autoSaveSlots': <String>[],
+              'savedSlots': ['G1R-002'],
+            },
+          ],
+          'activeProfileId': 0,
+        },
+      );
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await pumpEventQueue();
+
+      notifier.setPendingEdit(
+        'publicName',
+        const PendingSaveEdit(
+          edits: [
+            {'path': 'public.m_PlayerSaveName', 'value': 'Draft'},
+          ],
+        ),
+      );
+
+      final profileBefore = notifier.state.selectedProfileId;
+      await notifier.selectProfile(1);
+
+      // Profile must not have changed.
+      expect(notifier.state.selectedProfileId, profileBefore);
+      // An error must be set.
+      expect(notifier.state.error, isNotNull);
+      expect(notifier.state.error, contains('unsaved changes'));
+    },
+  );
+
+  test(
+    'refresh keeps selectedProfileId when the profile still exists',
+    () async {
+      final core = _RecordingCoreService(
+        scanData: {
+          'saves': [
+            {
+              'path': r'C:\tmp\saves\G1R-001.sav',
+              'slot': 'G1R-001',
+              'format': 'GSAV',
+              'fileSize': 100,
+              'sha1': 'a',
+              'status': 'ok',
+              'playerSaveName': 'Save A',
+              'persistentProfileId': 0,
+            },
+            {
+              'path': r'C:\tmp\saves\G1R-002.sav',
+              'slot': 'G1R-002',
+              'format': 'GSAV',
+              'fileSize': 100,
+              'sha1': 'b',
+              'status': 'ok',
+              'playerSaveName': 'Save B',
+              'persistentProfileId': 1,
+            },
+          ],
+          'profiles': [
+            {
+              'profileId': 0,
+              'profileName': '0',
+              'quickSaveSlots': <String>[],
+              'autoSaveSlots': <String>[],
+              'savedSlots': ['G1R-001'],
+            },
+            {
+              'profileId': 1,
+              'profileName': '1',
+              'quickSaveSlots': <String>[],
+              'autoSaveSlots': <String>[],
+              'savedSlots': ['G1R-002'],
+            },
+          ],
+          'activeProfileId': 0,
+        },
+      );
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await pumpEventQueue();
+
+      // Select profile 1 explicitly.
+      await notifier.selectProfile(1);
+      expect(notifier.state.selectedProfileId, 1);
+
+      // Refresh — profile 1 still exists in scan data.
+      await notifier.refresh();
+
+      // selectedProfileId must be preserved.
+      expect(notifier.state.selectedProfileId, 1);
+    },
+  );
 }
 
 class _MemoryEditorSettingsStore implements EditorSettingsStore {

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -809,6 +809,73 @@ void main() {
       });
     },
   );
+
+  // ---------------------------------------------------------------------------
+  // Progression query methods (Task 9)
+  // ---------------------------------------------------------------------------
+
+  test('loadProgressionQuests queries the core and parses the page', () async {
+    final core = _RecordingCoreService(
+      progressionData: {
+        'section': 'quests',
+        'total': 1,
+        'offset': 0,
+        'limit': 100,
+        'count': 1,
+        'stateCounts': {'Running': 1},
+        'quests': [
+          {
+            'questClass': '/Script/Angelscript.Quest_X',
+            'id': 'Quest_X',
+            'group': 'X',
+            'name': '',
+            'currentState': 'EQuestState::Running',
+            'statePath': [
+              'QuestDataByClass',
+              '{/Script/Angelscript.Quest_X}',
+              'CurrentState',
+            ],
+            'writable': true,
+          },
+        ],
+      },
+    );
+    final notifier = EditorNotifier(
+      core,
+      saveDir: r'C:\tmp\saves',
+      codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+      gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+    );
+    await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+    final page = await notifier.loadProgressionQuests(query: 'x');
+
+    expect(page.error, isNull);
+    expect(page.quests.single.id, 'Quest_X');
+    final call = core.requests.singleWhere(
+      (r) => r.command == 'query_progression',
+    );
+    expect(call.payload['section'], 'quests');
+    expect(call.payload['query'], 'x');
+    expect(call.payload['path'], r'C:\tmp\saves\G1R-001.sav');
+  });
+
+  test('progression loaders surface core errors inline', () async {
+    // The default _RecordingCoreService returns ok:false for query_progression
+    // (no progressionData set), so the loader should surface the error inline.
+    final core = _RecordingCoreService();
+    final notifier = EditorNotifier(
+      core,
+      saveDir: r'C:\tmp\saves',
+      codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+      gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+    );
+    await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+    final page = await notifier.loadKnowledgeCharacters();
+
+    expect(page.error, isNotNull);
+  });
 }
 
 class _MemoryEditorSettingsStore implements EditorSettingsStore {
@@ -839,6 +906,7 @@ class _RecordingCoreService implements GoresaveCoreService {
     this.codecCanCompress = true,
     this.typedSearchData,
     this.typedSearchPages,
+    this.progressionData,
   }) : scanData = scanData ?? {'saves': <Object?>[]};
 
   final Map<String, Object?> scanData;
@@ -850,6 +918,11 @@ class _RecordingCoreService implements GoresaveCoreService {
   /// [typedSearchData]. The last page repeats if called more often.
   final List<Map<String, Object?>>? typedSearchPages;
   var _typedSearchCalls = 0;
+
+  /// Canned response data for query_progression. When null the command falls
+  /// through to the default unhandled-command error response.
+  final Map<String, Object?>? progressionData;
+
   final requests = <_RecordedRequest>[];
 
   @override
@@ -1007,6 +1080,14 @@ class _RecordingCoreService implements GoresaveCoreService {
             'adapter': 'g1r_binary_host',
             'message': 'G1R codec host is configured.',
           },
+        };
+      case 'query_progression':
+        if (progressionData != null) {
+          return {'ok': true, 'data': progressionData!};
+        }
+        return {
+          'ok': false,
+          'error': {'message': 'Unhandled command $command'},
         };
       default:
         return {

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -5,6 +5,7 @@ import 'package:goresave/features/editor/domain/core_service.dart';
 import 'package:goresave/features/editor/domain/editor_notifier.dart';
 import 'package:goresave/features/editor/domain/editor_settings_store.dart';
 import 'package:goresave/features/editor/domain/pending_edits.dart';
+import 'package:goresave/features/editor/domain/progression_models.dart';
 
 void main() {
   test('uses persisted editor paths before defaults', () {
@@ -265,7 +266,11 @@ void main() {
           edits: [
             {
               'path': 'private.player.setAttribute',
-              'value': {'id': 'Health', 'baseValue': 77.0, 'currentValue': 66.0},
+              'value': {
+                'id': 'Health',
+                'baseValue': 77.0,
+                'currentValue': 66.0,
+              },
             },
           ],
         ),
@@ -295,10 +300,7 @@ void main() {
     'saveAllPending sets syncPersistentDataList true when any edit requests it',
     () async {
       final core = _RecordingCoreService();
-      final notifier = EditorNotifier(
-        core,
-        saveDir: r'C:\tmp\saves',
-      );
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
       await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
 
       notifier.setPendingEdit(
@@ -316,7 +318,11 @@ void main() {
           edits: [
             {
               'path': 'private.player.setAttribute',
-              'value': {'id': 'Health', 'baseValue': 80.0, 'currentValue': 80.0},
+              'value': {
+                'id': 'Health',
+                'baseValue': 80.0,
+                'currentValue': 80.0,
+              },
             },
           ],
         ),
@@ -324,9 +330,7 @@ void main() {
 
       await notifier.saveAllPending();
 
-      final write = core.requests.lastWhere(
-        (r) => r.command == 'write_save',
-      );
+      final write = core.requests.lastWhere((r) => r.command == 'write_save');
       expect(write.payload['syncPersistentDataList'], isTrue);
       expect(write.payload['backup'], isTrue);
     },
@@ -412,47 +416,46 @@ void main() {
     expect(notifier.state.pendingEdits, isEmpty);
   });
 
-  test('saveAllPending refuses conflicting edits for the same typed path',
-      () async {
-    final core = _RecordingCoreService();
-    final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
-    await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+  test(
+    'saveAllPending refuses conflicting edits for the same typed path',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
 
-    const path = ['m_GenericData', '{X}', 'BaseValue'];
-    notifier.setPendingEdit(
-      'heroStats',
-      const PendingSaveEdit(
-        edits: [
-          {
-            'path': 'private.typed.setValue',
-            'value': {'path': path, 'value': 1.0},
-          },
-        ],
-      ),
-    );
-    notifier.setPendingEdit(
-      'typed:m_GenericData {X} BaseValue',
-      const PendingSaveEdit(
-        edits: [
-          {
-            'path': 'private.typed.setValue',
-            'value': {'path': path, 'value': 2.0},
-          },
-        ],
-      ),
-    );
+      const path = ['m_GenericData', '{X}', 'BaseValue'];
+      notifier.setPendingEdit(
+        'heroStats',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {'path': path, 'value': 1.0},
+            },
+          ],
+        ),
+      );
+      notifier.setPendingEdit(
+        'typed:m_GenericData {X} BaseValue',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {'path': path, 'value': 2.0},
+            },
+          ],
+        ),
+      );
 
-    final ok = await notifier.saveAllPending();
+      final ok = await notifier.saveAllPending();
 
-    expect(ok, isFalse);
-    expect(notifier.state.error, contains('Conflicting'));
-    expect(
-      core.requests.where((r) => r.command == 'write_save'),
-      isEmpty,
-    );
-    // Both pending entries survive so the user can resolve the conflict.
-    expect(notifier.state.pendingEdits.length, 2);
-  });
+      expect(ok, isFalse);
+      expect(notifier.state.error, contains('Conflicting'));
+      expect(core.requests.where((r) => r.command == 'write_save'), isEmpty);
+      // Both pending entries survive so the user can resolve the conflict.
+      expect(notifier.state.pendingEdits.length, 2);
+    },
+  );
 
   test('failed same-save re-inspect keeps pending edits retryable', () async {
     final core = _FailingSecondInspectCoreService();
@@ -501,7 +504,10 @@ void main() {
         edits: [
           {
             'path': 'private.typed.setValue',
-            'value': {'path': ['MaxHealth'], 'value': 99.0},
+            'value': {
+              'path': ['MaxHealth'],
+              'value': 99.0,
+            },
           },
         ],
       ),
@@ -511,8 +517,11 @@ void main() {
     // Toolbar Refresh — same selected path stays selected.
     await notifier.refresh();
 
-    expect(notifier.state.pendingEdits, isEmpty,
-        reason: 'refresh() must clear ALL pending edits');
+    expect(
+      notifier.state.pendingEdits,
+      isEmpty,
+      reason: 'refresh() must clear ALL pending edits',
+    );
   });
 
   test('restoreBackup() clears all pending edits via refresh()', () async {
@@ -532,8 +541,11 @@ void main() {
 
     await notifier.restoreBackup(r'C:\tmp\saves\G1R-001.sav.bak.200');
 
-    expect(notifier.state.pendingEdits, isEmpty,
-        reason: 'restoreBackup() must clear pending edits via refresh()');
+    expect(
+      notifier.state.pendingEdits,
+      isEmpty,
+      reason: 'restoreBackup() must clear pending edits via refresh()',
+    );
   });
 
   test('pendingEditCount on EditorState counts individual edits', () async {
@@ -548,11 +560,17 @@ void main() {
         edits: [
           {
             'path': 'private.typed.setValue',
-            'value': {'path': ['MaxHealth'], 'value': 99.0},
+            'value': {
+              'path': ['MaxHealth'],
+              'value': 99.0,
+            },
           },
           {
             'path': 'private.typed.setValue',
-            'value': {'path': ['Strength'], 'value': 20.0},
+            'value': {
+              'path': ['Strength'],
+              'value': 20.0,
+            },
           },
         ],
       ),
@@ -719,69 +737,71 @@ void main() {
     expect(result.attributes.single.id, 'MaxHealth');
   });
 
-  test('loadHeroAttributes pages through results beyond the search cap',
-      () async {
-    Map<String, Object?> heroHit(String id, String leaf, String value) => {
-          'path': [
-            'm_GenericData',
-            '{CharacterStates}',
-            'AnyCharacterType',
-            'AttributesByGlobalId',
-            '{Hero}',
-            'AttributeSetsByClass',
-            '{/Script/G1R.AttributeSet_Health}',
-            'Attributes',
-            '{$id}',
-            leaf,
-          ],
-          'display': '…',
-          'type': 'FloatProperty',
-          'value': value,
-          'editable': true,
-        };
-    final core = _RecordingCoreService(
-      typedSearchPages: [
-        {
-          'query': 'AttributesByGlobalId {Hero}',
-          'offset': 0,
-          'limit': 1000,
-          'total': 2,
-          'count': 1,
-          'results': [heroHit('MaxHealth', 'BaseValue', '64')],
-        },
-        {
-          'query': 'AttributesByGlobalId {Hero}',
-          'offset': 1,
-          'limit': 1000,
-          'total': 2,
-          'count': 1,
-          'results': [heroHit('MaxHealth', 'CurrentValue', '64')],
-        },
-      ],
-    );
-    final notifier = EditorNotifier(
-      core,
-      saveDir: r'C:\tmp\saves',
-      codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
-      gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
-    );
-    await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+  test(
+    'loadHeroAttributes pages through results beyond the search cap',
+    () async {
+      Map<String, Object?> heroHit(String id, String leaf, String value) => {
+        'path': [
+          'm_GenericData',
+          '{CharacterStates}',
+          'AnyCharacterType',
+          'AttributesByGlobalId',
+          '{Hero}',
+          'AttributeSetsByClass',
+          '{/Script/G1R.AttributeSet_Health}',
+          'Attributes',
+          '{$id}',
+          leaf,
+        ],
+        'display': '…',
+        'type': 'FloatProperty',
+        'value': value,
+        'editable': true,
+      };
+      final core = _RecordingCoreService(
+        typedSearchPages: [
+          {
+            'query': 'AttributesByGlobalId {Hero}',
+            'offset': 0,
+            'limit': 1000,
+            'total': 2,
+            'count': 1,
+            'results': [heroHit('MaxHealth', 'BaseValue', '64')],
+          },
+          {
+            'query': 'AttributesByGlobalId {Hero}',
+            'offset': 1,
+            'limit': 1000,
+            'total': 2,
+            'count': 1,
+            'results': [heroHit('MaxHealth', 'CurrentValue', '64')],
+          },
+        ],
+      );
+      final notifier = EditorNotifier(
+        core,
+        saveDir: r'C:\tmp\saves',
+        codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+        gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+      );
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
 
-    final result = await notifier.loadHeroAttributes();
+      final result = await notifier.loadHeroAttributes();
 
-    final searches = core.requests
-        .where((request) => request.command == 'search_typed_properties')
-        .toList();
-    expect(searches, hasLength(2));
-    expect(searches[0].payload['offset'], 0);
-    expect(searches[1].payload['offset'], 1);
-    expect(result.error, isNull);
-    // Both pages were folded into one fully paired attribute.
-    final attribute = result.attributes.single;
-    expect(attribute.id, 'MaxHealth');
-    expect(attribute.baseValue, 64);
-    expect(attribute.currentValue, 64);
-  });
+      final searches = core.requests
+          .where((request) => request.command == 'search_typed_properties')
+          .toList();
+      expect(searches, hasLength(2));
+      expect(searches[0].payload['offset'], 0);
+      expect(searches[1].payload['offset'], 1);
+      expect(result.error, isNull);
+      // Both pages were folded into one fully paired attribute.
+      final attribute = result.attributes.single;
+      expect(attribute.id, 'MaxHealth');
+      expect(attribute.baseValue, 64);
+      expect(attribute.currentValue, 64);
+    },
+  );
 
   test(
     'validateCodecRoundtrip sends selected save and binary host paths',
@@ -876,6 +896,54 @@ void main() {
 
     expect(page.error, isNotNull);
   });
+
+  test(
+    'applyMemoryEventEdit is blocked and sets error when pendingEdits is non-empty',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(
+        core,
+        saveDir: r'C:\tmp\saves',
+        codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+        gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+      );
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      // Seed a pending edit (e.g. an unsaved quest-state change).
+      notifier.setPendingEdit(
+        'x',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {
+                'path': ['CurrentState'],
+                'value': 'EQuestState::None',
+              },
+            },
+          ],
+        ),
+      );
+
+      final writesBefore = core.requests
+          .where((r) => r.command == 'write_save')
+          .length;
+
+      final result = await notifier.applyMemoryEventEdit(
+        MemoryEventEdit.remove(arrayPath: const ['MemorizedEvents'], index: 0),
+      );
+
+      expect(result, isFalse);
+      expect(notifier.state.error, isNotNull);
+      // No write_save must have been issued.
+      final writesAfter = core.requests
+          .where((r) => r.command == 'write_save')
+          .length;
+      expect(writesAfter, writesBefore);
+      // Pending edit must still be intact.
+      expect(notifier.state.pendingEdits.containsKey('x'), isTrue);
+    },
+  );
 }
 
 class _MemoryEditorSettingsStore implements EditorSettingsStore {
@@ -1046,7 +1114,8 @@ class _RecordingCoreService implements GoresaveCoreService {
         }
         return {
           'ok': true,
-          'data': typedSearchData ??
+          'data':
+              typedSearchData ??
               {
                 'query': '',
                 'offset': 0,
@@ -1106,7 +1175,9 @@ class _FailingWriteCoreService extends _RecordingCoreService {
     Map<String, Object?> payload = const {},
   }) async {
     if (command == 'write_save') {
-      requests.add(_RecordedRequest(command, Map<String, Object?>.from(payload)));
+      requests.add(
+        _RecordedRequest(command, Map<String, Object?>.from(payload)),
+      );
       return {
         'ok': false,
         'error': {'message': 'write failed'},
@@ -1169,7 +1240,9 @@ class _FailingVerifyCoreService extends _RecordingCoreService {
     Map<String, Object?> payload = const {},
   }) async {
     if (command == 'validate_codec_roundtrip') {
-      requests.add(_RecordedRequest(command, Map<String, Object?>.from(payload)));
+      requests.add(
+        _RecordedRequest(command, Map<String, Object?>.from(payload)),
+      );
       return {
         'ok': false,
         'error': {

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -943,6 +943,51 @@ void main() {
   });
 
   test(
+    'applyMemoryEventEdit is blocked and sets error when isLoading is true',
+    () async {
+      // Use a slow write to hold the notifier in isLoading state, then verify
+      // that a concurrent applyMemoryEventEdit sets a user-visible error.
+      final gate = Completer<void>();
+      final core = _SlowWriteCoreService(gate.future);
+      final notifier = EditorNotifier(
+        core,
+        saveDir: r'C:\tmp\saves',
+        codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+        gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+      );
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+      notifier.setPendingEdit(
+        'x',
+        const PendingSaveEdit(
+          edits: [
+            {'path': 'public.m_PlayerSaveName', 'value': 'Slow'},
+          ],
+        ),
+      );
+
+      // Start a write that will stall — notifier is now isLoading.
+      final writeFuture = notifier.saveAllPending();
+      expect(notifier.state.isLoading, isTrue);
+
+      // applyMemoryEventEdit must refuse and set an error while loading.
+      final result = await notifier.applyMemoryEventEdit(
+        MemoryEventEdit.remove(arrayPath: const ['MemorizedEvents'], index: 0),
+      );
+
+      expect(result, isFalse);
+      expect(notifier.state.error, isNotNull);
+      expect(
+        notifier.state.error,
+        contains('Another operation is in progress'),
+      );
+
+      // Unblock the write so the test can cleanly complete.
+      gate.complete();
+      await writeFuture;
+    },
+  );
+
+  test(
     'applyMemoryEventEdit is blocked and sets error when pendingEdits is non-empty',
     () async {
       final core = _RecordingCoreService();

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -880,6 +880,51 @@ void main() {
     expect(call.payload['path'], r'C:\tmp\saves\G1R-001.sav');
   });
 
+  test(
+    'loadProgressionQuests passes state and group params to the core',
+    () async {
+      final core = _RecordingCoreService(
+        progressionData: {
+          'section': 'quests',
+          'total': 0,
+          'offset': 0,
+          'limit': 50,
+          'count': 0,
+          'stateCounts': <String, Object?>{},
+          'groupCounts': <String, Object?>{},
+          'quests': <Object?>[],
+        },
+      );
+      final notifier = EditorNotifier(
+        core,
+        saveDir: r'C:\tmp\saves',
+        codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+        gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+      );
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      await notifier.loadProgressionQuests(
+        state: 'Running',
+        group: 'OldCamp',
+        limit: 50,
+      );
+
+      final call = core.requests.lastWhere(
+        (r) => r.command == 'query_progression',
+      );
+      expect(call.payload['state'], 'Running');
+      expect(call.payload['group'], 'OldCamp');
+
+      // Null/empty filters must NOT appear in the payload.
+      await notifier.loadProgressionQuests(limit: 50);
+      final callNoFilter = core.requests.lastWhere(
+        (r) => r.command == 'query_progression',
+      );
+      expect(callNoFilter.payload.containsKey('state'), isFalse);
+      expect(callNoFilter.payload.containsKey('group'), isFalse);
+    },
+  );
+
   test('progression loaders surface core errors inline', () async {
     // The default _RecordingCoreService returns ok:false for query_progression
     // (no progressionData set), so the loader should surface the error inline.

--- a/apps/goresave/test/features/editor/domain/editor_models_test.dart
+++ b/apps/goresave/test/features/editor/domain/editor_models_test.dart
@@ -309,7 +309,7 @@ void main() {
     ]);
   });
 
-  test('SaveInspection reads typed private progression summary', () {
+  test('SaveInspection reads structured progression overview', () {
     final inspection = SaveInspection.fromJson({
       'format': 'GSAV',
       'path': r'C:\saves\G1R-001.sav',
@@ -319,41 +319,30 @@ void main() {
       'private': {
         'status': 'decoded',
         'progression': {
-          'candidateCount': 3,
-          'candidates': [
-            'Quest.Main.Chapter01',
-            'Dialog.Diego.IntroDone',
-            'Knowledge.OldCamp.PathKnown',
-          ],
-          'gameplayTags': ['Quest.Main.Chapter01', 'Dialog.Diego.IntroDone'],
-          'sections': ['Generated events', 'Memorized events'],
-          'scriptPaths': ['/Script/G1R.QuestSaveGameData'],
-          'properties': ['m_GeneratedEvents', 'm_MemorizedEvents'],
+          'status': 'ok',
+          'questTotal': 707,
+          'questStates': {'Available': 700, 'Running': 5, 'Succeeded': 2},
+          'knowledgeCharacters': 12,
+          'knowledgeEntries': 340,
+          'memoryCharacters': 3,
+          'memoryEvents': 1500,
+          'writable': ['private.typed.setValue', 'private.typed.setAdd'],
         },
       },
     });
 
-    expect(inspection.privateProgression.candidateCount, 3);
-    expect(inspection.privateProgression.candidates, [
-      'Quest.Main.Chapter01',
-      'Dialog.Diego.IntroDone',
-      'Knowledge.OldCamp.PathKnown',
-    ]);
-    expect(inspection.privateProgression.gameplayTags, [
-      'Quest.Main.Chapter01',
-      'Dialog.Diego.IntroDone',
-    ]);
-    expect(inspection.privateProgression.sections, [
-      'Generated events',
-      'Memorized events',
-    ]);
-    expect(inspection.privateProgression.scriptPaths, [
-      '/Script/G1R.QuestSaveGameData',
-    ]);
-    expect(inspection.privateProgression.properties, [
-      'm_GeneratedEvents',
-      'm_MemorizedEvents',
-    ]);
+    expect(inspection.privateProgression.status, 'ok');
+    expect(inspection.privateProgression.available, isTrue);
+    expect(inspection.privateProgression.questTotal, 707);
+    expect(inspection.privateProgression.questStates['Running'], 5);
+    expect(inspection.privateProgression.knowledgeCharacters, 12);
+    expect(inspection.privateProgression.knowledgeEntries, 340);
+    expect(inspection.privateProgression.memoryCharacters, 3);
+    expect(inspection.privateProgression.memoryEvents, 1500);
+    expect(
+      inspection.privateProgression.writable,
+      contains('private.typed.setAdd'),
+    );
   });
 
   test('SaveInspection treats decoded preview as usable private data', () {

--- a/apps/goresave/test/features/editor/progression_models_test.dart
+++ b/apps/goresave/test/features/editor/progression_models_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/progression_models.dart';
+
+void main() {
+  test('ProgressionOverview parses inspect json', () {
+    final overview = ProgressionOverview.fromJson({
+      'status': 'ok',
+      'questTotal': 707,
+      'questStates': {'Available': 700, 'Running': 5, 'Succeeded': 2},
+      'knowledgeCharacters': 12,
+      'knowledgeEntries': 340,
+      'memoryCharacters': 3,
+      'memoryEvents': 1500,
+      'writable': ['private.typed.setValue', 'private.typed.setAdd'],
+    });
+    expect(overview.status, 'ok');
+    expect(overview.available, isTrue);
+    expect(overview.questTotal, 707);
+    expect(overview.questStates['Running'], 5);
+    expect(overview.knowledgeCharacters, 12);
+    expect(overview.memoryEvents, 1500);
+    expect(overview.writable, contains('private.typed.setAdd'));
+
+    final unavailable = ProgressionOverview.fromJson({'status': 'unavailable'});
+    expect(unavailable.available, isFalse);
+  });
+
+  test('ProgressionQuestPage parses query json', () {
+    final page = ProgressionQuestPage.fromJson({
+      'total': 2,
+      'offset': 0,
+      'limit': 100,
+      'stateCounts': {'Available': 1, 'Running': 1},
+      'quests': [
+        {
+          'questClass': '/Script/Angelscript.Quest_OldCamp_SLEEPER',
+          'id': 'Quest_OldCamp_SLEEPER',
+          'group': 'OldCamp',
+          'name': 'SLEEPER',
+          'currentState': 'EQuestState::Running',
+          'statePath': [
+            'QuestDataByClass',
+            '{/Script/Angelscript.Quest_OldCamp_SLEEPER}',
+            'CurrentState',
+          ],
+          'writable': true,
+        },
+      ],
+    });
+    expect(page.total, 2);
+    expect(page.quests.single.group, 'OldCamp');
+    expect(page.quests.single.currentState, 'EQuestState::Running');
+    expect(page.quests.single.writable, isTrue);
+    expect(page.quests.single.statePath, hasLength(3));
+  });
+
+  test('edit intents emit core edit json', () {
+    final questEdit = QuestStateChange(
+      statePath: const ['QuestDataByClass', '{X}', 'CurrentState'],
+      state: 'EQuestState::Succeeded',
+    );
+    expect(questEdit.toEditJson(), {
+      'path': 'private.typed.setValue',
+      'value': {
+        'path': ['QuestDataByClass', '{X}', 'CurrentState'],
+        'value': 'EQuestState::Succeeded',
+      },
+    });
+
+    final add = KnowledgeEntryEdit.add(
+      setPath: const ['CharacterKnowledgeByUniqueName', '{Diego}', 'Knowledge'],
+      entry: 'Voiceline_X',
+    );
+    expect(add.toEditJson(), {
+      'path': 'private.typed.setAdd',
+      'value': {
+        'path': ['CharacterKnowledgeByUniqueName', '{Diego}', 'Knowledge'],
+        'value': 'Voiceline_X',
+      },
+    });
+
+    final remove = KnowledgeEntryEdit.remove(
+      setPath: const ['CharacterKnowledgeByUniqueName', '{Diego}', 'Knowledge'],
+      entry: 'Voiceline_X',
+    );
+    expect(remove.toEditJson()['path'], 'private.typed.setRemove');
+
+    final removeEvent = MemoryEventEdit.remove(
+      arrayPath: const ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+      index: 4,
+    );
+    expect(removeEvent.toEditJson(), {
+      'path': 'private.typed.arrayRemove',
+      'value': {
+        'path': ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+        'index': 4,
+      },
+    });
+
+    final duplicate = MemoryEventEdit.duplicate(
+      arrayPath: const ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+      index: 4,
+    );
+    expect(duplicate.toEditJson()['path'], 'private.typed.arrayDuplicate');
+  });
+
+  test('knowledge and event pages parse', () {
+    final chars = KnowledgeCharactersPage.fromJson({
+      'total': 1,
+      'offset': 0,
+      'limit': 100,
+      'characters': [
+        {'name': 'OC_STT_Diego', 'entryCount': 2},
+      ],
+    });
+    expect(chars.characters.single.name, 'OC_STT_Diego');
+
+    final entries = KnowledgeEntriesPage.fromJson({
+      'character': 'OC_STT_Diego',
+      'total': 2,
+      'offset': 0,
+      'limit': 200,
+      'entries': ['A', 'B'],
+      'setPath': ['CharacterKnowledgeByUniqueName', '{OC_STT_Diego}', 'Knowledge'],
+    });
+    expect(entries.entries, ['A', 'B']);
+    expect(entries.setPath, hasLength(3));
+
+    final events = MemoryEventsPage.fromJson({
+      'character': 'Hero',
+      'total': 1,
+      'offset': 0,
+      'limit': 100,
+      'events': [
+        {
+          'index': 0,
+          'tags': ['Memory.Quest.Started'],
+          'timeSeconds': 12.5,
+          'affected': 'Hero',
+        },
+      ],
+      'arrayPath': ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+    });
+    expect(events.events.single.tags, ['Memory.Quest.Started']);
+    expect(events.events.single.timeSeconds, 12.5);
+  });
+}

--- a/apps/goresave/test/features/editor/progression_models_test.dart
+++ b/apps/goresave/test/features/editor/progression_models_test.dart
@@ -31,6 +31,7 @@ void main() {
       'offset': 0,
       'limit': 100,
       'stateCounts': {'Available': 1, 'Running': 1},
+      'groupCounts': {'BanditsCamp': 1, 'OldCamp': 1},
       'quests': [
         {
           'questClass': '/Script/Angelscript.Quest_OldCamp_SLEEPER',
@@ -52,6 +53,18 @@ void main() {
     expect(page.quests.single.currentState, 'EQuestState::Running');
     expect(page.quests.single.writable, isTrue);
     expect(page.quests.single.statePath, hasLength(3));
+    // groupCounts parsing.
+    expect(page.groupCounts['BanditsCamp'], 1);
+    expect(page.groupCounts['OldCamp'], 1);
+    // Defaults to empty when absent.
+    final noGroups = ProgressionQuestPage.fromJson({
+      'total': 0,
+      'offset': 0,
+      'limit': 100,
+      'stateCounts': <String, Object?>{},
+      'quests': <Object?>[],
+    });
+    expect(noGroups.groupCounts, isEmpty);
   });
 
   test('edit intents emit core edit json', () {
@@ -86,7 +99,11 @@ void main() {
     expect(remove.toEditJson()['path'], 'private.typed.setRemove');
 
     final removeEvent = MemoryEventEdit.remove(
-      arrayPath: const ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+      arrayPath: const [
+        'LongTermMemoryByGlobalId',
+        '{Hero}',
+        'MemorizedEvents',
+      ],
       index: 4,
     );
     expect(removeEvent.toEditJson(), {
@@ -98,7 +115,11 @@ void main() {
     });
 
     final duplicate = MemoryEventEdit.duplicate(
-      arrayPath: const ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+      arrayPath: const [
+        'LongTermMemoryByGlobalId',
+        '{Hero}',
+        'MemorizedEvents',
+      ],
       index: 4,
     );
     expect(duplicate.toEditJson()['path'], 'private.typed.arrayDuplicate');
@@ -121,7 +142,11 @@ void main() {
       'offset': 0,
       'limit': 200,
       'entries': ['A', 'B'],
-      'setPath': ['CharacterKnowledgeByUniqueName', '{OC_STT_Diego}', 'Knowledge'],
+      'setPath': [
+        'CharacterKnowledgeByUniqueName',
+        '{OC_STT_Diego}',
+        'Knowledge',
+      ],
     });
     expect(entries.entries, ['A', 'B']);
     expect(entries.setPath, hasLength(3));

--- a/apps/goresave/test/widget_test.dart
+++ b/apps/goresave/test/widget_test.dart
@@ -69,9 +69,7 @@ void main() {
     // Global Save button starts disabled (no pending edits yet).
     expect(
       tester
-          .widget<FilledButton>(
-            find.widgetWithText(FilledButton, 'Save'),
-          )
+          .widget<FilledButton>(find.widgetWithText(FilledButton, 'Save'))
           .onPressed,
       isNull,
     );
@@ -102,9 +100,7 @@ void main() {
     expect(find.widgetWithText(FilledButton, 'Save'), findsOneWidget);
     expect(
       tester
-          .widget<FilledButton>(
-            find.widgetWithText(FilledButton, 'Save'),
-          )
+          .widget<FilledButton>(find.widgetWithText(FilledButton, 'Save'))
           .onPressed,
       isNull,
     );
@@ -117,10 +113,7 @@ void main() {
     expect(find.text('Save version'), findsNothing);
     expect(find.text('Current world'), findsNothing);
     expect(find.text('Profile name'), findsNothing);
-    expect(
-      find.widgetWithText(TextField, 'Private player name'),
-      findsNothing,
-    );
+    expect(find.widgetWithText(TextField, 'Private player name'), findsNothing);
     expect(
       find.widgetWithText(TextField, 'Private profile name'),
       findsNothing,
@@ -188,10 +181,11 @@ void main() {
     // Stable key order: 'attr:Health' < 'transform'.
     expect(edits, hasLength(2));
     expect(edits[0]['path'], 'private.player.setAttribute');
-    expect(
-      edits[0]['value'],
-      {'id': 'Health', 'baseValue': 77.0, 'currentValue': 66.0},
-    );
+    expect(edits[0]['value'], {
+      'id': 'Health',
+      'baseValue': 77.0,
+      'currentValue': 66.0,
+    });
     expect(edits[1]['path'], 'private.player.setTransform');
     expect(edits[1]['value'], {
       'location': {'x': 100.0, 'y': 200.0, 'z': 300.0},
@@ -267,15 +261,20 @@ void main() {
     await tester.tap(find.widgetWithText(Tab, 'Progression'));
     await tester.pumpAndSettle();
 
-    // Overview card is visible with the structured data.
-    expect(find.text('Progression summary'), findsOneWidget);
-    expect(find.text('Quests total'), findsOneWidget);
-    // Quests card loads and shows the fake quest name.
-    expect(find.text('SLEEPER'), findsOneWidget);
-    // Knowledge NPCs count chip is visible in the overview.
-    expect(find.text('Knowledge NPCs'), findsOneWidget);
+    // Overview/summary card is gone; sidebar entries are visible instead.
+    expect(find.text('Progression summary'), findsNothing);
+    expect(find.text('Quests total'), findsNothing);
+    expect(find.text('Knowledge NPCs'), findsNothing);
 
-    // Search quests — filter is inside the Quests card's TextField.
+    // Sidebar: Quests is default selection; quest list loads immediately.
+    // 'Quests' appears in both the sidebar tile and the detail header.
+    expect(find.text('Quests'), findsAtLeastNWidgets(1));
+    expect(find.text('Knowledge'), findsOneWidget);
+    expect(find.text('Events'), findsOneWidget);
+    // Quests detail loads and shows the fake quest name.
+    expect(find.text('SLEEPER'), findsOneWidget);
+
+    // Search quests — filter is inside the Quests detail's TextField.
     await tester.enterText(
       find.widgetWithText(TextField, 'Search quests'),
       'sleeper',
@@ -322,58 +321,58 @@ void main() {
     );
   });
 
-  testWidgets(
-    'switching tabs preserves unsaved edit and Save count',
-    (tester) async {
-      await tester.binding.setSurfaceSize(const Size(1400, 1000));
-      addTearDown(() => tester.binding.setSurfaceSize(null));
-      final core = _FakeCoreService();
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            coreServiceProvider.overrideWithValue(core),
-            editorSettingsStoreProvider.overrideWithValue(
-              const NoopEditorSettingsStore(),
-            ),
-          ],
-          child: const GoresaveApp(),
-        ),
-      );
-      await tester.pumpAndSettle();
+  testWidgets('switching tabs preserves unsaved edit and Save count', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1400, 1000));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final core = _FakeCoreService();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          coreServiceProvider.overrideWithValue(core),
+          editorSettingsStoreProvider.overrideWithValue(
+            const NoopEditorSettingsStore(),
+          ),
+        ],
+        child: const GoresaveApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      // Enter a draft in the public name field on Overview.
-      await tester.enterText(
-        find.widgetWithText(TextField, 'Public save name'),
-        'Draft Name',
-      );
-      await tester.pump();
-      // Save button now shows 1 pending edit.
-      expect(find.widgetWithText(FilledButton, 'Save (1)'), findsOneWidget);
+    // Enter a draft in the public name field on Overview.
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Public save name'),
+      'Draft Name',
+    );
+    await tester.pump();
+    // Save button now shows 1 pending edit.
+    expect(find.widgetWithText(FilledButton, 'Save (1)'), findsOneWidget);
 
-      // Switch to Player tab.
-      await tester.tap(find.widgetWithText(Tab, 'Player'));
-      await tester.pumpAndSettle();
+    // Switch to Player tab.
+    await tester.tap(find.widgetWithText(Tab, 'Player'));
+    await tester.pumpAndSettle();
 
-      // Save count must still be 1 (tab switch must not drop pending edits).
-      expect(find.widgetWithText(FilledButton, 'Save (1)'), findsOneWidget);
+    // Save count must still be 1 (tab switch must not drop pending edits).
+    expect(find.widgetWithText(FilledButton, 'Save (1)'), findsOneWidget);
 
-      // Switch back to Overview tab.
-      await tester.tap(find.widgetWithText(Tab, 'Overview'));
-      await tester.pumpAndSettle();
+    // Switch back to Overview tab.
+    await tester.tap(find.widgetWithText(Tab, 'Overview'));
+    await tester.pumpAndSettle();
 
-      // The draft text must still be visible in the field.
-      final field = find.widgetWithText(TextField, 'Public save name');
-      final editableText = tester.widget<EditableText>(
-        find.descendant(of: field, matching: find.byType(EditableText)),
-      );
-      expect(editableText.controller.text, 'Draft Name');
-      // Save button still shows 1.
-      expect(find.widgetWithText(FilledButton, 'Save (1)'), findsOneWidget);
-    },
-  );
+    // The draft text must still be visible in the field.
+    final field = find.widgetWithText(TextField, 'Public save name');
+    final editableText = tester.widget<EditableText>(
+      find.descendant(of: field, matching: find.byType(EditableText)),
+    );
+    expect(editableText.controller.text, 'Draft Name');
+    // Save button still shows 1.
+    expect(find.widgetWithText(FilledButton, 'Save (1)'), findsOneWidget);
+  });
 
-  testWidgets('Reset button discards pending and restores field text',
-      (tester) async {
+  testWidgets('Reset button discards pending and restores field text', (
+    tester,
+  ) async {
     await tester.binding.setSurfaceSize(const Size(1400, 1000));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     final core = _FakeCoreService();
@@ -393,10 +392,7 @@ void main() {
     // Confirm Reset is disabled with no pending edits.
     final resetFinder = find.widgetWithText(OutlinedButton, 'Reset');
     expect(resetFinder, findsOneWidget);
-    expect(
-      tester.widget<OutlinedButton>(resetFinder).onPressed,
-      isNull,
-    );
+    expect(tester.widget<OutlinedButton>(resetFinder).onPressed, isNull);
 
     // Enter a draft in the public name field.
     final originalName = 'Die Welt der Verurteilten';
@@ -407,10 +403,7 @@ void main() {
     await tester.pump();
     expect(find.widgetWithText(FilledButton, 'Save (1)'), findsOneWidget);
     // Reset should now be enabled.
-    expect(
-      tester.widget<OutlinedButton>(resetFinder).onPressed,
-      isNotNull,
-    );
+    expect(tester.widget<OutlinedButton>(resetFinder).onPressed, isNotNull);
 
     // Tap Reset.
     await tester.tap(resetFinder);
@@ -424,10 +417,7 @@ void main() {
           .onPressed,
       isNull,
     );
-    expect(
-      tester.widget<OutlinedButton>(resetFinder).onPressed,
-      isNull,
-    );
+    expect(tester.widget<OutlinedButton>(resetFinder).onPressed, isNull);
 
     // The field must display the canonical (original) name again.
     final field = find.widgetWithText(TextField, 'Public save name');
@@ -629,11 +619,7 @@ class _FakeCoreService implements GoresaveCoreService {
               'progression': {
                 'status': 'ok',
                 'questTotal': 3,
-                'questStates': {
-                  'Available': 1,
-                  'Running': 1,
-                  'Succeeded': 1,
-                },
+                'questStates': {'Available': 1, 'Running': 1, 'Succeeded': 1},
                 'knowledgeCharacters': 2,
                 'knowledgeEntries': 5,
                 'memoryCharacters': 1,

--- a/apps/goresave/test/widget_test.dart
+++ b/apps/goresave/test/widget_test.dart
@@ -267,19 +267,22 @@ void main() {
     await tester.tap(find.widgetWithText(Tab, 'Progression'));
     await tester.pumpAndSettle();
 
+    // Overview card is visible with the structured data.
     expect(find.text('Progression summary'), findsOneWidget);
-    expect(find.text('Generated events'), findsOneWidget);
-    expect(find.text('Quest.Main.Chapter01'), findsOneWidget);
-    expect(find.text('Dialog.Diego.IntroDone'), findsOneWidget);
+    expect(find.text('Quests total'), findsOneWidget);
+    // Quests card loads and shows the fake quest name.
+    expect(find.text('SLEEPER'), findsOneWidget);
+    // Knowledge NPCs count chip is visible in the overview.
+    expect(find.text('Knowledge NPCs'), findsOneWidget);
 
+    // Search quests — filter is inside the Quests card's TextField.
     await tester.enterText(
-      find.widgetWithText(TextField, 'Filter progression'),
-      'dialog',
+      find.widgetWithText(TextField, 'Search quests'),
+      'sleeper',
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Dialog.Diego.IntroDone'), findsOneWidget);
-    expect(find.text('Quest.Main.Chapter01'), findsNothing);
+    expect(find.text('SLEEPER'), findsOneWidget);
 
     await tester.drag(find.byType(TabBar), const Offset(-500, 0));
     await tester.pumpAndSettle();
@@ -624,19 +627,24 @@ class _FakeCoreService implements GoresaveCoreService {
                 'writable': ['private.inventory.setItemCount'],
               },
               'progression': {
-                'candidateCount': 3,
-                'candidates': [
-                  'Quest.Main.Chapter01',
-                  'Dialog.Diego.IntroDone',
-                  'Knowledge.OldCamp.PathKnown',
+                'status': 'ok',
+                'questTotal': 3,
+                'questStates': {
+                  'Available': 1,
+                  'Running': 1,
+                  'Succeeded': 1,
+                },
+                'knowledgeCharacters': 2,
+                'knowledgeEntries': 5,
+                'memoryCharacters': 1,
+                'memoryEvents': 12,
+                'writable': [
+                  'private.typed.setValue',
+                  'private.typed.setAdd',
+                  'private.typed.setRemove',
+                  'private.typed.arrayRemove',
+                  'private.typed.arrayDuplicate',
                 ],
-                'gameplayTags': [
-                  'Quest.Main.Chapter01',
-                  'Dialog.Diego.IntroDone',
-                ],
-                'sections': ['Generated events', 'Memorized events'],
-                'scriptPaths': ['/Script/G1R.QuestSaveGameData'],
-                'properties': ['m_GeneratedEvents', 'm_MemorizedEvents'],
               },
             },
           },
@@ -704,6 +712,112 @@ class _FakeCoreService implements GoresaveCoreService {
             'path': payload['path'],
             'restoredFrom': payload['backupPath'],
             'backupPath': r'C:\tmp\saves\G1R-001.sav.bak.300',
+          },
+        };
+      case 'query_progression':
+        final section = payload['section'] as String? ?? 'quests';
+        if (section == 'quests') {
+          return {
+            'ok': true,
+            'data': {
+              'section': 'quests',
+              'total': 1,
+              'offset': 0,
+              'limit': 100,
+              'count': 1,
+              'stateCounts': {'Running': 1},
+              'quests': [
+                {
+                  'questClass': '/Script/Angelscript.Quest_OldCamp_SLEEPER',
+                  'id': 'Quest_OldCamp_SLEEPER',
+                  'group': 'OldCamp',
+                  'name': 'SLEEPER',
+                  'currentState': 'EQuestState::Running',
+                  'statePath': [
+                    'QuestDataByClass',
+                    '{/Script/Angelscript.Quest_OldCamp_SLEEPER}',
+                    'CurrentState',
+                  ],
+                  'writable': true,
+                },
+              ],
+            },
+          };
+        }
+        if (section == 'knowledge') {
+          final character = payload['character'] as String?;
+          if (character == null) {
+            return {
+              'ok': true,
+              'data': {
+                'section': 'knowledge',
+                'total': 1,
+                'offset': 0,
+                'limit': 100,
+                'count': 1,
+                'characters': [
+                  {'name': 'OC_STT_Diego', 'entryCount': 2},
+                ],
+              },
+            };
+          }
+          return {
+            'ok': true,
+            'data': {
+              'section': 'knowledge',
+              'character': character,
+              'total': 1,
+              'offset': 0,
+              'limit': 200,
+              'count': 1,
+              'entries': ['Voiceline_info_diego'],
+              'setPath': [
+                'CharacterKnowledgeByUniqueName',
+                '{$character}',
+                'Knowledge',
+              ],
+            },
+          };
+        }
+        // events section
+        final character = payload['character'] as String?;
+        if (character == null) {
+          return {
+            'ok': true,
+            'data': {
+              'section': 'events',
+              'total': 1,
+              'offset': 0,
+              'limit': 100,
+              'count': 1,
+              'characters': [
+                {'id': 'Hero', 'eventCount': 1},
+              ],
+            },
+          };
+        }
+        return {
+          'ok': true,
+          'data': {
+            'section': 'events',
+            'character': character,
+            'total': 1,
+            'offset': 0,
+            'limit': 100,
+            'count': 1,
+            'events': [
+              {
+                'index': 0,
+                'tags': ['Memory.Quest.Started'],
+                'timeSeconds': 100.0,
+                'affected': 'Hero',
+              },
+            ],
+            'arrayPath': [
+              'LongTermMemoryByGlobalId',
+              '{$character}',
+              'MemorizedEvents',
+            ],
           },
         };
       default:

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -1210,18 +1210,45 @@ pub fn list_save_backups(path: &Path) -> Result<Vec<BackupListItem>, CoreError> 
     }
     let prefix = backup_file_prefix(path)?;
     let mut backups = Vec::new();
+
+    // Collect candidate (backup_path, file_name) pairs from both locations:
+    // 1. Legacy: files in the save's parent directory matching the prefix.
+    // 2. New: files in the goresave_backups subfolder matching the prefix.
+    let mut candidates: Vec<(PathBuf, String)> = Vec::new();
     for entry in fs::read_dir(parent)? {
         let entry = entry?;
-        let backup_path = entry.path();
-        let Some(file_name) = backup_path.file_name().and_then(|value| value.to_str()) else {
-            continue;
-        };
-        if !file_name.starts_with(&prefix) {
+        let p = entry.path();
+        if !p.is_file() {
             continue;
         }
+        let Some(file_name) = p.file_name().and_then(|v| v.to_str()).map(str::to_owned) else {
+            continue;
+        };
+        if file_name.starts_with(&prefix) {
+            candidates.push((p, file_name));
+        }
+    }
+    let subfolder = parent.join("goresave_backups");
+    if subfolder.is_dir() {
+        for entry in fs::read_dir(&subfolder)? {
+            let entry = entry?;
+            let p = entry.path();
+            if !p.is_file() {
+                continue;
+            }
+            let Some(file_name) = p.file_name().and_then(|v| v.to_str()).map(str::to_owned) else {
+                continue;
+            };
+            if file_name.starts_with(&prefix) {
+                candidates.push((p, file_name));
+            }
+        }
+    }
+
+    for (backup_path, file_name) in candidates {
         let data = fs::read(&backup_path)?;
-        let metadata = entry.metadata()?;
-        let created_epoch = parse_backup_epoch(file_name, &prefix);
+        let metadata = fs::metadata(&backup_path)?;
+        let created_epoch = parse_backup_epoch(&file_name, &prefix);
         let (status, player_save_name, slot_name) =
             match inspect_bytes(&data, Some(&backup_path), false) {
                 Ok(info) => {
@@ -1242,7 +1269,7 @@ pub fn list_save_backups(path: &Path) -> Result<Vec<BackupListItem>, CoreError> 
             };
         backups.push(BackupListItem {
             path: backup_path.display().to_string(),
-            file_name: file_name.to_string(),
+            file_name,
             file_size: metadata.len(),
             sha1: sha1_hex(&data),
             created_epoch,
@@ -1273,27 +1300,54 @@ fn list_persistent_data_list_backups_for_save(
     let persistent_path = parent.join("PersistentDataList.sav");
     let prefix = backup_file_prefix(&persistent_path)?;
     let mut backups = Vec::new();
+
+    // Collect candidate (backup_path, file_name) pairs from both locations:
+    // 1. Legacy: files in the save's parent directory matching the prefix.
+    // 2. New: files in the goresave_backups subfolder matching the prefix.
+    let mut candidates: Vec<(PathBuf, String)> = Vec::new();
     for entry in fs::read_dir(parent)? {
         let entry = entry?;
-        let backup_path = entry.path();
-        let Some(file_name) = backup_path.file_name().and_then(|value| value.to_str()) else {
-            continue;
-        };
-        if !file_name.starts_with(&prefix) {
+        let p = entry.path();
+        if !p.is_file() {
             continue;
         }
+        let Some(file_name) = p.file_name().and_then(|v| v.to_str()).map(str::to_owned) else {
+            continue;
+        };
+        if file_name.starts_with(&prefix) {
+            candidates.push((p, file_name));
+        }
+    }
+    let subfolder = parent.join("goresave_backups");
+    if subfolder.is_dir() {
+        for entry in fs::read_dir(&subfolder)? {
+            let entry = entry?;
+            let p = entry.path();
+            if !p.is_file() {
+                continue;
+            }
+            let Some(file_name) = p.file_name().and_then(|v| v.to_str()).map(str::to_owned) else {
+                continue;
+            };
+            if file_name.starts_with(&prefix) {
+                candidates.push((p, file_name));
+            }
+        }
+    }
+
+    for (backup_path, file_name) in candidates {
         let data = fs::read(&backup_path)?;
-        let metadata = entry.metadata()?;
-        let created_epoch = parse_backup_epoch(file_name, &prefix);
+        let metadata = fs::metadata(&backup_path)?;
+        let created_epoch = parse_backup_epoch(&file_name, &prefix);
         let (status, player_save_name, slot_name) =
             match inspect_bytes(&data, Some(&backup_path), false) {
                 Ok(_) => {
                     let persistent_slots = parse_persistent_slot_metadata(&data);
                     match persistent_slots.get(slot) {
-                        Some(metadata) => (
+                        Some(slot_meta) => (
                             "ok".to_string(),
-                            metadata.player_save_name.clone(),
-                            metadata
+                            slot_meta.player_save_name.clone(),
+                            slot_meta
                                 .slot_name
                                 .clone()
                                 .or_else(|| Some(slot.to_string())),
@@ -1309,7 +1363,7 @@ fn list_persistent_data_list_backups_for_save(
             };
         backups.push(BackupListItem {
             path: backup_path.display().to_string(),
-            file_name: file_name.to_string(),
+            file_name,
             file_size: metadata.len(),
             sha1: sha1_hex(&data),
             created_epoch,
@@ -1456,15 +1510,29 @@ fn prepare_paired_persistent_data_list_restore(
 
     let companion_prefix = backup_file_prefix(&persistent_path)?;
     let mut companion_backup_path = None;
-    for entry in fs::read_dir(parent)? {
-        let entry = entry?;
-        let candidate = entry.path();
-        let Some(name) = candidate.file_name().and_then(|value| value.to_str()) else {
+    // Search the legacy parent directory first, then the goresave_backups subfolder.
+    let search_dirs: Vec<PathBuf> = {
+        let mut dirs = vec![parent.to_path_buf()];
+        let subfolder = parent.join("goresave_backups");
+        if subfolder.is_dir() {
+            dirs.push(subfolder);
+        }
+        dirs
+    };
+    'outer: for search_dir in &search_dirs {
+        if !search_dir.is_dir() {
             continue;
-        };
-        if name.strip_prefix(&companion_prefix) == Some(slot_suffix) {
-            companion_backup_path = Some(candidate);
-            break;
+        }
+        for entry in fs::read_dir(search_dir)? {
+            let entry = entry?;
+            let candidate = entry.path();
+            let Some(name) = candidate.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if name.strip_prefix(&companion_prefix) == Some(slot_suffix) {
+                companion_backup_path = Some(candidate);
+                break 'outer;
+            }
         }
     }
     let Some(companion_backup_path) = companion_backup_path else {
@@ -1508,9 +1576,16 @@ fn ensure_backup_belongs_to_save(path: &Path, backup_path: &Path) -> Result<(), 
     }
     let save_parent = path.parent().unwrap_or_else(|| Path::new("."));
     let backup_parent = backup_path.parent().unwrap_or_else(|| Path::new("."));
-    if fs::canonicalize(save_parent)? != fs::canonicalize(backup_parent)? {
+    let canonical_save_parent = fs::canonicalize(save_parent)?;
+    let canonical_backup_parent = fs::canonicalize(backup_parent)?;
+    // Accept backups both in the save's parent directory (legacy) and in
+    // its goresave_backups subfolder (new layout).
+    let subfolder = canonical_save_parent.join("goresave_backups");
+    if canonical_backup_parent != canonical_save_parent
+        && canonical_backup_parent != subfolder
+    {
         return Err(CoreError::InvalidRequest(
-            "backupPath must be next to the selected save file".to_string(),
+            "backupPath must be next to the selected save file or in its goresave_backups subfolder".to_string(),
         ));
     }
     Ok(())
@@ -1549,6 +1624,30 @@ impl PendingReplace {
     }
 }
 
+/// Map an I/O error that occurred while renaming or replacing a live save file
+/// into a human-readable [`CoreError`] when the error indicates that another
+/// process holds the file open (Windows sharing/lock violation).
+///
+/// `context` is appended to the message for disambiguation (e.g. the file path
+/// or operation description). On non-Windows platforms or for unrelated errors
+/// the original error is wrapped unchanged.
+fn map_locked_file_error(err: std::io::Error, context: &str) -> CoreError {
+    let is_locked = match err.raw_os_error() {
+        // ERROR_SHARING_VIOLATION = 32, ERROR_LOCK_VIOLATION = 33
+        Some(32) | Some(33) => true,
+        _ => err.kind() == std::io::ErrorKind::PermissionDenied,
+    };
+    if is_locked {
+        CoreError::Io(format!(
+            "the save file is locked by another process \
+             (is the game running?) — close the game or its load screen, \
+             then retry: {err} ({context})"
+        ))
+    } else {
+        CoreError::Io(err.to_string())
+    }
+}
+
 /// Replace `target` with the staged file at `staged` without ever leaving
 /// `target` missing on failure. Windows `rename` cannot overwrite, so the
 /// current file is moved aside first; if renaming the staged file in fails, the
@@ -1556,7 +1655,7 @@ impl PendingReplace {
 /// [`PendingReplace`] must be either committed or rolled back.
 fn begin_replace(target: &Path, staged: &Path) -> Result<PendingReplace, CoreError> {
     if !target.exists() {
-        fs::rename(staged, target)?;
+        fs::rename(staged, target).map_err(|e| map_locked_file_error(e, &target.display().to_string()))?;
         return Ok(PendingReplace {
             target: target.to_path_buf(),
             aside: None,
@@ -1565,7 +1664,8 @@ fn begin_replace(target: &Path, staged: &Path) -> Result<PendingReplace, CoreErr
     let aside = target.with_extension("sav.replaced-goresave");
     // Clear any leftover aside from a previously interrupted write.
     let _ = fs::remove_file(&aside);
-    fs::rename(target, &aside)?;
+    fs::rename(target, &aside)
+        .map_err(|e| map_locked_file_error(e, &target.display().to_string()))?;
     match fs::rename(staged, target) {
         Ok(()) => Ok(PendingReplace {
             target: target.to_path_buf(),
@@ -1574,13 +1674,16 @@ fn begin_replace(target: &Path, staged: &Path) -> Result<PendingReplace, CoreErr
         Err(err) => {
             // Roll back so the target path is never left absent.
             let _ = fs::rename(&aside, target);
-            Err(err.into())
+            Err(map_locked_file_error(err, &target.display().to_string()))
         }
     }
 }
 
 fn create_backup_copy(path: &Path) -> Result<PathBuf, CoreError> {
     let backup_path = unique_backup_path(path);
+    if let Some(parent) = backup_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
     fs::copy(path, &backup_path)?;
     Ok(backup_path)
 }
@@ -1591,11 +1694,21 @@ fn unique_backup_path(path: &Path) -> PathBuf {
 }
 
 fn backup_path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
-    path.with_extension(format!("sav.bak.{suffix}"))
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    parent
+        .join("goresave_backups")
+        .join(format!("{file_name}.bak.{suffix}"))
 }
 
 fn create_backup_with_suffix(path: &Path, suffix: &str) -> Result<PathBuf, CoreError> {
     let backup_path = backup_path_with_suffix(path, suffix);
+    if let Some(parent) = backup_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
     fs::copy(path, &backup_path)?;
     Ok(backup_path)
 }
@@ -6345,9 +6458,12 @@ mod tests {
     fn list_backups_returns_matching_save_backups_newest_first() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
-        let older = dir.path().join("G1R-001.sav.bak.100");
-        let newer = dir.path().join("G1R-001.sav.bak.200");
-        let unrelated = dir.path().join("G1R-002.sav.bak.300");
+        let subfolder = dir.path().join("goresave_backups");
+        fs::create_dir_all(&subfolder).unwrap();
+        let older = subfolder.join("G1R-001.sav.bak.100");
+        let newer = subfolder.join("G1R-001.sav.bak.200");
+        // Unrelated file in subfolder must not appear.
+        let unrelated = subfolder.join("G1R-002.sav.bak.300");
         fs::write(&path, minimal_gsav("Live")).unwrap();
         fs::write(&older, minimal_gsav("Older")).unwrap();
         fs::write(&newer, minimal_gsav("Newer")).unwrap();
@@ -6380,11 +6496,66 @@ mod tests {
     }
 
     #[test]
+    fn list_backups_includes_legacy_backups_next_to_save_alongside_subfolder_ones() {
+        // Legacy backups (placed directly in the save's parent dir) must still
+        // appear in list_save_backups alongside new subfolder backups.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-001.sav");
+        let subfolder = dir.path().join("goresave_backups");
+        fs::create_dir_all(&subfolder).unwrap();
+        // Legacy file next to the save.
+        let legacy = dir.path().join("G1R-001.sav.bak.50");
+        // New file in the subfolder.
+        let new_backup = subfolder.join("G1R-001.sav.bak.150");
+        fs::write(&path, minimal_gsav("Live")).unwrap();
+        fs::write(&legacy, minimal_gsav("Legacy")).unwrap();
+        fs::write(&new_backup, minimal_gsav("New")).unwrap();
+
+        let backups = list_save_backups(&path).unwrap();
+        assert_eq!(backups.len(), 2, "both legacy and subfolder backups expected");
+        // Newest-first: epoch 150 before epoch 50.
+        assert!(backups[0].path.contains("150"), "subfolder backup first");
+        assert!(backups[1].path.contains("50"), "legacy backup second");
+    }
+
+    #[test]
+    fn create_backup_copy_writes_two_consecutive_backups_to_subfolder() {
+        // Two consecutive backup writes must produce two distinct files, both
+        // located in the goresave_backups subfolder.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-001.sav");
+        fs::write(&path, minimal_gsav("Slot A")).unwrap();
+
+        // First backup — also triggers subfolder creation.
+        let b1 = create_backup_copy(&path).unwrap();
+        // Mutate the file so the second backup is distinct.
+        fs::write(&path, minimal_gsav("Slot B")).unwrap();
+        let b2 = create_backup_copy(&path).unwrap();
+
+        assert_ne!(b1, b2, "two backups must have distinct paths");
+        assert!(b1.exists(), "first backup file must exist");
+        assert!(b2.exists(), "second backup file must exist");
+
+        let subfolder = dir.path().join("goresave_backups");
+        assert!(
+            b1.starts_with(&subfolder),
+            "first backup must be in goresave_backups subfolder"
+        );
+        assert!(
+            b2.starts_with(&subfolder),
+            "second backup must be in goresave_backups subfolder"
+        );
+    }
+
+    #[test]
     fn list_backups_returns_persistent_data_list_companion_backups_for_selected_slot() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
-        let companion = dir.path().join("PersistentDataList.sav.bak.250");
-        let unrelated = dir.path().join("G1R-002.sav.bak.300");
+        let subfolder = dir.path().join("goresave_backups");
+        fs::create_dir_all(&subfolder).unwrap();
+        let companion = subfolder.join("PersistentDataList.sav.bak.250");
+        // Unrelated file in subfolder must not appear.
+        let unrelated = subfolder.join("G1R-002.sav.bak.300");
         fs::write(&path, minimal_gsav("Live")).unwrap();
         fs::write(
             &companion,
@@ -6437,7 +6608,9 @@ mod tests {
     fn restore_backup_validates_backup_and_preserves_current_save() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
-        let backup = dir.path().join("G1R-001.sav.bak.200");
+        let subfolder = dir.path().join("goresave_backups");
+        fs::create_dir_all(&subfolder).unwrap();
+        let backup = subfolder.join("G1R-001.sav.bak.200");
         fs::write(&path, minimal_gsav("Live")).unwrap();
         fs::write(&backup, minimal_gsav("Backup")).unwrap();
 
@@ -6457,6 +6630,11 @@ mod tests {
         );
         let current_backup = PathBuf::from(value["data"]["backupPath"].as_str().unwrap());
         assert!(current_backup.exists());
+        // The safety backup of "Live" must also be in the subfolder.
+        assert!(
+            current_backup.starts_with(&subfolder),
+            "safety backup must be written to goresave_backups subfolder"
+        );
         assert_eq!(
             inspect_save(&path, false).unwrap()["public"]["playerSaveName"],
             "Backup"
@@ -6471,9 +6649,11 @@ mod tests {
     fn restore_backup_also_restores_paired_persistent_data_list_backup() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
-        let slot_backup = dir.path().join("G1R-001.sav.bak.200");
+        let subfolder = dir.path().join("goresave_backups");
+        fs::create_dir_all(&subfolder).unwrap();
+        let slot_backup = subfolder.join("G1R-001.sav.bak.200");
         let persistent = dir.path().join("PersistentDataList.sav");
-        let persistent_backup = dir.path().join("PersistentDataList.sav.bak.200");
+        let persistent_backup = subfolder.join("PersistentDataList.sav.bak.200");
 
         fs::write(&path, minimal_gsav("Live")).unwrap();
         fs::write(&slot_backup, minimal_gsav("Backup")).unwrap();
@@ -6536,12 +6716,14 @@ mod tests {
     fn restore_backup_pairs_companion_by_full_suffix_within_same_second() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
+        let subfolder = dir.path().join("goresave_backups");
+        fs::create_dir_all(&subfolder).unwrap();
         // Two paired backups created in the same second: ".200" and ".200.1".
-        let slot_backup_first = dir.path().join("G1R-001.sav.bak.200");
-        let slot_backup_second = dir.path().join("G1R-001.sav.bak.200.1");
+        let slot_backup_first = subfolder.join("G1R-001.sav.bak.200");
+        let slot_backup_second = subfolder.join("G1R-001.sav.bak.200.1");
         let persistent = dir.path().join("PersistentDataList.sav");
-        let persistent_first = dir.path().join("PersistentDataList.sav.bak.200");
-        let persistent_second = dir.path().join("PersistentDataList.sav.bak.200.1");
+        let persistent_first = subfolder.join("PersistentDataList.sav.bak.200");
+        let persistent_second = subfolder.join("PersistentDataList.sav.bak.200.1");
 
         fs::write(&path, minimal_gsav("Live")).unwrap();
         fs::write(&slot_backup_first, minimal_gsav("First")).unwrap();
@@ -6573,7 +6755,9 @@ mod tests {
     fn restore_backup_flags_present_companion_left_unrestored() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
-        let slot_backup = dir.path().join("G1R-001.sav.bak.200");
+        let subfolder = dir.path().join("goresave_backups");
+        fs::create_dir_all(&subfolder).unwrap();
+        let slot_backup = subfolder.join("G1R-001.sav.bak.200");
         let persistent = dir.path().join("PersistentDataList.sav");
         // PersistentDataList exists but there is no .bak.200 companion for it.
         fs::write(&path, minimal_gsav("Live")).unwrap();
@@ -6600,7 +6784,9 @@ mod tests {
     fn restore_backup_rejects_mismatched_container_format() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
-        let backup = dir.path().join("G1R-001.sav.bak.200");
+        let subfolder = dir.path().join("goresave_backups");
+        fs::create_dir_all(&subfolder).unwrap();
+        let backup = subfolder.join("G1R-001.sav.bak.200");
         fs::write(&path, minimal_gsav("Live")).unwrap();
         // A GVAS sidecar misnamed as a slot backup must not replace the GSAV slot.
         fs::write(
@@ -6621,9 +6807,11 @@ mod tests {
     fn restore_backup_aborts_without_touching_slot_when_companion_invalid() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
-        let slot_backup = dir.path().join("G1R-001.sav.bak.200");
+        let subfolder = dir.path().join("goresave_backups");
+        fs::create_dir_all(&subfolder).unwrap();
+        let slot_backup = subfolder.join("G1R-001.sav.bak.200");
         let persistent = dir.path().join("PersistentDataList.sav");
-        let persistent_backup = dir.path().join("PersistentDataList.sav.bak.200");
+        let persistent_backup = subfolder.join("PersistentDataList.sav.bak.200");
 
         fs::write(&path, minimal_gsav("Live")).unwrap();
         fs::write(&slot_backup, minimal_gsav("Backup")).unwrap();
@@ -6640,6 +6828,31 @@ mod tests {
             "Live"
         );
         assert_eq!(fs::read(&persistent).unwrap(), b"GVAS-new-name");
+    }
+
+    #[test]
+    fn map_locked_file_error_produces_game_running_message_for_sharing_violation() {
+        // ERROR_SHARING_VIOLATION = 32 (Windows). The helper must produce a
+        // message that contains "is the game running" so the user knows the
+        // cause without a raw OS error code.
+        let io_err = std::io::Error::from_raw_os_error(32);
+        let core_err = map_locked_file_error(io_err, "G1R-001.sav");
+        let msg = core_err.to_string();
+        assert!(
+            msg.contains("is the game running"),
+            "message should mention game running, got: {msg}"
+        );
+
+        // ERROR_LOCK_VIOLATION = 33 must also trigger the friendly message.
+        let io_err_33 = std::io::Error::from_raw_os_error(33);
+        let core_err_33 = map_locked_file_error(io_err_33, "G1R-001.sav");
+        assert!(core_err_33.to_string().contains("is the game running"));
+
+        // An unrelated OS error (e.g. ENOENT = 2) must NOT produce the game-
+        // running message; it must propagate the original description.
+        let io_unrelated = std::io::Error::from_raw_os_error(2);
+        let core_unrelated = map_locked_file_error(io_unrelated, "G1R-001.sav");
+        assert!(!core_unrelated.to_string().contains("is the game running"));
     }
 
     #[test]

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -1510,12 +1510,19 @@ fn prepare_paired_persistent_data_list_restore(
 
     let companion_prefix = backup_file_prefix(&persistent_path)?;
     let mut companion_backup_path = None;
-    // Search the legacy parent directory first, then the goresave_backups subfolder.
+    // Paired backups share one suffix AND one directory (they are written in
+    // the same round). Search the selected slot backup's own directory first,
+    // so a companion in the other location with a colliding suffix cannot
+    // pair the slot and companion to different write rounds.
     let search_dirs: Vec<PathBuf> = {
-        let mut dirs = vec![parent.to_path_buf()];
-        let subfolder = parent.join("goresave_backups");
-        if subfolder.is_dir() {
-            dirs.push(subfolder);
+        let mut dirs = Vec::new();
+        if let Some(backup_dir) = slot_backup_path.parent() {
+            dirs.push(backup_dir.to_path_buf());
+        }
+        for fallback in [parent.to_path_buf(), parent.join("goresave_backups")] {
+            if !dirs.contains(&fallback) {
+                dirs.push(fallback);
+            }
         }
         dirs
     };

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -3852,6 +3852,31 @@ fn apply_private_edits(
             ))),
         })
         .collect::<Result<Vec<_>, _>>()?;
+    // Index-addressed structural edits are interpreted against the array as
+    // it exists when that edit applies, so a second arrayRemove/arrayDuplicate
+    // in the same batch would silently target shifted indices. Reject the
+    // batch instead of guessing the caller's intent.
+    let structural_array_edits = edit_specs
+        .iter()
+        .filter(|edit| {
+            matches!(
+                edit,
+                PrivateEdit::TypedContainer(PrivateTypedContainerEdit {
+                    edit: properties::ContainerEdit::ArrayRemove(_)
+                        | properties::ContainerEdit::ArrayDuplicate(_),
+                    ..
+                })
+            )
+        })
+        .count();
+    if structural_array_edits > 1 {
+        return Err(CoreError::UnsupportedEdit(format!(
+            "a write may contain at most one structural array edit \
+             (arrayRemove/arrayDuplicate); got {structural_array_edits} — \
+             indices shift after each structural change, submit them as \
+             separate writes"
+        )));
+    }
     let mut private_payload = decompress_private_payload(data, &stream, backend)?;
     for edit in &edit_specs {
         apply_private_edit_to_payload(&mut private_payload, edit)?;
@@ -8095,6 +8120,88 @@ mod tests {
         assert_eq!(value["private"]["typedParse"]["status"], "ok");
         let strings = value["private"]["strings"].as_array().unwrap();
         assert!(strings.iter().any(|s| s == "ChoiceB"));
+    }
+
+    fn private_str_array_property(name: &str, values: &[&str]) -> Vec<u8> {
+        let mut body = (values.len() as u32).to_le_bytes().to_vec();
+        for v in values {
+            body.extend_from_slice(&fstring(v));
+        }
+        let mut out = fstring(name);
+        out.extend_from_slice(&fstring("ArrayProperty"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("StrProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes()); // array_index
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.push(0); // tag_flags
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn write_save_rejects_multiple_structural_array_edits() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-001.sav");
+        let output_path = dir.path().join("G1R-001-multi.sav");
+        let private_payload = {
+            let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+            p.push(0);
+            p.extend_from_slice(&private_str_array_property("Events", &["A", "B", "C"]));
+            p.extend_from_slice(&fstring("None"));
+            p.extend_from_slice(&0u32.to_le_bytes());
+            p
+        };
+        let seed_compressed = b"seed-compressed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot A"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        // Two index-addressed structural edits in one batch are rejected: the
+        // second index would silently target the post-splice array.
+        let err = write_save_with_codec_backend(
+            &path,
+            &[
+                json!({
+                    "path": "private.typed.arrayRemove",
+                    "value": { "path": ["Events"], "index": 0 }
+                }),
+                json!({
+                    "path": "private.typed.arrayRemove",
+                    "value": { "path": ["Events"], "index": 1 }
+                }),
+            ],
+            false,
+            Some(&output_path),
+            Some(&backend),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("at most one structural array edit"),
+            "unexpected error: {err}"
+        );
+        assert!(!output_path.exists(), "rejected write must not produce a file");
+
+        // A single structural edit (even alongside a value-addressed edit)
+        // still applies.
+        let response = write_save_with_codec_backend(
+            &path,
+            &[json!({
+                "path": "private.typed.arrayRemove",
+                "value": { "path": ["Events"], "index": 1 }
+            })],
+            false,
+            Some(&output_path),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(response["editsApplied"], 1);
     }
 
     // ── Task 5 helpers ──────────────────────────────────────────────────────

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2608,9 +2608,18 @@ fn progression_quests(
             "QuestDataByClass is not a map".to_string(),
         ));
     };
-    let mut state_counts = std::collections::BTreeMap::<String, usize>::new();
-    let mut group_counts = std::collections::BTreeMap::<String, usize>::new();
-    let mut matches: Vec<(String, String, String, String, Option<String>)> = Vec::new();
+    // Collect all entries as tuples first, then do three filtered passes for
+    // faceted counts (each facet counts over every OTHER active filter but not
+    // its own) plus one pass for the quests list.
+    struct Entry {
+        class_path: String,
+        id: String,
+        group: String,
+        name: String,
+        state: Option<String>,
+        label: String,
+    }
+    let mut all: Vec<Entry> = Vec::new();
     for (key, value) in entries {
         let Some(class_path) = map_key_string(key) else {
             continue;
@@ -2624,47 +2633,79 @@ fn progression_quests(
             .map(short_enum_label)
             .unwrap_or("unknown")
             .to_string();
-        *state_counts.entry(label.clone()).or_default() += 1;
-        // Compute group for every entry (used for groupCounts and group filter).
         let (id, group, name) = quest_id_group_name(class_path);
-        *group_counts.entry(group.clone()).or_default() += 1;
-        // --- filters (applied after counts are updated) ---
-        if !query.is_empty() && !class_path.to_ascii_lowercase().contains(query) {
-            continue;
-        }
-        if let Some(sf) = state_filter {
-            // Accept both short label ("running") and full enum form
-            // ("equeststate::running") — normalize via short_enum_label.
-            let short = short_enum_label(state.as_deref().unwrap_or("")).to_ascii_lowercase();
-            let full = state.as_deref().unwrap_or("").to_ascii_lowercase();
-            if short != sf && full != sf {
-                continue;
-            }
-        }
-        if let Some(gf) = group_filter {
-            if group.to_ascii_lowercase() != gf {
-                continue;
-            }
-        }
-        matches.push((class_path.to_string(), id, group, name, state));
+        all.push(Entry {
+            class_path: class_path.to_string(),
+            id,
+            group,
+            name,
+            state,
+            label,
+        });
     }
-    matches.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Helper closures for each filter predicate.
+    let matches_query = |e: &Entry| -> bool {
+        query.is_empty() || e.class_path.to_ascii_lowercase().contains(query)
+    };
+    let matches_state = |e: &Entry| -> bool {
+        match state_filter {
+            None => true,
+            Some(sf) => {
+                // Accept short label ("Running") or full enum form ("EQuestState::Running"),
+                // both case-insensitive.
+                let short =
+                    short_enum_label(e.state.as_deref().unwrap_or("")).to_ascii_lowercase();
+                let full = e.state.as_deref().unwrap_or("").to_ascii_lowercase();
+                short == sf || full == sf
+            }
+        }
+    };
+    let matches_group = |e: &Entry| -> bool {
+        match group_filter {
+            None => true,
+            Some(gf) => e.group.to_ascii_lowercase() == gf,
+        }
+    };
+
+    // stateCounts: query + group filter, state filter NOT applied.
+    let mut state_counts = std::collections::BTreeMap::<String, usize>::new();
+    for e in &all {
+        if matches_query(e) && matches_group(e) {
+            *state_counts.entry(e.label.clone()).or_default() += 1;
+        }
+    }
+
+    // groupCounts: query + state filter, group filter NOT applied.
+    let mut group_counts = std::collections::BTreeMap::<String, usize>::new();
+    for e in &all {
+        if matches_query(e) && matches_state(e) {
+            *group_counts.entry(e.group.clone()).or_default() += 1;
+        }
+    }
+
+    // Quests list: all three filters, sorted by class_path.
+    let mut matches: Vec<&Entry> = all
+        .iter()
+        .filter(|e| matches_query(e) && matches_state(e) && matches_group(e))
+        .collect();
+    matches.sort_by(|a, b| a.class_path.cmp(&b.class_path));
     let total = matches.len();
     let quests = matches
         .into_iter()
         .skip(offset)
         .take(limit)
-        .map(|(class_path, id, group, name, state)| {
+        .map(|e| {
             let mut state_path = base_path.clone();
-            state_path.push(format!("{{{class_path}}}"));
+            state_path.push(format!("{{{}}}", e.class_path));
             state_path.push("CurrentState".to_string());
-            let writable = state.is_some();
+            let writable = e.state.is_some();
             json!({
-                "questClass": class_path,
-                "id": id,
-                "group": group,
-                "name": name,
-                "currentState": state,
+                "questClass": e.class_path,
+                "id": e.id,
+                "group": e.group,
+                "name": e.name,
+                "currentState": e.state,
                 "statePath": state_path,
                 "writable": writable,
             })
@@ -8211,22 +8252,26 @@ mod tests {
             seed_uncompressed: private_payload,
         };
 
-        // groupCounts is always over all entries regardless of filters.
+        // No filters: both facets cover all entries.
         let base = query_progression(&path, &json!({ "section": "quests" }), Some(&backend))
             .unwrap();
         assert_eq!(base["groupCounts"]["BanditsCamp"], 1);
         assert_eq!(base["groupCounts"]["OldCamp"], 1);
+        assert_eq!(base["stateCounts"]["Running"], 1);
+        assert_eq!(base["stateCounts"]["Available"], 1);
 
         // state:"Running" → 1 hit (SLEEPER).
+        // groupCounts respects query+state (not group), so only Running entries counted.
+        // stateCounts respects query+group (no group filter), so all entries counted.
         let running =
             query_progression(&path, &json!({ "section": "quests", "state": "Running" }), Some(&backend))
                 .unwrap();
         assert_eq!(running["total"], 1);
         assert_eq!(running["quests"][0]["name"], "SLEEPER");
-        // groupCounts still covers all entries.
-        assert_eq!(running["groupCounts"]["BanditsCamp"], 1);
+        // groupCounts: only Running entries → OldCamp=1, BanditsCamp absent.
         assert_eq!(running["groupCounts"]["OldCamp"], 1);
-        // stateCounts still covers all entries.
+        assert!(running["groupCounts"]["BanditsCamp"].is_null());
+        // stateCounts: no group filter applied → all entries.
         assert_eq!(running["stateCounts"]["Running"], 1);
         assert_eq!(running["stateCounts"]["Available"], 1);
 
@@ -8250,7 +8295,9 @@ mod tests {
         assert_eq!(running_lower["total"], 1);
         assert_eq!(running_lower["quests"][0]["name"], "SLEEPER");
 
-        // group:"banditscamp" (case-insensitive) → 1 hit (BANDITSTRUST).
+        // group:"banditscamp" → 1 hit (BANDITSTRUST).
+        // stateCounts respects query+group → only BanditsCamp entries → Available=1 only.
+        // groupCounts respects query+state (no state filter) → all entries.
         let by_group = query_progression(
             &path,
             &json!({ "section": "quests", "group": "banditscamp" }),
@@ -8259,8 +8306,14 @@ mod tests {
         .unwrap();
         assert_eq!(by_group["total"], 1);
         assert_eq!(by_group["quests"][0]["name"], "BANDITSTRUST");
+        assert_eq!(by_group["stateCounts"]["Available"], 1);
+        assert!(by_group["stateCounts"]["Running"].is_null());
+        assert_eq!(by_group["groupCounts"]["BanditsCamp"], 1);
+        assert_eq!(by_group["groupCounts"]["OldCamp"], 1);
 
-        // Combined state+group with no match → 0 results, but counts stay full.
+        // Combined state=Running + group=BanditsCamp → 0 results (Running quest is in OldCamp).
+        // stateCounts: query+group(BanditsCamp) → only BanditsCamp entry → Available=1.
+        // groupCounts: query+state(Running) → only Running entry → OldCamp=1.
         let no_match = query_progression(
             &path,
             &json!({ "section": "quests", "state": "Running", "group": "BanditsCamp" }),
@@ -8268,10 +8321,12 @@ mod tests {
         )
         .unwrap();
         assert_eq!(no_match["total"], 0);
-        assert_eq!(no_match["stateCounts"]["Running"], 1);
+        // stateCounts sees only BanditsCamp entries (Available).
         assert_eq!(no_match["stateCounts"]["Available"], 1);
-        assert_eq!(no_match["groupCounts"]["BanditsCamp"], 1);
+        assert!(no_match["stateCounts"]["Running"].is_null());
+        // groupCounts sees only Running entries (OldCamp).
         assert_eq!(no_match["groupCounts"]["OldCamp"], 1);
+        assert!(no_match["groupCounts"]["BanditsCamp"].is_null());
     }
 
     // ── Task 6 helpers ──────────────────────────────────────────────────────

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2131,8 +2131,16 @@ fn inspect_private_payload(
                 .collect::<Vec<_>>();
             let player = summarize_private_player_payload(&payload, &refs);
             let inventory = summarize_private_inventory_payload(&payload, &refs);
-            let progression = summarize_private_progression_payload(&refs);
-            let typed_parse = summarize_typed_parse(&payload, preview);
+            let typed_result = if preview {
+                None
+            } else {
+                Some(properties::parse_private_root(&payload))
+            };
+            let typed_parse = summarize_typed_parse_result(&payload, typed_result.as_ref());
+            let typed_ok = typed_parse["status"] == "ok";
+            let progression = summarize_private_progression_overview(
+                typed_result.as_ref().and_then(|r| r.as_ref().ok()).filter(|_| typed_ok),
+            );
             let mut writable = vec!["private.replaceFString"];
             if typed_parse["status"] == "ok" {
                 writable.extend([
@@ -2306,14 +2314,20 @@ fn summarize_private_inventory_payload(payload: &[u8], refs: &[FStringRef]) -> V
 /// edits; for now it surfaces whether the proven UE property grammar fully
 /// accounts for this save's bytes. Skipped for previews (truncated payloads
 /// cannot parse to completion).
-fn summarize_typed_parse(payload: &[u8], preview: bool) -> Value {
-    if preview {
+///
+/// `result` is `None` when the parse was skipped (preview mode); `Some(&Ok(...))`
+/// or `Some(&Err(...))` when parsing was attempted.
+fn summarize_typed_parse_result(
+    payload: &[u8],
+    result: Option<&Result<properties::RootObject, CoreError>>,
+) -> Value {
+    let Some(result) = result else {
         return json!({
             "status": "skipped_preview",
             "message": "Typed parse needs the full decoded payload.",
         });
-    }
-    match properties::parse_private_root(payload) {
+    };
+    match result {
         Ok(root) => {
             let counts = properties::count_properties(&root.properties);
             json!({
@@ -2874,48 +2888,75 @@ fn progression_events(
     }
 }
 
-fn summarize_private_progression_payload(refs: &[FStringRef]) -> Value {
-    let script_paths = unique_strings(
-        refs.iter()
-            .map(|r| r.value.as_str())
-            .filter(|value| value.starts_with("/Script/") && looks_progression_text(value)),
-        80,
-    );
-    let properties = unique_strings(
-        refs.iter()
-            .map(|r| r.value.as_str())
-            .filter(|value| value.starts_with("m_") && looks_progression_text(value)),
-        120,
-    );
-    let candidates = unique_strings(
-        refs.iter()
-            .map(|r| r.value.as_str())
-            .filter(|value| looks_progression_candidate(value)),
-        240,
-    );
-    let gameplay_tags = unique_strings(
-        candidates
-            .iter()
-            .map(String::as_str)
-            .filter(|value| looks_gameplay_tag_candidate(value)),
-        240,
-    );
-    let sections = unique_strings(
-        properties
-            .iter()
-            .filter_map(|property| progression_section_label(property)),
-        80,
-    );
+/// Structured progression overview for the inspect response: quest counts by
+/// state plus knowledge/memory totals. `root` is Some only when the strict
+/// typed parse succeeded on a full (non-preview) decode.
+fn summarize_private_progression_overview(root: Option<&properties::RootObject>) -> Value {
+    let Some(root) = root else {
+        return json!({ "status": "unavailable", "writable": [] });
+    };
+    let mut quest_total = 0usize;
+    let mut quest_states = std::collections::BTreeMap::<String, usize>::new();
+    if let Some((_, prop)) = properties::find_property_by_name(root, "QuestDataByClass") {
+        if let properties::PropertyValue::Map { entries, .. } = &prop.value {
+            quest_total = entries.len();
+            for (_, value) in entries {
+                let label = match struct_member(value, "CurrentState") {
+                    Some(properties::PropertyValue::Enum(s)) => short_enum_label(s).to_string(),
+                    _ => "unknown".to_string(),
+                };
+                *quest_states.entry(label).or_default() += 1;
+            }
+        }
+    }
+    let mut knowledge_characters = 0usize;
+    let mut knowledge_entries = 0usize;
+    if let Some((_, prop)) =
+        properties::find_property_by_name(root, "CharacterKnowledgeByUniqueName")
+    {
+        if let properties::PropertyValue::Map { entries, .. } = &prop.value {
+            knowledge_characters = entries.len();
+            for (_, value) in entries {
+                if let Some(properties::PropertyValue::Set { elements, .. }) =
+                    struct_member(value, "Knowledge")
+                {
+                    knowledge_entries += elements.len();
+                }
+            }
+        }
+    }
+    let mut memory_characters = 0usize;
+    let mut memory_events = 0usize;
+    if let Some((_, prop)) = properties::find_property_by_name(root, "LongTermMemoryByGlobalId") {
+        if let properties::PropertyValue::Map { entries, .. } = &prop.value {
+            memory_characters = entries.len();
+            for (_, value) in entries {
+                if let Some(properties::PropertyValue::Array { elements }) =
+                    struct_member(value, "MemorizedEvents")
+                {
+                    memory_events += elements.len();
+                }
+            }
+        }
+    }
     json!({
-        "candidateCount": candidates.len(),
-        "candidates": candidates,
-        "gameplayTags": gameplay_tags,
-        "sections": sections,
-        "scriptPaths": script_paths,
-        "properties": properties,
-        "writable": [],
+        "status": "ok",
+        "questTotal": quest_total,
+        "questStates": quest_states,
+        "knowledgeCharacters": knowledge_characters,
+        "knowledgeEntries": knowledge_entries,
+        "memoryCharacters": memory_characters,
+        "memoryEvents": memory_events,
+        "writable": [
+            "private.typed.setValue",
+            "private.typed.setAdd",
+            "private.typed.setRemove",
+            "private.typed.arrayRemove",
+            "private.typed.arrayDuplicate",
+        ],
     })
 }
+
 
 fn summarize_private_inventory_items(
     payload: &[u8],
@@ -3102,58 +3143,6 @@ fn looks_inventory_candidate(value: &str) -> bool {
         return true;
     }
     lower.contains("/items/") || lower.contains("bp_item_") || lower.contains("inventoryitem")
-}
-
-fn looks_progression_candidate(value: &str) -> bool {
-    if value.starts_with("m_") || value.starts_with("/Script/") || is_property_type_name(value) {
-        return false;
-    }
-    if matches!(
-        value,
-        "GameplayTag" | "GameplayTagContainer" | "TagName" | "None"
-    ) {
-        return false;
-    }
-    looks_progression_text(value) && value.contains('.')
-}
-
-fn looks_gameplay_tag_candidate(value: &str) -> bool {
-    value.contains('.')
-        && !value.starts_with('/')
-        && !value.starts_with("m_")
-        && looks_progression_text(value)
-}
-
-fn looks_progression_text(value: &str) -> bool {
-    contains_any_ci(
-        value,
-        &[
-            "quest",
-            "dialog",
-            "knowledge",
-            "event",
-            "chapter",
-            "guild",
-            "faction",
-            "mission",
-            "journal",
-            "progress",
-            "gameplaytag",
-        ],
-    )
-}
-
-fn progression_section_label(property: &str) -> Option<&'static str> {
-    match property {
-        "m_GeneratedEvents" | "GeneratedEvents" => Some("Generated events"),
-        "m_MemorizedEvents" | "MemorizedEvents" => Some("Memorized events"),
-        "m_ActiveQuestTags" | "ActiveQuestTags" => Some("Active quest tags"),
-        "m_ActiveQuests" | "ActiveQuests" => Some("Active quests"),
-        "m_CompletedQuests" | "CompletedQuests" => Some("Completed quests"),
-        "m_QuestLog" | "QuestLog" => Some("Quest log"),
-        "m_Knowledge" | "Knowledge" => Some("Knowledge"),
-        _ => None,
-    }
 }
 
 fn contains_any_ci(value: &str, needles: &[&str]) -> bool {
@@ -5290,8 +5279,8 @@ mod tests {
 
     #[test]
     fn summarize_typed_parse_reports_status() {
-        // skipped for previews
-        let skipped = summarize_typed_parse(&[], true);
+        // skipped for previews (result = None)
+        let skipped = summarize_typed_parse_result(&[], None);
         assert_eq!(skipped["status"], "skipped_preview");
 
         // ok for a valid minimal root object
@@ -5305,13 +5294,15 @@ mod tests {
         payload.extend_from_slice(&7i32.to_le_bytes());
         payload.extend_from_slice(&fstring("None"));
         payload.extend_from_slice(&0u32.to_le_bytes()); // footer
-        let ok = summarize_typed_parse(&payload, false);
+        let parse_ok = properties::parse_private_root(&payload);
+        let ok = summarize_typed_parse_result(&payload, Some(&parse_ok));
         assert_eq!(ok["status"], "ok");
         assert_eq!(ok["propertyCount"], 1);
         assert_eq!(ok["consumed"], payload.len());
 
         // failed for garbage
-        let bad = summarize_typed_parse(&[1, 2, 3, 4, 5, 6], false);
+        let parse_bad = properties::parse_private_root(&[1, 2, 3, 4, 5, 6]);
+        let bad = summarize_typed_parse_result(&[1, 2, 3, 4, 5, 6], Some(&parse_bad));
         assert_eq!(bad["status"], "failed");
     }
 
@@ -7640,20 +7631,16 @@ mod tests {
     }
 
     #[test]
-    fn inspect_save_reports_private_progression_summary() {
+    fn inspect_save_reports_progression_overview_unavailable_on_bad_payload() {
+        // When the private payload cannot be typed-parsed the overview reports
+        // "unavailable" rather than returning the deleted heuristic shape.
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
+        // Raw fstrings are not a valid typed payload — the typed parse will fail.
         let private_payload = [
             fstring("/Script/G1R.QuestSaveGameData"),
             fstring("m_GeneratedEvents"),
-            fstring("m_MemorizedEvents"),
-            fstring("m_ActiveQuestTags"),
-            fstring("GameplayTag"),
-            fstring("TagName"),
             fstring("Quest.Main.Chapter01"),
-            fstring("Dialog.Diego.IntroDone"),
-            fstring("Knowledge.OldCamp.PathKnown"),
-            fstring("m_ItemCount"),
         ]
         .concat();
         let seed_compressed = b"seed-compressed".to_vec();
@@ -7670,39 +7657,12 @@ mod tests {
 
         let value = inspect_save_with_codec_backend(&path, true, Some(&backend), None).unwrap();
 
-        assert_eq!(value["private"]["progression"]["candidateCount"], 3);
-        assert_eq!(
-            value["private"]["progression"]["candidates"],
-            json!([
-                "Quest.Main.Chapter01",
-                "Dialog.Diego.IntroDone",
-                "Knowledge.OldCamp.PathKnown"
-            ])
-        );
-        assert_eq!(
-            value["private"]["progression"]["properties"],
-            json!([
-                "m_GeneratedEvents",
-                "m_MemorizedEvents",
-                "m_ActiveQuestTags"
-            ])
-        );
-        assert_eq!(
-            value["private"]["progression"]["scriptPaths"],
-            json!(["/Script/G1R.QuestSaveGameData"])
-        );
-        assert_eq!(
-            value["private"]["progression"]["sections"],
-            json!(["Generated events", "Memorized events", "Active quest tags"])
-        );
-        assert_eq!(
-            value["private"]["progression"]["gameplayTags"],
-            json!([
-                "Quest.Main.Chapter01",
-                "Dialog.Diego.IntroDone",
-                "Knowledge.OldCamp.PathKnown"
-            ])
-        );
+        // Typed parse fails on garbage → overview is unavailable.
+        assert_eq!(value["private"]["progression"]["status"], "unavailable");
+        // Old heuristic fields must not appear.
+        assert!(value["private"]["progression"].get("candidates").is_none());
+        assert!(value["private"]["progression"].get("sections").is_none());
+        assert!(value["private"]["progression"].get("gameplayTags").is_none());
     }
 
     #[test]
@@ -8422,5 +8382,42 @@ mod tests {
         )
         .unwrap();
         assert_eq!(filtered["total"], 0);
+    }
+
+    #[test]
+    fn inspect_reports_structured_progression_overview() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-overview.sav");
+        let private_payload = quest_map_payload();
+        let seed_compressed = b"seed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let value = inspect_save_with_codec_backend(&path, true, Some(&backend), None).unwrap();
+        let progression = &value["private"]["progression"];
+        assert_eq!(progression["status"], "ok");
+        assert_eq!(progression["questTotal"], 2);
+        assert_eq!(progression["questStates"]["Running"], 1);
+        assert_eq!(progression["questStates"]["Available"], 1);
+        // No knowledge/memory maps in this fixture.
+        assert_eq!(progression["knowledgeCharacters"], 0);
+        assert_eq!(progression["memoryCharacters"], 0);
+        assert!(
+            progression["writable"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("private.typed.setValue"))
+        );
+        // The old heuristic fields are gone.
+        assert!(progression.get("candidates").is_none());
+        assert!(progression.get("sections").is_none());
     }
 }

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2622,27 +2622,256 @@ fn progression_quests(
 }
 
 fn progression_knowledge(
-    _root: &properties::RootObject,
-    _query: &str,
-    _character: Option<&str>,
-    _offset: usize,
-    _limit: usize,
+    root: &properties::RootObject,
+    query: &str,
+    character: Option<&str>,
+    offset: usize,
+    limit: usize,
 ) -> Result<Value, CoreError> {
-    Err(CoreError::InvalidRequest(
-        "knowledge section not implemented yet".to_string(),
-    ))
+    let (base_path, map_prop) =
+        properties::find_property_by_name(root, "CharacterKnowledgeByUniqueName").ok_or_else(
+            || {
+                CoreError::Parse(
+                    "CharacterKnowledgeByUniqueName not found in the decoded payload".to_string(),
+                )
+            },
+        )?;
+    let properties::PropertyValue::Map { entries, .. } = &map_prop.value else {
+        return Err(CoreError::Parse(
+            "CharacterKnowledgeByUniqueName is not a map".to_string(),
+        ));
+    };
+    let knowledge_entries = |value: &properties::PropertyValue| -> Vec<String> {
+        match struct_member(value, "Knowledge") {
+            Some(properties::PropertyValue::Set { elements, .. }) => elements
+                .iter()
+                .filter_map(|e| match e {
+                    properties::PropertyValue::Name(s) | properties::PropertyValue::Str(s) => {
+                        Some(s.clone())
+                    }
+                    _ => None,
+                })
+                .collect(),
+            _ => Vec::new(),
+        }
+    };
+    match character {
+        None => {
+            let mut characters: Vec<(String, usize)> = entries
+                .iter()
+                .filter_map(|(key, value)| {
+                    let name = map_key_string(key)?;
+                    if !query.is_empty() && !name.to_ascii_lowercase().contains(query) {
+                        return None;
+                    }
+                    Some((name.to_string(), knowledge_entries(value).len()))
+                })
+                .collect();
+            characters.sort_by(|a, b| a.0.cmp(&b.0));
+            let total = characters.len();
+            let page = characters
+                .into_iter()
+                .skip(offset)
+                .take(limit)
+                .map(|(name, entry_count)| json!({ "name": name, "entryCount": entry_count }))
+                .collect::<Vec<_>>();
+            Ok(json!({
+                "section": "knowledge",
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+                "count": page.len(),
+                "characters": page,
+            }))
+        }
+        Some(character) => {
+            let value = entries
+                .iter()
+                .find(|(key, _)| map_key_string(key) == Some(character))
+                .map(|(_, value)| value)
+                .ok_or_else(|| {
+                    CoreError::Parse(format!("character {character:?} has no knowledge entry"))
+                })?;
+            let mut all = knowledge_entries(value);
+            if !query.is_empty() {
+                all.retain(|e| e.to_ascii_lowercase().contains(query));
+            }
+            let total = all.len();
+            let page = all
+                .into_iter()
+                .skip(offset)
+                .take(limit)
+                .collect::<Vec<_>>();
+            let mut set_path = base_path.clone();
+            set_path.push(format!("{{{character}}}"));
+            set_path.push("Knowledge".to_string());
+            Ok(json!({
+                "section": "knowledge",
+                "character": character,
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+                "count": page.len(),
+                "entries": page,
+                "setPath": set_path,
+            }))
+        }
+    }
 }
 
 fn progression_events(
-    _root: &properties::RootObject,
-    _query: &str,
-    _character: Option<&str>,
-    _offset: usize,
-    _limit: usize,
+    root: &properties::RootObject,
+    query: &str,
+    character: Option<&str>,
+    offset: usize,
+    limit: usize,
 ) -> Result<Value, CoreError> {
-    Err(CoreError::InvalidRequest(
-        "events section not implemented yet".to_string(),
-    ))
+    let (base_path, map_prop) =
+        properties::find_property_by_name(root, "LongTermMemoryByGlobalId").ok_or_else(|| {
+            CoreError::Parse(
+                "LongTermMemoryByGlobalId not found in the decoded payload".to_string(),
+            )
+        })?;
+    let properties::PropertyValue::Map { entries, .. } = &map_prop.value else {
+        return Err(CoreError::Parse(
+            "LongTermMemoryByGlobalId is not a map".to_string(),
+        ));
+    };
+    let memorized = |value: &properties::PropertyValue| -> Option<usize> {
+        match struct_member(value, "MemorizedEvents") {
+            Some(properties::PropertyValue::Array { elements }) => Some(elements.len()),
+            _ => None,
+        }
+    };
+    match character {
+        None => {
+            let mut characters: Vec<(String, usize)> = entries
+                .iter()
+                .filter_map(|(key, value)| {
+                    let id = map_key_string(key)?;
+                    if !query.is_empty() && !id.to_ascii_lowercase().contains(query) {
+                        return None;
+                    }
+                    Some((id.to_string(), memorized(value).unwrap_or(0)))
+                })
+                .collect();
+            characters.sort_by(|a, b| a.0.cmp(&b.0));
+            let total = characters.len();
+            let page = characters
+                .into_iter()
+                .skip(offset)
+                .take(limit)
+                .map(|(id, event_count)| json!({ "id": id, "eventCount": event_count }))
+                .collect::<Vec<_>>();
+            Ok(json!({
+                "section": "events",
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+                "count": page.len(),
+                "characters": page,
+            }))
+        }
+        Some(character) => {
+            let value = entries
+                .iter()
+                .find(|(key, _)| map_key_string(key) == Some(character))
+                .map(|(_, value)| value)
+                .ok_or_else(|| {
+                    CoreError::Parse(format!("character {character:?} has no memory entry"))
+                })?;
+            let Some(properties::PropertyValue::Array { elements }) =
+                struct_member(value, "MemorizedEvents")
+            else {
+                return Err(CoreError::Parse(
+                    "MemorizedEvents missing or not an array".to_string(),
+                ));
+            };
+            let event_json = |index: usize, element: &properties::PropertyValue| -> Value {
+                let tags = match struct_member(element, "EventTags") {
+                    Some(properties::PropertyValue::Struct(
+                        properties::StructValue::GameplayTagContainer(tags),
+                    )) => tags.clone(),
+                    _ => Vec::new(),
+                };
+                let in_game_seconds = |name: &str| -> Option<f64> {
+                    match struct_member(element, name)
+                        .and_then(|t| struct_member(t, "TotalSeconds"))
+                    {
+                        Some(properties::PropertyValue::Double(v)) => Some(*v),
+                        _ => None,
+                    }
+                };
+                let name_member = |name: &str| -> Option<String> {
+                    match struct_member(element, name) {
+                        Some(properties::PropertyValue::Name(s)) => Some(s.clone()),
+                        _ => None,
+                    }
+                };
+                let soft_member = |name: &str| -> Option<String> {
+                    match struct_member(element, name) {
+                        Some(properties::PropertyValue::SoftObject(p))
+                            if !p.package_name.is_empty() && p.package_name != "None" =>
+                        {
+                            Some(p.package_name.clone())
+                        }
+                        _ => None,
+                    }
+                };
+                let magnitude = match struct_member(element, "Magnitude") {
+                    Some(properties::PropertyValue::Float(v)) => Some(f64::from(*v)),
+                    _ => None,
+                };
+                json!({
+                    "index": index,
+                    "tags": tags,
+                    "magnitude": magnitude,
+                    "timeSeconds": in_game_seconds("Time"),
+                    "durationSeconds": in_game_seconds("Duration"),
+                    "instigator": name_member("InstigatorGlobalId"),
+                    "affected": name_member("AffectedCharacterGlobalId"),
+                    "optionalClass1": soft_member("OptionalClass1"),
+                    "optionalClass2": soft_member("OptionalClass2"),
+                })
+            };
+            let matches_query = |event: &Value| -> bool {
+                if query.is_empty() {
+                    return true;
+                }
+                let hay = [
+                    event["tags"].to_string(),
+                    event["instigator"].to_string(),
+                    event["affected"].to_string(),
+                    event["optionalClass1"].to_string(),
+                    event["optionalClass2"].to_string(),
+                ]
+                .join(" ")
+                .to_ascii_lowercase();
+                hay.contains(query)
+            };
+            let all: Vec<Value> = elements
+                .iter()
+                .enumerate()
+                .map(|(index, element)| event_json(index, element))
+                .filter(|e| matches_query(e))
+                .collect();
+            let total = all.len();
+            let page = all.into_iter().skip(offset).take(limit).collect::<Vec<_>>();
+            let mut array_path = base_path.clone();
+            array_path.push(format!("{{{character}}}"));
+            array_path.push("MemorizedEvents".to_string());
+            Ok(json!({
+                "section": "events",
+                "character": character,
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+                "count": page.len(),
+                "events": page,
+                "arrayPath": array_path,
+            }))
+        }
+    }
 }
 
 fn summarize_private_progression_payload(refs: &[FStringRef]) -> Value {
@@ -7950,5 +8179,248 @@ mod tests {
         )
         .unwrap();
         assert_eq!(after["quests"][0]["currentState"], "EQuestState::Succeeded");
+    }
+
+    // ── Task 6 helpers ──────────────────────────────────────────────────────
+
+    fn private_double_property(name: &str, value: f64) -> Vec<u8> {
+        let mut out = fstring(name);
+        out.extend_from_slice(&fstring("DoubleProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&8u32.to_le_bytes());
+        out.push(0);
+        out.extend_from_slice(&value.to_le_bytes());
+        out
+    }
+
+    fn private_struct_property(name: &str, struct_type: &str, body: &[u8], flags: u8) -> Vec<u8> {
+        let mut out = fstring(name);
+        out.extend_from_slice(&fstring("StructProperty"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring(struct_type));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("/Script/G1R"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.push(flags);
+        out.extend_from_slice(body);
+        out
+    }
+
+    fn name_keyed_struct_map(map_name: &str, entries: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        let mut map_body = 0u32.to_le_bytes().to_vec();
+        map_body.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+        for (key, value_props) in entries {
+            map_body.extend_from_slice(&fstring(key));
+            map_body.extend_from_slice(value_props);
+            map_body.extend_from_slice(&fstring("None"));
+        }
+        let mut out = fstring(map_name);
+        out.extend_from_slice(&fstring("MapProperty"));
+        out.extend_from_slice(&2u32.to_le_bytes());
+        out.extend_from_slice(&fstring("NameProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&fstring("StructProperty"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("KnowledgeSet"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("/Script/G1R"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&(map_body.len() as u32).to_le_bytes());
+        out.push(0);
+        out.extend_from_slice(&map_body);
+        out
+    }
+
+    #[test]
+    fn query_progression_knowledge_lists_characters_and_entries() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-knowledge.sav");
+        let private_payload = {
+            let diego = private_name_set_property(
+                "Knowledge",
+                &["Voiceline_info_diego_gamestart_11_00", "ChoiceDiegoGamestart"],
+            );
+            let xardas = private_name_set_property("Knowledge", &["Voiceline_xardas_intro"]);
+            let map = name_keyed_struct_map(
+                "CharacterKnowledgeByUniqueName",
+                &[("OC_STT_Diego", diego), ("NoneCamp_Xardas", xardas)],
+            );
+            let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+            p.push(0);
+            p.extend_from_slice(&map);
+            p.extend_from_slice(&fstring("None"));
+            p.extend_from_slice(&0u32.to_le_bytes());
+            p
+        };
+        let seed_compressed = b"seed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        // Character list (no `character` param).
+        let value =
+            query_progression(&path, &json!({ "section": "knowledge" }), Some(&backend)).unwrap();
+        assert_eq!(value["total"], 2);
+        // Sorted by name: NoneCamp_Xardas before OC_STT_Diego.
+        assert_eq!(value["characters"][0]["name"], "NoneCamp_Xardas");
+        assert_eq!(value["characters"][0]["entryCount"], 1);
+        assert_eq!(value["characters"][1]["name"], "OC_STT_Diego");
+        assert_eq!(value["characters"][1]["entryCount"], 2);
+
+        // Entries for one character.
+        let value = query_progression(
+            &path,
+            &json!({ "section": "knowledge", "character": "OC_STT_Diego" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(value["character"], "OC_STT_Diego");
+        assert_eq!(value["total"], 2);
+        assert_eq!(
+            value["setPath"],
+            json!([
+                "CharacterKnowledgeByUniqueName",
+                "{OC_STT_Diego}",
+                "Knowledge"
+            ])
+        );
+        let entries = value["entries"].as_array().unwrap();
+        assert!(entries.contains(&json!("ChoiceDiegoGamestart")));
+
+        // Query filter on entries.
+        let value = query_progression(
+            &path,
+            &json!({ "section": "knowledge", "character": "OC_STT_Diego", "query": "choice" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(value["total"], 1);
+
+        // Unknown character errors.
+        assert!(
+            query_progression(
+                &path,
+                &json!({ "section": "knowledge", "character": "Nobody" }),
+                Some(&backend),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn query_progression_events_lists_characters_and_events() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-events.sav");
+        let private_payload = {
+            // One memory event struct: EventTags (native GameplayTagContainer)
+            // + Time (InGameTime property list) + AffectedCharacterGlobalId.
+            let event = {
+                let mut tags_body = 1u32.to_le_bytes().to_vec();
+                tags_body.extend_from_slice(&fstring("Memory.Quest.Started"));
+                let mut e = private_struct_property(
+                    "EventTags",
+                    "GameplayTagContainer",
+                    &tags_body,
+                    properties::TAG_FLAG_NATIVE_SERIALIZE,
+                );
+                let time_body = {
+                    let mut t = private_double_property("TotalSeconds", 1234.5);
+                    t.extend_from_slice(&fstring("None"));
+                    t
+                };
+                e.extend_from_slice(&private_struct_property(
+                    "Time", "InGameTime", &time_body, 0,
+                ));
+                let mut affected = fstring("AffectedCharacterGlobalId");
+                affected.extend_from_slice(&fstring("NameProperty"));
+                affected.extend_from_slice(&0u32.to_le_bytes());
+                let hero = fstring("Hero");
+                affected.extend_from_slice(&(hero.len() as u32).to_le_bytes());
+                affected.push(0);
+                affected.extend_from_slice(&hero);
+                e.extend_from_slice(&affected);
+                e
+            };
+            // MemorizedEvents: ArrayProperty of MemoryEvent structs (inline
+            // tagged property lists, "None"-terminated).
+            let memorized = {
+                let mut element = event.clone();
+                element.extend_from_slice(&fstring("None"));
+                let mut body = 1u32.to_le_bytes().to_vec();
+                body.extend_from_slice(&element);
+                let mut out = fstring("MemorizedEvents");
+                out.extend_from_slice(&fstring("ArrayProperty"));
+                out.extend_from_slice(&1u32.to_le_bytes());
+                out.extend_from_slice(&fstring("StructProperty"));
+                out.extend_from_slice(&1u32.to_le_bytes());
+                out.extend_from_slice(&fstring("MemoryEvent"));
+                out.extend_from_slice(&1u32.to_le_bytes());
+                out.extend_from_slice(&fstring("/Script/G1R"));
+                out.extend_from_slice(&0u32.to_le_bytes());
+                out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+                out.push(0);
+                out.extend_from_slice(&body);
+                out
+            };
+            let map = name_keyed_struct_map("LongTermMemoryByGlobalId", &[("Hero", memorized)]);
+            let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+            p.push(0);
+            p.extend_from_slice(&map);
+            p.extend_from_slice(&fstring("None"));
+            p.extend_from_slice(&0u32.to_le_bytes());
+            p
+        };
+        let seed_compressed = b"seed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let value =
+            query_progression(&path, &json!({ "section": "events" }), Some(&backend)).unwrap();
+        assert_eq!(value["total"], 1);
+        assert_eq!(value["characters"][0]["id"], "Hero");
+        assert_eq!(value["characters"][0]["eventCount"], 1);
+
+        let value = query_progression(
+            &path,
+            &json!({ "section": "events", "character": "Hero" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(value["character"], "Hero");
+        assert_eq!(value["total"], 1);
+        assert_eq!(
+            value["arrayPath"],
+            json!(["LongTermMemoryByGlobalId", "{Hero}", "MemorizedEvents"])
+        );
+        let event = &value["events"][0];
+        assert_eq!(event["index"], 0);
+        assert_eq!(event["tags"], json!(["Memory.Quest.Started"]));
+        assert_eq!(event["timeSeconds"], 1234.5);
+        assert_eq!(event["affected"], "Hero");
+
+        // Tag query filter.
+        let filtered = query_progression(
+            &path,
+            &json!({ "section": "events", "character": "Hero", "query": "guild" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(filtered["total"], 0);
     }
 }

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -408,6 +408,17 @@ fn execute_json_inner(input: &str) -> Result<Value, CoreError> {
                 .map(|backend| backend as &dyn codec_backend::CodecBackend);
             search_typed_properties(&path, &payload, codec_backend)
         }
+        "query_progression" => {
+            let path = required_path(&payload)?;
+            let codec_backend = payload
+                .get("binaryHost")
+                .map(binary_host_backend_from_config)
+                .transpose()?;
+            let codec_backend = codec_backend
+                .as_ref()
+                .map(|backend| backend as &dyn codec_backend::CodecBackend);
+            query_progression(&path, &payload, codec_backend)
+        }
         "validate_roundtrip" => {
             let path = required_path(&payload)?;
             Ok(validate_roundtrip(&path)?)
@@ -2440,6 +2451,198 @@ fn search_typed_properties(
         "count": results.len(),
         "results": results,
     }))
+}
+
+/// Structured progression queries over the decoded private payload. Sections:
+/// "quests" (QuestDataByClass entries with setValue-addressable state paths),
+/// "knowledge" (per-NPC dialog knowledge sets), "events" (per-character
+/// memorized event arrays). Uses the shared decode cache like the typed
+/// property search.
+fn query_progression(
+    path: &Path,
+    payload: &Value,
+    backend: Option<&dyn codec_backend::CodecBackend>,
+) -> Result<Value, CoreError> {
+    let backend = backend.ok_or_else(|| {
+        CoreError::Codec(
+            "progression queries require a configured and verified G1R codec host".to_string(),
+        )
+    })?;
+    let section = payload
+        .get("section")
+        .and_then(Value::as_str)
+        .unwrap_or("quests");
+    let query = payload
+        .get("query")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    let limit = payload
+        .get("limit")
+        .and_then(Value::as_u64)
+        .map(|v| v as usize)
+        .unwrap_or(100)
+        .clamp(1, 1000);
+    let offset = payload
+        .get("offset")
+        .and_then(Value::as_u64)
+        .map(|v| v as usize)
+        .unwrap_or(0);
+    let character = payload.get("character").and_then(Value::as_str);
+
+    let data = fs::read(path)?;
+    if !data.starts_with(b"GSAV") {
+        return Err(CoreError::UnsupportedEdit(
+            "progression queries are only available for GSAV files".to_string(),
+        ));
+    }
+    let parts = split_gsav(&data)?;
+    let stream = parse_compressed_stream(&data, 13 + parts.public_payload.len())?;
+    let decoded = decoded_private_payload_cached(path, &data, &stream, backend)?;
+    let root = properties::parse_private_root(&decoded)?;
+    match section {
+        "quests" => progression_quests(&root, &query, offset, limit),
+        "knowledge" => progression_knowledge(&root, &query, character, offset, limit),
+        "events" => progression_events(&root, &query, character, offset, limit),
+        other => Err(CoreError::InvalidRequest(format!(
+            "unknown progression section {other:?}"
+        ))),
+    }
+}
+
+/// Property lookup inside a struct-valued map entry (tagged property list or
+/// InstancedStruct wrapper).
+fn struct_member<'a>(
+    value: &'a properties::PropertyValue,
+    name: &str,
+) -> Option<&'a properties::PropertyValue> {
+    let props = match value {
+        properties::PropertyValue::Struct(properties::StructValue::Properties(p)) => p,
+        properties::PropertyValue::Struct(properties::StructValue::Instanced(Some(i))) => {
+            &i.properties
+        }
+        _ => return None,
+    };
+    props.iter().find(|p| p.name == name).map(|p| &p.value)
+}
+
+fn map_key_string(key: &properties::PropertyValue) -> Option<&str> {
+    match key {
+        properties::PropertyValue::Str(s)
+        | properties::PropertyValue::Name(s)
+        | properties::PropertyValue::Enum(s)
+        | properties::PropertyValue::Object(s) => Some(s),
+        _ => None,
+    }
+}
+
+/// "EQuestState::Running" → "Running" for the overview/state-count labels.
+fn short_enum_label(value: &str) -> &str {
+    value.rsplit("::").next().unwrap_or(value)
+}
+
+fn progression_quests(
+    root: &properties::RootObject,
+    query: &str,
+    offset: usize,
+    limit: usize,
+) -> Result<Value, CoreError> {
+    let (base_path, map_prop) = properties::find_property_by_name(root, "QuestDataByClass")
+        .ok_or_else(|| {
+            CoreError::Parse("QuestDataByClass not found in the decoded payload".to_string())
+        })?;
+    let properties::PropertyValue::Map { entries, .. } = &map_prop.value else {
+        return Err(CoreError::Parse(
+            "QuestDataByClass is not a map".to_string(),
+        ));
+    };
+    let mut state_counts = std::collections::BTreeMap::<String, usize>::new();
+    let mut matches: Vec<(String, Option<String>)> = Vec::new();
+    for (key, value) in entries {
+        let Some(class_path) = map_key_string(key) else {
+            continue;
+        };
+        let state = struct_member(value, "CurrentState").and_then(|v| match v {
+            properties::PropertyValue::Enum(s) => Some(s.clone()),
+            _ => None,
+        });
+        let label = state
+            .as_deref()
+            .map(short_enum_label)
+            .unwrap_or("unknown")
+            .to_string();
+        *state_counts.entry(label).or_default() += 1;
+        if !query.is_empty() && !class_path.to_ascii_lowercase().contains(&*query) {
+            continue;
+        }
+        matches.push((class_path.to_string(), state));
+    }
+    matches.sort_by(|a, b| a.0.cmp(&b.0));
+    let total = matches.len();
+    let quests = matches
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(|(class_path, state)| {
+            let id = class_path
+                .rsplit('.')
+                .next()
+                .unwrap_or(class_path.as_str())
+                .to_string();
+            let trimmed = id.strip_prefix("Quest_").unwrap_or(&id);
+            let (group, name) = match trimmed.split_once('_') {
+                Some((g, n)) => (g.to_string(), n.to_string()),
+                None => (trimmed.to_string(), String::new()),
+            };
+            let mut state_path = base_path.clone();
+            state_path.push(format!("{{{class_path}}}"));
+            state_path.push("CurrentState".to_string());
+            let writable = state.is_some();
+            json!({
+                "questClass": class_path,
+                "id": id,
+                "group": group,
+                "name": name,
+                "currentState": state,
+                "statePath": state_path,
+                "writable": writable,
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "section": "quests",
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "count": quests.len(),
+        "stateCounts": state_counts,
+        "quests": quests,
+    }))
+}
+
+fn progression_knowledge(
+    _root: &properties::RootObject,
+    _query: &str,
+    _character: Option<&str>,
+    _offset: usize,
+    _limit: usize,
+) -> Result<Value, CoreError> {
+    Err(CoreError::InvalidRequest(
+        "knowledge section not implemented yet".to_string(),
+    ))
+}
+
+fn progression_events(
+    _root: &properties::RootObject,
+    _query: &str,
+    _character: Option<&str>,
+    _offset: usize,
+    _limit: usize,
+) -> Result<Value, CoreError> {
+    Err(CoreError::InvalidRequest(
+        "events section not implemented yet".to_string(),
+    ))
 }
 
 fn summarize_private_progression_payload(refs: &[FStringRef]) -> Value {
@@ -7610,5 +7813,142 @@ mod tests {
         assert_eq!(value["private"]["typedParse"]["status"], "ok");
         let strings = value["private"]["strings"].as_array().unwrap();
         assert!(strings.iter().any(|s| s == "ChoiceB"));
+    }
+
+    // ── Task 5 helpers ──────────────────────────────────────────────────────
+
+    fn private_enum_property(name: &str, enum_type: &str, label: &str) -> Vec<u8> {
+        let body = fstring(label);
+        let mut out = fstring(name);
+        out.extend_from_slice(&fstring("EnumProperty"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring(enum_type));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("/Script/G1R"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("ByteProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes()); // array_index
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.push(0); // tag_flags
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn quest_map_payload() -> Vec<u8> {
+        let quest_value = |state: &str| {
+            let mut v = private_enum_property("CurrentState", "EQuestState", state);
+            v.extend_from_slice(&fstring("None"));
+            v
+        };
+        let mut map_body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        map_body.extend_from_slice(&2u32.to_le_bytes()); // count
+        map_body.extend_from_slice(&fstring("/Script/Angelscript.Quest_OldCamp_SLEEPER"));
+        map_body.extend_from_slice(&quest_value("EQuestState::Running"));
+        map_body.extend_from_slice(&fstring("/Script/Angelscript.Quest_BanditsCamp_BANDITSTRUST"));
+        map_body.extend_from_slice(&quest_value("EQuestState::Available"));
+
+        let mut props = fstring("QuestDataByClass");
+        props.extend_from_slice(&fstring("MapProperty"));
+        props.extend_from_slice(&2u32.to_le_bytes());
+        props.extend_from_slice(&fstring("ObjectProperty"));
+        props.extend_from_slice(&0u32.to_le_bytes()); // key_flags
+        props.extend_from_slice(&fstring("StructProperty"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("SingleQuestSaveGameData"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("/Script/G1R"));
+        props.extend_from_slice(&0u32.to_le_bytes()); // array_index
+        props.extend_from_slice(&(map_body.len() as u32).to_le_bytes());
+        props.push(0); // tag_flags (struct map values are tagged property lists)
+        props.extend_from_slice(&map_body);
+
+        let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+        p.push(0);
+        p.extend_from_slice(&props);
+        p.extend_from_slice(&fstring("None"));
+        p.extend_from_slice(&0u32.to_le_bytes());
+        p
+    }
+
+    #[test]
+    fn query_progression_lists_quests_with_state_paths() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-quests.sav");
+        let private_payload = quest_map_payload();
+        let seed_compressed = b"seed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let value =
+            query_progression(&path, &json!({ "section": "quests" }), Some(&backend)).unwrap();
+        assert_eq!(value["section"], "quests");
+        assert_eq!(value["total"], 2);
+        assert_eq!(value["stateCounts"]["Running"], 1);
+        assert_eq!(value["stateCounts"]["Available"], 1);
+        // Sorted by class path: BanditsCamp before OldCamp.
+        let first = &value["quests"][0];
+        assert_eq!(
+            first["questClass"],
+            "/Script/Angelscript.Quest_BanditsCamp_BANDITSTRUST"
+        );
+        assert_eq!(first["id"], "Quest_BanditsCamp_BANDITSTRUST");
+        assert_eq!(first["group"], "BanditsCamp");
+        assert_eq!(first["name"], "BANDITSTRUST");
+        assert_eq!(first["currentState"], "EQuestState::Available");
+        assert_eq!(
+            first["statePath"],
+            json!([
+                "QuestDataByClass",
+                "{/Script/Angelscript.Quest_BanditsCamp_BANDITSTRUST}",
+                "CurrentState"
+            ])
+        );
+
+        // Query filter + paging.
+        let filtered = query_progression(
+            &path,
+            &json!({ "section": "quests", "query": "sleeper" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(filtered["total"], 1);
+        assert_eq!(filtered["quests"][0]["name"], "SLEEPER");
+
+        // The statePath round-trips through the existing setValue write.
+        let output_path = dir.path().join("G1R-quests-out.sav");
+        let response = write_save_with_codec_backend(
+            &path,
+            &[json!({
+                "path": "private.typed.setValue",
+                "value": {
+                    "path": [
+                        "QuestDataByClass",
+                        "{/Script/Angelscript.Quest_BanditsCamp_BANDITSTRUST}",
+                        "CurrentState"
+                    ],
+                    "value": "EQuestState::Succeeded"
+                }
+            })],
+            false,
+            Some(&output_path),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(response["editsApplied"], 1);
+        let after = query_progression(
+            &output_path,
+            &json!({ "section": "quests", "query": "banditstrust" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(after["quests"][0]["currentState"], "EQuestState::Succeeded");
     }
 }

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2124,7 +2124,13 @@ fn inspect_private_payload(
             let typed_parse = summarize_typed_parse(&payload, preview);
             let mut writable = vec!["private.replaceFString"];
             if typed_parse["status"] == "ok" {
-                writable.push("private.typed.setValue");
+                writable.extend([
+                    "private.typed.setValue",
+                    "private.typed.setAdd",
+                    "private.typed.setRemove",
+                    "private.typed.arrayRemove",
+                    "private.typed.arrayDuplicate",
+                ]);
             }
             Ok(json!({
                 "status": if preview { "decoded_preview" } else { "decoded" },
@@ -3320,6 +3326,13 @@ fn apply_private_edits(
             "private.typed.setValue" => {
                 parse_private_typed_set_value_edit(edit).map(PrivateEdit::TypedSetValue)
             }
+            "private.typed.setAdd"
+            | "private.typed.setRemove"
+            | "private.typed.arrayRemove"
+            | "private.typed.arrayDuplicate" => {
+                parse_private_typed_container_edit(edit, edit.path.as_str())
+                    .map(PrivateEdit::TypedContainer)
+            }
             other => Err(CoreError::UnsupportedEdit(format!(
                 "{other} is not writable in this build"
             ))),
@@ -3397,6 +3410,7 @@ enum PrivateEdit {
     PlayerTransform(PrivatePlayerTransformEdit),
     InventoryItemCount(PrivateInventoryItemCountEdit),
     TypedSetValue(PrivateTypedSetValueEdit),
+    TypedContainer(PrivateTypedContainerEdit),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -3405,38 +3419,104 @@ struct PrivateTypedSetValueEdit {
     value: Value,
 }
 
-fn parse_private_typed_set_value_edit(edit: &Edit) -> Result<PrivateTypedSetValueEdit, CoreError> {
-    let value = edit.value.as_object().ok_or_else(|| {
-        CoreError::InvalidRequest("private.typed.setValue value must be an object".to_string())
-    })?;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PrivateTypedContainerEdit {
+    path: Vec<properties::PathSeg>,
+    edit: properties::ContainerEdit,
+}
+
+fn parse_typed_edit_path(
+    op: &str,
+    value: &serde_json::Map<String, Value>,
+) -> Result<Vec<properties::PathSeg>, CoreError> {
     let segments = value
         .get("path")
         .and_then(Value::as_array)
         .ok_or_else(|| {
-            CoreError::InvalidRequest(
-                "private.typed.setValue requires value.path as an array of segments".to_string(),
-            )
+            CoreError::InvalidRequest(format!(
+                "{op} requires value.path as an array of segments"
+            ))
         })?
         .iter()
         .map(|segment| {
             segment.as_str().map(str::to_string).ok_or_else(|| {
-                CoreError::InvalidRequest(
-                    "private.typed.setValue path segments must be strings".to_string(),
-                )
+                CoreError::InvalidRequest(format!("{op} path segments must be strings"))
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
     if segments.is_empty() {
-        return Err(CoreError::InvalidRequest(
-            "private.typed.setValue requires a non-empty value.path".to_string(),
-        ));
+        return Err(CoreError::InvalidRequest(format!(
+            "{op} requires a non-empty value.path"
+        )));
     }
+    properties::parse_path(&segments)
+}
+
+fn parse_private_typed_set_value_edit(edit: &Edit) -> Result<PrivateTypedSetValueEdit, CoreError> {
+    let value = edit.value.as_object().ok_or_else(|| {
+        CoreError::InvalidRequest("private.typed.setValue value must be an object".to_string())
+    })?;
+    let path = parse_typed_edit_path("private.typed.setValue", value)?;
     let new_value = value.get("value").cloned().ok_or_else(|| {
         CoreError::InvalidRequest("private.typed.setValue requires value.value".to_string())
     })?;
     Ok(PrivateTypedSetValueEdit {
-        path: properties::parse_path(&segments)?,
+        path,
         value: new_value,
+    })
+}
+
+fn parse_private_typed_container_edit(
+    edit: &Edit,
+    op: &str,
+) -> Result<PrivateTypedContainerEdit, CoreError> {
+    let value = edit.value.as_object().ok_or_else(|| {
+        CoreError::InvalidRequest(format!("{op} value must be an object"))
+    })?;
+    let path = parse_typed_edit_path(op, value)?;
+    let container_edit = match op {
+        "private.typed.setAdd" | "private.typed.setRemove" => {
+            let element = value
+                .get("value")
+                .and_then(Value::as_str)
+                .filter(|s| !s.trim().is_empty())
+                .ok_or_else(|| {
+                    CoreError::InvalidRequest(format!(
+                        "{op} requires a non-empty string value.value"
+                    ))
+                })?
+                .to_string();
+            if op == "private.typed.setAdd" {
+                properties::ContainerEdit::SetAdd(element)
+            } else {
+                properties::ContainerEdit::SetRemove(element)
+            }
+        }
+        "private.typed.arrayRemove" | "private.typed.arrayDuplicate" => {
+            let index = value
+                .get("index")
+                .and_then(Value::as_u64)
+                .and_then(|v| usize::try_from(v).ok())
+                .ok_or_else(|| {
+                    CoreError::InvalidRequest(format!(
+                        "{op} requires a non-negative integer value.index"
+                    ))
+                })?;
+            if op == "private.typed.arrayRemove" {
+                properties::ContainerEdit::ArrayRemove(index)
+            } else {
+                properties::ContainerEdit::ArrayDuplicate(index)
+            }
+        }
+        other => {
+            return Err(CoreError::UnsupportedEdit(format!(
+                "{other} is not a typed container edit"
+            )));
+        }
+    };
+    Ok(PrivateTypedContainerEdit {
+        path,
+        edit: container_edit,
     })
 }
 
@@ -3910,7 +3990,36 @@ fn apply_private_edit_to_payload(
         PrivateEdit::TypedSetValue(edit) => {
             apply_private_typed_set_value_edit_to_payload(payload, edit)
         }
+        PrivateEdit::TypedContainer(edit) => {
+            apply_private_typed_container_edit_to_payload(payload, edit)
+        }
     }
+}
+
+fn apply_private_typed_container_edit_to_payload(
+    payload: &mut Vec<u8>,
+    edit: &PrivateTypedContainerEdit,
+) -> Result<(), CoreError> {
+    let root = properties::parse_private_root(payload)?;
+    let resolved = properties::resolve_chain(&root.properties, &edit.path)?;
+    let target = resolved.target.clone();
+    // Length-changing patch: work on a scratch copy and prove with a strict
+    // re-parse that every size and count field was fixed up, so a bug cannot
+    // corrupt the caller's payload (or the save).
+    let mut patched = payload.clone();
+    properties::patch_container(
+        &mut patched,
+        &target,
+        &resolved.enclosing_size_fields,
+        &edit.edit,
+    )?;
+    properties::parse_private_root(&patched).map_err(|err| {
+        CoreError::Parse(format!(
+            "container patch produced an inconsistent payload: {err}"
+        ))
+    })?;
+    *payload = patched;
+    Ok(())
 }
 
 fn apply_private_fstring_edit_to_payload(
@@ -7386,5 +7495,120 @@ mod tests {
                 .unwrap()
                 .contains("io error")
         );
+    }
+
+    fn private_name_set_property(name: &str, values: &[&str]) -> Vec<u8> {
+        let mut body = 0u32.to_le_bytes().to_vec();
+        body.extend_from_slice(&(values.len() as u32).to_le_bytes());
+        for v in values {
+            body.extend_from_slice(&fstring(v));
+        }
+        let mut out = fstring(name);
+        out.extend_from_slice(&fstring("SetProperty"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("NameProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes()); // array_index
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.push(0); // tag_flags
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn typed_container_edits_apply_and_validate() {
+        let mut payload = fstring("/Script/Test.Save");
+        payload.push(0);
+        payload.extend_from_slice(&private_name_set_property("Knowledge", &["A", "B"]));
+        payload.extend_from_slice(&fstring("None"));
+        payload.extend_from_slice(&0u32.to_le_bytes());
+
+        let edit = PrivateTypedContainerEdit {
+            path: properties::parse_path(&["Knowledge".to_string()]).unwrap(),
+            edit: properties::ContainerEdit::SetAdd("C".to_string()),
+        };
+        apply_private_typed_container_edit_to_payload(&mut payload, &edit).unwrap();
+        let edit = PrivateTypedContainerEdit {
+            path: properties::parse_path(&["Knowledge".to_string()]).unwrap(),
+            edit: properties::ContainerEdit::SetRemove("A".to_string()),
+        };
+        apply_private_typed_container_edit_to_payload(&mut payload, &edit).unwrap();
+
+        let root = properties::parse_private_root(&payload).unwrap();
+        assert_eq!(
+            root.properties[0].value,
+            properties::PropertyValue::Set {
+                num_to_remove: 0,
+                elements: vec![
+                    properties::PropertyValue::Name("B".to_string()),
+                    properties::PropertyValue::Name("C".to_string()),
+                ],
+            }
+        );
+
+        // Unknown path fails without mutation.
+        let copy = payload.clone();
+        let bad = PrivateTypedContainerEdit {
+            path: properties::parse_path(&["Nope".to_string()]).unwrap(),
+            edit: properties::ContainerEdit::SetAdd("X".to_string()),
+        };
+        assert!(apply_private_typed_container_edit_to_payload(&mut payload, &bad).is_err());
+        assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn write_save_applies_typed_container_edits() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-001.sav");
+        let output_path = dir.path().join("G1R-001-container.sav");
+        let private_payload = {
+            let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+            p.push(0);
+            p.extend_from_slice(&private_name_set_property("Knowledge", &["Voiceline_A"]));
+            p.extend_from_slice(&fstring("None"));
+            p.extend_from_slice(&0u32.to_le_bytes());
+            p
+        };
+        let seed_compressed = b"seed-compressed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot A"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        // The container ops must be advertised once the typed parse is ok.
+        let inspected = inspect_save_with_codec_backend(&path, true, Some(&backend), None).unwrap();
+        let writable = inspected["private"]["writable"].as_array().unwrap();
+        for op in [
+            "private.typed.setAdd",
+            "private.typed.setRemove",
+            "private.typed.arrayRemove",
+            "private.typed.arrayDuplicate",
+        ] {
+            assert!(writable.contains(&json!(op)), "missing writable {op}");
+        }
+
+        let response = write_save_with_codec_backend(
+            &path,
+            &[json!({
+                "path": "private.typed.setAdd",
+                "value": { "path": ["Knowledge"], "value": "ChoiceB" }
+            })],
+            false,
+            Some(&output_path),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(response["editsApplied"], 1);
+
+        let value =
+            inspect_save_with_codec_backend(&output_path, true, Some(&backend), None).unwrap();
+        assert_eq!(value["private"]["typedParse"]["status"], "ok");
+        let strings = value["private"]["strings"].as_array().unwrap();
+        assert!(strings.iter().any(|s| s == "ChoiceB"));
     }
 }

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -3747,6 +3747,11 @@ fn apply_private_edits(
             "private.typed.setValue" => {
                 parse_private_typed_set_value_edit(edit).map(PrivateEdit::TypedSetValue)
             }
+            // Index-addressed edits (arrayRemove/arrayDuplicate) target indices
+            // that shift after each structural change within the same batch;
+            // callers must submit at most one structural array edit per write.
+            // Each edit re-parses the payload, so value-addressed ops
+            // (setAdd/setRemove) batch safely.
             "private.typed.setAdd"
             | "private.typed.setRemove"
             | "private.typed.arrayRemove"

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2504,6 +2504,16 @@ fn query_progression(
         .map(|v| v as usize)
         .unwrap_or(0);
     let character = payload.get("character").and_then(Value::as_str);
+    let state_filter = payload
+        .get("state")
+        .and_then(Value::as_str)
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty());
+    let group_filter = payload
+        .get("group")
+        .and_then(Value::as_str)
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty());
 
     let data = fs::read(path)?;
     if !data.starts_with(b"GSAV") {
@@ -2516,7 +2526,14 @@ fn query_progression(
     let decoded = decoded_private_payload_cached(path, &data, &stream, backend)?;
     let root = properties::parse_private_root(&decoded)?;
     match section {
-        "quests" => progression_quests(&root, &query, offset, limit),
+        "quests" => progression_quests(
+            &root,
+            &query,
+            state_filter.as_deref(),
+            group_filter.as_deref(),
+            offset,
+            limit,
+        ),
         "knowledge" => progression_knowledge(&root, &query, character, offset, limit),
         "events" => progression_events(&root, &query, character, offset, limit),
         other => Err(CoreError::InvalidRequest(format!(
@@ -2556,9 +2573,29 @@ fn short_enum_label(value: &str) -> &str {
     value.rsplit("::").next().unwrap_or(value)
 }
 
+/// Parse the id, group, and name from a quest class path. The tail after
+/// the last '.' is the id; strip "Quest_" prefix, then split on the first
+/// '_' to get group and name. This is factored out so the filter and the
+/// page-entry renderer use identical logic and can never diverge.
+fn quest_id_group_name(class_path: &str) -> (String, String, String) {
+    let id = class_path
+        .rsplit('.')
+        .next()
+        .unwrap_or(class_path)
+        .to_string();
+    let trimmed = id.strip_prefix("Quest_").unwrap_or(&id);
+    let (group, name) = match trimmed.split_once('_') {
+        Some((g, n)) => (g.to_string(), n.to_string()),
+        None => (trimmed.to_string(), String::new()),
+    };
+    (id, group, name)
+}
+
 fn progression_quests(
     root: &properties::RootObject,
     query: &str,
+    state_filter: Option<&str>,
+    group_filter: Option<&str>,
     offset: usize,
     limit: usize,
 ) -> Result<Value, CoreError> {
@@ -2572,7 +2609,8 @@ fn progression_quests(
         ));
     };
     let mut state_counts = std::collections::BTreeMap::<String, usize>::new();
-    let mut matches: Vec<(String, Option<String>)> = Vec::new();
+    let mut group_counts = std::collections::BTreeMap::<String, usize>::new();
+    let mut matches: Vec<(String, String, String, String, Option<String>)> = Vec::new();
     for (key, value) in entries {
         let Some(class_path) = map_key_string(key) else {
             continue;
@@ -2586,11 +2624,29 @@ fn progression_quests(
             .map(short_enum_label)
             .unwrap_or("unknown")
             .to_string();
-        *state_counts.entry(label).or_default() += 1;
-        if !query.is_empty() && !class_path.to_ascii_lowercase().contains(&*query) {
+        *state_counts.entry(label.clone()).or_default() += 1;
+        // Compute group for every entry (used for groupCounts and group filter).
+        let (id, group, name) = quest_id_group_name(class_path);
+        *group_counts.entry(group.clone()).or_default() += 1;
+        // --- filters (applied after counts are updated) ---
+        if !query.is_empty() && !class_path.to_ascii_lowercase().contains(query) {
             continue;
         }
-        matches.push((class_path.to_string(), state));
+        if let Some(sf) = state_filter {
+            // Accept both short label ("running") and full enum form
+            // ("equeststate::running") — normalize via short_enum_label.
+            let short = short_enum_label(state.as_deref().unwrap_or("")).to_ascii_lowercase();
+            let full = state.as_deref().unwrap_or("").to_ascii_lowercase();
+            if short != sf && full != sf {
+                continue;
+            }
+        }
+        if let Some(gf) = group_filter {
+            if group.to_ascii_lowercase() != gf {
+                continue;
+            }
+        }
+        matches.push((class_path.to_string(), id, group, name, state));
     }
     matches.sort_by(|a, b| a.0.cmp(&b.0));
     let total = matches.len();
@@ -2598,17 +2654,7 @@ fn progression_quests(
         .into_iter()
         .skip(offset)
         .take(limit)
-        .map(|(class_path, state)| {
-            let id = class_path
-                .rsplit('.')
-                .next()
-                .unwrap_or(class_path.as_str())
-                .to_string();
-            let trimmed = id.strip_prefix("Quest_").unwrap_or(&id);
-            let (group, name) = match trimmed.split_once('_') {
-                Some((g, n)) => (g.to_string(), n.to_string()),
-                None => (trimmed.to_string(), String::new()),
-            };
+        .map(|(class_path, id, group, name, state)| {
             let mut state_path = base_path.clone();
             state_path.push(format!("{{{class_path}}}"));
             state_path.push("CurrentState".to_string());
@@ -2631,6 +2677,7 @@ fn progression_quests(
         "limit": limit,
         "count": quests.len(),
         "stateCounts": state_counts,
+        "groupCounts": group_counts,
         "quests": quests,
     }))
 }
@@ -8144,6 +8191,87 @@ mod tests {
         )
         .unwrap();
         assert_eq!(after["quests"][0]["currentState"], "EQuestState::Succeeded");
+    }
+
+    #[test]
+    fn query_progression_quests_state_and_group_filters() {
+        // Fixture: OldCamp_SLEEPER Running, BanditsCamp_BANDITSTRUST Available.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-filter.sav");
+        let private_payload = quest_map_payload();
+        let seed_compressed = b"seed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        // groupCounts is always over all entries regardless of filters.
+        let base = query_progression(&path, &json!({ "section": "quests" }), Some(&backend))
+            .unwrap();
+        assert_eq!(base["groupCounts"]["BanditsCamp"], 1);
+        assert_eq!(base["groupCounts"]["OldCamp"], 1);
+
+        // state:"Running" → 1 hit (SLEEPER).
+        let running =
+            query_progression(&path, &json!({ "section": "quests", "state": "Running" }), Some(&backend))
+                .unwrap();
+        assert_eq!(running["total"], 1);
+        assert_eq!(running["quests"][0]["name"], "SLEEPER");
+        // groupCounts still covers all entries.
+        assert_eq!(running["groupCounts"]["BanditsCamp"], 1);
+        assert_eq!(running["groupCounts"]["OldCamp"], 1);
+        // stateCounts still covers all entries.
+        assert_eq!(running["stateCounts"]["Running"], 1);
+        assert_eq!(running["stateCounts"]["Available"], 1);
+
+        // state:"EQuestState::Running" (full form) → same result.
+        let running_full = query_progression(
+            &path,
+            &json!({ "section": "quests", "state": "EQuestState::Running" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(running_full["total"], 1);
+        assert_eq!(running_full["quests"][0]["name"], "SLEEPER");
+
+        // state:"running" (case-insensitive) → same result.
+        let running_lower = query_progression(
+            &path,
+            &json!({ "section": "quests", "state": "running" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(running_lower["total"], 1);
+        assert_eq!(running_lower["quests"][0]["name"], "SLEEPER");
+
+        // group:"banditscamp" (case-insensitive) → 1 hit (BANDITSTRUST).
+        let by_group = query_progression(
+            &path,
+            &json!({ "section": "quests", "group": "banditscamp" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(by_group["total"], 1);
+        assert_eq!(by_group["quests"][0]["name"], "BANDITSTRUST");
+
+        // Combined state+group with no match → 0 results, but counts stay full.
+        let no_match = query_progression(
+            &path,
+            &json!({ "section": "quests", "state": "Running", "group": "BanditsCamp" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(no_match["total"], 0);
+        assert_eq!(no_match["stateCounts"]["Running"], 1);
+        assert_eq!(no_match["stateCounts"]["Available"], 1);
+        assert_eq!(no_match["groupCounts"]["BanditsCamp"], 1);
+        assert_eq!(no_match["groupCounts"]["OldCamp"], 1);
     }
 
     // ── Task 6 helpers ──────────────────────────────────────────────────────

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -1030,11 +1030,18 @@ pub fn patch_container(
             }
             let elements = set_string_elements(target)
                 .ok_or_else(|| CoreError::Parse("set value not parsed as a set".into()))?;
-            // UE FNames compare case-insensitively, so a case-variant of an
-            // existing member would be an effective duplicate in the game.
+            // UE FNames compare case-insensitively, so for Name sets a
+            // case-variant of an existing member would be an effective
+            // duplicate in the game. Str sets hold regular strings where
+            // case-only variants are distinct values.
+            let names_fold_case = layout.inner_type == "NameProperty";
             let duplicate = elements.iter().any(|e| match e {
                 PropertyValue::Name(s) | PropertyValue::Str(s) => {
-                    s.eq_ignore_ascii_case(value)
+                    if names_fold_case {
+                        s.eq_ignore_ascii_case(value)
+                    } else {
+                        s == value
+                    }
                 }
                 _ => false,
             });
@@ -2868,6 +2875,57 @@ mod tests {
                 &target,
                 &[],
                 &ContainerEdit::SetAdd("VOICELINE_a".to_string()),
+            )
+            .is_err()
+        );
+        assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn patch_container_str_set_add_keeps_case_sensitivity() {
+        // Str sets hold regular strings: case-only variants are distinct.
+        let mut body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        body.extend_from_slice(&1u32.to_le_bytes());
+        body.extend_from_slice(&fstring("foo"));
+        let mut props = tag("Tags", "SetProperty");
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("StrProperty"));
+        props.extend_from_slice(&header(body.len() as u32, 0));
+        props.extend_from_slice(&body);
+        let mut payload = root("/Script/Test.Save", &props);
+
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+        patch_container(
+            &mut payload,
+            &target,
+            &[],
+            &ContainerEdit::SetAdd("Foo".to_string()),
+        )
+        .unwrap();
+
+        let reparsed = parse_private_root(&payload).unwrap();
+        assert_eq!(
+            reparsed.properties[0].value,
+            PropertyValue::Set {
+                num_to_remove: 0,
+                elements: vec![
+                    PropertyValue::Str("foo".to_string()),
+                    PropertyValue::Str("Foo".to_string()),
+                ],
+            }
+        );
+
+        // Exact duplicates are still rejected.
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+        let copy = payload.clone();
+        assert!(
+            patch_container(
+                &mut payload,
+                &target,
+                &[],
+                &ContainerEdit::SetAdd("Foo".to_string()),
             )
             .is_err()
         );

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -884,6 +884,161 @@ pub fn container_layout(
     })
 }
 
+/// Structural container edit applied by `patch_container`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContainerEdit {
+    /// Append a Name/Str element to a SetProperty (rejects duplicates).
+    SetAdd(String),
+    /// Remove a Name/Str element from a SetProperty by value.
+    SetRemove(String),
+    /// Remove an ArrayProperty element by index.
+    ArrayRemove(usize),
+    /// Duplicate an ArrayProperty element in place (copy inserted right after
+    /// the source element).
+    ArrayDuplicate(usize),
+}
+
+fn set_string_elements(target: &Property) -> Option<&[PropertyValue]> {
+    match &target.value {
+        PropertyValue::Set { elements, .. } => Some(elements),
+        _ => None,
+    }
+}
+
+fn set_element_position(elements: &[PropertyValue], value: &str) -> Option<usize> {
+    elements.iter().position(|e| match e {
+        PropertyValue::Name(s) | PropertyValue::Str(s) => s == value,
+        _ => false,
+    })
+}
+
+/// Apply a structural set/array edit to a resolved container property. The
+/// element count, the property's own tag size, and every enclosing size field
+/// (from [`resolve_chain`]) are adjusted by the byte delta; all writes are
+/// validated before the first mutation, so a failed patch leaves the payload
+/// untouched. Offsets recorded in the parsed tree are stale after a successful
+/// patch — re-parse before further edits.
+pub fn patch_container(
+    payload: &mut Vec<u8>,
+    target: &Property,
+    enclosing_size_fields: &[usize],
+    edit: &ContainerEdit,
+) -> Result<(), CoreError> {
+    let layout = container_layout(payload, target)?;
+    let require_kind = |wanted: ContainerKind, op: &str| {
+        if layout.kind == wanted {
+            Ok(())
+        } else {
+            Err(CoreError::InvalidRequest(format!(
+                "{op} requires a {wanted:?} target, got {:?}",
+                layout.kind
+            )))
+        }
+    };
+    // Each edit is one splice: either remove a byte range or insert bytes at a
+    // position. `count_delta` is +1 or -1.
+    let (remove_range, insert_at, insert_bytes, count_delta): (
+        Option<core::ops::Range<usize>>,
+        usize,
+        Vec<u8>,
+        i64,
+    ) = match edit {
+        ContainerEdit::SetAdd(value) => {
+            require_kind(ContainerKind::Set, "setAdd")?;
+            if !matches!(layout.inner_type.as_str(), "NameProperty" | "StrProperty") {
+                return Err(CoreError::UnsupportedEdit(format!(
+                    "setAdd supports Name/Str sets; this set holds {}",
+                    layout.inner_type
+                )));
+            }
+            let elements = set_string_elements(target)
+                .ok_or_else(|| CoreError::Parse("set value not parsed as a set".into()))?;
+            if set_element_position(elements, value).is_some() {
+                return Err(CoreError::InvalidRequest(format!(
+                    "set already contains {value:?}"
+                )));
+            }
+            let end = target.value_offset + target.value_size;
+            (None, end, encode_fstring_value(value), 1)
+        }
+        ContainerEdit::SetRemove(value) => {
+            require_kind(ContainerKind::Set, "setRemove")?;
+            let elements = set_string_elements(target)
+                .ok_or_else(|| CoreError::Parse("set value not parsed as a set".into()))?;
+            let index = set_element_position(elements, value).ok_or_else(|| {
+                CoreError::Parse(format!("set does not contain {value:?}"))
+            })?;
+            let range = layout.element_ranges[index].clone();
+            (Some(range.clone()), range.start, Vec::new(), -1)
+        }
+        ContainerEdit::ArrayRemove(index) => {
+            require_kind(ContainerKind::Array, "arrayRemove")?;
+            let range = layout.element_ranges.get(*index).cloned().ok_or_else(|| {
+                CoreError::InvalidRequest(format!(
+                    "array index {index} out of bounds ({} elements)",
+                    layout.count
+                ))
+            })?;
+            (Some(range.clone()), range.start, Vec::new(), -1)
+        }
+        ContainerEdit::ArrayDuplicate(index) => {
+            require_kind(ContainerKind::Array, "arrayDuplicate")?;
+            let range = layout.element_ranges.get(*index).cloned().ok_or_else(|| {
+                CoreError::InvalidRequest(format!(
+                    "array index {index} out of bounds ({} elements)",
+                    layout.count
+                ))
+            })?;
+            let bytes = payload[range.clone()].to_vec();
+            (None, range.end, bytes, 1)
+        }
+    };
+    let removed = remove_range.as_ref().map_or(0, |r| r.len());
+    let delta = insert_bytes.len() as i64 - removed as i64;
+    let new_count = u32::try_from(layout.count as i64 + count_delta)
+        .map_err(|_| CoreError::Parse("container count underflow".to_string()))?;
+    let new_size = u32::try_from(target.value_size as i64 + delta)
+        .map_err(|_| CoreError::Parse("container size would leave the u32 range".to_string()))?;
+
+    // Compute every size-field rewrite up front; mutate only once all are
+    // valid (same discipline as patch_string).
+    let mut writes = Vec::with_capacity(enclosing_size_fields.len() + 2);
+    if target.value_offset < 5 {
+        return Err(CoreError::Parse("container tag offset underflow".to_string()));
+    }
+    writes.push((target.size_field_offset(), new_size));
+    for &offset in enclosing_size_fields {
+        if offset + 4 > target.value_offset {
+            return Err(CoreError::Parse(format!(
+                "enclosing size field at 0x{offset:x} does not precede the patch target"
+            )));
+        }
+        let old = u32::from_le_bytes(payload[offset..offset + 4].try_into().unwrap());
+        let updated = u32::try_from(i64::from(old) + delta).map_err(|_| {
+            CoreError::Parse(format!(
+                "enclosing size field at 0x{offset:x} would leave the u32 range"
+            ))
+        })?;
+        writes.push((offset, updated));
+    }
+    // The count field lives inside the value payload but always precedes the
+    // splice position (elements follow the count), so writing it before the
+    // splice is safe.
+    writes.push((layout.count_offset, new_count));
+    for (offset, value) in writes {
+        payload[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+    match remove_range {
+        Some(range) => {
+            payload.splice(range, core::iter::empty());
+        }
+        None => {
+            payload.splice(insert_at..insert_at, insert_bytes);
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct PropertyCounts {
     pub total: usize,
@@ -2538,6 +2693,197 @@ mod tests {
         let payload = root("/Script/Test.Save", &int_property("m_X", 1));
         let parsed = parse_private_root(&payload).unwrap();
         assert!(container_layout(&payload, &parsed.properties[0]).is_err());
+    }
+
+    fn struct_wrapping(name: &str, struct_type: &str, inner_props: &[u8]) -> Vec<u8> {
+        let mut body = inner_props.to_vec();
+        body.extend_from_slice(&fstring("None"));
+        let mut out = tag(name, "StructProperty");
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring(struct_type));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("/Script/Test"));
+        out.extend_from_slice(&header(body.len() as u32, 0));
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn resolve_set_target(payload: &[u8]) -> (RootObject, Vec<PathSeg>) {
+        let parsed = parse_private_root(payload).unwrap();
+        let path = parse_path(&[
+            "KnowledgeSet".to_string(),
+            "Knowledge".to_string(),
+        ])
+        .unwrap();
+        (parsed, path)
+    }
+
+    #[test]
+    fn patch_container_set_add_appends_and_fixes_sizes() {
+        let mut payload = root(
+            "/Script/Test.Save",
+            &struct_wrapping(
+                "KnowledgeSet",
+                "KnowledgeSet",
+                &name_set_property("Knowledge", &["Voiceline_A"]),
+            ),
+        );
+        let (parsed, path) = resolve_set_target(&payload);
+        let chain = resolve_chain(&parsed.properties, &path).unwrap();
+        let target = chain.target.clone();
+
+        patch_container(
+            &mut payload,
+            &target,
+            &chain.enclosing_size_fields,
+            &ContainerEdit::SetAdd("ChoiceB".to_string()),
+        )
+        .unwrap();
+
+        // Strict re-parse proves every size field (set tag + wrapping struct
+        // tag) was adjusted.
+        let reparsed = parse_private_root(&payload).unwrap();
+        let set = resolve(&reparsed.properties, &path).unwrap();
+        assert_eq!(
+            set.value,
+            PropertyValue::Set {
+                num_to_remove: 0,
+                elements: vec![
+                    PropertyValue::Name("Voiceline_A".to_string()),
+                    PropertyValue::Name("ChoiceB".to_string()),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn patch_container_set_add_rejects_duplicates_without_mutation() {
+        let mut payload = root(
+            "/Script/Test.Save",
+            &name_set_property("Knowledge", &["Voiceline_A"]),
+        );
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+        let copy = payload.clone();
+        assert!(
+            patch_container(
+                &mut payload,
+                &target,
+                &[],
+                &ContainerEdit::SetAdd("Voiceline_A".to_string()),
+            )
+            .is_err()
+        );
+        assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn patch_container_set_remove_splices_element_out() {
+        let mut payload = root(
+            "/Script/Test.Save",
+            &struct_wrapping(
+                "KnowledgeSet",
+                "KnowledgeSet",
+                &name_set_property("Knowledge", &["Voiceline_A", "ChoiceB", "Voiceline_C"]),
+            ),
+        );
+        let (parsed, path) = resolve_set_target(&payload);
+        let chain = resolve_chain(&parsed.properties, &path).unwrap();
+        let target = chain.target.clone();
+
+        patch_container(
+            &mut payload,
+            &target,
+            &chain.enclosing_size_fields,
+            &ContainerEdit::SetRemove("ChoiceB".to_string()),
+        )
+        .unwrap();
+
+        let reparsed = parse_private_root(&payload).unwrap();
+        let set = resolve(&reparsed.properties, &path).unwrap();
+        assert_eq!(
+            set.value,
+            PropertyValue::Set {
+                num_to_remove: 0,
+                elements: vec![
+                    PropertyValue::Name("Voiceline_A".to_string()),
+                    PropertyValue::Name("Voiceline_C".to_string()),
+                ],
+            }
+        );
+
+        // Removing a value that is not present fails without mutation.
+        let parsed = parse_private_root(&payload).unwrap();
+        let chain = resolve_chain(&parsed.properties, &path).unwrap();
+        let target = chain.target.clone();
+        let copy = payload.clone();
+        assert!(
+            patch_container(
+                &mut payload,
+                &target,
+                &chain.enclosing_size_fields,
+                &ContainerEdit::SetRemove("ChoiceB".to_string()),
+            )
+            .is_err()
+        );
+        assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn patch_container_array_remove_and_duplicate() {
+        let mut payload = root("/Script/Test.Save", &int_array_property("Nums", &[7, 8, 9]));
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+
+        patch_container(&mut payload, &target, &[], &ContainerEdit::ArrayRemove(1)).unwrap();
+        let reparsed = parse_private_root(&payload).unwrap();
+        assert_eq!(
+            reparsed.properties[0].value,
+            PropertyValue::Array {
+                elements: vec![PropertyValue::Int(7), PropertyValue::Int(9)],
+            }
+        );
+
+        let target = reparsed.properties[0].clone();
+        patch_container(&mut payload, &target, &[], &ContainerEdit::ArrayDuplicate(0)).unwrap();
+        let reparsed = parse_private_root(&payload).unwrap();
+        assert_eq!(
+            reparsed.properties[0].value,
+            PropertyValue::Array {
+                elements: vec![
+                    PropertyValue::Int(7),
+                    PropertyValue::Int(7),
+                    PropertyValue::Int(9),
+                ],
+            }
+        );
+
+        // Out-of-bounds index fails without mutation.
+        let target = reparsed.properties[0].clone();
+        let copy = payload.clone();
+        assert!(
+            patch_container(&mut payload, &target, &[], &ContainerEdit::ArrayRemove(3)).is_err()
+        );
+        assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn patch_container_rejects_kind_mismatch() {
+        let mut payload = root("/Script/Test.Save", &int_array_property("Nums", &[7]));
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+        // set ops on an array
+        assert!(
+            patch_container(&mut payload, &target, &[], &ContainerEdit::SetAdd("X".into()))
+                .is_err()
+        );
+        // array ops on a set
+        let mut payload = root("/Script/Test.Save", &name_set_property("S", &["A"]));
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+        assert!(
+            patch_container(&mut payload, &target, &[], &ContainerEdit::ArrayRemove(0)).is_err()
+        );
     }
 
     #[test]

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -1030,7 +1030,15 @@ pub fn patch_container(
             }
             let elements = set_string_elements(target)
                 .ok_or_else(|| CoreError::Parse("set value not parsed as a set".into()))?;
-            if set_element_position(elements, value).is_some() {
+            // UE FNames compare case-insensitively, so a case-variant of an
+            // existing member would be an effective duplicate in the game.
+            let duplicate = elements.iter().any(|e| match e {
+                PropertyValue::Name(s) | PropertyValue::Str(s) => {
+                    s.eq_ignore_ascii_case(value)
+                }
+                _ => false,
+            });
+            if duplicate {
                 return Err(CoreError::InvalidRequest(format!(
                     "set already contains {value:?}"
                 )));
@@ -2848,6 +2856,18 @@ mod tests {
                 &target,
                 &[],
                 &ContainerEdit::SetAdd("Voiceline_A".to_string()),
+            )
+            .is_err()
+        );
+        assert_eq!(payload, copy);
+
+        // UE FNames are case-insensitive: a case-variant is a duplicate too.
+        assert!(
+            patch_container(
+                &mut payload,
+                &target,
+                &[],
+                &ContainerEdit::SetAdd("VOICELINE_a".to_string()),
             )
             .is_err()
         );

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -982,9 +982,22 @@ fn set_string_elements(target: &Property) -> Option<&[PropertyValue]> {
     }
 }
 
-fn set_element_position(elements: &[PropertyValue], value: &str) -> Option<usize> {
+/// Locate a string element in a set. `fold_case` follows UE FName semantics:
+/// Name sets compare case-insensitively, Str sets hold regular strings where
+/// case-only variants are distinct values.
+fn set_element_position(
+    elements: &[PropertyValue],
+    value: &str,
+    fold_case: bool,
+) -> Option<usize> {
     elements.iter().position(|e| match e {
-        PropertyValue::Name(s) | PropertyValue::Str(s) => s == value,
+        PropertyValue::Name(s) | PropertyValue::Str(s) => {
+            if fold_case {
+                s.eq_ignore_ascii_case(value)
+            } else {
+                s == value
+            }
+        }
         _ => false,
     })
 }
@@ -1030,22 +1043,8 @@ pub fn patch_container(
             }
             let elements = set_string_elements(target)
                 .ok_or_else(|| CoreError::Parse("set value not parsed as a set".into()))?;
-            // UE FNames compare case-insensitively, so for Name sets a
-            // case-variant of an existing member would be an effective
-            // duplicate in the game. Str sets hold regular strings where
-            // case-only variants are distinct values.
-            let names_fold_case = layout.inner_type == "NameProperty";
-            let duplicate = elements.iter().any(|e| match e {
-                PropertyValue::Name(s) | PropertyValue::Str(s) => {
-                    if names_fold_case {
-                        s.eq_ignore_ascii_case(value)
-                    } else {
-                        s == value
-                    }
-                }
-                _ => false,
-            });
-            if duplicate {
+            let fold_case = layout.inner_type == "NameProperty";
+            if set_element_position(elements, value, fold_case).is_some() {
                 return Err(CoreError::InvalidRequest(format!(
                     "set already contains {value:?}"
                 )));
@@ -1057,7 +1056,8 @@ pub fn patch_container(
             require_kind(ContainerKind::Set, "setRemove")?;
             let elements = set_string_elements(target)
                 .ok_or_else(|| CoreError::Parse("set value not parsed as a set".into()))?;
-            let index = set_element_position(elements, value).ok_or_else(|| {
+            let fold_case = layout.inner_type == "NameProperty";
+            let index = set_element_position(elements, value, fold_case).ok_or_else(|| {
                 CoreError::Parse(format!("set does not contain {value:?}"))
             })?;
             let range = layout.element_ranges[index].clone();
@@ -2879,6 +2879,32 @@ mod tests {
             .is_err()
         );
         assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn patch_container_name_set_remove_folds_case() {
+        let mut payload = root(
+            "/Script/Test.Save",
+            &name_set_property("Knowledge", &["Voiceline_A", "ChoiceB"]),
+        );
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+        // FName semantics: a case-variant removes the existing member.
+        patch_container(
+            &mut payload,
+            &target,
+            &[],
+            &ContainerEdit::SetRemove("VOICELINE_a".to_string()),
+        )
+        .unwrap();
+        let reparsed = parse_private_root(&payload).unwrap();
+        assert_eq!(
+            reparsed.properties[0].value,
+            PropertyValue::Set {
+                num_to_remove: 0,
+                elements: vec![PropertyValue::Name("ChoiceB".to_string())],
+            }
+        );
     }
 
     #[test]

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -606,6 +606,83 @@ fn container_value_type(value: &PropertyValue) -> &'static str {
     }
 }
 
+/// Depth-first search for the first property named `name` anywhere in the
+/// tree. Returns the setValue-addressable path segments leading to it
+/// (inclusive) plus the property. Map entries whose keys cannot be rendered as
+/// path segments are skipped (a hit behind such a key would not be
+/// addressable anyway).
+pub fn find_property_by_name<'a>(
+    root: &'a RootObject,
+    name: &str,
+) -> Option<(Vec<String>, &'a Property)> {
+    fn in_props<'a>(
+        props: &'a [Property],
+        name: &str,
+        path: &mut Vec<String>,
+    ) -> Option<&'a Property> {
+        for p in props {
+            path.push(p.name.clone());
+            if p.name == name {
+                return Some(p);
+            }
+            if let Some(found) = in_value(&p.value, name, path) {
+                return Some(found);
+            }
+            path.pop();
+        }
+        None
+    }
+    fn in_value<'a>(
+        value: &'a PropertyValue,
+        name: &str,
+        path: &mut Vec<String>,
+    ) -> Option<&'a Property> {
+        match value {
+            PropertyValue::Struct(StructValue::Properties(inner)) => in_props(inner, name, path),
+            PropertyValue::Struct(StructValue::Instanced(Some(i))) => {
+                in_props(&i.properties, name, path)
+            }
+            PropertyValue::Map { entries, .. } => {
+                for (key, val) in entries {
+                    let Some(key) = map_key_to_string(key) else {
+                        continue;
+                    };
+                    path.push(format!("{{{key}}}"));
+                    if let Some(found) = in_value(val, name, path) {
+                        return Some(found);
+                    }
+                    path.pop();
+                }
+                None
+            }
+            PropertyValue::Array { elements } | PropertyValue::Set { elements, .. } => {
+                for (i, e) in elements.iter().enumerate() {
+                    path.push(format!("[{i}]"));
+                    if let Some(found) = in_value(e, name, path) {
+                        return Some(found);
+                    }
+                    path.pop();
+                }
+                None
+            }
+            PropertyValue::ObjectInstances(objs) => {
+                for (i, o) in objs.iter().enumerate() {
+                    path.push(format!("[{i}]"));
+                    if let Some(found) = in_props(&o.properties, name, path) {
+                        return Some(found);
+                    }
+                    path.pop();
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+    let mut path = Vec::new();
+    let target = in_props(&root.properties, name, &mut path)?;
+    Some((path, target))
+}
+
 /// Fixed-size scalar replacement value for in-place typed patching.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ScalarValue {
@@ -2884,6 +2961,47 @@ mod tests {
         assert!(
             patch_container(&mut payload, &target, &[], &ContainerEdit::ArrayRemove(0)).is_err()
         );
+    }
+
+    #[test]
+    fn find_property_by_name_returns_addressable_path() {
+        // Map { "CharacterStates" => InstancedStruct { Knowledge: Set } }
+        let nested = {
+            let mut n = name_set_property("Knowledge", &["Voiceline_A"]);
+            n.extend_from_slice(&fstring("None"));
+            n
+        };
+        let mut instanced = fstring("/Script/Test.CharacterStates");
+        instanced.extend_from_slice(&(nested.len() as u32).to_le_bytes());
+        instanced.extend_from_slice(&nested);
+
+        let mut map_body = 0u32.to_le_bytes().to_vec();
+        map_body.extend_from_slice(&1u32.to_le_bytes());
+        map_body.extend_from_slice(&fstring("CharacterStates")); // Name key
+        map_body.extend_from_slice(&instanced);
+
+        let mut props = tag("m_GenericData", "MapProperty");
+        props.extend_from_slice(&2u32.to_le_bytes());
+        props.extend_from_slice(&fstring("NameProperty"));
+        props.extend_from_slice(&0u32.to_le_bytes()); // key_flags
+        props.extend_from_slice(&fstring("StructProperty"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("InstancedStruct"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("/Script/StructUtils"));
+        props.extend_from_slice(&header(map_body.len() as u32, TAG_FLAG_NATIVE_SERIALIZE));
+        props.extend_from_slice(&map_body);
+        let payload = root("/Script/Test.Save", &props);
+
+        let parsed = parse_private_root(&payload).unwrap();
+        let (path, prop) = find_property_by_name(&parsed, "Knowledge").unwrap();
+        assert_eq!(path, vec!["m_GenericData", "{CharacterStates}", "Knowledge"]);
+        assert!(matches!(prop.value, PropertyValue::Set { .. }));
+        // The returned path round-trips through resolve().
+        let segs = parse_path(&path).unwrap();
+        assert_eq!(resolve(&parsed.properties, &segs).unwrap().name, "Knowledge");
+
+        assert!(find_property_by_name(&parsed, "DoesNotExist").is_none());
     }
 
     #[test]

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -806,6 +806,84 @@ pub fn patch_string(
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerKind {
+    Array,
+    Set,
+}
+
+/// Byte layout of a Set/Array property's value: where the element-count field
+/// sits and the absolute byte range of every element. Computed by re-reading
+/// the container body, since the parsed tree does not record inline element
+/// offsets.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContainerLayout {
+    pub kind: ContainerKind,
+    pub inner_type: String,
+    /// Absolute offset of the u32 element-count field.
+    pub count_offset: usize,
+    pub count: usize,
+    /// Absolute byte range of each element within the payload.
+    pub element_ranges: Vec<core::ops::Range<usize>>,
+}
+
+pub fn container_layout(
+    payload: &[u8],
+    property: &Property,
+) -> Result<ContainerLayout, CoreError> {
+    let kind = match property.type_name.as_str() {
+        "ArrayProperty" => ContainerKind::Array,
+        "SetProperty" => ContainerKind::Set,
+        other => {
+            return Err(CoreError::InvalidRequest(format!(
+                "container edits require an ArrayProperty or SetProperty target, got {other}"
+            )));
+        }
+    };
+    // Instanced-object arrays interleave full object streams; element-level
+    // splicing is not supported for them.
+    if matches!(property.value, PropertyValue::ObjectInstances(_)) {
+        return Err(CoreError::UnsupportedEdit(
+            "container edits do not support instanced-object arrays".to_string(),
+        ));
+    }
+    let inner = property
+        .descriptor
+        .inner
+        .as_deref()
+        .ok_or_else(|| CoreError::Parse("container property missing inner descriptor".into()))?;
+    let end = property
+        .value_offset
+        .checked_add(property.value_size)
+        .filter(|end| *end <= payload.len())
+        .ok_or_else(|| CoreError::Parse("container value out of bounds".to_string()))?;
+    let mut r = Reader::new(&payload[property.value_offset..end], property.value_offset);
+    if kind == ContainerKind::Set {
+        let _num_to_remove = r.u32()?;
+    }
+    let count_offset = r.abs_pos();
+    let count = r.u32()? as usize;
+    let mut element_ranges = Vec::with_capacity(count.min(1 << 16));
+    for _ in 0..count {
+        let start = r.abs_pos();
+        read_inline_value(&mut r, inner, 0)?;
+        element_ranges.push(start..r.abs_pos());
+    }
+    if r.remaining() != 0 {
+        return Err(CoreError::Parse(format!(
+            "container body left {} bytes after {count} elements",
+            r.remaining()
+        )));
+    }
+    Ok(ContainerLayout {
+        kind,
+        inner_type: inner.type_name.clone(),
+        count_offset,
+        count,
+        element_ranges,
+    })
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct PropertyCounts {
     pub total: usize,
@@ -2381,6 +2459,85 @@ mod tests {
         assert!(patch_scalar(&mut payload, &rank, ScalarValue::Byte(1)).is_err());
         // And the plain-byte form must reject a string patch.
         assert!(patch_string(&mut payload, &level, &[], "oops").is_err());
+    }
+
+    fn name_set_property(name: &str, values: &[&str]) -> Vec<u8> {
+        let mut body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        body.extend_from_slice(&(values.len() as u32).to_le_bytes());
+        for v in values {
+            body.extend_from_slice(&fstring(v));
+        }
+        let mut out = tag(name, "SetProperty");
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("NameProperty"));
+        out.extend_from_slice(&header(body.len() as u32, 0));
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn int_array_property(name: &str, values: &[i32]) -> Vec<u8> {
+        let mut body = (values.len() as u32).to_le_bytes().to_vec();
+        for v in values {
+            body.extend_from_slice(&v.to_le_bytes());
+        }
+        let mut out = tag(name, "ArrayProperty");
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("IntProperty"));
+        out.extend_from_slice(&header(body.len() as u32, 0));
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn container_layout_reports_set_element_ranges() {
+        let payload = root(
+            "/Script/Test.Save",
+            &name_set_property("Knowledge", &["Voiceline_A", "ChoiceB"]),
+        );
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = &parsed.properties[0];
+
+        let layout = container_layout(&payload, target).unwrap();
+        assert_eq!(layout.kind, ContainerKind::Set);
+        assert_eq!(layout.inner_type, "NameProperty");
+        assert_eq!(layout.count, 2);
+        // count field sits after the u32 num_to_remove
+        assert_eq!(layout.count_offset, target.value_offset + 4);
+        assert_eq!(layout.element_ranges.len(), 2);
+        // elements are FStrings: 4-byte length + chars + NUL
+        let first = &layout.element_ranges[0];
+        assert_eq!(first.start, target.value_offset + 8);
+        assert_eq!(first.len(), 4 + "Voiceline_A".len() + 1);
+        let second = &layout.element_ranges[1];
+        assert_eq!(second.start, first.end);
+        assert_eq!(second.end, target.value_offset + target.value_size);
+    }
+
+    #[test]
+    fn container_layout_reports_array_element_ranges() {
+        let payload = root("/Script/Test.Save", &int_array_property("Nums", &[7, 8, 9]));
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = &parsed.properties[0];
+
+        let layout = container_layout(&payload, target).unwrap();
+        assert_eq!(layout.kind, ContainerKind::Array);
+        assert_eq!(layout.count, 3);
+        assert_eq!(layout.count_offset, target.value_offset);
+        assert_eq!(
+            layout.element_ranges,
+            vec![
+                target.value_offset + 4..target.value_offset + 8,
+                target.value_offset + 8..target.value_offset + 12,
+                target.value_offset + 12..target.value_offset + 16,
+            ]
+        );
+    }
+
+    #[test]
+    fn container_layout_rejects_non_container_targets() {
+        let payload = root("/Script/Test.Save", &int_property("m_X", 1));
+        let parsed = parse_private_root(&payload).unwrap();
+        assert!(container_layout(&payload, &parsed.properties[0]).is_err());
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-06-11-progression-tab-v2.md
+++ b/docs/superpowers/plans/2026-06-11-progression-tab-v2.md
@@ -1,0 +1,3380 @@
+# Progression Tab v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Progression tab's heuristic string dump with structured, editable quests / dialog-knowledge / memory-events views backed by the typed property engine, including four new generic container edit ops in the Rust core.
+
+**Architecture:** The real progression data lives in the decoded private payload: `QuestDataByClass` (MapProperty, ObjectProperty keys → `SingleQuestSaveGameData` structs with a `CurrentState` EnumProperty), `CharacterKnowledgeByUniqueName` (MapProperty, Name keys → structs with a `Knowledge` SetProperty of Names), and `LongTermMemoryByGlobalId` (MapProperty, Name keys → structs with a `MemorizedEvents` ArrayProperty of event structs). A new `query_progression` core command walks the typed tree (decode is cached) and serves paged section data. Quest states are written with the existing `private.typed.setValue` (EnumProperty string patch). Set/array membership changes get four new ops — `private.typed.setAdd`, `private.typed.setRemove`, `private.typed.arrayRemove`, `private.typed.arrayDuplicate` — built on a new `patch_container` in `properties.rs` that reuses the proven size-chain fixup discipline of `patch_string`. The Flutter side gets progression models, notifier methods, and a new `ProgressionPanel` (own file, like `hero_stats_card.dart`) following the Inventory-card pending-edit pattern.
+
+**Tech Stack:** Rust (goresave_core), Flutter/Dart (apps/goresave), cargo test, flutter_test.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-progression-tab-design.md`
+
+**Verified groundwork (real save G1R-001, 76.8 MB decoded payload):**
+- `QuestDataByClass` entries: key `/Script/Angelscript.Quest_BanditsCamp_BANDITSTRUST` (ObjectProperty), value struct with `CurrentState: EnumProperty EQuestState (ByteProperty underlying)` holding `EQuestState::None|Available|Running|Succeeded|Failed`, plus `StateReachedAtTime` and `TimeLastViewedByPlayer` maps. 707 quest classes present (unstarted = `Available`), so no map-entry insertion is needed.
+- Knowledge entries are voiceline/choice Names per NPC unique name (e.g. `OC_STT_Diego`).
+- Memory events carry `EventTags` (native `GameplayTagContainer`, 32-tag taxonomy `Memory.*`), `Magnitude` (Float), `Payload` (InstancedStruct), `OptionalClass1/2` (SoftObjectProperty), `position` (Vector), `Time`/`Duration` (struct `InGameTime` → `TotalSeconds` DoubleProperty), `InstigatorGlobalId`/`AffectedCharacterGlobalId` (Name).
+- The typed parser already traverses all of this (maps by `{key}`, Object keys addressable since the hero-stats work). `private.typed.setValue` already patches EnumProperty strings with length change + ancestor size fixes.
+- Hardcoded sections of the old heuristic (`m_QuestLog`, `m_Knowledge`, `m_ActiveQuests`, …) do not exist in real saves; the heuristic code is deleted, not preserved.
+
+**Conventions used below:**
+- Rust tests live in the existing `#[cfg(test)] mod tests` blocks; reuse existing builders (`fstring`, `tag`, `header`, `int_property`, `root`, `compressed_stream_with_one_chunk`, `build_gsav`, `PrefixCodecBackend`, `public_payload`) — add new builders only when missing in that module.
+- Run Rust tests with `cargo test -p goresave_core <name>`; full check `cargo test -p goresave_core`.
+- Run Dart tests from `apps/goresave` with `flutter test <path>`; static check `flutter analyze`.
+- Commit after each green task with a conventional-commit message ending in the Co-Authored-By trailer used by this repo:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+
+---
+
+### Task 1: Rust core — container layout (element byte ranges)
+
+Container edits need the absolute byte range of each set/array element and the count-field offset. The parsed tree does not record inline element offsets, so re-read the container body with a position-tracking `Reader`.
+
+**Files:**
+- Modify: `crates/goresave_core/src/properties.rs` (new public API next to `patch_string`, ~line 808; tests at the bottom)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `properties.rs`. First two new fixture builders (skip any that already exist):
+
+```rust
+    fn name_set_property(name: &str, values: &[&str]) -> Vec<u8> {
+        let mut body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        body.extend_from_slice(&(values.len() as u32).to_le_bytes());
+        for v in values {
+            body.extend_from_slice(&fstring(v));
+        }
+        let mut out = tag(name, "SetProperty");
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("NameProperty"));
+        out.extend_from_slice(&header(body.len() as u32, 0));
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn int_array_property(name: &str, values: &[i32]) -> Vec<u8> {
+        let mut body = (values.len() as u32).to_le_bytes().to_vec();
+        for v in values {
+            body.extend_from_slice(&v.to_le_bytes());
+        }
+        let mut out = tag(name, "ArrayProperty");
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("IntProperty"));
+        out.extend_from_slice(&header(body.len() as u32, 0));
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn container_layout_reports_set_element_ranges() {
+        let payload = root(
+            "/Script/Test.Save",
+            &name_set_property("Knowledge", &["Voiceline_A", "ChoiceB"]),
+        );
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = &parsed.properties[0];
+
+        let layout = container_layout(&payload, target).unwrap();
+        assert_eq!(layout.kind, ContainerKind::Set);
+        assert_eq!(layout.inner_type, "NameProperty");
+        assert_eq!(layout.count, 2);
+        // count field sits after the u32 num_to_remove
+        assert_eq!(layout.count_offset, target.value_offset + 4);
+        assert_eq!(layout.element_ranges.len(), 2);
+        // elements are FStrings: 4-byte length + chars + NUL
+        let first = &layout.element_ranges[0];
+        assert_eq!(first.start, target.value_offset + 8);
+        assert_eq!(first.len(), 4 + "Voiceline_A".len() + 1);
+        let second = &layout.element_ranges[1];
+        assert_eq!(second.start, first.end);
+        assert_eq!(second.end, target.value_offset + target.value_size);
+    }
+
+    #[test]
+    fn container_layout_reports_array_element_ranges() {
+        let payload = root("/Script/Test.Save", &int_array_property("Nums", &[7, 8, 9]));
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = &parsed.properties[0];
+
+        let layout = container_layout(&payload, target).unwrap();
+        assert_eq!(layout.kind, ContainerKind::Array);
+        assert_eq!(layout.count, 3);
+        assert_eq!(layout.count_offset, target.value_offset);
+        assert_eq!(
+            layout.element_ranges,
+            vec![
+                target.value_offset + 4..target.value_offset + 8,
+                target.value_offset + 8..target.value_offset + 12,
+                target.value_offset + 12..target.value_offset + 16,
+            ]
+        );
+    }
+
+    #[test]
+    fn container_layout_rejects_non_container_targets() {
+        let payload = root("/Script/Test.Save", &int_property("m_X", 1));
+        let parsed = parse_private_root(&payload).unwrap();
+        assert!(container_layout(&payload, &parsed.properties[0]).is_err());
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p goresave_core container_layout`
+Expected: FAIL to compile — `container_layout`/`ContainerKind` not defined.
+
+- [ ] **Step 3: Implement `container_layout`**
+
+Add after `patch_string` in `properties.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerKind {
+    Array,
+    Set,
+}
+
+/// Byte layout of a Set/Array property's value: where the element-count field
+/// sits and the absolute byte range of every element. Computed by re-reading
+/// the container body, since the parsed tree does not record inline element
+/// offsets.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContainerLayout {
+    pub kind: ContainerKind,
+    pub inner_type: String,
+    /// Absolute offset of the u32 element-count field.
+    pub count_offset: usize,
+    pub count: usize,
+    /// Absolute byte range of each element within the payload.
+    pub element_ranges: Vec<core::ops::Range<usize>>,
+}
+
+pub fn container_layout(
+    payload: &[u8],
+    property: &Property,
+) -> Result<ContainerLayout, CoreError> {
+    let kind = match property.type_name.as_str() {
+        "ArrayProperty" => ContainerKind::Array,
+        "SetProperty" => ContainerKind::Set,
+        other => {
+            return Err(CoreError::InvalidRequest(format!(
+                "container edits require an ArrayProperty or SetProperty target, got {other}"
+            )));
+        }
+    };
+    // Instanced-object arrays interleave full object streams; element-level
+    // splicing is not supported for them.
+    if matches!(property.value, PropertyValue::ObjectInstances(_)) {
+        return Err(CoreError::UnsupportedEdit(
+            "container edits do not support instanced-object arrays".to_string(),
+        ));
+    }
+    let inner = property
+        .descriptor
+        .inner
+        .as_deref()
+        .ok_or_else(|| CoreError::Parse("container property missing inner descriptor".into()))?;
+    let end = property
+        .value_offset
+        .checked_add(property.value_size)
+        .filter(|end| *end <= payload.len())
+        .ok_or_else(|| CoreError::Parse("container value out of bounds".to_string()))?;
+    let mut r = Reader::new(&payload[property.value_offset..end], property.value_offset);
+    if kind == ContainerKind::Set {
+        let _num_to_remove = r.u32()?;
+    }
+    let count_offset = r.abs_pos();
+    let count = r.u32()? as usize;
+    let mut element_ranges = Vec::with_capacity(count.min(1 << 16));
+    for _ in 0..count {
+        let start = r.abs_pos();
+        read_inline_value(&mut r, inner, 0)?;
+        element_ranges.push(start..r.abs_pos());
+    }
+    if r.remaining() != 0 {
+        return Err(CoreError::Parse(format!(
+            "container body left {} bytes after {count} elements",
+            r.remaining()
+        )));
+    }
+    Ok(ContainerLayout {
+        kind,
+        inner_type: inner.type_name.clone(),
+        count_offset,
+        count,
+        element_ranges,
+    })
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p goresave_core container_layout`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/properties.rs
+git commit -m "feat(core): container layout with element byte ranges"
+```
+
+---
+
+### Task 2: Rust core — `patch_container` (setAdd / setRemove / arrayRemove / arrayDuplicate)
+
+One splice per edit, with the same all-writes-validated-up-front discipline as `patch_string`: the target's own tag size, every enclosing size field, and the element count are updated by the byte delta, then the splice runs. Offsets in the parsed tree are stale afterwards — callers re-parse.
+
+**Files:**
+- Modify: `crates/goresave_core/src/properties.rs` (after `container_layout`; tests at the bottom)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module (uses Task 1's builders). The nested fixture proves the enclosing-size-chain fixup through a struct wrapper:
+
+```rust
+    fn struct_wrapping(name: &str, struct_type: &str, inner_props: &[u8]) -> Vec<u8> {
+        let mut body = inner_props.to_vec();
+        body.extend_from_slice(&fstring("None"));
+        let mut out = tag(name, "StructProperty");
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring(struct_type));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("/Script/Test"));
+        out.extend_from_slice(&header(body.len() as u32, 0));
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn resolve_set_target(payload: &[u8]) -> (RootObject, Vec<PathSeg>) {
+        let parsed = parse_private_root(payload).unwrap();
+        let path = parse_path(&[
+            "KnowledgeSet".to_string(),
+            "Knowledge".to_string(),
+        ])
+        .unwrap();
+        (parsed, path)
+    }
+
+    #[test]
+    fn patch_container_set_add_appends_and_fixes_sizes() {
+        let mut payload = root(
+            "/Script/Test.Save",
+            &struct_wrapping(
+                "KnowledgeSet",
+                "KnowledgeSet",
+                &name_set_property("Knowledge", &["Voiceline_A"]),
+            ),
+        );
+        let (parsed, path) = resolve_set_target(&payload);
+        let chain = resolve_chain(&parsed.properties, &path).unwrap();
+        let target = chain.target.clone();
+
+        patch_container(
+            &mut payload,
+            &target,
+            &chain.enclosing_size_fields,
+            &ContainerEdit::SetAdd("ChoiceB".to_string()),
+        )
+        .unwrap();
+
+        // Strict re-parse proves every size field (set tag + wrapping struct
+        // tag) was adjusted.
+        let reparsed = parse_private_root(&payload).unwrap();
+        let set = resolve(&reparsed.properties, &path).unwrap();
+        assert_eq!(
+            set.value,
+            PropertyValue::Set {
+                num_to_remove: 0,
+                elements: vec![
+                    PropertyValue::Name("Voiceline_A".to_string()),
+                    PropertyValue::Name("ChoiceB".to_string()),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn patch_container_set_add_rejects_duplicates_without_mutation() {
+        let mut payload = root(
+            "/Script/Test.Save",
+            &name_set_property("Knowledge", &["Voiceline_A"]),
+        );
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+        let copy = payload.clone();
+        assert!(
+            patch_container(
+                &mut payload,
+                &target,
+                &[],
+                &ContainerEdit::SetAdd("Voiceline_A".to_string()),
+            )
+            .is_err()
+        );
+        assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn patch_container_set_remove_splices_element_out() {
+        let mut payload = root(
+            "/Script/Test.Save",
+            &struct_wrapping(
+                "KnowledgeSet",
+                "KnowledgeSet",
+                &name_set_property("Knowledge", &["Voiceline_A", "ChoiceB", "Voiceline_C"]),
+            ),
+        );
+        let (parsed, path) = resolve_set_target(&payload);
+        let chain = resolve_chain(&parsed.properties, &path).unwrap();
+        let target = chain.target.clone();
+
+        patch_container(
+            &mut payload,
+            &target,
+            &chain.enclosing_size_fields,
+            &ContainerEdit::SetRemove("ChoiceB".to_string()),
+        )
+        .unwrap();
+
+        let reparsed = parse_private_root(&payload).unwrap();
+        let set = resolve(&reparsed.properties, &path).unwrap();
+        assert_eq!(
+            set.value,
+            PropertyValue::Set {
+                num_to_remove: 0,
+                elements: vec![
+                    PropertyValue::Name("Voiceline_A".to_string()),
+                    PropertyValue::Name("Voiceline_C".to_string()),
+                ],
+            }
+        );
+
+        // Removing a value that is not present fails without mutation.
+        let parsed = parse_private_root(&payload).unwrap();
+        let chain = resolve_chain(&parsed.properties, &path).unwrap();
+        let target = chain.target.clone();
+        let copy = payload.clone();
+        assert!(
+            patch_container(
+                &mut payload,
+                &target,
+                &chain.enclosing_size_fields,
+                &ContainerEdit::SetRemove("ChoiceB".to_string()),
+            )
+            .is_err()
+        );
+        assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn patch_container_array_remove_and_duplicate() {
+        let mut payload = root("/Script/Test.Save", &int_array_property("Nums", &[7, 8, 9]));
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+
+        patch_container(&mut payload, &target, &[], &ContainerEdit::ArrayRemove(1)).unwrap();
+        let reparsed = parse_private_root(&payload).unwrap();
+        assert_eq!(
+            reparsed.properties[0].value,
+            PropertyValue::Array {
+                elements: vec![PropertyValue::Int(7), PropertyValue::Int(9)],
+            }
+        );
+
+        let target = reparsed.properties[0].clone();
+        patch_container(&mut payload, &target, &[], &ContainerEdit::ArrayDuplicate(0)).unwrap();
+        let reparsed = parse_private_root(&payload).unwrap();
+        assert_eq!(
+            reparsed.properties[0].value,
+            PropertyValue::Array {
+                elements: vec![
+                    PropertyValue::Int(7),
+                    PropertyValue::Int(7),
+                    PropertyValue::Int(9),
+                ],
+            }
+        );
+
+        // Out-of-bounds index fails without mutation.
+        let target = reparsed.properties[0].clone();
+        let copy = payload.clone();
+        assert!(
+            patch_container(&mut payload, &target, &[], &ContainerEdit::ArrayRemove(3)).is_err()
+        );
+        assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn patch_container_rejects_kind_mismatch() {
+        let mut payload = root("/Script/Test.Save", &int_array_property("Nums", &[7]));
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+        // set ops on an array
+        assert!(
+            patch_container(&mut payload, &target, &[], &ContainerEdit::SetAdd("X".into()))
+                .is_err()
+        );
+        // array ops on a set
+        let mut payload = root("/Script/Test.Save", &name_set_property("S", &["A"]));
+        let parsed = parse_private_root(&payload).unwrap();
+        let target = parsed.properties[0].clone();
+        assert!(
+            patch_container(&mut payload, &target, &[], &ContainerEdit::ArrayRemove(0)).is_err()
+        );
+        // setAdd on a non-string set inner type
+        let mut payload = root("/Script/Test.Save", &int_array_property("Nums", &[7]));
+        let parsed = parse_private_root(&payload).unwrap();
+        let _ = (&mut payload, parsed); // (int set builder not needed; kind check above covers it)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p goresave_core patch_container`
+Expected: FAIL to compile — `ContainerEdit`/`patch_container` not defined.
+
+- [ ] **Step 3: Implement `ContainerEdit` and `patch_container`**
+
+Add after `container_layout`:
+
+```rust
+/// Structural container edit applied by `patch_container`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContainerEdit {
+    /// Append a Name/Str element to a SetProperty (rejects duplicates).
+    SetAdd(String),
+    /// Remove a Name/Str element from a SetProperty by value.
+    SetRemove(String),
+    /// Remove an ArrayProperty element by index.
+    ArrayRemove(usize),
+    /// Duplicate an ArrayProperty element in place (copy inserted right after
+    /// the source element).
+    ArrayDuplicate(usize),
+}
+
+fn set_string_elements(target: &Property) -> Option<&[PropertyValue]> {
+    match &target.value {
+        PropertyValue::Set { elements, .. } => Some(elements),
+        _ => None,
+    }
+}
+
+fn set_element_position(elements: &[PropertyValue], value: &str) -> Option<usize> {
+    elements.iter().position(|e| match e {
+        PropertyValue::Name(s) | PropertyValue::Str(s) => s == value,
+        _ => false,
+    })
+}
+
+/// Apply a structural set/array edit to a resolved container property. The
+/// element count, the property's own tag size, and every enclosing size field
+/// (from [`resolve_chain`]) are adjusted by the byte delta; all writes are
+/// validated before the first mutation, so a failed patch leaves the payload
+/// untouched. Offsets recorded in the parsed tree are stale after a successful
+/// patch — re-parse before further edits.
+pub fn patch_container(
+    payload: &mut Vec<u8>,
+    target: &Property,
+    enclosing_size_fields: &[usize],
+    edit: &ContainerEdit,
+) -> Result<(), CoreError> {
+    let layout = container_layout(payload, target)?;
+    let require_kind = |wanted: ContainerKind, op: &str| {
+        if layout.kind == wanted {
+            Ok(())
+        } else {
+            Err(CoreError::InvalidRequest(format!(
+                "{op} requires a {wanted:?} target, got {:?}",
+                layout.kind
+            )))
+        }
+    };
+    // Each edit is one splice: either remove a byte range or insert bytes at a
+    // position. `count_delta` is +1 or -1.
+    let (remove_range, insert_at, insert_bytes, count_delta): (
+        Option<core::ops::Range<usize>>,
+        usize,
+        Vec<u8>,
+        i64,
+    ) = match edit {
+        ContainerEdit::SetAdd(value) => {
+            require_kind(ContainerKind::Set, "setAdd")?;
+            if !matches!(layout.inner_type.as_str(), "NameProperty" | "StrProperty") {
+                return Err(CoreError::UnsupportedEdit(format!(
+                    "setAdd supports Name/Str sets; this set holds {}",
+                    layout.inner_type
+                )));
+            }
+            let elements = set_string_elements(target)
+                .ok_or_else(|| CoreError::Parse("set value not parsed as a set".into()))?;
+            if set_element_position(elements, value).is_some() {
+                return Err(CoreError::InvalidRequest(format!(
+                    "set already contains {value:?}"
+                )));
+            }
+            let end = target.value_offset + target.value_size;
+            (None, end, encode_fstring_value(value), 1)
+        }
+        ContainerEdit::SetRemove(value) => {
+            require_kind(ContainerKind::Set, "setRemove")?;
+            let elements = set_string_elements(target)
+                .ok_or_else(|| CoreError::Parse("set value not parsed as a set".into()))?;
+            let index = set_element_position(elements, value).ok_or_else(|| {
+                CoreError::Parse(format!("set does not contain {value:?}"))
+            })?;
+            let range = layout.element_ranges[index].clone();
+            (Some(range.clone()), range.start, Vec::new(), -1)
+        }
+        ContainerEdit::ArrayRemove(index) => {
+            require_kind(ContainerKind::Array, "arrayRemove")?;
+            let range = layout.element_ranges.get(*index).cloned().ok_or_else(|| {
+                CoreError::InvalidRequest(format!(
+                    "array index {index} out of bounds ({} elements)",
+                    layout.count
+                ))
+            })?;
+            (Some(range.clone()), range.start, Vec::new(), -1)
+        }
+        ContainerEdit::ArrayDuplicate(index) => {
+            require_kind(ContainerKind::Array, "arrayDuplicate")?;
+            let range = layout.element_ranges.get(*index).cloned().ok_or_else(|| {
+                CoreError::InvalidRequest(format!(
+                    "array index {index} out of bounds ({} elements)",
+                    layout.count
+                ))
+            })?;
+            let bytes = payload[range.clone()].to_vec();
+            (None, range.end, bytes, 1)
+        }
+    };
+    let removed = remove_range.as_ref().map_or(0, ExactSizeIterator::len);
+    let delta = insert_bytes.len() as i64 - removed as i64;
+    let new_count = u32::try_from(layout.count as i64 + count_delta)
+        .map_err(|_| CoreError::Parse("container count underflow".to_string()))?;
+    let new_size = u32::try_from(target.value_size as i64 + delta)
+        .map_err(|_| CoreError::Parse("container size would leave the u32 range".to_string()))?;
+
+    // Compute every size-field rewrite up front; mutate only once all are
+    // valid (same discipline as patch_string).
+    let mut writes = Vec::with_capacity(enclosing_size_fields.len() + 2);
+    if target.value_offset < 5 {
+        return Err(CoreError::Parse("container tag offset underflow".to_string()));
+    }
+    writes.push((target.size_field_offset(), new_size));
+    for &offset in enclosing_size_fields {
+        if offset + 4 > target.value_offset {
+            return Err(CoreError::Parse(format!(
+                "enclosing size field at 0x{offset:x} does not precede the patch target"
+            )));
+        }
+        let old = u32::from_le_bytes(payload[offset..offset + 4].try_into().unwrap());
+        let updated = u32::try_from(i64::from(old) + delta).map_err(|_| {
+            CoreError::Parse(format!(
+                "enclosing size field at 0x{offset:x} would leave the u32 range"
+            ))
+        })?;
+        writes.push((offset, updated));
+    }
+    // The count field lives inside the value payload but always precedes the
+    // splice position (elements follow the count), so writing it before the
+    // splice is safe.
+    writes.push((layout.count_offset, new_count));
+    for (offset, value) in writes {
+        payload[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+    match remove_range {
+        Some(range) => {
+            payload.splice(range, core::iter::empty());
+        }
+        None => {
+            payload.splice(insert_at..insert_at, insert_bytes);
+        }
+    }
+    Ok(())
+}
+```
+
+Note: `remove_range.as_ref().map_or(0, ExactSizeIterator::len)` — if the trait call reads awkwardly, `map_or(0, |r| r.len())` is equivalent; use whichever compiles cleanly.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p goresave_core patch_container`
+Expected: 5 PASS. Also run `cargo test -p goresave_core` to confirm no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/properties.rs
+git commit -m "feat(core): patch_container set/array structural edits"
+```
+
+---
+
+### Task 3: Rust core — `find_property_by_name` tree walker
+
+`query_progression` and the inspect overview locate `QuestDataByClass` / `CharacterKnowledgeByUniqueName` / `LongTermMemoryByGlobalId` without hardcoding their nesting, returning the setValue-addressable path prefix.
+
+**Files:**
+- Modify: `crates/goresave_core/src/properties.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn find_property_by_name_returns_addressable_path() {
+        // Map { "CharacterStates" => InstancedStruct { Knowledge: Set } }
+        let nested = {
+            let mut n = name_set_property("Knowledge", &["Voiceline_A"]);
+            n.extend_from_slice(&fstring("None"));
+            n
+        };
+        let mut instanced = fstring("/Script/Test.CharacterStates");
+        instanced.extend_from_slice(&(nested.len() as u32).to_le_bytes());
+        instanced.extend_from_slice(&nested);
+
+        let mut map_body = 0u32.to_le_bytes().to_vec();
+        map_body.extend_from_slice(&1u32.to_le_bytes());
+        map_body.extend_from_slice(&fstring("CharacterStates")); // Name key
+        map_body.extend_from_slice(&instanced);
+
+        let mut props = tag("m_GenericData", "MapProperty");
+        props.extend_from_slice(&2u32.to_le_bytes());
+        props.extend_from_slice(&fstring("NameProperty"));
+        props.extend_from_slice(&0u32.to_le_bytes()); // key_flags
+        props.extend_from_slice(&fstring("StructProperty"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("InstancedStruct"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("/Script/StructUtils"));
+        props.extend_from_slice(&header(map_body.len() as u32, TAG_FLAG_NATIVE_SERIALIZE));
+        props.extend_from_slice(&map_body);
+        let payload = root("/Script/Test.Save", &props);
+
+        let parsed = parse_private_root(&payload).unwrap();
+        let (path, prop) = find_property_by_name(&parsed, "Knowledge").unwrap();
+        assert_eq!(path, vec!["m_GenericData", "{CharacterStates}", "Knowledge"]);
+        assert!(matches!(prop.value, PropertyValue::Set { .. }));
+        // The returned path round-trips through resolve().
+        let segs = parse_path(&path).unwrap();
+        assert_eq!(resolve(&parsed.properties, &segs).unwrap().name, "Knowledge");
+
+        assert!(find_property_by_name(&parsed, "DoesNotExist").is_none());
+    }
+```
+
+If the map fixture builder pattern already exists from the hero-stats tests (`map_of_object_keyed_instanced_payload`), follow its exact byte layout for descriptors.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p goresave_core find_property_by_name`
+Expected: FAIL to compile.
+
+- [ ] **Step 3: Implement**
+
+Add near `search_properties`:
+
+```rust
+/// Depth-first search for the first property named `name` anywhere in the
+/// tree. Returns the setValue-addressable path segments leading to it
+/// (inclusive) plus the property. Map entries whose keys cannot be rendered as
+/// path segments are skipped (a hit behind such a key would not be
+/// addressable anyway).
+pub fn find_property_by_name<'a>(
+    root: &'a RootObject,
+    name: &str,
+) -> Option<(Vec<String>, &'a Property)> {
+    fn in_props<'a>(
+        props: &'a [Property],
+        name: &str,
+        path: &mut Vec<String>,
+    ) -> Option<&'a Property> {
+        for p in props {
+            path.push(p.name.clone());
+            if p.name == name {
+                return Some(p);
+            }
+            if let Some(found) = in_value(&p.value, name, path) {
+                return Some(found);
+            }
+            path.pop();
+        }
+        None
+    }
+    fn in_value<'a>(
+        value: &'a PropertyValue,
+        name: &str,
+        path: &mut Vec<String>,
+    ) -> Option<&'a Property> {
+        match value {
+            PropertyValue::Struct(StructValue::Properties(inner)) => in_props(inner, name, path),
+            PropertyValue::Struct(StructValue::Instanced(Some(i))) => {
+                in_props(&i.properties, name, path)
+            }
+            PropertyValue::Map { entries, .. } => {
+                for (key, val) in entries {
+                    let Some(key) = map_key_to_string(key) else {
+                        continue;
+                    };
+                    path.push(format!("{{{key}}}"));
+                    if let Some(found) = in_value(val, name, path) {
+                        return Some(found);
+                    }
+                    path.pop();
+                }
+                None
+            }
+            PropertyValue::Array { elements } | PropertyValue::Set { elements, .. } => {
+                for (i, e) in elements.iter().enumerate() {
+                    path.push(format!("[{i}]"));
+                    if let Some(found) = in_value(e, name, path) {
+                        return Some(found);
+                    }
+                    path.pop();
+                }
+                None
+            }
+            PropertyValue::ObjectInstances(objs) => {
+                for (i, o) in objs.iter().enumerate() {
+                    path.push(format!("[{i}]"));
+                    if let Some(found) = in_props(&o.properties, name, path) {
+                        return Some(found);
+                    }
+                    path.pop();
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+    let mut path = Vec::new();
+    let target = in_props(&root.properties, name, &mut path)?;
+    Some((path, target))
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p goresave_core find_property_by_name`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/properties.rs
+git commit -m "feat(core): find_property_by_name typed-tree walker"
+```
+
+---
+
+### Task 4: Rust core — wire the four container ops into the edit pipeline
+
+New edit paths `private.typed.setAdd`, `private.typed.setRemove`, `private.typed.arrayRemove`, `private.typed.arrayDuplicate`, applied with the scratch-copy + strict-re-parse pattern of `apply_private_typed_set_value_edit_to_payload`, and advertised in the inspect `writable` list when the typed parse is ok.
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+  - dispatch match in `apply_private_edits` (~line 3300)
+  - `PrivateEdit` enum (~line 3391) and edit structs above it
+  - apply dispatch in `apply_private_edit_to_payload` (~line 3893)
+  - writable list in the inspect private summary (~line 2125)
+  - tests at the bottom
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the lib.rs `tests` module. The unit test exercises the apply path on a raw payload; the integration test goes through `write_save_with_codec_backend` like `write_save_applies_typed_set_value_edit` (~line 6468). Reuse the test module's existing builders; add this one if missing (mirror the byte layout from the properties.rs tests):
+
+```rust
+    fn private_name_set_property(name: &str, values: &[&str]) -> Vec<u8> {
+        let mut body = 0u32.to_le_bytes().to_vec();
+        body.extend_from_slice(&(values.len() as u32).to_le_bytes());
+        for v in values {
+            body.extend_from_slice(&fstring(v));
+        }
+        let mut out = fstring(name);
+        out.extend_from_slice(&fstring("SetProperty"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("NameProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes()); // array_index
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.push(0); // tag_flags
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn typed_container_edits_apply_and_validate() {
+        let mut payload = fstring("/Script/Test.Save");
+        payload.push(0);
+        payload.extend_from_slice(&private_name_set_property("Knowledge", &["A", "B"]));
+        payload.extend_from_slice(&fstring("None"));
+        payload.extend_from_slice(&0u32.to_le_bytes());
+
+        let edit = PrivateTypedContainerEdit {
+            path: properties::parse_path(&["Knowledge".to_string()]).unwrap(),
+            edit: properties::ContainerEdit::SetAdd("C".to_string()),
+        };
+        apply_private_typed_container_edit_to_payload(&mut payload, &edit).unwrap();
+        let edit = PrivateTypedContainerEdit {
+            path: properties::parse_path(&["Knowledge".to_string()]).unwrap(),
+            edit: properties::ContainerEdit::SetRemove("A".to_string()),
+        };
+        apply_private_typed_container_edit_to_payload(&mut payload, &edit).unwrap();
+
+        let root = properties::parse_private_root(&payload).unwrap();
+        assert_eq!(
+            root.properties[0].value,
+            properties::PropertyValue::Set {
+                num_to_remove: 0,
+                elements: vec![
+                    properties::PropertyValue::Name("B".to_string()),
+                    properties::PropertyValue::Name("C".to_string()),
+                ],
+            }
+        );
+
+        // Unknown path fails without mutation.
+        let copy = payload.clone();
+        let bad = PrivateTypedContainerEdit {
+            path: properties::parse_path(&["Nope".to_string()]).unwrap(),
+            edit: properties::ContainerEdit::SetAdd("X".to_string()),
+        };
+        assert!(apply_private_typed_container_edit_to_payload(&mut payload, &bad).is_err());
+        assert_eq!(payload, copy);
+    }
+
+    #[test]
+    fn write_save_applies_typed_container_edits() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-001.sav");
+        let output_path = dir.path().join("G1R-001-container.sav");
+        let private_payload = {
+            let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+            p.push(0);
+            p.extend_from_slice(&private_name_set_property("Knowledge", &["Voiceline_A"]));
+            p.extend_from_slice(&fstring("None"));
+            p.extend_from_slice(&0u32.to_le_bytes());
+            p
+        };
+        let seed_compressed = b"seed-compressed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot A"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        // The container ops must be advertised once the typed parse is ok.
+        let inspected = inspect_save_with_codec_backend(&path, true, Some(&backend), None).unwrap();
+        let writable = inspected["private"]["writable"].as_array().unwrap();
+        for op in [
+            "private.typed.setAdd",
+            "private.typed.setRemove",
+            "private.typed.arrayRemove",
+            "private.typed.arrayDuplicate",
+        ] {
+            assert!(writable.contains(&json!(op)), "missing writable {op}");
+        }
+
+        let response = write_save_with_codec_backend(
+            &path,
+            &[json!({
+                "path": "private.typed.setAdd",
+                "value": { "path": ["Knowledge"], "value": "ChoiceB" }
+            })],
+            false,
+            Some(&output_path),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(response["editsApplied"], 1);
+
+        let value =
+            inspect_save_with_codec_backend(&output_path, true, Some(&backend), None).unwrap();
+        assert_eq!(value["private"]["typedParse"]["status"], "ok");
+        let strings = value["private"]["strings"].as_array().unwrap();
+        assert!(strings.iter().any(|s| s == "ChoiceB"));
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p goresave_core typed_container`
+Expected: FAIL to compile — `PrivateTypedContainerEdit` not defined.
+
+- [ ] **Step 3: Implement parse/dispatch/apply + writable**
+
+Next to `PrivateTypedSetValueEdit` (search for it, ~line 3400), add:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PrivateTypedContainerEdit {
+    path: Vec<properties::PathSeg>,
+    edit: properties::ContainerEdit,
+}
+```
+
+Add a variant to `PrivateEdit` (~line 3391):
+
+```rust
+    TypedContainer(PrivateTypedContainerEdit),
+```
+
+Add the parser next to `parse_private_typed_set_value_edit`. It shares the path extraction; factor the segment parsing into a helper so both ops use it:
+
+```rust
+fn parse_typed_edit_path(op: &str, value: &serde_json::Map<String, Value>) -> Result<Vec<properties::PathSeg>, CoreError> {
+    let segments = value
+        .get("path")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            CoreError::InvalidRequest(format!(
+                "{op} requires value.path as an array of segments"
+            ))
+        })?
+        .iter()
+        .map(|segment| {
+            segment.as_str().map(str::to_string).ok_or_else(|| {
+                CoreError::InvalidRequest(format!("{op} path segments must be strings"))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if segments.is_empty() {
+        return Err(CoreError::InvalidRequest(format!(
+            "{op} requires a non-empty value.path"
+        )));
+    }
+    properties::parse_path(&segments)
+}
+
+fn parse_private_typed_container_edit(
+    edit: &Edit,
+    op: &str,
+) -> Result<PrivateTypedContainerEdit, CoreError> {
+    let value = edit.value.as_object().ok_or_else(|| {
+        CoreError::InvalidRequest(format!("{op} value must be an object"))
+    })?;
+    let path = parse_typed_edit_path(op, value)?;
+    let container_edit = match op {
+        "private.typed.setAdd" | "private.typed.setRemove" => {
+            let element = value
+                .get("value")
+                .and_then(Value::as_str)
+                .filter(|s| !s.trim().is_empty())
+                .ok_or_else(|| {
+                    CoreError::InvalidRequest(format!(
+                        "{op} requires a non-empty string value.value"
+                    ))
+                })?
+                .to_string();
+            if op == "private.typed.setAdd" {
+                properties::ContainerEdit::SetAdd(element)
+            } else {
+                properties::ContainerEdit::SetRemove(element)
+            }
+        }
+        "private.typed.arrayRemove" | "private.typed.arrayDuplicate" => {
+            let index = value
+                .get("index")
+                .and_then(Value::as_u64)
+                .and_then(|v| usize::try_from(v).ok())
+                .ok_or_else(|| {
+                    CoreError::InvalidRequest(format!(
+                        "{op} requires a non-negative integer value.index"
+                    ))
+                })?;
+            if op == "private.typed.arrayRemove" {
+                properties::ContainerEdit::ArrayRemove(index)
+            } else {
+                properties::ContainerEdit::ArrayDuplicate(index)
+            }
+        }
+        other => {
+            return Err(CoreError::UnsupportedEdit(format!(
+                "{other} is not a typed container edit"
+            )));
+        }
+    };
+    Ok(PrivateTypedContainerEdit {
+        path,
+        edit: container_edit,
+    })
+}
+```
+
+Refactor `parse_private_typed_set_value_edit` to use `parse_typed_edit_path` (drop its inline copy of the segment extraction).
+
+Dispatch arms in `apply_private_edits` (~line 3320), after the `private.typed.setValue` arm:
+
+```rust
+            "private.typed.setAdd"
+            | "private.typed.setRemove"
+            | "private.typed.arrayRemove"
+            | "private.typed.arrayDuplicate" => {
+                parse_private_typed_container_edit(edit, edit.path.as_str())
+                    .map(PrivateEdit::TypedContainer)
+            }
+```
+
+Apply dispatch in `apply_private_edit_to_payload` (~line 3893):
+
+```rust
+        PrivateEdit::TypedContainer(edit) => {
+            apply_private_typed_container_edit_to_payload(payload, edit)
+        }
+```
+
+Apply function next to `apply_private_typed_set_value_edit_to_payload`:
+
+```rust
+fn apply_private_typed_container_edit_to_payload(
+    payload: &mut Vec<u8>,
+    edit: &PrivateTypedContainerEdit,
+) -> Result<(), CoreError> {
+    let root = properties::parse_private_root(payload)?;
+    let resolved = properties::resolve_chain(&root.properties, &edit.path)?;
+    let target = resolved.target.clone();
+    // Length-changing patch: work on a scratch copy and prove with a strict
+    // re-parse that every size and count field was fixed up, so a bug cannot
+    // corrupt the caller's payload (or the save).
+    let mut patched = payload.clone();
+    properties::patch_container(
+        &mut patched,
+        &target,
+        &resolved.enclosing_size_fields,
+        &edit.edit,
+    )?;
+    properties::parse_private_root(&patched).map_err(|err| {
+        CoreError::Parse(format!(
+            "container patch produced an inconsistent payload: {err}"
+        ))
+    })?;
+    *payload = patched;
+    Ok(())
+}
+```
+
+Writable list in the inspect private summary (~line 2125), replace the single push:
+
+```rust
+            let mut writable = vec!["private.replaceFString"];
+            if typed_parse["status"] == "ok" {
+                writable.extend([
+                    "private.typed.setValue",
+                    "private.typed.setAdd",
+                    "private.typed.setRemove",
+                    "private.typed.arrayRemove",
+                    "private.typed.arrayDuplicate",
+                ]);
+            }
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p goresave_core typed_container` then `cargo test -p goresave_core`
+Expected: new tests PASS; full suite green (an existing test asserting the exact writable list may need the four new entries added — update it, that is an intended behavior change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): private.typed.setAdd/setRemove/arrayRemove/arrayDuplicate edit ops"
+```
+
+---
+
+### Task 5: Rust core — `query_progression` command (quests section)
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+  - command dispatch in `execute_json_inner` (next to `"search_typed_properties"`, ~line 400)
+  - new functions next to `search_typed_properties` (~line 2380)
+  - tests at the bottom
+
+- [ ] **Step 1: Write the failing test**
+
+The fixture builds a `QuestDataByClass` map with ObjectProperty keys and struct values holding a `CurrentState` EnumProperty, wrapped in a GSAV container like the other command tests:
+
+```rust
+    fn private_enum_property(name: &str, enum_type: &str, label: &str) -> Vec<u8> {
+        let body = fstring(label);
+        let mut out = fstring(name);
+        out.extend_from_slice(&fstring("EnumProperty"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring(enum_type));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("/Script/G1R"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("ByteProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes()); // array_index
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.push(0); // tag_flags
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn quest_map_payload() -> Vec<u8> {
+        let quest_value = |state: &str| {
+            let mut v = private_enum_property("CurrentState", "EQuestState", state);
+            v.extend_from_slice(&fstring("None"));
+            v
+        };
+        let mut map_body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        map_body.extend_from_slice(&2u32.to_le_bytes()); // count
+        map_body.extend_from_slice(&fstring("/Script/Angelscript.Quest_OldCamp_SLEEPER"));
+        map_body.extend_from_slice(&quest_value("EQuestState::Running"));
+        map_body.extend_from_slice(&fstring("/Script/Angelscript.Quest_BanditsCamp_BANDITSTRUST"));
+        map_body.extend_from_slice(&quest_value("EQuestState::Available"));
+
+        let mut props = fstring("QuestDataByClass");
+        props.extend_from_slice(&fstring("MapProperty"));
+        props.extend_from_slice(&2u32.to_le_bytes());
+        props.extend_from_slice(&fstring("ObjectProperty"));
+        props.extend_from_slice(&0u32.to_le_bytes()); // key_flags
+        props.extend_from_slice(&fstring("StructProperty"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("SingleQuestSaveGameData"));
+        props.extend_from_slice(&1u32.to_le_bytes());
+        props.extend_from_slice(&fstring("/Script/G1R"));
+        props.extend_from_slice(&0u32.to_le_bytes()); // array_index
+        props.extend_from_slice(&(map_body.len() as u32).to_le_bytes());
+        props.push(0); // tag_flags (struct map values are tagged property lists)
+        props.extend_from_slice(&map_body);
+
+        let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+        p.push(0);
+        p.extend_from_slice(&props);
+        p.extend_from_slice(&fstring("None"));
+        p.extend_from_slice(&0u32.to_le_bytes());
+        p
+    }
+
+    #[test]
+    fn query_progression_lists_quests_with_state_paths() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-quests.sav");
+        let private_payload = quest_map_payload();
+        let seed_compressed = b"seed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let value =
+            query_progression(&path, &json!({ "section": "quests" }), Some(&backend)).unwrap();
+        assert_eq!(value["section"], "quests");
+        assert_eq!(value["total"], 2);
+        assert_eq!(value["stateCounts"]["Running"], 1);
+        assert_eq!(value["stateCounts"]["Available"], 1);
+        // Sorted by class path: BanditsCamp before OldCamp.
+        let first = &value["quests"][0];
+        assert_eq!(
+            first["questClass"],
+            "/Script/Angelscript.Quest_BanditsCamp_BANDITSTRUST"
+        );
+        assert_eq!(first["id"], "Quest_BanditsCamp_BANDITSTRUST");
+        assert_eq!(first["group"], "BanditsCamp");
+        assert_eq!(first["name"], "BANDITSTRUST");
+        assert_eq!(first["currentState"], "EQuestState::Available");
+        assert_eq!(
+            first["statePath"],
+            json!([
+                "QuestDataByClass",
+                "{/Script/Angelscript.Quest_BanditsCamp_BANDITSTRUST}",
+                "CurrentState"
+            ])
+        );
+
+        // Query filter + paging.
+        let filtered = query_progression(
+            &path,
+            &json!({ "section": "quests", "query": "sleeper" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(filtered["total"], 1);
+        assert_eq!(filtered["quests"][0]["name"], "SLEEPER");
+
+        // The statePath round-trips through the existing setValue write.
+        let output_path = dir.path().join("G1R-quests-out.sav");
+        let response = write_save_with_codec_backend(
+            &path,
+            &[json!({
+                "path": "private.typed.setValue",
+                "value": {
+                    "path": [
+                        "QuestDataByClass",
+                        "{/Script/Angelscript.Quest_BanditsCamp_BANDITSTRUST}",
+                        "CurrentState"
+                    ],
+                    "value": "EQuestState::Succeeded"
+                }
+            })],
+            false,
+            Some(&output_path),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(response["editsApplied"], 1);
+        let after = query_progression(
+            &output_path,
+            &json!({ "section": "quests", "query": "banditstrust" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(after["quests"][0]["currentState"], "EQuestState::Succeeded");
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p goresave_core query_progression_lists_quests`
+Expected: FAIL to compile — `query_progression` not defined.
+
+- [ ] **Step 3: Implement command + quests section**
+
+Dispatch in `execute_json_inner`, after the `"search_typed_properties"` arm (same backend plumbing):
+
+```rust
+        "query_progression" => {
+            let path = required_path(&payload)?;
+            let codec_backend = payload
+                .get("binaryHost")
+                .map(binary_host_backend_from_config)
+                .transpose()?;
+            let codec_backend = codec_backend
+                .as_ref()
+                .map(|backend| backend as &dyn codec_backend::CodecBackend);
+            query_progression(&path, &payload, codec_backend)
+        }
+```
+
+Implementation next to `search_typed_properties`:
+
+```rust
+/// Structured progression queries over the decoded private payload. Sections:
+/// "quests" (QuestDataByClass entries with setValue-addressable state paths),
+/// "knowledge" (per-NPC dialog knowledge sets), "events" (per-character
+/// memorized event arrays). Uses the shared decode cache like the typed
+/// property search.
+fn query_progression(
+    path: &Path,
+    payload: &Value,
+    backend: Option<&dyn codec_backend::CodecBackend>,
+) -> Result<Value, CoreError> {
+    let backend = backend.ok_or_else(|| {
+        CoreError::Codec(
+            "progression queries require a configured and verified G1R codec host".to_string(),
+        )
+    })?;
+    let section = payload
+        .get("section")
+        .and_then(Value::as_str)
+        .unwrap_or("quests");
+    let query = payload
+        .get("query")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    let limit = payload
+        .get("limit")
+        .and_then(Value::as_u64)
+        .map(|v| v as usize)
+        .unwrap_or(100)
+        .clamp(1, 1000);
+    let offset = payload
+        .get("offset")
+        .and_then(Value::as_u64)
+        .map(|v| v as usize)
+        .unwrap_or(0);
+    let character = payload.get("character").and_then(Value::as_str);
+
+    let data = fs::read(path)?;
+    if !data.starts_with(b"GSAV") {
+        return Err(CoreError::UnsupportedEdit(
+            "progression queries are only available for GSAV files".to_string(),
+        ));
+    }
+    let parts = split_gsav(&data)?;
+    let stream = parse_compressed_stream(&data, 13 + parts.public_payload.len())?;
+    let decoded = decoded_private_payload_cached(path, &data, &stream, backend)?;
+    let root = properties::parse_private_root(&decoded)?;
+    match section {
+        "quests" => progression_quests(&root, &query, offset, limit),
+        "knowledge" => progression_knowledge(&root, &query, character, offset, limit),
+        "events" => progression_events(&root, &query, character, offset, limit),
+        other => Err(CoreError::InvalidRequest(format!(
+            "unknown progression section {other:?}"
+        ))),
+    }
+}
+
+/// Property lookup inside a struct-valued map entry (tagged property list or
+/// InstancedStruct wrapper).
+fn struct_member<'a>(
+    value: &'a properties::PropertyValue,
+    name: &str,
+) -> Option<&'a properties::PropertyValue> {
+    let props = match value {
+        properties::PropertyValue::Struct(properties::StructValue::Properties(p)) => p,
+        properties::PropertyValue::Struct(properties::StructValue::Instanced(Some(i))) => {
+            &i.properties
+        }
+        _ => return None,
+    };
+    props.iter().find(|p| p.name == name).map(|p| &p.value)
+}
+
+fn map_key_string(key: &properties::PropertyValue) -> Option<&str> {
+    match key {
+        properties::PropertyValue::Str(s)
+        | properties::PropertyValue::Name(s)
+        | properties::PropertyValue::Enum(s)
+        | properties::PropertyValue::Object(s) => Some(s),
+        _ => None,
+    }
+}
+
+/// "EQuestState::Running" → "Running" for the overview/state-count labels.
+fn short_enum_label(value: &str) -> &str {
+    value.rsplit("::").next().unwrap_or(value)
+}
+
+fn progression_quests(
+    root: &properties::RootObject,
+    query: &str,
+    offset: usize,
+    limit: usize,
+) -> Result<Value, CoreError> {
+    let (base_path, map_prop) = properties::find_property_by_name(root, "QuestDataByClass")
+        .ok_or_else(|| {
+            CoreError::Parse("QuestDataByClass not found in the decoded payload".to_string())
+        })?;
+    let properties::PropertyValue::Map { entries, .. } = &map_prop.value else {
+        return Err(CoreError::Parse(
+            "QuestDataByClass is not a map".to_string(),
+        ));
+    };
+    let mut state_counts = std::collections::BTreeMap::<String, usize>::new();
+    let mut matches: Vec<(String, Option<String>)> = Vec::new();
+    for (key, value) in entries {
+        let Some(class_path) = map_key_string(key) else {
+            continue;
+        };
+        let state = struct_member(value, "CurrentState").and_then(|v| match v {
+            properties::PropertyValue::Enum(s) => Some(s.clone()),
+            _ => None,
+        });
+        let label = state
+            .as_deref()
+            .map(short_enum_label)
+            .unwrap_or("unknown")
+            .to_string();
+        *state_counts.entry(label).or_default() += 1;
+        if !query.is_empty() && !class_path.to_ascii_lowercase().contains(query) {
+            continue;
+        }
+        matches.push((class_path.to_string(), state));
+    }
+    matches.sort_by(|a, b| a.0.cmp(&b.0));
+    let total = matches.len();
+    let quests = matches
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(|(class_path, state)| {
+            let id = class_path
+                .rsplit('.')
+                .next()
+                .unwrap_or(class_path.as_str())
+                .to_string();
+            let trimmed = id.strip_prefix("Quest_").unwrap_or(&id);
+            let (group, name) = match trimmed.split_once('_') {
+                Some((g, n)) => (g.to_string(), n.to_string()),
+                None => (trimmed.to_string(), String::new()),
+            };
+            let mut state_path = base_path.clone();
+            state_path.push(format!("{{{class_path}}}"));
+            state_path.push("CurrentState".to_string());
+            json!({
+                "questClass": class_path,
+                "id": id,
+                "group": group,
+                "name": name,
+                "currentState": state,
+                "statePath": state_path,
+                "writable": state.is_some(),
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "section": "quests",
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "count": quests.len(),
+        "stateCounts": state_counts,
+        "quests": quests,
+    }))
+}
+```
+
+Wait — `state` is moved into the closure before `"writable": state.is_some()` can read it; compute `let writable = state.is_some();` first, then build the json. Write it that way:
+
+```rust
+            let writable = state.is_some();
+            // ... json!({ ..., "currentState": state, "statePath": state_path, "writable": writable })
+```
+
+Add placeholder stubs so the file compiles before Task 6 (they are replaced there):
+
+```rust
+fn progression_knowledge(
+    _root: &properties::RootObject,
+    _query: &str,
+    _character: Option<&str>,
+    _offset: usize,
+    _limit: usize,
+) -> Result<Value, CoreError> {
+    Err(CoreError::InvalidRequest(
+        "knowledge section not implemented yet".to_string(),
+    ))
+}
+
+fn progression_events(
+    _root: &properties::RootObject,
+    _query: &str,
+    _character: Option<&str>,
+    _offset: usize,
+    _limit: usize,
+) -> Result<Value, CoreError> {
+    Err(CoreError::InvalidRequest(
+        "events section not implemented yet".to_string(),
+    ))
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p goresave_core query_progression_lists_quests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): query_progression command with quests section"
+```
+
+---
+
+### Task 6: Rust core — knowledge and events sections
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs` (replace the Task 5 stubs; tests at the bottom)
+
+- [ ] **Step 1: Write the failing tests**
+
+The fixture nests both maps the way real saves do (map values as tagged struct property lists). Reuse `private_name_set_property` from Task 4 and the builders below:
+
+```rust
+    fn private_double_property(name: &str, value: f64) -> Vec<u8> {
+        let mut out = fstring(name);
+        out.extend_from_slice(&fstring("DoubleProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&8u32.to_le_bytes());
+        out.push(0);
+        out.extend_from_slice(&value.to_le_bytes());
+        out
+    }
+
+    fn private_struct_property(name: &str, struct_type: &str, body: &[u8], flags: u8) -> Vec<u8> {
+        let mut out = fstring(name);
+        out.extend_from_slice(&fstring("StructProperty"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring(struct_type));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("/Script/G1R"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.push(flags);
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn name_keyed_struct_map(map_name: &str, entries: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        let mut map_body = 0u32.to_le_bytes().to_vec();
+        map_body.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+        for (key, value_props) in entries {
+            map_body.extend_from_slice(&fstring(key));
+            map_body.extend_from_slice(value_props);
+            map_body.extend_from_slice(&fstring("None"));
+        }
+        let mut out = fstring(map_name);
+        out.extend_from_slice(&fstring("MapProperty"));
+        out.extend_from_slice(&2u32.to_le_bytes());
+        out.extend_from_slice(&fstring("NameProperty"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&fstring("StructProperty"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("KnowledgeSet"));
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring("/Script/G1R"));
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&(map_body.len() as u32).to_le_bytes());
+        out.push(0);
+        out.extend_from_slice(&map_body);
+        out
+    }
+```
+
+Note on the map-value layout: struct map values are inline tagged property lists terminated by `"None"` (see `read_inline_value` → `read_struct_value` with `native = false` — `is_native_struct_type("KnowledgeSet")` is false). The `name_keyed_struct_map` builder above appends the terminator itself; pass `value_props` WITHOUT a trailing `None`.
+
+```rust
+    #[test]
+    fn query_progression_knowledge_lists_characters_and_entries() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-knowledge.sav");
+        let private_payload = {
+            let diego = private_name_set_property(
+                "Knowledge",
+                &["Voiceline_info_diego_gamestart_11_00", "ChoiceDiegoGamestart"],
+            );
+            let xardas = private_name_set_property("Knowledge", &["Voiceline_xardas_intro"]);
+            let map = name_keyed_struct_map(
+                "CharacterKnowledgeByUniqueName",
+                &[("OC_STT_Diego", diego), ("NoneCamp_Xardas", xardas)],
+            );
+            let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+            p.push(0);
+            p.extend_from_slice(&map);
+            p.extend_from_slice(&fstring("None"));
+            p.extend_from_slice(&0u32.to_le_bytes());
+            p
+        };
+        let seed_compressed = b"seed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        // Character list (no `character` param).
+        let value =
+            query_progression(&path, &json!({ "section": "knowledge" }), Some(&backend)).unwrap();
+        assert_eq!(value["total"], 2);
+        // Sorted by name: NoneCamp_Xardas before OC_STT_Diego.
+        assert_eq!(value["characters"][0]["name"], "NoneCamp_Xardas");
+        assert_eq!(value["characters"][0]["entryCount"], 1);
+        assert_eq!(value["characters"][1]["name"], "OC_STT_Diego");
+        assert_eq!(value["characters"][1]["entryCount"], 2);
+
+        // Entries for one character.
+        let value = query_progression(
+            &path,
+            &json!({ "section": "knowledge", "character": "OC_STT_Diego" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(value["character"], "OC_STT_Diego");
+        assert_eq!(value["total"], 2);
+        assert_eq!(
+            value["setPath"],
+            json!([
+                "CharacterKnowledgeByUniqueName",
+                "{OC_STT_Diego}",
+                "Knowledge"
+            ])
+        );
+        let entries = value["entries"].as_array().unwrap();
+        assert!(entries.contains(&json!("ChoiceDiegoGamestart")));
+
+        // Query filter on entries.
+        let value = query_progression(
+            &path,
+            &json!({ "section": "knowledge", "character": "OC_STT_Diego", "query": "choice" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(value["total"], 1);
+
+        // Unknown character errors.
+        assert!(
+            query_progression(
+                &path,
+                &json!({ "section": "knowledge", "character": "Nobody" }),
+                Some(&backend),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn query_progression_events_lists_characters_and_events() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-events.sav");
+        let private_payload = {
+            // One memory event struct: EventTags (native GameplayTagContainer)
+            // + Time (InGameTime property list) + AffectedCharacterGlobalId.
+            let event = {
+                let mut tags_body = 1u32.to_le_bytes().to_vec();
+                tags_body.extend_from_slice(&fstring("Memory.Quest.Started"));
+                let mut e = private_struct_property(
+                    "EventTags",
+                    "GameplayTagContainer",
+                    &tags_body,
+                    TAG_FLAG_NATIVE_SERIALIZE,
+                );
+                let time_body = {
+                    let mut t = private_double_property("TotalSeconds", 1234.5);
+                    t.extend_from_slice(&fstring("None"));
+                    t
+                };
+                e.extend_from_slice(&private_struct_property(
+                    "Time", "InGameTime", &time_body, 0,
+                ));
+                let mut affected = fstring("AffectedCharacterGlobalId");
+                affected.extend_from_slice(&fstring("NameProperty"));
+                affected.extend_from_slice(&0u32.to_le_bytes());
+                let hero = fstring("Hero");
+                affected.extend_from_slice(&(hero.len() as u32).to_le_bytes());
+                affected.push(0);
+                affected.extend_from_slice(&hero);
+                e.extend_from_slice(&affected);
+                e
+            };
+            // MemorizedEvents: ArrayProperty of MemoryEvent structs (inline
+            // tagged property lists, "None"-terminated).
+            let memorized = {
+                let mut element = event.clone();
+                element.extend_from_slice(&fstring("None"));
+                let mut body = 1u32.to_le_bytes().to_vec();
+                body.extend_from_slice(&element);
+                let mut out = fstring("MemorizedEvents");
+                out.extend_from_slice(&fstring("ArrayProperty"));
+                out.extend_from_slice(&1u32.to_le_bytes());
+                out.extend_from_slice(&fstring("StructProperty"));
+                out.extend_from_slice(&1u32.to_le_bytes());
+                out.extend_from_slice(&fstring("MemoryEvent"));
+                out.extend_from_slice(&1u32.to_le_bytes());
+                out.extend_from_slice(&fstring("/Script/G1R"));
+                out.extend_from_slice(&0u32.to_le_bytes());
+                out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+                out.push(0);
+                out.extend_from_slice(&body);
+                out
+            };
+            let map = name_keyed_struct_map("LongTermMemoryByGlobalId", &[("Hero", memorized)]);
+            let mut p = fstring("/Script/Angelscript.GothicFinalDataGame");
+            p.push(0);
+            p.extend_from_slice(&map);
+            p.extend_from_slice(&fstring("None"));
+            p.extend_from_slice(&0u32.to_le_bytes());
+            p
+        };
+        let seed_compressed = b"seed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let value =
+            query_progression(&path, &json!({ "section": "events" }), Some(&backend)).unwrap();
+        assert_eq!(value["total"], 1);
+        assert_eq!(value["characters"][0]["id"], "Hero");
+        assert_eq!(value["characters"][0]["eventCount"], 1);
+
+        let value = query_progression(
+            &path,
+            &json!({ "section": "events", "character": "Hero" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(value["character"], "Hero");
+        assert_eq!(value["total"], 1);
+        assert_eq!(
+            value["arrayPath"],
+            json!(["LongTermMemoryByGlobalId", "{Hero}", "MemorizedEvents"])
+        );
+        let event = &value["events"][0];
+        assert_eq!(event["index"], 0);
+        assert_eq!(event["tags"], json!(["Memory.Quest.Started"]));
+        assert_eq!(event["timeSeconds"], 1234.5);
+        assert_eq!(event["affected"], "Hero");
+
+        // Tag query filter.
+        let filtered = query_progression(
+            &path,
+            &json!({ "section": "events", "character": "Hero", "query": "guild" }),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(filtered["total"], 0);
+    }
+```
+
+Adjust the `name_keyed_struct_map` struct-type descriptor per use if needed — the value struct type string is cosmetic for the parser (`KnowledgeSet` vs a memory holder); using one name everywhere is fine since `is_native_struct_type` only checks known native names.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p goresave_core query_progression`
+Expected: knowledge/events tests FAIL with "not implemented yet".
+
+- [ ] **Step 3: Replace the stubs**
+
+```rust
+fn progression_knowledge(
+    root: &properties::RootObject,
+    query: &str,
+    character: Option<&str>,
+    offset: usize,
+    limit: usize,
+) -> Result<Value, CoreError> {
+    let (base_path, map_prop) =
+        properties::find_property_by_name(root, "CharacterKnowledgeByUniqueName").ok_or_else(
+            || {
+                CoreError::Parse(
+                    "CharacterKnowledgeByUniqueName not found in the decoded payload".to_string(),
+                )
+            },
+        )?;
+    let properties::PropertyValue::Map { entries, .. } = &map_prop.value else {
+        return Err(CoreError::Parse(
+            "CharacterKnowledgeByUniqueName is not a map".to_string(),
+        ));
+    };
+    let knowledge_entries = |value: &properties::PropertyValue| -> Vec<String> {
+        match struct_member(value, "Knowledge") {
+            Some(properties::PropertyValue::Set { elements, .. }) => elements
+                .iter()
+                .filter_map(|e| match e {
+                    properties::PropertyValue::Name(s) | properties::PropertyValue::Str(s) => {
+                        Some(s.clone())
+                    }
+                    _ => None,
+                })
+                .collect(),
+            _ => Vec::new(),
+        }
+    };
+    match character {
+        None => {
+            let mut characters: Vec<(String, usize)> = entries
+                .iter()
+                .filter_map(|(key, value)| {
+                    let name = map_key_string(key)?;
+                    if !query.is_empty() && !name.to_ascii_lowercase().contains(query) {
+                        return None;
+                    }
+                    Some((name.to_string(), knowledge_entries(value).len()))
+                })
+                .collect();
+            characters.sort_by(|a, b| a.0.cmp(&b.0));
+            let total = characters.len();
+            let page = characters
+                .into_iter()
+                .skip(offset)
+                .take(limit)
+                .map(|(name, entry_count)| json!({ "name": name, "entryCount": entry_count }))
+                .collect::<Vec<_>>();
+            Ok(json!({
+                "section": "knowledge",
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+                "count": page.len(),
+                "characters": page,
+            }))
+        }
+        Some(character) => {
+            let value = entries
+                .iter()
+                .find(|(key, _)| map_key_string(key) == Some(character))
+                .map(|(_, value)| value)
+                .ok_or_else(|| {
+                    CoreError::Parse(format!("character {character:?} has no knowledge entry"))
+                })?;
+            let mut all = knowledge_entries(value);
+            if !query.is_empty() {
+                all.retain(|e| e.to_ascii_lowercase().contains(query));
+            }
+            let total = all.len();
+            let page = all
+                .into_iter()
+                .skip(offset)
+                .take(limit)
+                .collect::<Vec<_>>();
+            let mut set_path = base_path.clone();
+            set_path.push(format!("{{{character}}}"));
+            set_path.push("Knowledge".to_string());
+            Ok(json!({
+                "section": "knowledge",
+                "character": character,
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+                "count": page.len(),
+                "entries": page,
+                "setPath": set_path,
+            }))
+        }
+    }
+}
+
+fn progression_events(
+    root: &properties::RootObject,
+    query: &str,
+    character: Option<&str>,
+    offset: usize,
+    limit: usize,
+) -> Result<Value, CoreError> {
+    let (base_path, map_prop) =
+        properties::find_property_by_name(root, "LongTermMemoryByGlobalId").ok_or_else(|| {
+            CoreError::Parse(
+                "LongTermMemoryByGlobalId not found in the decoded payload".to_string(),
+            )
+        })?;
+    let properties::PropertyValue::Map { entries, .. } = &map_prop.value else {
+        return Err(CoreError::Parse(
+            "LongTermMemoryByGlobalId is not a map".to_string(),
+        ));
+    };
+    let memorized = |value: &properties::PropertyValue| -> Option<usize> {
+        match struct_member(value, "MemorizedEvents") {
+            Some(properties::PropertyValue::Array { elements }) => Some(elements.len()),
+            _ => None,
+        }
+    };
+    match character {
+        None => {
+            let mut characters: Vec<(String, usize)> = entries
+                .iter()
+                .filter_map(|(key, value)| {
+                    let id = map_key_string(key)?;
+                    if !query.is_empty() && !id.to_ascii_lowercase().contains(query) {
+                        return None;
+                    }
+                    Some((id.to_string(), memorized(value).unwrap_or(0)))
+                })
+                .collect();
+            characters.sort_by(|a, b| a.0.cmp(&b.0));
+            let total = characters.len();
+            let page = characters
+                .into_iter()
+                .skip(offset)
+                .take(limit)
+                .map(|(id, event_count)| json!({ "id": id, "eventCount": event_count }))
+                .collect::<Vec<_>>();
+            Ok(json!({
+                "section": "events",
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+                "count": page.len(),
+                "characters": page,
+            }))
+        }
+        Some(character) => {
+            let value = entries
+                .iter()
+                .find(|(key, _)| map_key_string(key) == Some(character))
+                .map(|(_, value)| value)
+                .ok_or_else(|| {
+                    CoreError::Parse(format!("character {character:?} has no memory entry"))
+                })?;
+            let Some(properties::PropertyValue::Array { elements }) =
+                struct_member(value, "MemorizedEvents")
+            else {
+                return Err(CoreError::Parse(
+                    "MemorizedEvents missing or not an array".to_string(),
+                ));
+            };
+            let event_json = |index: usize, element: &properties::PropertyValue| -> Value {
+                let tags = match struct_member(element, "EventTags") {
+                    Some(properties::PropertyValue::Struct(
+                        properties::StructValue::GameplayTagContainer(tags),
+                    )) => tags.clone(),
+                    _ => Vec::new(),
+                };
+                let in_game_seconds = |name: &str| -> Option<f64> {
+                    match struct_member(element, name).and_then(|t| struct_member(t, "TotalSeconds"))
+                    {
+                        Some(properties::PropertyValue::Double(v)) => Some(*v),
+                        _ => None,
+                    }
+                };
+                let name_member = |name: &str| -> Option<String> {
+                    match struct_member(element, name) {
+                        Some(properties::PropertyValue::Name(s)) => Some(s.clone()),
+                        _ => None,
+                    }
+                };
+                let soft_member = |name: &str| -> Option<String> {
+                    match struct_member(element, name) {
+                        Some(properties::PropertyValue::SoftObject(p))
+                            if !p.package_name.is_empty() && p.package_name != "None" =>
+                        {
+                            Some(p.package_name.clone())
+                        }
+                        _ => None,
+                    }
+                };
+                let magnitude = match struct_member(element, "Magnitude") {
+                    Some(properties::PropertyValue::Float(v)) => Some(f64::from(*v)),
+                    _ => None,
+                };
+                json!({
+                    "index": index,
+                    "tags": tags,
+                    "magnitude": magnitude,
+                    "timeSeconds": in_game_seconds("Time"),
+                    "durationSeconds": in_game_seconds("Duration"),
+                    "instigator": name_member("InstigatorGlobalId"),
+                    "affected": name_member("AffectedCharacterGlobalId"),
+                    "optionalClass1": soft_member("OptionalClass1"),
+                    "optionalClass2": soft_member("OptionalClass2"),
+                })
+            };
+            let matches_query = |event: &Value| -> bool {
+                if query.is_empty() {
+                    return true;
+                }
+                let hay = [
+                    event["tags"].to_string(),
+                    event["instigator"].to_string(),
+                    event["affected"].to_string(),
+                    event["optionalClass1"].to_string(),
+                    event["optionalClass2"].to_string(),
+                ]
+                .join(" ")
+                .to_ascii_lowercase();
+                hay.contains(query)
+            };
+            let all: Vec<Value> = elements
+                .iter()
+                .enumerate()
+                .map(|(index, element)| event_json(index, element))
+                .filter(matches_query)
+                .collect();
+            let total = all.len();
+            let page = all.into_iter().skip(offset).take(limit).collect::<Vec<_>>();
+            let mut array_path = base_path.clone();
+            array_path.push(format!("{{{character}}}"));
+            array_path.push("MemorizedEvents".to_string());
+            Ok(json!({
+                "section": "events",
+                "character": character,
+                "total": total,
+                "offset": offset,
+                "limit": limit,
+                "count": page.len(),
+                "events": page,
+                "arrayPath": array_path,
+            }))
+        }
+    }
+}
+```
+
+Note: `.filter(matches_query)` over `Value` items needs `|e| matches_query(e)`; write the closure form that compiles.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p goresave_core query_progression`
+Expected: all 3 query_progression tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): query_progression knowledge and events sections"
+```
+
+---
+
+### Task 7: Rust core — structured progression overview in inspect; delete the heuristic
+
+`inspect_save` parses the typed root once (it already does, inside `summarize_typed_parse`), shares it with a new structured progression overview, and the old string-grep progression summary is deleted.
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+  - inspect decoded branch (~line 2121–2151)
+  - `summarize_typed_parse` (~line 2292)
+  - delete `summarize_private_progression_payload` (~line 2439), `looks_progression_candidate`, `looks_gameplay_tag_candidate`, `looks_progression_text`, `progression_section_label` (~lines 2669–2719)
+  - tests
+
+- [ ] **Step 1: Write the failing test**
+
+Reuse `quest_map_payload()` from Task 5 (extend it if convenient, or build a combined fixture):
+
+```rust
+    #[test]
+    fn inspect_reports_structured_progression_overview() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-overview.sav");
+        let private_payload = quest_map_payload();
+        let seed_compressed = b"seed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let value = inspect_save_with_codec_backend(&path, true, Some(&backend), None).unwrap();
+        let progression = &value["private"]["progression"];
+        assert_eq!(progression["status"], "ok");
+        assert_eq!(progression["questTotal"], 2);
+        assert_eq!(progression["questStates"]["Running"], 1);
+        assert_eq!(progression["questStates"]["Available"], 1);
+        // No knowledge/memory maps in this fixture.
+        assert_eq!(progression["knowledgeCharacters"], 0);
+        assert_eq!(progression["memoryCharacters"], 0);
+        assert!(
+            progression["writable"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("private.typed.setValue"))
+        );
+        // The old heuristic fields are gone.
+        assert!(progression.get("candidates").is_none());
+        assert!(progression.get("sections").is_none());
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p goresave_core inspect_reports_structured_progression_overview`
+Expected: FAIL — progression still has the heuristic shape.
+
+- [ ] **Step 3: Implement**
+
+(a) Refactor `summarize_typed_parse` so the parse result is reusable. Change its signature and split the parse out:
+
+```rust
+fn summarize_typed_parse_result(
+    payload: &[u8],
+    result: Option<&Result<properties::RootObject, CoreError>>,
+) -> Value {
+    let Some(result) = result else {
+        return json!({
+            "status": "skipped_preview",
+            "message": "Typed parse needs the full decoded payload.",
+        });
+    };
+    match result {
+        Ok(root) => { /* move the existing Ok-arm body of summarize_typed_parse here */ }
+        Err(err) => { /* move the existing Err-arm body here */ }
+    }
+}
+```
+
+Keep a thin compatibility wrapper only if other call sites exist (grep for `summarize_typed_parse(`); otherwise delete the old function.
+
+(b) In the inspect decoded branch (~line 2121), replace:
+
+```rust
+            let progression = summarize_private_progression_payload(&refs);
+            let typed_parse = summarize_typed_parse(&payload, preview);
+```
+
+with:
+
+```rust
+            let typed_result = if preview {
+                None
+            } else {
+                Some(properties::parse_private_root(&payload))
+            };
+            let typed_parse = summarize_typed_parse_result(&payload, typed_result.as_ref());
+            let typed_ok = typed_parse["status"] == "ok";
+            let progression = summarize_private_progression_overview(
+                typed_result.as_ref().and_then(|r| r.as_ref().ok()).filter(|_| typed_ok),
+            );
+```
+
+(c) New overview function (place near the other summarize functions). It reuses `struct_member`/`map_key_string`/`short_enum_label` from Task 5:
+
+```rust
+/// Structured progression overview for the inspect response: quest counts by
+/// state plus knowledge/memory totals. `root` is Some only when the strict
+/// typed parse succeeded on a full (non-preview) decode.
+fn summarize_private_progression_overview(root: Option<&properties::RootObject>) -> Value {
+    let Some(root) = root else {
+        return json!({ "status": "unavailable", "writable": [] });
+    };
+    let mut quest_total = 0usize;
+    let mut quest_states = std::collections::BTreeMap::<String, usize>::new();
+    if let Some((_, prop)) = properties::find_property_by_name(root, "QuestDataByClass") {
+        if let properties::PropertyValue::Map { entries, .. } = &prop.value {
+            quest_total = entries.len();
+            for (_, value) in entries {
+                let label = match struct_member(value, "CurrentState") {
+                    Some(properties::PropertyValue::Enum(s)) => short_enum_label(s).to_string(),
+                    _ => "unknown".to_string(),
+                };
+                *quest_states.entry(label).or_default() += 1;
+            }
+        }
+    }
+    let mut knowledge_characters = 0usize;
+    let mut knowledge_entries = 0usize;
+    if let Some((_, prop)) =
+        properties::find_property_by_name(root, "CharacterKnowledgeByUniqueName")
+    {
+        if let properties::PropertyValue::Map { entries, .. } = &prop.value {
+            knowledge_characters = entries.len();
+            for (_, value) in entries {
+                if let Some(properties::PropertyValue::Set { elements, .. }) =
+                    struct_member(value, "Knowledge")
+                {
+                    knowledge_entries += elements.len();
+                }
+            }
+        }
+    }
+    let mut memory_characters = 0usize;
+    let mut memory_events = 0usize;
+    if let Some((_, prop)) = properties::find_property_by_name(root, "LongTermMemoryByGlobalId") {
+        if let properties::PropertyValue::Map { entries, .. } = &prop.value {
+            memory_characters = entries.len();
+            for (_, value) in entries {
+                if let Some(properties::PropertyValue::Array { elements }) =
+                    struct_member(value, "MemorizedEvents")
+                {
+                    memory_events += elements.len();
+                }
+            }
+        }
+    }
+    json!({
+        "status": "ok",
+        "questTotal": quest_total,
+        "questStates": quest_states,
+        "knowledgeCharacters": knowledge_characters,
+        "knowledgeEntries": knowledge_entries,
+        "memoryCharacters": memory_characters,
+        "memoryEvents": memory_events,
+        "writable": [
+            "private.typed.setValue",
+            "private.typed.setAdd",
+            "private.typed.setRemove",
+            "private.typed.arrayRemove",
+            "private.typed.arrayDuplicate",
+        ],
+    })
+}
+```
+
+(d) Delete `summarize_private_progression_payload`, `looks_progression_candidate`, `looks_gameplay_tag_candidate`, `looks_progression_text`, and `progression_section_label`. Run `cargo build -p goresave_core` and chase dangling references; grep the test module for tests asserting the old progression shape (`grep -n "progression" crates/goresave_core/src/lib.rs`) and update them to the new overview shape (counts instead of candidate lists).
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `cargo test -p goresave_core`
+Expected: all green, including the new overview test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): structured progression overview, drop string-grep heuristic"
+```
+
+---
+
+### Task 8: Dart — progression models
+
+New file with section page models and edit intents; `SaveInspection` switches from `PrivateProgressionSummary` to the new overview.
+
+**Files:**
+- Create: `apps/goresave/lib/features/editor/domain/progression_models.dart`
+- Modify: `apps/goresave/lib/features/editor/domain/editor_models.dart` (replace `PrivateProgressionSummary` usage in `SaveInspection`; delete the class)
+- Test: `apps/goresave/test/features/editor/progression_models_test.dart` (create `test/features/editor/` if missing)
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/progression_models.dart';
+
+void main() {
+  test('ProgressionOverview parses inspect json', () {
+    final overview = ProgressionOverview.fromJson({
+      'status': 'ok',
+      'questTotal': 707,
+      'questStates': {'Available': 700, 'Running': 5, 'Succeeded': 2},
+      'knowledgeCharacters': 12,
+      'knowledgeEntries': 340,
+      'memoryCharacters': 3,
+      'memoryEvents': 1500,
+      'writable': ['private.typed.setValue', 'private.typed.setAdd'],
+    });
+    expect(overview.status, 'ok');
+    expect(overview.available, isTrue);
+    expect(overview.questTotal, 707);
+    expect(overview.questStates['Running'], 5);
+    expect(overview.knowledgeCharacters, 12);
+    expect(overview.memoryEvents, 1500);
+    expect(overview.writable, contains('private.typed.setAdd'));
+
+    final unavailable = ProgressionOverview.fromJson({'status': 'unavailable'});
+    expect(unavailable.available, isFalse);
+  });
+
+  test('ProgressionQuestPage parses query json', () {
+    final page = ProgressionQuestPage.fromJson({
+      'total': 2,
+      'offset': 0,
+      'limit': 100,
+      'stateCounts': {'Available': 1, 'Running': 1},
+      'quests': [
+        {
+          'questClass': '/Script/Angelscript.Quest_OldCamp_SLEEPER',
+          'id': 'Quest_OldCamp_SLEEPER',
+          'group': 'OldCamp',
+          'name': 'SLEEPER',
+          'currentState': 'EQuestState::Running',
+          'statePath': [
+            'QuestDataByClass',
+            '{/Script/Angelscript.Quest_OldCamp_SLEEPER}',
+            'CurrentState',
+          ],
+          'writable': true,
+        },
+      ],
+    });
+    expect(page.total, 2);
+    expect(page.quests.single.group, 'OldCamp');
+    expect(page.quests.single.currentState, 'EQuestState::Running');
+    expect(page.quests.single.writable, isTrue);
+    expect(page.quests.single.statePath, hasLength(3));
+  });
+
+  test('edit intents emit core edit json', () {
+    final questEdit = QuestStateChange(
+      statePath: const ['QuestDataByClass', '{X}', 'CurrentState'],
+      state: 'EQuestState::Succeeded',
+    );
+    expect(questEdit.toEditJson(), {
+      'path': 'private.typed.setValue',
+      'value': {
+        'path': ['QuestDataByClass', '{X}', 'CurrentState'],
+        'value': 'EQuestState::Succeeded',
+      },
+    });
+
+    final add = KnowledgeEntryEdit.add(
+      setPath: const ['CharacterKnowledgeByUniqueName', '{Diego}', 'Knowledge'],
+      entry: 'Voiceline_X',
+    );
+    expect(add.toEditJson(), {
+      'path': 'private.typed.setAdd',
+      'value': {
+        'path': ['CharacterKnowledgeByUniqueName', '{Diego}', 'Knowledge'],
+        'value': 'Voiceline_X',
+      },
+    });
+
+    final remove = KnowledgeEntryEdit.remove(
+      setPath: const ['CharacterKnowledgeByUniqueName', '{Diego}', 'Knowledge'],
+      entry: 'Voiceline_X',
+    );
+    expect(remove.toEditJson()['path'], 'private.typed.setRemove');
+
+    final removeEvent = MemoryEventEdit.remove(
+      arrayPath: const ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+      index: 4,
+    );
+    expect(removeEvent.toEditJson(), {
+      'path': 'private.typed.arrayRemove',
+      'value': {
+        'path': ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+        'index': 4,
+      },
+    });
+
+    final duplicate = MemoryEventEdit.duplicate(
+      arrayPath: const ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+      index: 4,
+    );
+    expect(duplicate.toEditJson()['path'], 'private.typed.arrayDuplicate');
+  });
+
+  test('knowledge and event pages parse', () {
+    final chars = KnowledgeCharactersPage.fromJson({
+      'total': 1,
+      'offset': 0,
+      'limit': 100,
+      'characters': [
+        {'name': 'OC_STT_Diego', 'entryCount': 2},
+      ],
+    });
+    expect(chars.characters.single.name, 'OC_STT_Diego');
+
+    final entries = KnowledgeEntriesPage.fromJson({
+      'character': 'OC_STT_Diego',
+      'total': 2,
+      'offset': 0,
+      'limit': 200,
+      'entries': ['A', 'B'],
+      'setPath': ['CharacterKnowledgeByUniqueName', '{OC_STT_Diego}', 'Knowledge'],
+    });
+    expect(entries.entries, ['A', 'B']);
+    expect(entries.setPath, hasLength(3));
+
+    final events = MemoryEventsPage.fromJson({
+      'character': 'Hero',
+      'total': 1,
+      'offset': 0,
+      'limit': 100,
+      'events': [
+        {
+          'index': 0,
+          'tags': ['Memory.Quest.Started'],
+          'timeSeconds': 12.5,
+          'affected': 'Hero',
+        },
+      ],
+      'arrayPath': ['LongTermMemoryByGlobalId', '{Hero}', 'MemorizedEvents'],
+    });
+    expect(events.events.single.tags, ['Memory.Quest.Started']);
+    expect(events.events.single.timeSeconds, 12.5);
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run (from `apps/goresave`): `flutter test test/features/editor/progression_models_test.dart`
+Expected: FAIL to compile — file missing.
+
+- [ ] **Step 3: Implement `progression_models.dart`**
+
+```dart
+/// Models for the Progression tab: the inspect overview, paged section
+/// queries (quests / knowledge / events), and the edit intents that map to
+/// core write ops. All pages carry an optional [error] (set by the notifier
+/// instead of throwing) so cards can render failures inline.
+
+class ProgressionOverview {
+  const ProgressionOverview({
+    this.status,
+    this.questTotal = 0,
+    this.questStates = const {},
+    this.knowledgeCharacters = 0,
+    this.knowledgeEntries = 0,
+    this.memoryCharacters = 0,
+    this.memoryEvents = 0,
+    this.writable = const [],
+  });
+
+  factory ProgressionOverview.fromJson(Map<String, Object?>? json) {
+    final states = <String, int>{};
+    (json?['questStates'] as Map?)?.forEach((key, value) {
+      if (key is String && value is num) states[key] = value.toInt();
+    });
+    return ProgressionOverview(
+      status: json?['status'] as String?,
+      questTotal: (json?['questTotal'] as num?)?.toInt() ?? 0,
+      questStates: states,
+      knowledgeCharacters: (json?['knowledgeCharacters'] as num?)?.toInt() ?? 0,
+      knowledgeEntries: (json?['knowledgeEntries'] as num?)?.toInt() ?? 0,
+      memoryCharacters: (json?['memoryCharacters'] as num?)?.toInt() ?? 0,
+      memoryEvents: (json?['memoryEvents'] as num?)?.toInt() ?? 0,
+      writable:
+          (json?['writable'] as List?)?.whereType<String>().toList() ??
+          const [],
+    );
+  }
+
+  final String? status;
+  final int questTotal;
+  final Map<String, int> questStates;
+  final int knowledgeCharacters;
+  final int knowledgeEntries;
+  final int memoryCharacters;
+  final int memoryEvents;
+  final List<String> writable;
+
+  bool get available => status == 'ok';
+}
+
+class ProgressionQuest {
+  const ProgressionQuest({
+    required this.questClass,
+    required this.id,
+    required this.group,
+    required this.name,
+    required this.statePath,
+    this.currentState,
+    this.writable = false,
+  });
+
+  factory ProgressionQuest.fromJson(Map<String, Object?> json) {
+    return ProgressionQuest(
+      questClass: json['questClass'] as String? ?? '',
+      id: json['id'] as String? ?? '',
+      group: json['group'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      currentState: json['currentState'] as String?,
+      statePath:
+          (json['statePath'] as List?)
+              ?.whereType<String>()
+              .toList(growable: false) ??
+          const [],
+      writable: json['writable'] as bool? ?? false,
+    );
+  }
+
+  final String questClass;
+  final String id;
+  final String group;
+  final String name;
+  final String? currentState;
+  final List<String> statePath;
+  final bool writable;
+}
+
+class ProgressionQuestPage {
+  const ProgressionQuestPage({
+    this.quests = const [],
+    this.stateCounts = const {},
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 100,
+    this.error,
+  });
+
+  factory ProgressionQuestPage.fromJson(Map<String, Object?> json) {
+    final counts = <String, int>{};
+    (json['stateCounts'] as Map?)?.forEach((key, value) {
+      if (key is String && value is num) counts[key] = value.toInt();
+    });
+    return ProgressionQuestPage(
+      quests:
+          (json['quests'] as List?)
+              ?.whereType<Map>()
+              .map((e) => ProgressionQuest.fromJson(e.cast<String, Object?>()))
+              .toList(growable: false) ??
+          const [],
+      stateCounts: counts,
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 100,
+    );
+  }
+
+  final List<ProgressionQuest> quests;
+  final Map<String, int> stateCounts;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+
+  bool get hasMore => offset + quests.length < total;
+}
+
+class KnowledgeCharacter {
+  const KnowledgeCharacter({required this.name, required this.entryCount});
+
+  factory KnowledgeCharacter.fromJson(Map<String, Object?> json) {
+    return KnowledgeCharacter(
+      name: json['name'] as String? ?? '',
+      entryCount: (json['entryCount'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  final String name;
+  final int entryCount;
+}
+
+class KnowledgeCharactersPage {
+  const KnowledgeCharactersPage({
+    this.characters = const [],
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 100,
+    this.error,
+  });
+
+  factory KnowledgeCharactersPage.fromJson(Map<String, Object?> json) {
+    return KnowledgeCharactersPage(
+      characters:
+          (json['characters'] as List?)
+              ?.whereType<Map>()
+              .map((e) => KnowledgeCharacter.fromJson(e.cast<String, Object?>()))
+              .toList(growable: false) ??
+          const [],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 100,
+    );
+  }
+
+  final List<KnowledgeCharacter> characters;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+
+  bool get hasMore => offset + characters.length < total;
+}
+
+class KnowledgeEntriesPage {
+  const KnowledgeEntriesPage({
+    this.character = '',
+    this.entries = const [],
+    this.setPath = const [],
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 200,
+    this.error,
+  });
+
+  factory KnowledgeEntriesPage.fromJson(Map<String, Object?> json) {
+    return KnowledgeEntriesPage(
+      character: json['character'] as String? ?? '',
+      entries:
+          (json['entries'] as List?)
+              ?.whereType<String>()
+              .toList(growable: false) ??
+          const [],
+      setPath:
+          (json['setPath'] as List?)
+              ?.whereType<String>()
+              .toList(growable: false) ??
+          const [],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 200,
+    );
+  }
+
+  final String character;
+  final List<String> entries;
+  final List<String> setPath;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+
+  bool get hasMore => offset + entries.length < total;
+}
+
+class MemoryCharacter {
+  const MemoryCharacter({required this.id, required this.eventCount});
+
+  factory MemoryCharacter.fromJson(Map<String, Object?> json) {
+    return MemoryCharacter(
+      id: json['id'] as String? ?? '',
+      eventCount: (json['eventCount'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  final String id;
+  final int eventCount;
+}
+
+class MemoryCharactersPage {
+  const MemoryCharactersPage({
+    this.characters = const [],
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 100,
+    this.error,
+  });
+
+  factory MemoryCharactersPage.fromJson(Map<String, Object?> json) {
+    return MemoryCharactersPage(
+      characters:
+          (json['characters'] as List?)
+              ?.whereType<Map>()
+              .map((e) => MemoryCharacter.fromJson(e.cast<String, Object?>()))
+              .toList(growable: false) ??
+          const [],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 100,
+    );
+  }
+
+  final List<MemoryCharacter> characters;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+}
+
+class MemoryEvent {
+  const MemoryEvent({
+    required this.index,
+    this.tags = const [],
+    this.magnitude,
+    this.timeSeconds,
+    this.durationSeconds,
+    this.instigator,
+    this.affected,
+    this.optionalClass1,
+    this.optionalClass2,
+  });
+
+  factory MemoryEvent.fromJson(Map<String, Object?> json) {
+    return MemoryEvent(
+      index: (json['index'] as num?)?.toInt() ?? 0,
+      tags:
+          (json['tags'] as List?)?.whereType<String>().toList(growable: false) ??
+          const [],
+      magnitude: (json['magnitude'] as num?)?.toDouble(),
+      timeSeconds: (json['timeSeconds'] as num?)?.toDouble(),
+      durationSeconds: (json['durationSeconds'] as num?)?.toDouble(),
+      instigator: json['instigator'] as String?,
+      affected: json['affected'] as String?,
+      optionalClass1: json['optionalClass1'] as String?,
+      optionalClass2: json['optionalClass2'] as String?,
+    );
+  }
+
+  final int index;
+  final List<String> tags;
+  final double? magnitude;
+  final double? timeSeconds;
+  final double? durationSeconds;
+  final String? instigator;
+  final String? affected;
+  final String? optionalClass1;
+  final String? optionalClass2;
+}
+
+class MemoryEventsPage {
+  const MemoryEventsPage({
+    this.character = '',
+    this.events = const [],
+    this.arrayPath = const [],
+    this.total = 0,
+    this.offset = 0,
+    this.limit = 100,
+    this.error,
+  });
+
+  factory MemoryEventsPage.fromJson(Map<String, Object?> json) {
+    return MemoryEventsPage(
+      character: json['character'] as String? ?? '',
+      events:
+          (json['events'] as List?)
+              ?.whereType<Map>()
+              .map((e) => MemoryEvent.fromJson(e.cast<String, Object?>()))
+              .toList(growable: false) ??
+          const [],
+      arrayPath:
+          (json['arrayPath'] as List?)
+              ?.whereType<String>()
+              .toList(growable: false) ??
+          const [],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      offset: (json['offset'] as num?)?.toInt() ?? 0,
+      limit: (json['limit'] as num?)?.toInt() ?? 100,
+    );
+  }
+
+  final String character;
+  final List<MemoryEvent> events;
+  final List<String> arrayPath;
+  final int total;
+  final int offset;
+  final int limit;
+  final String? error;
+
+  bool get hasMore => offset + events.length < total;
+}
+
+/// Pending quest-state change → `private.typed.setValue`.
+class QuestStateChange {
+  const QuestStateChange({required this.statePath, required this.state});
+
+  final List<String> statePath;
+  final String state;
+
+  Map<String, Object?> toEditJson() {
+    return {
+      'path': 'private.typed.setValue',
+      'value': {'path': statePath, 'value': state},
+    };
+  }
+}
+
+/// Pending knowledge add/remove → `private.typed.setAdd` / `setRemove`.
+class KnowledgeEntryEdit {
+  const KnowledgeEntryEdit.add({required this.setPath, required this.entry})
+      : isAdd = true;
+  const KnowledgeEntryEdit.remove({required this.setPath, required this.entry})
+      : isAdd = false;
+
+  final List<String> setPath;
+  final String entry;
+  final bool isAdd;
+
+  Map<String, Object?> toEditJson() {
+    return {
+      'path': isAdd ? 'private.typed.setAdd' : 'private.typed.setRemove',
+      'value': {'path': setPath, 'value': entry},
+    };
+  }
+}
+
+/// Structural memory-event edit → `private.typed.arrayRemove` /
+/// `arrayDuplicate`. Index-addressed, so the UI applies at most one per save
+/// round (indices shift after each structural change).
+class MemoryEventEdit {
+  const MemoryEventEdit.remove({required this.arrayPath, required this.index})
+      : isRemove = true;
+  const MemoryEventEdit.duplicate({
+    required this.arrayPath,
+    required this.index,
+  }) : isRemove = false;
+
+  final List<String> arrayPath;
+  final int index;
+  final bool isRemove;
+
+  Map<String, Object?> toEditJson() {
+    return {
+      'path': isRemove
+          ? 'private.typed.arrayRemove'
+          : 'private.typed.arrayDuplicate',
+      'value': {'path': arrayPath, 'index': index},
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Rewire `SaveInspection`**
+
+In `editor_models.dart`:
+- Add `import 'package:goresave/features/editor/domain/progression_models.dart';` (match the file's existing import style — it currently has none for siblings, so a relative `import 'progression_models.dart';` also works; follow `analysis_options.yaml` lints).
+- Replace the field `final PrivateProgressionSummary privateProgression;` with `final ProgressionOverview privateProgression;`, the constructor default with `this.privateProgression = const ProgressionOverview()`, and the `fromJson` line with `privateProgression: ProgressionOverview.fromJson(privateProgression)` (the local variable name already matches).
+- Delete the `PrivateProgressionSummary` class.
+
+- [ ] **Step 5: Run to verify**
+
+Run: `flutter test test/features/editor/progression_models_test.dart`
+Expected: PASS. Then `flutter analyze` — expect errors only in `editor_page.dart` (`_PrivateProgressionSummaryCard` still references the deleted class); that is fixed in Task 10. If the analyzer must be green per task, defer Step 4's deletion of `PrivateProgressionSummary` to Task 10 and keep both models temporarily — prefer the deferral only if needed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/domain/progression_models.dart apps/goresave/lib/features/editor/domain/editor_models.dart apps/goresave/test/features/editor/progression_models_test.dart
+git commit -m "feat(app): progression models and edit intents"
+```
+
+---
+
+### Task 9: Dart — notifier query and apply methods
+
+**Files:**
+- Modify: `apps/goresave/lib/features/editor/domain/editor_notifier.dart` (next to `searchTypedProperties`, ~line 746)
+- Test: `apps/goresave/test/editor_notifier_test.dart` (follow the existing fake-core pattern in that file)
+
+- [ ] **Step 1: Write the failing test**
+
+Open `apps/goresave/test/editor_notifier_test.dart` and follow its existing fake `GoresaveCoreService` pattern (a fake that records `execute` calls and returns canned responses). Add:
+
+```dart
+  test('loadProgressionQuests queries the core and parses the page', () async {
+    // Arrange a fake core that returns one quest for 'query_progression'.
+    // (Reuse the file's existing fake-service scaffolding; the canned response:)
+    // {'ok': true, 'data': {'section': 'quests', 'total': 1, 'offset': 0,
+    //  'limit': 100, 'count': 1, 'stateCounts': {'Running': 1}, 'quests': [
+    //    {'questClass': '/Script/Angelscript.Quest_X', 'id': 'Quest_X',
+    //     'group': 'X', 'name': '', 'currentState': 'EQuestState::Running',
+    //     'statePath': ['QuestDataByClass', '{/Script/Angelscript.Quest_X}',
+    //     'CurrentState'], 'writable': true}]}}
+    // and a selected save path set beforehand (mirror how the hero-attribute
+    // tests select a save).
+    final page = await notifier.loadProgressionQuests(query: 'x');
+    expect(page.error, isNull);
+    expect(page.quests.single.id, 'Quest_X');
+    // The core received section + query + path.
+    final call = fakeCore.calls.singleWhere((c) => c.command == 'query_progression');
+    expect(call.payload['section'], 'quests');
+    expect(call.payload['query'], 'x');
+  });
+
+  test('progression loaders surface core errors inline', () async {
+    // Fake core returns {'ok': false, 'error': {...}}.
+    final page = await notifier.loadKnowledgeCharacters();
+    expect(page.error, isNotNull);
+  });
+```
+
+Adapt naming to the file's actual fake/service helpers — read the file first; do not invent a parallel scaffolding.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flutter test test/editor_notifier_test.dart`
+Expected: FAIL to compile — methods missing.
+
+- [ ] **Step 3: Implement the notifier methods**
+
+Add `import 'package:goresave/features/editor/domain/progression_models.dart';` and, next to `searchTypedProperties`:
+
+```dart
+  /// Run one progression section query. Returns the raw data map, or null
+  /// with [onError] set, so each typed loader below can build its own page
+  /// object with an inline error.
+  Future<Map<String, Object?>?> _queryProgression(
+    Map<String, Object?> params, {
+    required void Function(String message) onError,
+  }) async {
+    final path = state.selectedPath;
+    if (path == null) {
+      onError('No save selected.');
+      return null;
+    }
+    try {
+      final response = await _execute(
+        'query_progression',
+        payload: {'path': path, ...params, ..._codecPayload()},
+      );
+      if (response['ok'] != true) {
+        onError(_errorMessage(response));
+        return null;
+      }
+      return (response['data'] as Map).cast<String, Object?>();
+    } catch (error) {
+      onError('Progression query failed: $error');
+      return null;
+    }
+  }
+
+  Future<ProgressionQuestPage> loadProgressionQuests({
+    String query = '',
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {'section': 'quests', 'query': query, 'offset': offset, 'limit': limit},
+      onError: (message) => error = message,
+    );
+    if (data == null) return ProgressionQuestPage(error: error);
+    return ProgressionQuestPage.fromJson(data);
+  }
+
+  Future<KnowledgeCharactersPage> loadKnowledgeCharacters({
+    String query = '',
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {
+        'section': 'knowledge',
+        'query': query,
+        'offset': offset,
+        'limit': limit,
+      },
+      onError: (message) => error = message,
+    );
+    if (data == null) return KnowledgeCharactersPage(error: error);
+    return KnowledgeCharactersPage.fromJson(data);
+  }
+
+  Future<KnowledgeEntriesPage> loadKnowledgeEntries(
+    String character, {
+    String query = '',
+    int offset = 0,
+    int limit = 200,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {
+        'section': 'knowledge',
+        'character': character,
+        'query': query,
+        'offset': offset,
+        'limit': limit,
+      },
+      onError: (message) => error = message,
+    );
+    if (data == null) return KnowledgeEntriesPage(error: error);
+    return KnowledgeEntriesPage.fromJson(data);
+  }
+
+  Future<MemoryCharactersPage> loadMemoryCharacters({
+    String query = '',
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {'section': 'events', 'query': query, 'offset': offset, 'limit': limit},
+      onError: (message) => error = message,
+    );
+    if (data == null) return MemoryCharactersPage(error: error);
+    return MemoryCharactersPage.fromJson(data);
+  }
+
+  Future<MemoryEventsPage> loadMemoryEvents(
+    String character, {
+    String query = '',
+    int offset = 0,
+    int limit = 100,
+  }) async {
+    String? error;
+    final data = await _queryProgression(
+      {
+        'section': 'events',
+        'character': character,
+        'query': query,
+        'offset': offset,
+        'limit': limit,
+      },
+      onError: (message) => error = message,
+    );
+    if (data == null) return MemoryEventsPage(error: error);
+    return MemoryEventsPage.fromJson(data);
+  }
+
+  /// Apply one structural progression edit (event remove/duplicate)
+  /// immediately, with backup. Index-addressed array edits must go one per
+  /// write round — indices shift after every structural change — so this is
+  /// intentionally not part of the pending-edit registry.
+  Future<bool> applyMemoryEventEdit(MemoryEventEdit edit) async {
+    final savePath = state.selectedPath;
+    if (savePath == null) return false;
+    if (state.isLoading) return false;
+    return _runWrite(
+      payload: {
+        'path': savePath,
+        'backup': true,
+        'edits': [edit.toEditJson()],
+        ..._codecPayload(),
+      },
+      message: (data) => _backupMessage(
+        edit.isRemove ? 'Memory event removed' : 'Memory event duplicated',
+        data,
+      ),
+    );
+  }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `flutter test test/editor_notifier_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/domain/editor_notifier.dart apps/goresave/test/editor_notifier_test.dart
+git commit -m "feat(app): progression query and apply methods on the notifier"
+```
+
+---
+
+### Task 10: Dart — ProgressionPanel UI
+
+New file with the four cards, wired into the Progression tab; the old heuristic card and `_StringList` are deleted.
+
+**Files:**
+- Create: `apps/goresave/lib/features/editor/ui/progression_panel.dart`
+- Modify: `apps/goresave/lib/features/editor/ui/editor_page.dart`
+  - replace the `_ProgressionPanel` body (~line 1412) with the new panel
+  - delete `_PrivateProgressionSummaryCard` (~line 1447) and `_StringList` (~line 1582) — first `grep -n "_StringList" apps/goresave/lib` to confirm no other user
+
+- [ ] **Step 1: Check the tab call site and gating**
+
+Read how the Inventory tab gates editing (search `_InventoryPanel` ~line 1359 and where panels receive `notifier`): the panel receives `inspection` and `notifier`; editability combines `inspection.privateEditable`, `inspection.privateTypedVerified`, and the notifier state's `codecCompressReady`. Mirror exactly that gating for progression.
+
+- [ ] **Step 2: Implement `progression_panel.dart`**
+
+The panel skeleton (complete file — adapt private-widget naming to taste, keep the structure):
+
+```dart
+import 'package:flutter/material.dart';
+
+import '../domain/editor_models.dart';
+import '../domain/editor_notifier.dart';
+import '../domain/pending_edits.dart';
+import '../domain/progression_models.dart';
+
+/// All five EQuestState values, in dropdown order.
+const questStates = <String>[
+  'EQuestState::None',
+  'EQuestState::Available',
+  'EQuestState::Running',
+  'EQuestState::Succeeded',
+  'EQuestState::Failed',
+];
+
+String shortStateLabel(String state) {
+  final idx = state.lastIndexOf('::');
+  return idx < 0 ? state : state.substring(idx + 2);
+}
+
+/// Progression tab: structured quests / dialog knowledge / memory events.
+/// Data loads lazily per card through the notifier's query_progression
+/// wrappers. [reloadKey] identifies the inspected save (sha1); when it
+/// changes, cards drop local state and reload.
+class ProgressionPanel extends StatelessWidget {
+  const ProgressionPanel({
+    super.key,
+    required this.inspection,
+    required this.notifier,
+    required this.editable,
+  });
+
+  final SaveInspection inspection;
+  final EditorNotifier notifier;
+  final bool editable;
+
+  @override
+  Widget build(BuildContext context) {
+    final overview = inspection.privateProgression;
+    if (!inspection.privateDecoded) {
+      return const _MessagePane(
+        icon: Icons.flag_outlined,
+        title: 'Progression',
+        body:
+            'Progression data needs decoded private payload data from the G1R codec host.',
+      );
+    }
+    if (!overview.available) {
+      return const _MessagePane(
+        icon: Icons.flag_outlined,
+        title: 'Progression',
+        body:
+            'Structured progression data needs a fully decoded save with a '
+            'verified typed parse.',
+      );
+    }
+    final reloadKey = inspection.sha1;
+    return ListView(
+      padding: const EdgeInsets.all(20),
+      children: [
+        _OverviewCard(overview: overview),
+        const SizedBox(height: 16),
+        _QuestsCard(
+          notifier: notifier,
+          editable: editable,
+          reloadKey: reloadKey,
+        ),
+        const SizedBox(height: 16),
+        _KnowledgeCard(
+          notifier: notifier,
+          editable: editable,
+          reloadKey: reloadKey,
+        ),
+        const SizedBox(height: 16),
+        _EventsCard(
+          notifier: notifier,
+          editable: editable,
+          reloadKey: reloadKey,
+        ),
+      ],
+    );
+  }
+}
+```
+
+`_MessagePane` lives in `editor_page.dart` as a private widget — either export a copy here (duplicate the ~20-line widget as a private `_MessagePane` in this file) or pass fallback widgets from the call site; duplicating the small pane locally is the simpler, self-contained option.
+
+`_OverviewCard` (stateless): a `Card` with the flag icon header "Progression summary" and a `Wrap` of metric chips — quest total, one chip per `questStates` entry (label `'${entry.key}: ${entry.value}'`), knowledge characters/entries, memory characters/events. Mirror `_SummaryMetric` from `editor_page.dart` (duplicate the tiny widget locally).
+
+`_QuestsCard` (stateful), following the Inventory card's pending pattern:
+
+```dart
+class _QuestsCard extends StatefulWidget {
+  const _QuestsCard({
+    required this.notifier,
+    required this.editable,
+    required this.reloadKey,
+  });
+
+  final EditorNotifier notifier;
+  final bool editable;
+  final Object reloadKey;
+
+  @override
+  State<_QuestsCard> createState() => _QuestsCardState();
+}
+
+class _QuestsCardState extends State<_QuestsCard> {
+  final TextEditingController _search = TextEditingController();
+  ProgressionQuestPage _page = const ProgressionQuestPage();
+  final List<ProgressionQuest> _quests = [];
+  final Map<String, QuestStateChange> _pending = {};
+  bool _loading = false;
+  int _reloadEpoch = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _reload();
+  }
+
+  @override
+  void didUpdateWidget(covariant _QuestsCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.reloadKey != oldWidget.reloadKey) {
+      _pending.clear();
+      _reload();
+    }
+  }
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  Future<void> _reload({bool append = false}) async {
+    final epoch = ++_reloadEpoch;
+    setState(() => _loading = true);
+    final page = await widget.notifier.loadProgressionQuests(
+      query: _search.text.trim(),
+      offset: append ? _quests.length : 0,
+    );
+    if (!mounted || epoch != _reloadEpoch) return;
+    setState(() {
+      _loading = false;
+      _page = page;
+      if (!append) _quests.clear();
+      _quests.addAll(page.quests);
+    });
+  }
+
+  void _pushPending() {
+    if (_pending.isEmpty) {
+      widget.notifier.clearPendingEdit('progression.quests');
+    } else {
+      widget.notifier.setPendingEdit(
+        'progression.quests',
+        PendingSaveEdit(
+          edits: _pending.values.map((c) => c.toEditJson()).toList(),
+        ),
+      );
+    }
+  }
+
+  void _setQuestState(ProgressionQuest quest, String? state) {
+    setState(() {
+      if (state == null || state == quest.currentState) {
+        _pending.remove(quest.questClass);
+      } else {
+        _pending[quest.questClass] = QuestStateChange(
+          statePath: quest.statePath,
+          state: state,
+        );
+      }
+    });
+    _pushPending();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.flag_outlined),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Quests',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                if (widget.editable && _pending.isNotEmpty)
+                  Tooltip(
+                    message: 'Reset quest changes',
+                    child: IconButton(
+                      icon: const Icon(Icons.undo_outlined),
+                      onPressed: () {
+                        setState(_pending.clear);
+                        widget.notifier.clearPendingEdit('progression.quests');
+                      },
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _search,
+              decoration: const InputDecoration(
+                labelText: 'Search quests',
+                prefixIcon: Icon(Icons.search),
+              ),
+              onSubmitted: (_) => _reload(),
+            ),
+            if (_page.error != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                _page.error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ],
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 360,
+              child: _loading && _quests.isEmpty
+                  ? const Center(child: CircularProgressIndicator())
+                  : ListView.separated(
+                      itemCount: _quests.length + (_page.hasMore ? 1 : 0),
+                      separatorBuilder: (_, _) => const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        if (index >= _quests.length) {
+                          return TextButton(
+                            onPressed: _loading
+                                ? null
+                                : () => _reload(append: true),
+                            child: Text(
+                              'Load more (${_quests.length} of ${_page.total})',
+                            ),
+                          );
+                        }
+                        final quest = _quests[index];
+                        final pendingState =
+                            _pending[quest.questClass]?.state;
+                        return ListTile(
+                          dense: true,
+                          leading: const Icon(Icons.flag_outlined),
+                          title: SelectableText(
+                            quest.name.isEmpty ? quest.id : quest.name,
+                            maxLines: 1,
+                          ),
+                          subtitle: SelectableText(
+                            quest.group,
+                            maxLines: 1,
+                          ),
+                          trailing: widget.editable && quest.writable
+                              ? DropdownButton<String>(
+                                  value:
+                                      pendingState ?? quest.currentState,
+                                  underline: const SizedBox.shrink(),
+                                  items: questStates
+                                      .map(
+                                        (s) => DropdownMenuItem(
+                                          value: s,
+                                          child: Text(shortStateLabel(s)),
+                                        ),
+                                      )
+                                      .toList(),
+                                  onChanged: (s) =>
+                                      _setQuestState(quest, s),
+                                )
+                              : Text(
+                                  shortStateLabel(
+                                    quest.currentState ?? 'unknown',
+                                  ),
+                                ),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+Edge case: a quest whose `currentState` is not one of the five `questStates` values (or null) would crash `DropdownButton.value` — guard: if `pendingState ?? quest.currentState` is not contained in `questStates`, render the read-only `Text` branch instead.
+
+`_KnowledgeCard` (stateful): same skeleton; state holds `KnowledgeCharactersPage _characters`, `String? _selectedCharacter`, `KnowledgeEntriesPage _entries`, `final Map<String, KnowledgeEntryEdit> _pending` keyed by `'$character $entry'`, plus an add-`TextEditingController`.
+- Loads characters on init/reloadKey change; tapping a character loads its entries (`loadKnowledgeEntries`).
+- Layout: character `ListView` (left or top, height-capped like the quests list) with `'$name ($entryCount)'` tiles; below/beside, the selected character's entries as `Chip`s in a `Wrap`, each with `onDeleted` (editable only) registering a `KnowledgeEntryEdit.remove(setPath: _entries.setPath, entry: e)`; a pending-removed entry renders with strikethrough style and its delete icon turns into an undo that drops the pending edit.
+- Add row: `TextField` + button; validation: non-empty after trim, not already in `_entries.entries`, not already pending-added; registers `KnowledgeEntryEdit.add`. Pending adds render as extra chips with a distinct (e.g. tertiary) color and an undo delete.
+- `_pushPending()` mirrors the quests card with key `'progression.knowledge'`.
+- On reloadKey change: clear pending + reload characters and (if still selected) entries.
+
+`_EventsCard` (stateful): state holds `MemoryCharactersPage _characters`, `String? _selectedCharacter`, `MemoryEventsPage _events`, `_loading`.
+- Character tiles `'$id ($eventCount)'`; selecting loads `loadMemoryEvents`.
+- Event tiles: title = tags joined with `', '` (fallback `'(no tags)'`), subtitle = `'t=${event.timeSeconds?.toStringAsFixed(0) ?? '?'}s  ${event.affected ?? ''}'`; trailing (editable only) two `IconButton`s: delete (`Icons.delete_outline`) and duplicate (`Icons.copy_outlined`).
+- Both actions run an `AlertDialog` confirm ("Remove this memory event? A backup is written first." / duplicate equivalent), then `await widget.notifier.applyMemoryEventEdit(MemoryEventEdit.remove(arrayPath: _events.arrayPath, index: event.index))` — on success the notifier refreshes the inspection, which changes `reloadKey` and reloads this card. These are immediate single-edit writes (index-addressed edits must not batch).
+- Pagination: same "Load more" pattern as quests.
+
+- [ ] **Step 3: Wire into `editor_page.dart`**
+
+- Add `import 'package:goresave/features/editor/ui/progression_panel.dart';` (match the file's import style for `hero_stats_card.dart`).
+- Replace the `_ProgressionPanel` widget body: keep the class as a thin adapter or call `ProgressionPanel` directly from the tab builder — match how the tab list at ~line 475 builds panels. Pass `editable:` using the same expression the Inventory tab uses for its `editable`/`canCompress` gating combined with `inspection.privateTypedVerified`.
+- Delete `_PrivateProgressionSummaryCard`, its state class, and `_StringList` (after confirming `_StringList` has no other references).
+
+- [ ] **Step 4: Static check + tests + format**
+
+Run: `flutter analyze` (expect clean), `flutter test`, and `dart format lib/features/editor/ui/progression_panel.dart` (match repo formatting).
+Expected: analyzer clean, all tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/ui/progression_panel.dart apps/goresave/lib/features/editor/ui/editor_page.dart
+git commit -m "feat(ui): structured editable progression tab"
+```
+
+---
+
+### Task 11: End-to-end verification on a real save
+
+**Files:** none modified (verification only)
+
+- [ ] **Step 1: Full test suites**
+
+Run: `cargo test -p goresave_core` and (from `apps/goresave`) `flutter analyze && flutter test`
+Expected: all green.
+
+- [ ] **Step 2: Real-save query smoke test**
+
+Real saves live in `work/roundtrip_gsav/` (G1R-001…006). The codec host needs the configured game EXE; the app settings (used by the running app) already carry working paths. Two options, prefer (a):
+
+(a) Launch the app (`flutter run -d windows` from `apps/goresave`, or the existing build in `apps/goresave/build/windows/.../goresave.exe`), point the save dir at `C:\sbx\goresave\work\roundtrip_gsav`, select G1R-001, open the Progression tab, and verify:
+- Overview shows plausible counts (hundreds of quests, dozens of knowledge NPCs, large event counts).
+- Quests list loads, search filters, state dropdown changes register as pending edits, Save writes with backup, and the new state survives a reload.
+- Knowledge: select `OC_STT_Diego`, remove + re-add an entry, save, verify.
+- Events: select the hero character, duplicate an event, confirm, verify the count increased; then remove the duplicate.
+- Work on a COPY of the save directory if the saves are precious: `Copy-Item -Recurse work\roundtrip_gsav work\roundtrip_gsav_testrun` and point the app at the copy.
+
+(b) Headless: a scratch Rust test invoking `execute_json` with `query_progression` + a `binaryHost` config pointing at the local codec host/exe paths — only if the app route is unavailable.
+
+- [ ] **Step 3: Strict roundtrip assurance**
+
+After the edits in Step 2, re-inspect the edited save in the app and confirm `typedParse.status == ok` (visible in the Overview/All-data surfaces) — this is the byte-exact proof that size chains stayed consistent on a 76 MB real payload.
+
+- [ ] **Step 4: Update the spec status line**
+
+Edit `docs/superpowers/specs/2026-06-11-progression-tab-design.md`: change `Status:` to `implemented (branch progression-tab-v2)`.
+
+```bash
+git add docs/superpowers/specs/2026-06-11-progression-tab-design.md
+git commit -m "docs: mark progression tab v2 spec implemented"
+```

--- a/docs/superpowers/specs/2026-06-11-progression-tab-design.md
+++ b/docs/superpowers/specs/2026-06-11-progression-tab-design.md
@@ -119,10 +119,15 @@ Out of scope for v1:
 - Composing a memory event from scratch. "Add event" is
   `arrayDuplicate` + editing the duplicate's scalar leaves (time,
   magnitude, instigator/affected names).
-- Rewriting tags inside a duplicated event's `GameplayTagContainer`.
-  Stretch goal (v1.1): if the typed parser can address the tag FStrings
-  inside the container, the same splice machinery applies; otherwise the
-  duplicate keeps the source tags.
+- Deferred to v1.1: duplicate-then-edit scalar workflow. v1 ships
+  `arrayDuplicate` as an exact-clone operation with a confirmation
+  dialog; per-element leaf paths and an edit dialog on the duplicated
+  event are v1.1 work.
+- Deferred to v1.1: rewriting tags inside a duplicated event's
+  `GameplayTagContainer`. The duplicate keeps the source event's tags
+  in v1; tag rewriting requires addressing the FStrings inside the
+  container and is scoped together with the duplicate-then-edit
+  workflow above.
 
 ### 3. App side (Flutter, Inventory-card pattern)
 

--- a/docs/superpowers/specs/2026-06-11-progression-tab-design.md
+++ b/docs/superpowers/specs/2026-06-11-progression-tab-design.md
@@ -1,7 +1,7 @@
 # Progression Tab v2 — Design
 
 Date: 2026-06-11
-Status: approved by user (chat), pending spec review
+Status: implemented (branch progression-tab-v2)
 
 ## Problem
 


### PR DESCRIPTION
## Summary
- Replaces the Progression tab's heuristic string dump (which keyed on property names that don't exist in real saves) with structured data from the typed property tree: quests (`QuestDataByClass`), dialog knowledge (`CharacterKnowledgeByUniqueName`), and memory events (`LongTermMemoryByGlobalId`).
- New core command `query_progression` (paged quests/knowledge/events sections, decode-cache backed) and a structured progression overview in `inspect_save`; the old string-grep summary is deleted.
- Four new generic container edit ops — `private.typed.setAdd`, `setRemove`, `arrayRemove`, `arrayDuplicate` — built on `patch_container` with the same validate-all-before-mutate + strict-re-parse discipline as `setValue`. Quest states write through the existing `private.typed.setValue` (EnumProperty).
- New `ProgressionPanel` UI (Inventory-card pattern): quest state dropdowns with pending edits, per-NPC knowledge chips with add/remove, per-character event lists with delete/duplicate (immediate single-edit writes with backup, guarded against discarding unsaved drafts), search + paging on all lists.

## Spec / Plan
- `docs/superpowers/specs/2026-06-11-progression-tab-design.md`
- `docs/superpowers/plans/2026-06-11-progression-tab-v2.md`

## Test Plan
- [x] `cargo test -p goresave_core` — 170 passed (16 new tests across container layout, patch ops, edit pipeline, query sections, overview)
- [x] `flutter analyze` — clean; `flutter test` — 86 passed
- [x] E2E against real save G1R-001 with the game codec: all five edit ops round-trip (quest state change, knowledge add/remove, event duplicate/remove), strict typed parse stays `ok`, overview counts change exactly as expected (679 quests, 2273 events across 1328 characters)

Deferred to v1.1 (documented in spec): duplicate-then-edit scalar workflow and tag rewriting inside duplicated events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how save files are edited (typed progression ops and immediate structural memory writes) and how profile filtering moves the active slot, though pending-edit and loading guards reduce accidental data loss.
> 
> **Overview**
> The **Progression** tab no longer shows a string-grep summary (`PrivateProgressionSummary` is removed). Inspection now exposes a **`ProgressionOverview`**, and a new **`ProgressionPanel`** loads paged data through **`EditorNotifier`** helpers that call core **`query_progression`** for quests, dialog knowledge, and memory events.
> 
> Quest state and knowledge add/remove queue **`progression.quests`** / **`progression.knowledge`** pending edits (typed **`setValue`**, **`setAdd`**, **`setRemove`**). Memory event remove/duplicate uses **`applyMemoryEventEdit`** for an immediate **`write_save`** with backup, blocked while other pending edits or an in-flight write exist.
> 
> The save sidebar gains **explicit profile selection** (`selectedProfileId`, **`visibleSaves`**, **`selectProfile`**) with a header switcher and rescan confirm when drafts exist; refresh/rescan picks the first visible slot under the kept profile. Saves sort by **in-game playtime** (mtime tie-break) instead of file mtime alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c091a88350eca994f521e42687f43b8a76a3da5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->