### PR TITLE
feat: velopack auto-updater and GitHub release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve and verify version
+        id: version
+        shell: pwsh
+        run: |
+          $pubspec = Get-Content apps/goresave/pubspec.yaml -Raw
+          if ($pubspec -notmatch '(?m)^version:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$') {
+            Write-Error 'pubspec.yaml version must be plain X.Y.Z (no build number)'
+            exit 1
+          }
+          $version = $Matches[1]
+          if ('${{ github.ref_type }}' -eq 'tag') {
+            $tag = '${{ github.ref_name }}'
+            if ($tag -ne "v$version") {
+              Write-Error "tag $tag does not match pubspec version $version"
+              exit 1
+            }
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -27,18 +46,49 @@ jobs:
           channel: stable
           cache: true
 
+      # GIT_SHA comes from the GITHUB_SHA env via build.py.
       - name: Build distribution
         run: python build.py dist
+
+      - name: Install Velopack CLI
+        run: dotnet tool install -g vpk
+
+      # Pulls the previous release so vpk can build delta packages.
+      # Fails harmlessly on the very first release.
+      - name: Download previous Velopack release
+        continue-on-error: true
+        run: >-
+          vpk download github
+          --repoUrl https://github.com/${{ github.repository }}
+          --outputDir dist/velopack
+
+      - name: Velopack pack
+        run: >-
+          vpk pack
+          --packId Goresave
+          --packVersion ${{ steps.version.outputs.version }}
+          --packDir apps/goresave/build/windows/x64/runner/Release
+          --mainExe goresave.exe
+          --packTitle goresave
+          --packAuthors dh0er
+          --icon apps/goresave/windows/runner/resources/app_icon.ico
+          --outputDir dist/velopack
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: goresave-windows-x64
-          path: dist/*.zip
+          path: |
+            dist/*.zip
+            dist/velopack/*
 
+      # releases.win.json + packages must be attached so that
+      # releases/latest/download/ serves the update feed.
       - name: Publish GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*.zip
+          files: |
+            dist/*.zip
+            dist/velopack/*
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,10 @@ jobs:
       - name: Build distribution
         run: python build.py dist
 
+      # Pinned to the velopack crate version in goresave_core so the CLI's
+      # feed format and the in-app client move together deliberately.
       - name: Install Velopack CLI
-        run: dotnet tool install -g vpk
+        run: dotnet tool install -g vpk --version 1.2.0
 
       # Pulls the previous release so vpk can build delta packages.
       # Fails harmlessly on the very first release.
@@ -72,6 +74,7 @@ jobs:
           --packTitle goresave
           --packAuthors dh0er
           --icon apps/goresave/windows/runner/resources/app_icon.ico
+          --noPortable
           --outputDir dist/velopack
 
       - name: Upload build artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,27 @@ jobs:
             dist/*.zip
             dist/velopack/*
 
+      # Release notes come from CHANGELOG.md only; a missing or empty
+      # section for the released version fails the release.
+      - name: Extract release notes from CHANGELOG.md
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: pwsh
+        run: |
+          $version = '${{ steps.version.outputs.version }}'
+          $changelog = Get-Content CHANGELOG.md -Raw
+          $pattern = "(?ms)^## \[$([regex]::Escape($version))\][^`r`n]*`r?`n(.*?)(?=^## \[|\z)"
+          if ($changelog -notmatch $pattern) {
+            Write-Error "CHANGELOG.md has no section for $version"
+            exit 1
+          }
+          $notes = $Matches[1].Trim()
+          if (-not $notes) {
+            Write-Error "CHANGELOG.md section for $version is empty"
+            exit 1
+          }
+          New-Item -ItemType Directory -Force dist | Out-Null
+          [IO.File]::WriteAllText((Join-Path $PWD 'dist\RELEASE_NOTES.md'), $notes)
+
       # releases.win.json + packages must be attached so that
       # releases/latest/download/ serves the update feed.
       - name: Publish GitHub release
@@ -94,4 +115,4 @@ jobs:
           files: |
             dist/*.zip
             dist/velopack/*
-          generate_release_notes: true
+          body_path: dist/RELEASE_NOTES.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           }
           $version = $Matches[1]
           if ('${{ github.ref_type }}' -eq 'tag') {
-            $tag = '${{ github.ref_name }}'
+            $tag = $env:GITHUB_REF_NAME
             if ($tag -ne "v$version") {
               Write-Error "tag $tag does not match pubspec version $version"
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to goresave are documented here. The release workflow
+publishes the section matching the released version as the GitHub release
+notes, so every release needs an entry.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - 2026-06-11
+
+### Added
+
+- Browse Gothic Remake save slots, inspect GSAV container metadata and
+  PersistentDataList details.
+- Edit supported save metadata with automatic backups and slot-name sync.
+- Overview, player, inventory, progression, and JSON views into parsed saves.
+- List and restore backups created by the editor.
+- Optional out-of-process helper for advanced private payload support.
+- Automatic updates: the installed app checks GitHub Releases on startup,
+  downloads new versions in the background, and applies them on restart.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,10 +45,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpufeatures"
@@ -42,6 +105,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -55,13 +136,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -77,7 +200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,10 +210,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -104,6 +277,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -111,9 +295,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "goresave_core"
@@ -123,9 +314,10 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "tempfile",
  "thiserror",
+ "velopack",
 ]
 
 [[package]]
@@ -136,8 +328,8 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
 ]
@@ -170,10 +362,138 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -194,6 +514,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,10 +567,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "normpath"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "prettyplease"
@@ -236,7 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -264,6 +647,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,8 +716,49 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -309,7 +793,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -332,8 +816,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -343,8 +838,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -359,16 +912,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -388,8 +952,24 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -410,10 +990,138 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "rand",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "velopack"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3fd8e7b771e0d0fc4ca67249273ad4eacfabe2562617b3ca42065a5972a58c"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "derivative",
+ "glob",
+ "lazy_static",
+ "libc",
+ "log",
+ "normpath",
+ "rand",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "thiserror",
+ "ureq",
+ "url",
+ "uuid",
+ "wait-timeout",
+ "waitpid-any",
+ "windows",
+ "xml",
+ "zip",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "waitpid-any"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18aa3ce681e189f125c4c1e1388c03285e2fd434ef52c7203084012ac29c5e4a"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -431,6 +1139,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -468,10 +1221,132 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -481,6 +1356,79 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -518,7 +1466,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -534,7 +1482,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -577,7 +1525,134 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xml"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ auto-update.
 ### Releasing (maintainers)
 
 1. Set `version:` in `apps/goresave/pubspec.yaml` to the new `X.Y.Z`.
-2. Commit, then `git tag vX.Y.Z && git push origin vX.Y.Z`.
-3. The Release workflow builds the zip + Velopack packages and publishes the
-   GitHub release. The tag must match the pubspec version or the build fails.
+2. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md` — it becomes the
+   release notes.
+3. Commit, then `git tag vX.Y.Z && git push origin vX.Y.Z`.
+4. The Release workflow builds the zip + Velopack packages and publishes the
+   GitHub release. The tag must match the pubspec version and the changelog
+   section must exist, or the build fails.
 
 ## Project Layout
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ supported save metadata and structured views into parsed save data.
 - Configure optional local helper paths for advanced private payload support.
 - List and restore slot backups created by the editor.
 
+## Installation & Updates
+
+Download `Goresave-win-Setup.exe` from the
+[latest release](https://github.com/dh0er/goresave/releases/latest) and run it.
+The app checks GitHub Releases on startup, downloads updates in the background,
+and applies them when you click "Restart to update".
+
+A portable zip is also attached to each release; the portable build does not
+auto-update.
+
+### Releasing (maintainers)
+
+1. Set `version:` in `apps/goresave/pubspec.yaml` to the new `X.Y.Z`.
+2. Commit, then `git tag vX.Y.Z && git push origin vX.Y.Z`.
+3. The Release workflow builds the zip + Velopack packages and publishes the
+   GitHub release. The tag must match the pubspec version or the build fails.
+
 ## Project Layout
 
 - `apps/goresave`: Flutter Windows application.

--- a/apps/goresave/lib/features/app/domain/update_notifier.dart
+++ b/apps/goresave/lib/features/app/domain/update_notifier.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:goresave/features/editor/domain/core_service.dart';
+import 'package:goresave/providers/data_providers.dart';
+
+sealed class UpdateState {
+  const UpdateState();
+}
+
+/// No update staged: none available, updater disabled, or a check/download
+/// failed (updates are best-effort and never block the app).
+class UpdateIdle extends UpdateState {
+  const UpdateIdle();
+}
+
+/// An update is downloaded and staged; restarting applies [version].
+class UpdateReady extends UpdateState {
+  const UpdateReady(this.version);
+
+  final String version;
+}
+
+class UpdateNotifier extends StateNotifier<UpdateState> {
+  UpdateNotifier(this._core) : super(const UpdateIdle()) {
+    _checkAndDownload();
+  }
+
+  final GoresaveCoreService _core;
+
+  Future<void> _checkAndDownload() async {
+    try {
+      final check = await _core.execute('update_check');
+      final data = check['data'];
+      if (check['ok'] != true ||
+          data is! Map ||
+          data['status'] != 'updateAvailable') {
+        return;
+      }
+      final version = data['version'];
+      final download = await _core.execute('update_download');
+      if (download['ok'] == true && version is String && mounted) {
+        state = UpdateReady(version);
+      }
+    } catch (error) {
+      debugPrint('goresave update check failed: $error');
+    }
+  }
+
+  Future<void> applyAndRestart() async {
+    try {
+      await _core.execute('update_apply_restart');
+    } catch (error) {
+      debugPrint('goresave update apply failed: $error');
+    }
+  }
+}
+
+final updateProvider = StateNotifierProvider<UpdateNotifier, UpdateState>(
+  (ref) => UpdateNotifier(ref.watch(coreServiceProvider)),
+);

--- a/apps/goresave/lib/features/app/domain/update_notifier.dart
+++ b/apps/goresave/lib/features/app/domain/update_notifier.dart
@@ -48,7 +48,12 @@ class UpdateNotifier extends StateNotifier<UpdateState> {
 
   Future<void> applyAndRestart() async {
     try {
-      await _core.execute('update_apply_restart');
+      // On success Velopack restarts the process, so this only returns on
+      // failure (ok: false) — the core reports errors without throwing.
+      final response = await _core.execute('update_apply_restart');
+      if (response['ok'] != true) {
+        debugPrint('goresave update apply failed: ${response['error']}');
+      }
     } catch (error) {
       debugPrint('goresave update apply failed: $error');
     }

--- a/apps/goresave/lib/features/app/ui/about_dialog.dart
+++ b/apps/goresave/lib/features/app/ui/about_dialog.dart
@@ -4,10 +4,10 @@ import 'package:url_launcher/url_launcher.dart';
 
 const _githubUrl = 'https://github.com/dh0er/goresave';
 
-const String gitSha = String.fromEnvironment('GIT_SHA', defaultValue: 'dev');
+const String _gitSha = String.fromEnvironment('GIT_SHA', defaultValue: 'dev');
 
 String aboutVersionLabel(PackageInfo? info) =>
-    info == null ? '' : 'Version ${info.version} ($gitSha)';
+    info == null ? '' : 'Version ${info.version} ($_gitSha)';
 
 class GoresaveAboutDialog extends StatefulWidget {
   const GoresaveAboutDialog({super.key});

--- a/apps/goresave/lib/features/app/ui/about_dialog.dart
+++ b/apps/goresave/lib/features/app/ui/about_dialog.dart
@@ -4,6 +4,11 @@ import 'package:url_launcher/url_launcher.dart';
 
 const _githubUrl = 'https://github.com/dh0er/goresave';
 
+const String gitSha = String.fromEnvironment('GIT_SHA', defaultValue: 'dev');
+
+String aboutVersionLabel(PackageInfo? info) =>
+    info == null ? '' : 'Version ${info.version} ($gitSha)';
+
 class GoresaveAboutDialog extends StatefulWidget {
   const GoresaveAboutDialog({super.key});
 
@@ -37,10 +42,7 @@ class _GoresaveAboutDialogState extends State<GoresaveAboutDialog> {
               FutureBuilder<PackageInfo>(
                 future: _packageInfo,
                 builder: (context, snapshot) {
-                  final info = snapshot.data;
-                  final version = info == null
-                      ? ''
-                      : 'Version ${info.version} (Build ${info.buildNumber})';
+                  final version = aboutVersionLabel(snapshot.data);
                   return Text(version, style: textTheme.bodySmall);
                 },
               ),

--- a/apps/goresave/lib/features/app/ui/goresave_app.dart
+++ b/apps/goresave/lib/features/app/ui/goresave_app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:goresave/features/app/domain/ui_settings.dart';
 import 'package:goresave/features/app/ui/ui_scale_root.dart';
+import 'package:goresave/features/app/ui/update_banner.dart';
 import 'package:goresave/providers/data_providers.dart';
 import 'package:goresave/ui/design/app_theme.dart';
 
@@ -18,8 +19,9 @@ class GoresaveApp extends ConsumerWidget {
       theme: buildGoresaveTheme(),
       darkTheme: buildGoresaveDarkTheme(),
       themeMode: themeMode,
-      builder: (context, child) =>
-          UiScaleRoot(child: child ?? const SizedBox.shrink()),
+      builder: (context, child) => UiScaleRoot(
+        child: UpdateBannerHost(child: child ?? const SizedBox.shrink()),
+      ),
       routerConfig: router,
     );
   }

--- a/apps/goresave/lib/features/app/ui/update_banner.dart
+++ b/apps/goresave/lib/features/app/ui/update_banner.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:goresave/features/app/domain/update_notifier.dart';
+
+/// Wraps the app content and shows a slim banner above it once an update has
+/// been downloaded and staged.
+class UpdateBannerHost extends ConsumerWidget {
+  const UpdateBannerHost({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(updateProvider);
+    if (state is! UpdateReady) {
+      return child;
+    }
+    final theme = Theme.of(context);
+    final onContainer = theme.colorScheme.onPrimaryContainer;
+    return Column(
+      children: [
+        Material(
+          color: theme.colorScheme.primaryContainer,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Row(
+              children: [
+                Icon(Icons.system_update_alt, size: 16, color: onContainer),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Update ${state.version} ready',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: onContainer,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () =>
+                      ref.read(updateProvider.notifier).applyAndRestart(),
+                  child: const Text('Restart to update'),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Expanded(child: child),
+      ],
+    );
+  }
+}

--- a/apps/goresave/lib/features/editor/domain/core_service.dart
+++ b/apps/goresave/lib/features/editor/domain/core_service.dart
@@ -10,26 +10,6 @@ typedef _ExecuteNative = Pointer<Utf8> Function(Pointer<Utf8>);
 typedef _ExecuteDart = Pointer<Utf8> Function(Pointer<Utf8>);
 typedef _FreeNative = Void Function(Pointer<Utf8>);
 typedef _FreeDart = void Function(Pointer<Utf8>);
-typedef _StartupNative = Void Function();
-typedef _StartupDart = void Function();
-
-/// Runs Velopack install/update hooks in the native core. Must be the very
-/// first call in main(): Velopack may exit the process during hook
-/// invocations. A missing DLL is fine (dev run without a built core).
-void velopackStartup() {
-  for (final candidate in _candidateLibraryPaths()) {
-    try {
-      final library = DynamicLibrary.open(candidate);
-      final startup = library.lookupFunction<_StartupNative, _StartupDart>(
-        'goresave_velopack_startup',
-      );
-      startup();
-      return;
-    } catch (_) {
-      continue;
-    }
-  }
-}
 
 abstract class GoresaveCoreService {
   bool get isAvailable;

--- a/apps/goresave/lib/features/editor/domain/core_service.dart
+++ b/apps/goresave/lib/features/editor/domain/core_service.dart
@@ -10,6 +10,26 @@ typedef _ExecuteNative = Pointer<Utf8> Function(Pointer<Utf8>);
 typedef _ExecuteDart = Pointer<Utf8> Function(Pointer<Utf8>);
 typedef _FreeNative = Void Function(Pointer<Utf8>);
 typedef _FreeDart = void Function(Pointer<Utf8>);
+typedef _StartupNative = Void Function();
+typedef _StartupDart = void Function();
+
+/// Runs Velopack install/update hooks in the native core. Must be the very
+/// first call in main(): Velopack may exit the process during hook
+/// invocations. A missing DLL is fine (dev run without a built core).
+void velopackStartup() {
+  for (final candidate in _candidateLibraryPaths()) {
+    try {
+      final library = DynamicLibrary.open(candidate);
+      final startup = library.lookupFunction<_StartupNative, _StartupDart>(
+        'goresave_velopack_startup',
+      );
+      startup();
+      return;
+    } catch (_) {
+      continue;
+    }
+  }
+}
 
 abstract class GoresaveCoreService {
   bool get isAvailable;

--- a/apps/goresave/lib/main.dart
+++ b/apps/goresave/lib/main.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:goresave/features/app/ui/goresave_app.dart';
 import 'package:goresave/features/app/ui/window_chrome.dart';
+import 'package:goresave/features/editor/domain/core_service.dart';
 import 'package:window_manager/window_manager.dart';
 
 Future<void> main() async {
+  // Must run before anything else: Velopack hooks may exit the process.
+  velopackStartup();
   WidgetsFlutterBinding.ensureInitialized();
   if (windowChromeEnabled) {
     await windowManager.ensureInitialized();

--- a/apps/goresave/lib/main.dart
+++ b/apps/goresave/lib/main.dart
@@ -2,12 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:goresave/features/app/ui/goresave_app.dart';
 import 'package:goresave/features/app/ui/window_chrome.dart';
-import 'package:goresave/features/editor/domain/core_service.dart';
 import 'package:window_manager/window_manager.dart';
 
 Future<void> main() async {
-  // Must run before anything else: Velopack hooks may exit the process.
-  velopackStartup();
+  // Velopack startup hooks run in the native Windows runner (main.cpp)
+  // before the Flutter engine starts.
   WidgetsFlutterBinding.ensureInitialized();
   if (windowChromeEnabled) {
     await windowManager.ensureInitialized();

--- a/apps/goresave/pubspec.yaml
+++ b/apps/goresave/pubspec.yaml
@@ -1,7 +1,7 @@
 name: goresave
 description: "goresave: Gothic Remake Savegame-Editor"
 publish_to: "none"
-version: 0.1.0+1
+version: 0.1.0
 
 environment:
   sdk: ^3.12.0

--- a/apps/goresave/test/about_dialog_test.dart
+++ b/apps/goresave/test/about_dialog_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/app/ui/about_dialog.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  test('aboutVersionLabel shows version and git sha, no build number', () {
+    final info = PackageInfo(
+      appName: 'goresave',
+      packageName: 'goresave',
+      version: '1.2.3',
+      buildNumber: '7',
+    );
+    // Default GIT_SHA dart-define is 'dev' in tests.
+    expect(aboutVersionLabel(info), 'Version 1.2.3 (dev)');
+  });
+
+  test('aboutVersionLabel is empty while package info loads', () {
+    expect(aboutVersionLabel(null), '');
+  });
+}

--- a/apps/goresave/test/update_banner_test.dart
+++ b/apps/goresave/test/update_banner_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/app/domain/update_notifier.dart';
+import 'package:goresave/features/app/ui/update_banner.dart';
+import 'package:goresave/features/editor/domain/core_service.dart';
+
+class _FakeCoreService implements GoresaveCoreService {
+  _FakeCoreService(this.checkData);
+
+  final Map<String, Object?> checkData;
+  final List<String> commands = [];
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  String get description => 'fake';
+
+  @override
+  Future<Map<String, Object?>> execute(
+    String command, {
+    Map<String, Object?> payload = const {},
+  }) async {
+    commands.add(command);
+    return switch (command) {
+      'update_check' => {'ok': true, 'data': checkData},
+      _ => {'ok': true, 'data': const <String, Object?>{}},
+    };
+  }
+}
+
+Widget _host(GoresaveCoreService core) {
+  return ProviderScope(
+    overrides: [
+      updateProvider.overrideWith((ref) => UpdateNotifier(core)),
+    ],
+    child: const MaterialApp(
+      home: UpdateBannerHost(child: Text('content')),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('no banner when idle', (tester) async {
+    final core = _FakeCoreService({'status': 'upToDate'});
+    await tester.pumpWidget(_host(core));
+    await tester.pumpAndSettle();
+    expect(find.text('content'), findsOneWidget);
+    expect(find.textContaining('Update'), findsNothing);
+  });
+
+  testWidgets('banner shown when ready; restart triggers apply', (tester) async {
+    final core = _FakeCoreService({
+      'status': 'updateAvailable',
+      'version': '0.2.0',
+    });
+    await tester.pumpWidget(_host(core));
+    await tester.pumpAndSettle();
+    expect(find.text('Update 0.2.0 ready'), findsOneWidget);
+    expect(find.text('content'), findsOneWidget);
+
+    await tester.tap(find.text('Restart to update'));
+    await tester.pumpAndSettle();
+    expect(core.commands, contains('update_apply_restart'));
+  });
+}

--- a/apps/goresave/test/update_notifier_test.dart
+++ b/apps/goresave/test/update_notifier_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/app/domain/update_notifier.dart';
+import 'package:goresave/features/editor/domain/core_service.dart';
+
+class _FakeCoreService implements GoresaveCoreService {
+  _FakeCoreService(this.responses);
+
+  final Map<String, Object> responses;
+  final List<String> commands = [];
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  String get description => 'fake';
+
+  @override
+  Future<Map<String, Object?>> execute(
+    String command, {
+    Map<String, Object?> payload = const {},
+  }) async {
+    commands.add(command);
+    final response = responses[command];
+    if (response is Exception) {
+      throw response;
+    }
+    return (response as Map<String, Object?>?) ?? {'ok': false};
+  }
+}
+
+void main() {
+  test('downloads silently and becomes ready when update available', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'updateAvailable', 'version': '0.2.0'},
+      },
+      'update_download': {
+        'ok': true,
+        'data': {'downloaded': true, 'version': '0.2.0'},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(fake.commands, ['update_check', 'update_download']);
+    expect(notifier.state, isA<UpdateReady>());
+    expect((notifier.state as UpdateReady).version, '0.2.0');
+  });
+
+  test('stays idle when updater disabled', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'disabled'},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(fake.commands, ['update_check']);
+    expect(notifier.state, isA<UpdateIdle>());
+  });
+
+  test('stays idle when up to date', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'upToDate'},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(notifier.state, isA<UpdateIdle>());
+  });
+
+  test('stays idle and does not throw on check failure', () async {
+    final fake = _FakeCoreService({'update_check': Exception('offline')});
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(notifier.state, isA<UpdateIdle>());
+  });
+
+  test('stays idle when download fails', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'updateAvailable', 'version': '0.2.0'},
+      },
+      'update_download': {
+        'ok': false,
+        'error': {'code': 'UPDATE_ERROR', 'message': 'network'},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(notifier.state, isA<UpdateIdle>());
+  });
+
+  test('applyAndRestart sends update_apply_restart', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'disabled'},
+      },
+      'update_apply_restart': {
+        'ok': true,
+        'data': {'applied': true},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    await notifier.applyAndRestart();
+    expect(fake.commands.last, 'update_apply_restart');
+  });
+}

--- a/apps/goresave/windows/runner/main.cpp
+++ b/apps/goresave/windows/runner/main.cpp
@@ -2,11 +2,50 @@
 #include <flutter/flutter_view_controller.h>
 #include <windows.h>
 
+#include <string>
+
 #include "flutter_window.h"
 #include "utils.h"
 
+namespace {
+
+// Runs Velopack install/update hooks (--veloapp-install etc.) from the core
+// DLL next to the executable. Velopack may exit the process here, so this
+// must run before any Flutter or COM initialization. A missing DLL or export
+// is fine (dev run without a built core).
+void RunVelopackStartupHooks() {
+  wchar_t exe_path[MAX_PATH];
+  if (::GetModuleFileNameW(nullptr, exe_path, MAX_PATH) == 0) {
+    return;
+  }
+  std::wstring dll_path(exe_path);
+  size_t last_slash = dll_path.find_last_of(L"\\/");
+  if (last_slash == std::wstring::npos) {
+    return;
+  }
+  dll_path = dll_path.substr(0, last_slash + 1) + L"goresave_core.dll";
+  // Full path, so the Windows DLL search order cannot substitute a
+  // same-named DLL from elsewhere on the search path.
+  HMODULE core = ::LoadLibraryExW(dll_path.c_str(), nullptr,
+                                  LOAD_WITH_ALTERED_SEARCH_PATH);
+  if (core == nullptr) {
+    return;
+  }
+  using StartupFn = void (*)();
+  auto startup = reinterpret_cast<StartupFn>(
+      ::GetProcAddress(core, "goresave_velopack_startup"));
+  if (startup != nullptr) {
+    startup();
+  }
+}
+
+}  // namespace
+
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
+  // Must run before anything else: Velopack hooks may exit the process.
+  RunVelopackStartupHooks();
+
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {

--- a/build.py
+++ b/build.py
@@ -83,12 +83,15 @@ def resolve_git_sha(override: str | None) -> str:
     env_sha = os.environ.get("GITHUB_SHA", "")
     if env_sha:
         return env_sha[:7]
-    probe = subprocess.run(
-        ["git", "rev-parse", "--short=7", "HEAD"],
-        cwd=ROOT,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        probe = subprocess.run(
+            ["git", "rev-parse", "--short=7", "HEAD"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return "dev"
     if probe.returncode == 0 and probe.stdout.strip():
         return probe.stdout.strip()
     return "dev"

--- a/build.py
+++ b/build.py
@@ -76,13 +76,35 @@ def read_version() -> str:
     return match.group(1) if match else "0.0.0"
 
 
-def dist(version: str) -> Path:
+def resolve_git_sha(override: str | None) -> str:
+    """Short commit SHA for the About dialog: flag > CI env > git > 'dev'."""
+    if override:
+        return override
+    env_sha = os.environ.get("GITHUB_SHA", "")
+    if env_sha:
+        return env_sha[:7]
+    probe = subprocess.run(
+        ["git", "rev-parse", "--short=7", "HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode == 0 and probe.stdout.strip():
+        return probe.stdout.strip()
+    return "dev"
+
+
+def dist(version: str, git_sha: str) -> Path:
     run("Build core (release)", [CARGO, "build", "--release", "-p", "goresave_core"])
     run(
         "Build codec host (release)",
         [CARGO, "build", "--release", "-p", "goresave_g1r_codec_host"],
     )
-    run("Flutter Windows release", [FLUTTER, "build", "windows", "--release"], cwd=APP)
+    run(
+        "Flutter Windows release",
+        [FLUTTER, "build", "windows", "--release", f"--dart-define=GIT_SHA={git_sha}"],
+        cwd=APP,
+    )
 
     if not RELEASE_DIR.exists():
         raise SystemExit(f"missing Flutter release output: {RELEASE_DIR}")
@@ -107,8 +129,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("command", nargs="?", choices=["dist"], default="dist")
     parser.add_argument("--version", help="Override version (default: from pubspec).")
+    parser.add_argument("--git-sha", help="Short commit SHA (default: env/git).")
     args = parser.parse_args()
-    dist(args.version or read_version())
+    dist(args.version or read_version(), resolve_git_sha(args.git_sha))
     return 0
 
 

--- a/crates/goresave_core/Cargo.toml
+++ b/crates/goresave_core/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha1 = "0.10"
 thiserror = "2"
+velopack = "1.2.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod codec_backend;
 mod kraken;
+mod updater;
 pub mod properties;
 
 use base64::{Engine as _, engine::general_purpose};
@@ -32,6 +33,8 @@ pub enum CoreError {
     Codec(String),
     #[error("validation failed: {0}")]
     Validation(String),
+    #[error("update error: {0}")]
+    Update(String),
 }
 
 impl From<std::io::Error> for CoreError {
@@ -328,6 +331,7 @@ pub fn execute_json(input: &str) -> String {
                 CoreError::UnsupportedEdit(_) => "UNSUPPORTED_EDIT",
                 CoreError::Codec(_) => "CODEC_ERROR",
                 CoreError::Validation(_) => "VALIDATION_FAILED",
+                CoreError::Update(_) => "UPDATE_ERROR",
             };
             json!({
                 "ok": false,
@@ -476,6 +480,9 @@ fn execute_json_inner(input: &str) -> Result<Value, CoreError> {
                 sync_persistent_data_list,
             )?)
         }
+        "update_check" => updater::update_check(&payload),
+        "update_download" => updater::update_download(&payload),
+        "update_apply_restart" => updater::update_apply_restart(&payload),
         other => Err(CoreError::InvalidRequest(format!(
             "unknown command {other:?}"
         ))),
@@ -4722,6 +4729,13 @@ pub extern "C" fn goresave_execute(request_json: *const c_char) -> *mut c_char {
         .to_string_lossy()
         .to_string();
     cstring_ptr(execute_json(&input))
+}
+
+/// Velopack startup hook. Call before any other FFI function; may exit the
+/// process when invoked as an install/update hook.
+#[unsafe(no_mangle)]
+pub extern "C" fn goresave_velopack_startup() {
+    updater::velopack_startup();
 }
 
 #[unsafe(no_mangle)]

--- a/crates/goresave_core/src/updater.rs
+++ b/crates/goresave_core/src/updater.rs
@@ -20,7 +20,10 @@ static PENDING_UPDATE: Mutex<Option<UpdateInfo>> = Mutex::new(None);
 /// Runs Velopack startup hooks (install/update/uninstall callbacks). May exit
 /// the process, so the app must call this before any other work.
 pub fn velopack_startup() {
-    VelopackApp::build().run();
+    // Updates apply only through the user-confirmed "Restart to update" flow;
+    // Velopack's default would silently install a staged update on startup,
+    // and update_check surfaces such packages through the banner instead.
+    VelopackApp::build().set_auto_apply_on_startup(false).run();
 }
 
 /// None when the app is not Velopack-installed (dev run, portable zip).

--- a/crates/goresave_core/src/updater.rs
+++ b/crates/goresave_core/src/updater.rs
@@ -1,0 +1,102 @@
+//! Velopack-backed self-update commands.
+//!
+//! The update feed is the latest GitHub release: `releases/latest/download/`
+//! redirects to the newest release's assets, where CI uploads
+//! `releases.win.json` and the Velopack packages. No API calls, no token.
+
+use std::sync::Mutex;
+
+use serde_json::{Value, json};
+use velopack::sources::HttpSource;
+use velopack::{UpdateCheck, UpdateInfo, UpdateManager, VelopackApp};
+
+use crate::CoreError;
+
+const UPDATE_FEED_URL: &str = "https://github.com/dh0er/goresave/releases/latest/download/";
+
+/// Update found by `update_check`, consumed by download/apply.
+static PENDING_UPDATE: Mutex<Option<UpdateInfo>> = Mutex::new(None);
+
+/// Runs Velopack startup hooks (install/update/uninstall callbacks). May exit
+/// the process, so the app must call this before any other work.
+pub fn velopack_startup() {
+    VelopackApp::build().run();
+}
+
+/// None when the app is not Velopack-installed (dev run, portable zip).
+fn update_manager() -> Option<UpdateManager> {
+    let source = HttpSource::new(UPDATE_FEED_URL);
+    UpdateManager::new(source, None, None).ok()
+}
+
+pub fn update_check(_payload: &Value) -> Result<Value, CoreError> {
+    let Some(manager) = update_manager() else {
+        return Ok(json!({ "status": "disabled" }));
+    };
+    match manager.check_for_updates() {
+        Ok(UpdateCheck::UpdateAvailable(info)) => {
+            let version = info.TargetFullRelease.Version.clone();
+            *PENDING_UPDATE.lock().unwrap() = Some(*info);
+            Ok(json!({ "status": "updateAvailable", "version": version }))
+        }
+        Ok(_) => Ok(json!({ "status": "upToDate" })),
+        Err(err) => Err(CoreError::Update(err.to_string())),
+    }
+}
+
+pub fn update_download(_payload: &Value) -> Result<Value, CoreError> {
+    let manager =
+        update_manager().ok_or_else(|| CoreError::Update("updater is disabled".to_string()))?;
+    let pending = PENDING_UPDATE.lock().unwrap().clone();
+    let info = pending
+        .ok_or_else(|| CoreError::Update("no update pending; run update_check".to_string()))?;
+    manager
+        .download_updates(&info, None)
+        .map_err(|err| CoreError::Update(err.to_string()))?;
+    Ok(json!({
+        "downloaded": true,
+        "version": info.TargetFullRelease.Version,
+    }))
+}
+
+pub fn update_apply_restart(_payload: &Value) -> Result<Value, CoreError> {
+    let manager =
+        update_manager().ok_or_else(|| CoreError::Update("updater is disabled".to_string()))?;
+    let pending = PENDING_UPDATE.lock().unwrap().clone();
+    let info = pending
+        .ok_or_else(|| CoreError::Update("no update pending; run update_check".to_string()))?;
+    manager
+        .apply_updates_and_restart(&info)
+        .map_err(|err| CoreError::Update(err.to_string()))?;
+    Ok(json!({ "applied": true }))
+}
+
+#[cfg(test)]
+mod tests {
+    // cargo test binaries are never Velopack-installed, so the updater must
+    // report itself disabled instead of erroring.
+    #[test]
+    fn update_check_reports_disabled_outside_velopack_install() {
+        let response = crate::execute_json(r#"{"command":"update_check","payload":{}}"#);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value["ok"], true, "response: {response}");
+        assert_eq!(value["data"]["status"], "disabled");
+    }
+
+    #[test]
+    fn update_download_without_pending_update_fails() {
+        let response = crate::execute_json(r#"{"command":"update_download","payload":{}}"#);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["error"]["code"], "UPDATE_ERROR");
+    }
+
+    #[test]
+    fn update_apply_restart_without_pending_update_fails() {
+        let response =
+            crate::execute_json(r#"{"command":"update_apply_restart","payload":{}}"#);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["error"]["code"], "UPDATE_ERROR");
+    }
+}

--- a/crates/goresave_core/src/updater.rs
+++ b/crates/goresave_core/src/updater.rs
@@ -36,6 +36,21 @@ pub fn update_check(_payload: &Value) -> Result<Value, CoreError> {
         *PENDING_UPDATE.lock().unwrap() = None;
         return Ok(json!({ "status": "disabled" }));
     };
+    // An update downloaded in an earlier run but not applied yet must surface
+    // without network access: prefer the locally staged package over the
+    // remote check. download_updates skips the download when the package file
+    // already exists, so the regular check -> download -> ready flow works
+    // offline for it.
+    if let Some(asset) = manager.get_update_pending_restart() {
+        let version = asset.Version.clone();
+        *PENDING_UPDATE.lock().unwrap() = Some(UpdateInfo {
+            TargetFullRelease: asset,
+            BaseRelease: None,
+            DeltasToTarget: Vec::new(),
+            IsDowngrade: false,
+        });
+        return Ok(json!({ "status": "updateAvailable", "version": version }));
+    }
     match manager.check_for_updates() {
         Ok(UpdateCheck::UpdateAvailable(info)) => {
             let version = info.TargetFullRelease.Version.clone();

--- a/crates/goresave_core/src/updater.rs
+++ b/crates/goresave_core/src/updater.rs
@@ -68,6 +68,8 @@ pub fn update_apply_restart(_payload: &Value) -> Result<Value, CoreError> {
     manager
         .apply_updates_and_restart(&info)
         .map_err(|err| CoreError::Update(err.to_string()))?;
+    // On success Velopack exits this process before we get here; this response
+    // only ever reaches the caller if the restart could not be initiated.
     Ok(json!({ "applied": true }))
 }
 

--- a/crates/goresave_core/src/updater.rs
+++ b/crates/goresave_core/src/updater.rs
@@ -31,6 +31,9 @@ fn update_manager() -> Option<UpdateManager> {
 
 pub fn update_check(_payload: &Value) -> Result<Value, CoreError> {
     let Some(manager) = update_manager() else {
+        // A previously stored update must not survive a check that no longer
+        // reports one, or download/apply could act on a superseded package.
+        *PENDING_UPDATE.lock().unwrap() = None;
         return Ok(json!({ "status": "disabled" }));
     };
     match manager.check_for_updates() {
@@ -39,7 +42,10 @@ pub fn update_check(_payload: &Value) -> Result<Value, CoreError> {
             *PENDING_UPDATE.lock().unwrap() = Some(*info);
             Ok(json!({ "status": "updateAvailable", "version": version }))
         }
-        Ok(_) => Ok(json!({ "status": "upToDate" })),
+        Ok(_) => {
+            *PENDING_UPDATE.lock().unwrap() = None;
+            Ok(json!({ "status": "upToDate" }))
+        }
         Err(err) => Err(CoreError::Update(err.to_string())),
     }
 }
@@ -100,5 +106,18 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert_eq!(value["ok"], false);
         assert_eq!(value["error"]["code"], "UPDATE_ERROR");
+    }
+
+    // A check whose outcome is not "updateAvailable" must drop any previously
+    // stored update so download/apply cannot act on a superseded package.
+    // (Safe alongside the tests above: with the updater disabled they fail on
+    // the manager guard before ever reading PENDING_UPDATE.)
+    #[test]
+    fn update_check_clears_stale_pending_update() {
+        *super::PENDING_UPDATE.lock().unwrap() = Some(velopack::UpdateInfo::default());
+        let response = crate::execute_json(r#"{"command":"update_check","payload":{}}"#);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value["data"]["status"], "disabled");
+        assert!(super::PENDING_UPDATE.lock().unwrap().is_none());
     }
 }

--- a/docs/superpowers/plans/2026-06-11-auto-updater.md
+++ b/docs/superpowers/plans/2026-06-11-auto-updater.md
@@ -187,7 +187,10 @@ git commit -m "feat(build): inject GIT_SHA dart-define into Windows release buil
 - [ ] **Step 1: Add dependency**
 
 Run: `cargo add velopack -p goresave_core`
-Expected: latest `velopack` 0.0.x added to `crates/goresave_core/Cargo.toml`.
+Expected: latest `velopack` added to `crates/goresave_core/Cargo.toml`.
+(As built: velopack 1.2.0, whose API uses PascalCase fields like
+`info.TargetFullRelease.Version` instead of the snake_case shown in the
+snippets below — the snippets predate the 1.x release.)
 
 - [ ] **Step 2: Add CoreError variant**
 

--- a/docs/superpowers/plans/2026-06-11-auto-updater.md
+++ b/docs/superpowers/plans/2026-06-11-auto-updater.md
@@ -1,0 +1,983 @@
+# Auto-Updater + GitHub Release Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** goresave updates itself from GitHub Releases via Velopack; a tag push builds and publishes the installer + update feed.
+
+**Architecture:** The Rust core (`goresave_core`) gains a `velopack`-backed updater module exposed through the existing `goresave_execute(json)` FFI channel plus one new startup export. Flutter calls the startup hook first thing in `main()`, checks/downloads updates in the background via a `StateNotifier`, and shows a banner when an update is staged. CI packs the Flutter release folder with `vpk` and attaches the Velopack assets to the GitHub release; the app reads the feed from the stable `releases/latest/download/` URL (no token, repo is public).
+
+**Tech Stack:** Rust (`velopack` crate, thiserror, serde_json), Flutter/Dart (riverpod `StateNotifier`, dart:ffi), GitHub Actions (`vpk` CLI via dotnet tool).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-auto-updater-design.md`
+
+**Repo facts (verified):**
+- FFI entry: `crates/goresave_core/src/lib.rs:4717` `goresave_execute`, command dispatch in `execute_json_inner` at `lib.rs:344-353`, response wrapper `execute_json` at `lib.rs:320` (`{"ok":true,"data":...}` / `{"ok":false,"error":{code,message}}`).
+- `CoreError` enum at `lib.rs:22-35` (thiserror, string payloads), error-code mapping at `lib.rs:324-331`.
+- Dart service: `apps/goresave/lib/features/editor/domain/core_service.dart` — `GoresaveCoreService.execute(command, {payload})`, DLL candidates in `_candidateLibraryPaths()`.
+- Provider: `apps/goresave/lib/providers/data_providers.dart:8` `coreServiceProvider`.
+- App shell: `apps/goresave/lib/features/app/ui/goresave_app.dart` — `MaterialApp.router` with `builder: UiScaleRoot(...)`.
+- About dialog: `apps/goresave/lib/features/app/ui/about_dialog.dart:43` shows `Version X (Build N)`.
+- `build.py` builds core DLL + codec host + Flutter release into `apps/goresave/build/windows/x64/runner/Release`, zips to `dist/`.
+- Riverpod style: legacy `StateNotifier` (`import 'package:flutter_riverpod/legacy.dart'`), see `ui_settings.dart`.
+- Icon exists: `apps/goresave/windows/runner/resources/app_icon.ico`.
+- Test runner: `python test.py` (runs cargo + flutter tests). Flutter tests live flat in `apps/goresave/test/`.
+
+---
+
+### Task 1: Drop build number, show git short SHA in About dialog
+
+**Files:**
+- Modify: `apps/goresave/pubspec.yaml` (version line)
+- Modify: `apps/goresave/lib/features/app/ui/about_dialog.dart`
+- Test: `apps/goresave/test/about_dialog_test.dart` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/goresave/test/about_dialog_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/app/ui/about_dialog.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  test('aboutVersionLabel shows version and git sha, no build number', () {
+    final info = PackageInfo(
+      appName: 'goresave',
+      packageName: 'goresave',
+      version: '1.2.3',
+      buildNumber: '7',
+    );
+    // Default GIT_SHA dart-define is 'dev' in tests.
+    expect(aboutVersionLabel(info), 'Version 1.2.3 (dev)');
+  });
+
+  test('aboutVersionLabel is empty while package info loads', () {
+    expect(aboutVersionLabel(null), '');
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/about_dialog_test.dart` (cwd `apps/goresave`; use `fvm flutter` / the 3.44.0 toolchain as `test.py` does)
+Expected: FAIL — `aboutVersionLabel` is not defined.
+
+- [ ] **Step 3: Implement**
+
+In `about_dialog.dart`, add below the `_githubUrl` const:
+
+```dart
+const String gitSha = String.fromEnvironment('GIT_SHA', defaultValue: 'dev');
+
+String aboutVersionLabel(PackageInfo? info) =>
+    info == null ? '' : 'Version ${info.version} ($gitSha)';
+```
+
+Replace the version computation inside the `FutureBuilder` (lines 41-43):
+
+```dart
+                  final version = aboutVersionLabel(snapshot.data);
+```
+
+(The `final info = snapshot.data;` line and the old ternary are removed.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/about_dialog_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Remove build number from pubspec**
+
+In `apps/goresave/pubspec.yaml` change line 4:
+
+```yaml
+version: 0.1.0
+```
+
+(was `version: 0.1.0+1`)
+
+- [ ] **Step 6: Full test suite**
+
+Run: `python test.py` (repo root)
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/goresave/pubspec.yaml apps/goresave/lib/features/app/ui/about_dialog.dart apps/goresave/test/about_dialog_test.dart
+git commit -m "feat(app): replace build number with git short sha in about dialog"
+```
+
+---
+
+### Task 2: Plumb GIT_SHA through build.py
+
+**Files:**
+- Modify: `build.py`
+
+No automated test (build script); verified by CI and local dist builds.
+
+- [ ] **Step 1: Add SHA resolution and dart-define**
+
+In `build.py`, add after `read_version()` (line 76):
+
+```python
+def resolve_git_sha(override: str | None) -> str:
+    """Short commit SHA for the About dialog: flag > CI env > git > 'dev'."""
+    if override:
+        return override
+    env_sha = os.environ.get("GITHUB_SHA", "")
+    if env_sha:
+        return env_sha[:7]
+    probe = subprocess.run(
+        ["git", "rev-parse", "--short=7", "HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode == 0 and probe.stdout.strip():
+        return probe.stdout.strip()
+    return "dev"
+```
+
+Change `dist()` signature and the Flutter build line:
+
+```python
+def dist(version: str, git_sha: str) -> Path:
+```
+
+```python
+    run(
+        "Flutter Windows release",
+        [FLUTTER, "build", "windows", "--release", f"--dart-define=GIT_SHA={git_sha}"],
+        cwd=APP,
+    )
+```
+
+In `main()` add the argument and pass it through:
+
+```python
+    parser.add_argument("--git-sha", help="Short commit SHA (default: env/git).")
+    args = parser.parse_args()
+    dist(args.version or read_version(), resolve_git_sha(args.git_sha))
+```
+
+- [ ] **Step 2: Smoke-check argument parsing**
+
+Run: `python build.py --help`
+Expected: shows `--git-sha` option, exits 0. (Do not run a full dist build here.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add build.py
+git commit -m "feat(build): inject GIT_SHA dart-define into Windows release build"
+```
+
+---
+
+### Task 3: Rust updater module (velopack)
+
+**Files:**
+- Modify: `crates/goresave_core/Cargo.toml`
+- Create: `crates/goresave_core/src/updater.rs`
+- Modify: `crates/goresave_core/src/lib.rs` (module decl, `CoreError` variant, error code, dispatch arms, FFI export)
+
+- [ ] **Step 1: Add dependency**
+
+Run: `cargo add velopack -p goresave_core`
+Expected: latest `velopack` 0.0.x added to `crates/goresave_core/Cargo.toml`.
+
+- [ ] **Step 2: Add CoreError variant**
+
+In `lib.rs`, extend the enum (after the `Validation` variant, line 34):
+
+```rust
+    #[error("update error: {0}")]
+    Update(String),
+```
+
+And the code mapping in `execute_json` (after the `Validation` arm, line 330):
+
+```rust
+                CoreError::Update(_) => "UPDATE_ERROR",
+```
+
+- [ ] **Step 3: Write failing tests**
+
+Create `crates/goresave_core/src/updater.rs` with tests only for now:
+
+```rust
+#[cfg(test)]
+mod tests {
+    // cargo test binaries are never Velopack-installed, so the updater must
+    // report itself disabled instead of erroring.
+    #[test]
+    fn update_check_reports_disabled_outside_velopack_install() {
+        let response = crate::execute_json(r#"{"command":"update_check","payload":{}}"#);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value["ok"], true, "response: {response}");
+        assert_eq!(value["data"]["status"], "disabled");
+    }
+
+    #[test]
+    fn update_download_without_pending_update_fails() {
+        let response = crate::execute_json(r#"{"command":"update_download","payload":{}}"#);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["error"]["code"], "UPDATE_ERROR");
+    }
+
+    #[test]
+    fn update_apply_restart_without_pending_update_fails() {
+        let response =
+            crate::execute_json(r#"{"command":"update_apply_restart","payload":{}}"#);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["error"]["code"], "UPDATE_ERROR");
+    }
+}
+```
+
+Add to `lib.rs` next to the existing module declarations (top of file, near `mod codec_backend;`):
+
+```rust
+mod updater;
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `cargo test -p goresave_core updater`
+Expected: compile error — `update_check` command unknown / functions missing.
+
+- [ ] **Step 5: Implement updater.rs**
+
+Prepend to `updater.rs` (above the test module):
+
+```rust
+//! Velopack-backed self-update commands.
+//!
+//! The update feed is the latest GitHub release: `releases/latest/download/`
+//! redirects to the newest release's assets, where CI uploads
+//! `releases.win.json` and the Velopack packages. No API calls, no token.
+
+use std::sync::Mutex;
+
+use serde_json::{json, Value};
+use velopack::sources::HttpSource;
+use velopack::{UpdateCheck, UpdateInfo, UpdateManager, VelopackApp};
+
+use crate::CoreError;
+
+const UPDATE_FEED_URL: &str = "https://github.com/dh0er/goresave/releases/latest/download/";
+
+/// Update found by `update_check`, consumed by download/apply.
+static PENDING_UPDATE: Mutex<Option<UpdateInfo>> = Mutex::new(None);
+
+/// Runs Velopack startup hooks (install/update/uninstall callbacks). May exit
+/// the process, so the app must call this before any other work.
+pub fn velopack_startup() {
+    VelopackApp::build().run();
+}
+
+/// None when the app is not Velopack-installed (dev run, portable zip).
+fn update_manager() -> Option<UpdateManager> {
+    let source = HttpSource::new(UPDATE_FEED_URL);
+    UpdateManager::new(source, None, None).ok()
+}
+
+pub fn update_check(_payload: &Value) -> Result<Value, CoreError> {
+    let Some(manager) = update_manager() else {
+        return Ok(json!({ "status": "disabled" }));
+    };
+    match manager.check_for_updates() {
+        Ok(UpdateCheck::UpdateAvailable(info)) => {
+            let version = info.target_full_release.version.clone();
+            *PENDING_UPDATE.lock().unwrap() = Some(info);
+            Ok(json!({ "status": "updateAvailable", "version": version }))
+        }
+        Ok(_) => Ok(json!({ "status": "upToDate" })),
+        Err(err) => Err(CoreError::Update(err.to_string())),
+    }
+}
+
+pub fn update_download(_payload: &Value) -> Result<Value, CoreError> {
+    let manager = update_manager()
+        .ok_or_else(|| CoreError::Update("updater is disabled".to_string()))?;
+    let pending = PENDING_UPDATE.lock().unwrap().clone();
+    let info = pending
+        .ok_or_else(|| CoreError::Update("no update pending; run update_check".to_string()))?;
+    manager
+        .download_updates(&info, None)
+        .map_err(|err| CoreError::Update(err.to_string()))?;
+    Ok(json!({
+        "downloaded": true,
+        "version": info.target_full_release.version,
+    }))
+}
+
+pub fn update_apply_restart(_payload: &Value) -> Result<Value, CoreError> {
+    let manager = update_manager()
+        .ok_or_else(|| CoreError::Update("updater is disabled".to_string()))?;
+    let pending = PENDING_UPDATE.lock().unwrap().clone();
+    let info = pending
+        .ok_or_else(|| CoreError::Update("no update pending; run update_check".to_string()))?;
+    manager
+        .apply_updates_and_restart(&info)
+        .map_err(|err| CoreError::Update(err.to_string()))?;
+    Ok(json!({ "applied": true }))
+}
+```
+
+API-drift note: signatures above follow the velopack crate README (`UpdateManager::new(source, options, locator)`, `UpdateCheck::UpdateAvailable`, `download_updates(&info, None)`, `apply_updates_and_restart(&info)`). If the resolved crate version differs (e.g. `UpdateInfo` not `Clone` — then use `.take()` instead of `.clone()` on the mutex guard; or `apply_updates_and_restart` wants `&info.target_full_release`), adapt to the compiler against https://docs.rs/velopack. Behavior and JSON shapes must stay exactly as specified.
+
+Add dispatch arms in `execute_json_inner` (`lib.rs`, inside `match command`, before the unknown-command fallthrough):
+
+```rust
+        "update_check" => updater::update_check(&payload),
+        "update_download" => updater::update_download(&payload),
+        "update_apply_restart" => updater::update_apply_restart(&payload),
+```
+
+Add the FFI export next to `goresave_execute`/`goresave_free` (`lib.rs:4716+`):
+
+```rust
+/// Velopack startup hook. Call before any other FFI function; may exit the
+/// process when invoked as an install/update hook.
+#[unsafe(no_mangle)]
+pub extern "C" fn goresave_velopack_startup() {
+    updater::velopack_startup();
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test -p goresave_core`
+Expected: PASS, including the three new updater tests. (Test order safety: all three tests rely on `PENDING_UPDATE` staying `None`; `update_check` returns `disabled` before touching it, so parallel test order cannot break them.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/goresave_core/Cargo.toml Cargo.lock crates/goresave_core/src/updater.rs crates/goresave_core/src/lib.rs
+git commit -m "feat(core): velopack updater commands and startup hook"
+```
+
+---
+
+### Task 4: Dart — Velopack startup call in main()
+
+**Files:**
+- Modify: `apps/goresave/lib/features/editor/domain/core_service.dart`
+- Modify: `apps/goresave/lib/main.dart`
+
+No unit test: the function is a thin FFI passthrough whose only observable behavior (process exit during hooks) cannot run under `flutter test`. Covered by manual E2E (Task 8).
+
+- [ ] **Step 1: Add startup binding in core_service.dart**
+
+Add typedefs next to the existing ones (after line 12):
+
+```dart
+typedef _StartupNative = Void Function();
+typedef _StartupDart = void Function();
+```
+
+Add a top-level function (above `class GoresaveCoreService`):
+
+```dart
+/// Runs Velopack install/update hooks in the native core. Must be the very
+/// first call in main(): Velopack may exit the process during hook
+/// invocations. A missing DLL is fine (dev run without a built core).
+void velopackStartup() {
+  for (final candidate in _candidateLibraryPaths()) {
+    try {
+      final library = DynamicLibrary.open(candidate);
+      final startup = library.lookupFunction<_StartupNative, _StartupDart>(
+        'goresave_velopack_startup',
+      );
+      startup();
+      return;
+    } catch (_) {
+      continue;
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Call it first in main()**
+
+In `apps/goresave/lib/main.dart`, add import and call as the first statement of `main()`:
+
+```dart
+import 'package:goresave/features/editor/domain/core_service.dart';
+```
+
+```dart
+Future<void> main() async {
+  // Must run before anything else: Velopack hooks may exit the process.
+  velopackStartup();
+  WidgetsFlutterBinding.ensureInitialized();
+```
+
+- [ ] **Step 3: Analyze + tests**
+
+Run: `flutter analyze` and `flutter test` (cwd `apps/goresave`)
+Expected: no new issues, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/domain/core_service.dart apps/goresave/lib/main.dart
+git commit -m "feat(app): run velopack startup hook before app init"
+```
+
+---
+
+### Task 5: Dart — UpdateNotifier (check, silent download, state)
+
+**Files:**
+- Create: `apps/goresave/lib/features/app/domain/update_notifier.dart`
+- Test: `apps/goresave/test/update_notifier_test.dart` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/goresave/test/update_notifier_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/app/domain/update_notifier.dart';
+import 'package:goresave/features/editor/domain/core_service.dart';
+
+class _FakeCoreService implements GoresaveCoreService {
+  _FakeCoreService(this.responses);
+
+  final Map<String, Object> responses;
+  final List<String> commands = [];
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  String get description => 'fake';
+
+  @override
+  Future<Map<String, Object?>> execute(
+    String command, {
+    Map<String, Object?> payload = const {},
+  }) async {
+    commands.add(command);
+    final response = responses[command];
+    if (response is Exception) {
+      throw response;
+    }
+    return (response as Map<String, Object?>?) ?? {'ok': false};
+  }
+}
+
+void main() {
+  test('downloads silently and becomes ready when update available', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'updateAvailable', 'version': '0.2.0'},
+      },
+      'update_download': {
+        'ok': true,
+        'data': {'downloaded': true, 'version': '0.2.0'},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(fake.commands, ['update_check', 'update_download']);
+    expect(notifier.state, isA<UpdateReady>());
+    expect((notifier.state as UpdateReady).version, '0.2.0');
+  });
+
+  test('stays idle when updater disabled', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'disabled'},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(fake.commands, ['update_check']);
+    expect(notifier.state, isA<UpdateIdle>());
+  });
+
+  test('stays idle when up to date', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'upToDate'},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(notifier.state, isA<UpdateIdle>());
+  });
+
+  test('stays idle and does not throw on check failure', () async {
+    final fake = _FakeCoreService({'update_check': Exception('offline')});
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(notifier.state, isA<UpdateIdle>());
+  });
+
+  test('stays idle when download fails', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'updateAvailable', 'version': '0.2.0'},
+      },
+      'update_download': {
+        'ok': false,
+        'error': {'code': 'UPDATE_ERROR', 'message': 'network'},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    expect(notifier.state, isA<UpdateIdle>());
+  });
+
+  test('applyAndRestart sends update_apply_restart', () async {
+    final fake = _FakeCoreService({
+      'update_check': {
+        'ok': true,
+        'data': {'status': 'disabled'},
+      },
+      'update_apply_restart': {
+        'ok': true,
+        'data': {'applied': true},
+      },
+    });
+    final notifier = UpdateNotifier(fake);
+    await pumpEventQueue();
+    await notifier.applyAndRestart();
+    expect(fake.commands.last, 'update_apply_restart');
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/update_notifier_test.dart`
+Expected: FAIL — `update_notifier.dart` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/goresave/lib/features/app/domain/update_notifier.dart`:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:goresave/features/editor/domain/core_service.dart';
+import 'package:goresave/providers/data_providers.dart';
+
+sealed class UpdateState {
+  const UpdateState();
+}
+
+/// No update staged: none available, updater disabled, or a check/download
+/// failed (updates are best-effort and never block the app).
+class UpdateIdle extends UpdateState {
+  const UpdateIdle();
+}
+
+/// An update is downloaded and staged; restarting applies [version].
+class UpdateReady extends UpdateState {
+  const UpdateReady(this.version);
+
+  final String version;
+}
+
+class UpdateNotifier extends StateNotifier<UpdateState> {
+  UpdateNotifier(this._core) : super(const UpdateIdle()) {
+    _checkAndDownload();
+  }
+
+  final GoresaveCoreService _core;
+
+  Future<void> _checkAndDownload() async {
+    try {
+      final check = await _core.execute('update_check');
+      final data = check['data'];
+      if (check['ok'] != true ||
+          data is! Map ||
+          data['status'] != 'updateAvailable') {
+        return;
+      }
+      final version = data['version'];
+      final download = await _core.execute('update_download');
+      if (download['ok'] == true && version is String && mounted) {
+        state = UpdateReady(version);
+      }
+    } catch (error) {
+      debugPrint('goresave update check failed: $error');
+    }
+  }
+
+  Future<void> applyAndRestart() async {
+    try {
+      await _core.execute('update_apply_restart');
+    } catch (error) {
+      debugPrint('goresave update apply failed: $error');
+    }
+  }
+}
+
+final updateProvider = StateNotifierProvider<UpdateNotifier, UpdateState>(
+  (ref) => UpdateNotifier(ref.watch(coreServiceProvider)),
+);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/update_notifier_test.dart`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/goresave/lib/features/app/domain/update_notifier.dart apps/goresave/test/update_notifier_test.dart
+git commit -m "feat(app): update notifier with silent background download"
+```
+
+---
+
+### Task 6: Dart — update banner in app shell
+
+**Files:**
+- Create: `apps/goresave/lib/features/app/ui/update_banner.dart`
+- Modify: `apps/goresave/lib/features/app/ui/goresave_app.dart`
+- Test: `apps/goresave/test/update_banner_test.dart` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/goresave/test/update_banner_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/app/domain/update_notifier.dart';
+import 'package:goresave/features/app/ui/update_banner.dart';
+import 'package:goresave/features/editor/domain/core_service.dart';
+
+class _FakeCoreService implements GoresaveCoreService {
+  _FakeCoreService(this.checkData);
+
+  final Map<String, Object?> checkData;
+  final List<String> commands = [];
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  String get description => 'fake';
+
+  @override
+  Future<Map<String, Object?>> execute(
+    String command, {
+    Map<String, Object?> payload = const {},
+  }) async {
+    commands.add(command);
+    return switch (command) {
+      'update_check' => {'ok': true, 'data': checkData},
+      _ => {'ok': true, 'data': const <String, Object?>{}},
+    };
+  }
+}
+
+Widget _host(GoresaveCoreService core) {
+  return ProviderScope(
+    overrides: [
+      updateProvider.overrideWith((ref) => UpdateNotifier(core)),
+    ],
+    child: const MaterialApp(
+      home: UpdateBannerHost(child: Text('content')),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('no banner when idle', (tester) async {
+    final core = _FakeCoreService({'status': 'upToDate'});
+    await tester.pumpWidget(_host(core));
+    await tester.pumpAndSettle();
+    expect(find.text('content'), findsOneWidget);
+    expect(find.textContaining('Update'), findsNothing);
+  });
+
+  testWidgets('banner shown when ready; restart triggers apply', (tester) async {
+    final core = _FakeCoreService({
+      'status': 'updateAvailable',
+      'version': '0.2.0',
+    });
+    await tester.pumpWidget(_host(core));
+    await tester.pumpAndSettle();
+    expect(find.text('Update 0.2.0 ready'), findsOneWidget);
+    expect(find.text('content'), findsOneWidget);
+
+    await tester.tap(find.text('Restart to update'));
+    await tester.pumpAndSettle();
+    expect(core.commands, contains('update_apply_restart'));
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/update_banner_test.dart`
+Expected: FAIL — `update_banner.dart` does not exist.
+
+- [ ] **Step 3: Implement the banner**
+
+Create `apps/goresave/lib/features/app/ui/update_banner.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:goresave/features/app/domain/update_notifier.dart';
+
+/// Wraps the app content and shows a slim banner above it once an update has
+/// been downloaded and staged.
+class UpdateBannerHost extends ConsumerWidget {
+  const UpdateBannerHost({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(updateProvider);
+    if (state is! UpdateReady) {
+      return child;
+    }
+    final theme = Theme.of(context);
+    final onContainer = theme.colorScheme.onPrimaryContainer;
+    return Column(
+      children: [
+        Material(
+          color: theme.colorScheme.primaryContainer,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Row(
+              children: [
+                Icon(Icons.system_update_alt, size: 16, color: onContainer),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Update ${state.version} ready',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: onContainer,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () =>
+                      ref.read(updateProvider.notifier).applyAndRestart(),
+                  child: const Text('Restart to update'),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Mount in GoresaveApp**
+
+In `goresave_app.dart` add the import and wrap the builder child:
+
+```dart
+import 'package:goresave/features/app/ui/update_banner.dart';
+```
+
+```dart
+      builder: (context, child) => UiScaleRoot(
+        child: UpdateBannerHost(child: child ?? const SizedBox.shrink()),
+      ),
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `flutter test test/update_banner_test.dart`, then `flutter test` (full)
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/goresave/lib/features/app/ui/update_banner.dart apps/goresave/lib/features/app/ui/goresave_app.dart apps/goresave/test/update_banner_test.dart
+git commit -m "feat(ui): update-ready banner with restart action"
+```
+
+---
+
+### Task 7: Release workflow — version check + vpk pack
+
+**Files:**
+- Modify: `.github/workflows/release.yml` (full replacement below)
+- Modify: `README.md`
+
+- [ ] **Step 1: Replace release.yml**
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve and verify version
+        id: version
+        shell: pwsh
+        run: |
+          $pubspec = Get-Content apps/goresave/pubspec.yaml -Raw
+          if ($pubspec -notmatch '(?m)^version:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$') {
+            Write-Error 'pubspec.yaml version must be plain X.Y.Z (no build number)'
+            exit 1
+          }
+          $version = $Matches[1]
+          if ('${{ github.ref_type }}' -eq 'tag') {
+            $tag = '${{ github.ref_name }}'
+            if ($tag -ne "v$version") {
+              Write-Error "tag $tag does not match pubspec version $version"
+              exit 1
+            }
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.0
+          channel: stable
+          cache: true
+
+      # GIT_SHA comes from the GITHUB_SHA env via build.py.
+      - name: Build distribution
+        run: python build.py dist
+
+      - name: Install Velopack CLI
+        run: dotnet tool install -g vpk
+
+      # Pulls the previous release so vpk can build delta packages.
+      # Fails harmlessly on the very first release.
+      - name: Download previous Velopack release
+        continue-on-error: true
+        run: >-
+          vpk download github
+          --repoUrl https://github.com/${{ github.repository }}
+          --outputDir dist/velopack
+
+      - name: Velopack pack
+        run: >-
+          vpk pack
+          --packId Goresave
+          --packVersion ${{ steps.version.outputs.version }}
+          --packDir apps/goresave/build/windows/x64/runner/Release
+          --mainExe goresave.exe
+          --packTitle goresave
+          --packAuthors dh0er
+          --icon apps/goresave/windows/runner/resources/app_icon.ico
+          --outputDir dist/velopack
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: goresave-windows-x64
+          path: |
+            dist/*.zip
+            dist/velopack/*
+
+      # releases.win.json + packages must be attached so that
+      # releases/latest/download/ serves the update feed.
+      - name: Publish GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.zip
+            dist/velopack/*
+          generate_release_notes: true
+```
+
+- [ ] **Step 2: Validate workflow syntax**
+
+Run: `gh workflow list` is not enough; instead lint locally:
+`python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml', encoding='utf-8'))"`
+Expected: exits 0.
+
+- [ ] **Step 3: Document install/update in README**
+
+In `README.md`, add after the Features section:
+
+```markdown
+## Installation & Updates
+
+Download `Goresave-win-Setup.exe` from the
+[latest release](https://github.com/dh0er/goresave/releases/latest) and run it.
+The app checks GitHub Releases on startup, downloads updates in the background,
+and applies them when you click "Restart to update".
+
+A portable zip is also attached to each release; the portable build does not
+auto-update.
+
+### Releasing (maintainers)
+
+1. Set `version:` in `apps/goresave/pubspec.yaml` to the new `X.Y.Z`.
+2. Commit, then `git tag vX.Y.Z && git push origin vX.Y.Z`.
+3. The Release workflow builds the zip + Velopack packages and publishes the
+   GitHub release. The tag must match the pubspec version or the build fails.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yml README.md
+git commit -m "feat(ci): velopack packaging and update feed in release workflow"
+```
+
+---
+
+### Task 8: Verification + manual E2E (after merge)
+
+Automated, before merge:
+
+- [ ] **Step 1: Full suite**
+
+Run: `python test.py` (repo root)
+Expected: cargo + flutter tests all pass.
+
+- [ ] **Step 2: Local dist smoke test**
+
+Run: `python build.py dist`
+Expected: zip produced; launch `apps/goresave/build/windows/x64/runner/Release/goresave.exe` — app starts normally, no banner (updater disabled, not Velopack-installed), About dialog shows `Version 0.1.0 (<sha>)`.
+
+Manual, after merge to main (requires repo public — `gh repo edit dh0er/goresave --visibility public`):
+
+- [ ] **Step 3: Release v0.1.0** — tag and push; verify the workflow publishes Setup.exe, nupkg, `releases.win.json`, zip.
+- [ ] **Step 4: Install** via Setup.exe; verify app launches and About shows version + sha.
+- [ ] **Step 5: Release v0.1.1** (bump pubspec, tag); relaunch installed app; verify banner "Update 0.1.1 ready" appears, click "Restart to update", app restarts on 0.1.1.
+- [ ] **Step 6: Portable check** — unzip the 0.1.1 zip, run it, verify no banner appears.

--- a/docs/superpowers/specs/2026-06-11-auto-updater-design.md
+++ b/docs/superpowers/specs/2026-06-11-auto-updater-design.md
@@ -1,0 +1,100 @@
+# Auto-Updater + GitHub Release Workflow — Design
+
+Date: 2026-06-11
+Status: Approved
+
+## Goal
+
+goresave updates itself from GitHub Releases. A tag push produces a Velopack
+installer release; the installed app silently downloads new versions and
+applies them on user-confirmed restart.
+
+## Decisions
+
+- **Repo goes public.** The updater reads release assets anonymously; no token
+  ships in the binary.
+- **Velopack** is the update/packaging mechanism (Rust crate in
+  `goresave_core`, `vpk` CLI in CI). Chosen over WinSparkle (too much
+  infrastructure: appcast hosting, Inno Setup, signing keys) and over a custom
+  self-swap updater (more edge cases to own).
+- **Tag-driven releases** stay: `git tag vX.Y.Z` + push triggers the workflow.
+  The workflow fails if the tag version does not match `pubspec.yaml`.
+- **Build number removed.** `pubspec.yaml` version becomes plain SemVer
+  (`0.1.0`, no `+1`). No store requires a build code, and Velopack ignores
+  SemVer build metadata when comparing versions. The About dialog shows the
+  version plus the git short SHA instead, injected via
+  `--dart-define=GIT_SHA=<sha>` in CI (empty/`dev` for local builds).
+- **Update UX:** check on startup in the background, download silently, show a
+  discreet banner "Update X ready — restart". Clicking applies the update and
+  restarts. No modal dialog, no forced update. Errors (offline, rate limit,
+  parse) are logged and never block the app.
+- **Portable zip stays** as a secondary artifact without auto-update. Velopack
+  detects a non-installed app; the updater then disables itself (no banner).
+  There are no existing portable users, so no migration path is needed.
+
+## Architecture
+
+### CI / Packaging (`.github/workflows/release.yml`)
+
+Existing flow (checkout, Rust, Flutter, `python build.py dist`) is extended:
+
+1. Verify tag `vX.Y.Z` matches `pubspec.yaml` version; fail on mismatch.
+2. Pass git short SHA into the Flutter build (`--dart-define=GIT_SHA=...`,
+   plumbed through `build.py`).
+3. `dotnet tool install -g vpk`, then
+   `vpk pack --packId Goresave --packVersion X.Y.Z --packDir <Release folder>
+   --mainExe goresave.exe`.
+4. Attach to the GitHub release: `*-Setup.exe`, `*-full.nupkg`, delta
+   packages, `releases.win.json`, and the portable zip from `build.py dist`.
+
+### Update source — no token, no API
+
+Base URL: `https://github.com/dh0er/goresave/releases/latest/download/`
+
+GitHub redirects this stable URL to the newest release's assets.
+`releases.win.json` references packages by file name relative to that base, so
+Velopack's `HttpSource` works against it directly — no GitHub API calls, no
+auth, no rate-limit concerns.
+
+### Rust (`crates/goresave_core`)
+
+- Add the `velopack` crate.
+- New FFI export `goresave_velopack_startup()`: runs
+  `VelopackApp::build().run()`. Must be called first thing in Dart `main()`
+  because Velopack install/update hooks may exit the process.
+- Update operations ride the existing `goresave_execute(json) -> json`
+  command channel:
+  - `update_check` — returns available version or "none" (also "disabled"
+    when running un-installed, e.g. portable zip).
+  - `update_download` — downloads silently, reports progress/completion.
+  - `update_apply_restart` — applies staged update and restarts the app.
+
+### Flutter (`apps/goresave`)
+
+- On startup: `update_check` in the background; if an update exists,
+  `update_download` silently; on completion show the banner.
+- Banner click calls `update_apply_restart`.
+- About dialog: version string becomes `X.Y.Z (shortsha)` from
+  `String.fromEnvironment('GIT_SHA')`; build number display removed.
+
+## Error handling
+
+- Any updater failure is non-blocking: log and continue; app works fully
+  offline.
+- Workflow hard-fails on tag/pubspec version mismatch before building.
+
+## Testing
+
+- Rust unit tests for update command parsing/serialization (network layer kept
+  thin; Velopack calls isolated behind the command handlers).
+- Manual end-to-end: release v0.1.1, install via Setup.exe, tag v0.1.2, verify
+  banner appears and restart applies the new version.
+- Portable zip: verify the updater self-disables (no banner, `update_check`
+  returns "disabled").
+
+## Out of scope
+
+- Code signing of the installer (unsigned for now; SmartScreen warning
+  accepted).
+- Update channels (beta/stable) — single stable channel.
+- Linux/macOS builds.


### PR DESCRIPTION
## Summary

- Rust core gains a velopack-backed updater (`update_check` / `update_download` / `update_apply_restart` over the existing JSON FFI channel, plus a `goresave_velopack_startup` hook that must run first in `main()`).
- Flutter checks for updates on startup, downloads silently, and shows a slim "Update X ready — Restart to update" banner; errors never block the app, and non-installed (dev/portable) runs self-disable.
- Release workflow verifies tag == pubspec version, packs the build with `vpk` (pinned 1.2.0), and attaches Setup.exe, nupkg packages, and `releases.win.json` to the GitHub release; the app reads the feed from the stable `releases/latest/download/` URL (no token, no API).
- Build number dropped from pubspec; the About dialog shows the git short SHA instead (`--dart-define=GIT_SHA`, plumbed through `build.py`).

Design spec: `docs/superpowers/specs/2026-06-11-auto-updater-design.md`. Requires the repo to be public before the first release so the anonymous update feed works.

## Test Plan

- [x] `python test.py` — Rust 231 + Flutter 89 tests pass
- [x] `python build.py dist` — release build, GIT_SHA injected, app launches with updater silently disabled (portable mode)
- [ ] After merge + repo public: release v0.1.0, install Setup.exe, release v0.1.1, verify banner + restart-update (manual E2E from the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ships a new update/download/restart path and changes release artifacts; logic is gated when not Velopack-installed and errors are non-blocking, but a bad feed or packaging mismatch could affect installed users.
> 
> **Overview**
> Introduces **Velopack-based auto-updates** for the Windows app: `goresave_core` adds an `updater` module (crate `velopack` 1.2.0) with JSON commands `update_check`, `update_download`, and `update_apply_restart`, plus `goresave_velopack_startup` invoked from **native `main.cpp`** before Flutter starts. Updates pull from `releases/latest/download/` with no GitHub API token; auto-apply on startup is disabled so users confirm via **Restart to update**.
> 
> On the Flutter side, an **`UpdateNotifier`** checks and silently downloads on launch, a top **banner** appears when staged, and failures stay non-blocking. **About** drops the build number and shows **`GIT_SHA`** from `build.py` (`--dart-define` / CI `GITHUB_SHA`). **pubspec** version is plain `X.Y.Z`.
> 
> **Release workflow** now verifies tag vs pubspec, runs **`vpk pack`** (CLI pinned 1.2.0, `--noPortable`, optional delta download), uploads zip + Velopack assets, and sets release body from **`CHANGELOG.md`** (required section) instead of auto-generated notes. README documents install/update and maintainer release steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87af02f2a0c4d8d624401cd5e1af0c908f170765. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->