### PR TITLE
fix(codec): scale runtime worker timeout with payload size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ notes, so every release needs an entry.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.1] - 2026-06-12
+
+### Fixed
+
+- Saving no longer fails with a codec timeout error on slower machines. The
+  codec worker timeout now scales with save size (60s base + 1s per MiB)
+  instead of the fixed 5 seconds that the quick selftest uses.
+
 ## [0.1.0] - 2026-06-11
 
 ### First Release

--- a/apps/goresave/pubspec.yaml
+++ b/apps/goresave/pubspec.yaml
@@ -1,7 +1,7 @@
 name: goresave
 description: "goresave: Gothic Remake Savegame-Editor"
 publish_to: "none"
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ^3.12.0

--- a/crates/goresave_g1r_codec_host/src/lib.rs
+++ b/crates/goresave_g1r_codec_host/src/lib.rs
@@ -31,6 +31,21 @@ const MAX_CODEC_COMPRESSED_OUTPUT_SIZE: usize = MAX_CODEC_UNCOMPRESSED_SIZE + 0x
 const MAX_RUNTIME_REPEAT_COUNT: usize = 100;
 const OODLE_COMPRESSOR_KRAKEN: i32 = 8;
 const RUNTIME_SELFTEST_WORKER_TIMEOUT: Duration = Duration::from_secs(5);
+// Work commands (compress/decompress and their _many variants) re-read and map
+// the full game executable per worker run and process real payloads, so their
+// timeout must absorb cold disk reads, antivirus scans, and slow CPUs that the
+// tiny selftest sample never hits.
+const RUNTIME_WORK_WORKER_BASE_TIMEOUT: Duration = Duration::from_secs(60);
+const RUNTIME_WORK_WORKER_MAX_TIMEOUT: Duration = Duration::from_secs(600);
+const RUNTIME_WORK_WORKER_SECS_PER_MIB: u64 = 1;
+
+fn runtime_work_worker_timeout(total_payload_bytes: usize) -> Duration {
+    let payload_mib = (total_payload_bytes as u64).div_ceil(1024 * 1024);
+    let scaled_secs = payload_mib
+        .saturating_mul(RUNTIME_WORK_WORKER_SECS_PER_MIB)
+        .saturating_add(RUNTIME_WORK_WORKER_BASE_TIMEOUT.as_secs());
+    Duration::from_secs(scaled_secs).min(RUNTIME_WORK_WORKER_MAX_TIMEOUT)
+}
 #[cfg(windows)]
 const RUNTIME_WORKER_JOB_MEMORY_LIMIT_BYTES: usize = 1024 * 1024 * 1024;
 #[cfg(windows)]
@@ -2037,7 +2052,7 @@ fn decompress_with_runtime_worker(
     };
     let mut report = run_runtime_selftest_worker_with_request(
         runtime_worker_path,
-        RUNTIME_SELFTEST_WORKER_TIMEOUT,
+        runtime_work_worker_timeout(request.input.len().saturating_add(request.expected_size)),
         &[],
         &worker_request,
     );
@@ -2111,9 +2126,14 @@ fn decompress_many_with_runtime_worker(
         compress_sample: None,
         compress_samples: Vec::new(),
     };
+    let total_payload_bytes = request.chunks.iter().fold(0usize, |total, chunk| {
+        total
+            .saturating_add(chunk.input.len())
+            .saturating_add(chunk.expected_size)
+    });
     let mut report = run_runtime_selftest_worker_with_request(
         runtime_worker_path,
-        RUNTIME_SELFTEST_WORKER_TIMEOUT,
+        runtime_work_worker_timeout(total_payload_bytes),
         &[],
         &worker_request,
     );
@@ -2211,7 +2231,7 @@ fn compress_with_runtime_worker(
     };
     let mut report = run_runtime_selftest_worker_with_request(
         runtime_worker_path,
-        RUNTIME_SELFTEST_WORKER_TIMEOUT,
+        runtime_work_worker_timeout(request.input.len()),
         &[],
         &worker_request,
     );
@@ -2288,9 +2308,12 @@ fn compress_many_with_runtime_worker(
         compress_sample: Some(first_sample),
         compress_samples: samples,
     };
+    let total_payload_bytes = request.chunks.iter().fold(0usize, |total, chunk| {
+        total.saturating_add(chunk.input.len())
+    });
     let mut report = run_runtime_selftest_worker_with_request(
         runtime_worker_path,
-        RUNTIME_SELFTEST_WORKER_TIMEOUT,
+        runtime_work_worker_timeout(total_payload_bytes),
         &[],
         &worker_request,
     );
@@ -3701,6 +3724,42 @@ mod runtime_worker_job_tests {
             info.process_memory_limit,
             RUNTIME_WORKER_JOB_MEMORY_LIMIT_BYTES
         );
+    }
+}
+
+#[cfg(test)]
+mod runtime_work_timeout_tests {
+    use super::*;
+
+    #[test]
+    fn work_timeout_starts_at_base_for_empty_input() {
+        assert_eq!(runtime_work_worker_timeout(0), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn work_timeout_scales_per_mebibyte_of_payload() {
+        assert_eq!(
+            runtime_work_worker_timeout(100 * 1024 * 1024),
+            Duration::from_secs(160)
+        );
+    }
+
+    #[test]
+    fn work_timeout_rounds_partial_mebibytes_up() {
+        assert_eq!(runtime_work_worker_timeout(1), Duration::from_secs(61));
+    }
+
+    #[test]
+    fn work_timeout_is_capped() {
+        assert_eq!(
+            runtime_work_worker_timeout(usize::MAX),
+            Duration::from_secs(600)
+        );
+    }
+
+    #[test]
+    fn work_timeout_always_exceeds_selftest_timeout() {
+        assert!(runtime_work_worker_timeout(0) > RUNTIME_SELFTEST_WORKER_TIMEOUT);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes save failures reported as `codec error: codec host unsupported_exe: compress_many worker failed runtime verification: runtime selftest worker timed out after 5000 ms`.

Work commands (`compress`, `decompress`, `compress_many`, `decompress_many`) shared the 5-second selftest timeout, but each worker run re-reads and maps the full game executable and processes real save payloads. On machines with cold disk caches, antivirus scans, or slower CPUs this exceeded 5 seconds and saving failed.

## Changes

- New scaled work timeout: 60s base + 1s per MiB of payload, capped at 600s (`runtime_work_worker_timeout`).
- All four work commands use the scaled timeout; payload size includes the expected decompressed output for decompress calls.
- The quick runtime selftest keeps its 5-second limit.
- Version bump to 0.1.1 with changelog entry.

## Testing

- 5 new unit tests for the timeout scaling (base, per-MiB scaling, rounding up, cap, exceeds selftest timeout), written test-first.
- Full `goresave_g1r_codec_host` suite passes (72 tests), `cargo fmt` and `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized timeout policy change in the codec host with unit tests; no auth or data-format changes, only longer waits before failing saves on slow systems.
> 
> **Overview**
> Fixes save failures where real **compress/decompress** work hit the codec host’s **5s** runtime worker limit (the same limit used for quick selftests).
> 
> **Codec host** now uses **`runtime_work_worker_timeout`**: **60s** base plus **1s per MiB** of payload (capped at **600s**) for **`compress`**, **`decompress`**, and their **`_many`** paths. Payload sizing includes expected decompressed size for decompress calls. **Runtime selftests** still use the **5s** timeout.
> 
> Release **0.1.1** with a changelog note; **five unit tests** cover base, scaling, rounding, cap, and that work timeouts exceed selftest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d8ef7379ba6601d9aa46a40452de215589fb4b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->