### PR TITLE
feat: editable difficulty editor (per-save + profile propagation)

### DIFF
--- a/apps/goresave/lib/features/editor/domain/editor_models.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_models.dart
@@ -165,6 +165,53 @@ class ProfileSummary {
   }
 }
 
+/// Maps a difficulty class short-name suffix to its UI label.
+String _difficultyLevelLabel(String? className) {
+  if (className == null) return '-';
+  if (className.endsWith('_Easy')) return 'Novice';
+  if (className.endsWith('_Standard')) return 'Gothic';
+  if (className.endsWith('_Hard')) return 'Hard';
+  if (className.endsWith('_Custom')) return 'Custom';
+  return className;
+}
+
+class DifficultySettings {
+  const DifficultySettings({
+    this.preset,
+    this.combat,
+    this.resources,
+    this.progression,
+    this.flowHelper,
+    this.permadeath,
+  });
+
+  factory DifficultySettings.fromJson(Map<String, Object?> json) {
+    return DifficultySettings(
+      preset: json['preset'] as String?,
+      combat: json['combat'] as String?,
+      resources: json['resources'] as String?,
+      progression: json['progression'] as String?,
+      flowHelper: json['flowHelper'] as bool?,
+      permadeath: json['permadeath'] as bool?,
+    );
+  }
+
+  static DifficultySettings? maybeFromJson(Object? json) =>
+      json is Map ? DifficultySettings.fromJson(json.cast<String, Object?>()) : null;
+
+  final String? preset;
+  final String? combat;
+  final String? resources;
+  final String? progression;
+  final bool? flowHelper;
+  final bool? permadeath;
+
+  String get presetLabel => _difficultyLevelLabel(preset);
+  String get combatLabel => _difficultyLevelLabel(combat);
+  String get resourcesLabel => _difficultyLevelLabel(resources);
+  String get progressionLabel => _difficultyLevelLabel(progression);
+}
+
 class SaveSlot {
   const SaveSlot({
     required this.path,
@@ -186,6 +233,7 @@ class SaveSlot {
     this.autoSave,
     this.persistentProfileId,
     this.screenshot,
+    this.difficulty,
   });
 
   factory SaveSlot.fromJson(Map<String, Object?> json) {
@@ -209,6 +257,7 @@ class SaveSlot {
       autoSave: json['autoSave'] as bool?,
       persistentProfileId: (json['persistentProfileId'] as num?)?.toInt(),
       screenshot: ScreenshotSummary.maybeFromJson(json['screenshot']),
+      difficulty: DifficultySettings.maybeFromJson(json['difficulty']),
     );
   }
 
@@ -231,6 +280,7 @@ class SaveSlot {
   final bool? autoSave;
   final int? persistentProfileId;
   final ScreenshotSummary? screenshot;
+  final DifficultySettings? difficulty;
 
   String get displayName {
     final name = playerSaveName ?? persistentPlayerSaveName;
@@ -261,6 +311,7 @@ class SaveInspection {
     this.autoSave,
     this.persistentProfileId,
     this.screenshot,
+    this.difficulty,
     this.privateStatus,
     this.privateDecoded = false,
     this.privateDecompressedSize,
@@ -310,6 +361,7 @@ class SaveInspection {
       autoSave: persistent?['autoSave'] as bool?,
       persistentProfileId: (persistent?['profileId'] as num?)?.toInt(),
       screenshot: ScreenshotSummary.maybeFromJson(json['screenshot']),
+      difficulty: DifficultySettings.maybeFromJson(json['difficulty']),
       privateStatus: privateStatus,
       privateDecoded:
           privateStatus == 'decoded' || privateStatus == 'decoded_preview',
@@ -358,6 +410,7 @@ class SaveInspection {
   final bool? autoSave;
   final int? persistentProfileId;
   final ScreenshotSummary? screenshot;
+  final DifficultySettings? difficulty;
   final String? privateStatus;
   final bool privateDecoded;
   final int? privateDecompressedSize;

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -667,6 +667,44 @@ class EditorNotifier extends StateNotifier<EditorState> {
       return false;
     }
 
+    // A difficulty edit (Difficulty card) and a typed "All data" edit that
+    // targets one of the difficulty properties are BOTH pending. write_difficulty
+    // runs AFTER write_save, so the Difficulty card would silently overwrite the
+    // typed value and both drafts would be cleared as "saved". The slot-internal
+    // duplicate-path guard above can't see this (it only compares typed edits to
+    // each other). Refuse loudly and keep BOTH pending sets so the user resolves
+    // it. Mirrors the codec-not-ready / unresolvable-profile abort-and-keep guards.
+    const difficultyPropertyNames = {
+      'm_difficultyPreset',
+      'm_customCombatSettings',
+      'm_customResourcesSettings',
+      'm_customProgressionSettings',
+      'm_PermanentDeath',
+      'm_PermaDeath',
+      'm_FakeSloppyCombos',
+    };
+    if (difficultyEdit != null) {
+      final typedTargetsDifficulty = allEdits.any((edit) {
+        if (edit['path'] != 'private.typed.setValue') return false;
+        final value = edit['value'];
+        if (value is! Map) return false;
+        final path = value['path'];
+        if (path is! List) return false;
+        return path.any(
+          (seg) => difficultyPropertyNames.contains(seg?.toString()),
+        );
+      });
+      if (typedTargetsDifficulty) {
+        state = state.copyWith(
+          error:
+              'Conflicting difficulty edits: you changed difficulty both in '
+              'the Difficulty card and via All data. Save or reset one of '
+              'them first.',
+        );
+        return false;
+      }
+    }
+
     // Propagation (alsoProfile/allSaves) binds to the EDITED SAVE's profile.
     // If that profile cannot be resolved (no persistentProfileId on the save,
     // or no matching profile in state.profiles), _buildDifficultyPayload would

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -805,9 +805,12 @@ class EditorNotifier extends StateNotifier<EditorState> {
       state = state.copyWith(
         inspection: SaveInspection.fromJson(data),
         clearPendingEdits: true,
-        // A fresh inspection re-seeds the Difficulty card from the stored
-        // value, so any prior draft is no longer dirty.
-        difficultyDirty: false,
+        // A slot switch must not carry a difficulty draft into a different
+        // save, so drop it. A same-save re-inspect (e.g. a confirmed rescan, or
+        // an incidental refresh after a hero/inventory save) must PRESERVE a
+        // dirty draft — the card re-seeds itself only when the save identity
+        // changes — so leave the flag untouched here.
+        difficultyDirty: switchingSlot ? false : null,
       );
       final backupSnapshot = await _loadBackups(path, seq);
       if (backupSnapshot == null) return;

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -667,6 +667,28 @@ class EditorNotifier extends StateNotifier<EditorState> {
       return false;
     }
 
+    // Propagation (alsoProfile/allSaves) binds to the EDITED SAVE's profile.
+    // If that profile cannot be resolved (no persistentProfileId on the save,
+    // or no matching profile in state.profiles), _buildDifficultyPayload would
+    // silently omit the profile target and never expand the all-saves set —
+    // dropping the propagation the user explicitly requested while the
+    // current-slot write still succeeds. Refuse loudly instead: abort the save
+    // and KEEP the pending difficulty so nothing is silently lost. Mirrors the
+    // codec-not-ready guard above (abort-and-keep). Uses the same resolution as
+    // state.editedSaveProfile (profile whose profileId == the selected save's
+    // persistentProfileId).
+    if (difficultyEdit != null &&
+        (difficultyEdit.alsoProfile || difficultyEdit.allSaves) &&
+        state.editedSaveProfile == null) {
+      state = state.copyWith(
+        error:
+            'Cannot propagate difficulty: the edited save\'s profile could '
+            'not be resolved. Save without "Also update the profile" / '
+            '"Apply to all saves of this profile", or reselect the save.',
+      );
+      return false;
+    }
+
     final difficultyPayload = difficultyEdit == null
         ? null
         : _buildDifficultyPayload(difficultyEdit);

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -294,16 +294,19 @@ class EditorNotifier extends StateNotifier<EditorState> {
     }
   }
 
-  /// Run a `write_save` request as a tracked load, then rescan on success.
-  /// Returns true only when the core accepted the write; a rejected write sets
-  /// `state.error` and returns false so callers can skip success-only follow-ups.
+  /// Run a write request (`write_save` by default) as a tracked load, then
+  /// rescan on success. Returns true only when the core accepted the write; a
+  /// rejected write sets `state.error` and returns false so callers can skip
+  /// success-only follow-ups. The post-success `refresh()` rescans saves AND
+  /// profiles, so difficulty writes targeting the profile are reflected too.
   Future<bool> _runWrite({
     required Map<String, Object?> payload,
     required String Function(Map<String, Object?> data) message,
+    String command = 'write_save',
   }) async {
     var ok = false;
     await _withLoading(() async {
-      final response = await _execute('write_save', payload: payload);
+      final response = await _execute(command, payload: payload);
       if (response['ok'] != true) {
         state = state.copyWith(error: _errorMessage(response));
         return;
@@ -314,6 +317,43 @@ class EditorNotifier extends StateNotifier<EditorState> {
       ok = true;
     });
     return ok;
+  }
+
+  /// Write a difficulty configuration to the given save files and, optionally,
+  /// the profile's `PersistentDataList.sav`. Dispatched through [_runWrite] so
+  /// the overlay shows, errors surface, and a successful write rescans saves +
+  /// profiles (so the sidebar difficulty badge and the card both update).
+  ///
+  /// The `binaryHost` codec host is attached exactly as the `write_save` path
+  /// does (via [_codecPayload]) — the private-payload edit on save targets
+  /// requires the codec host, and the core errors without it.
+  Future<bool> writeDifficulty({
+    required Map<String, Object?> difficulty,
+    required List<String> savePaths,
+    ({String path, int profileId})? profile,
+  }) async {
+    final targets = <String, Object?>{
+      'saves': savePaths,
+      if (profile != null)
+        'profile': {'path': profile.path, 'profileId': profile.profileId},
+    };
+    final n = savePaths.length + (profile != null ? 1 : 0);
+    return _runWrite(
+      command: 'write_difficulty',
+      payload: {
+        'difficulty': difficulty,
+        'targets': targets,
+        'backup': true,
+        ..._codecPayload(),
+      },
+      // The core returns { targetsWritten, paths } (no backup-path fields), so
+      // report the count directly rather than via _backupMessage.
+      message: (data) {
+        final written = (data['targetsWritten'] as num?)?.toInt() ?? n;
+        return 'Difficulty written to $written '
+            'target${written == 1 ? '' : 's'} (backup created)';
+      },
+    );
   }
 
   /// Serializes all core calls. The native layer runs each command in its own

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -69,7 +69,7 @@ class EditorState {
     this.codecError,
     this.lastWriteMessage,
     this.pendingEdits = const {},
-    this.difficultyDirty = false,
+    this.pendingDifficulty,
   });
 
   final String saveDir;
@@ -96,18 +96,21 @@ class EditorState {
   /// different save, or selection change.
   final Map<String, PendingSaveEdit> pendingEdits;
 
-  /// True when the Difficulty card holds an unsaved draft that differs from the
-  /// selected save's stored difficulty. The Difficulty card manages its draft in
-  /// widget-local state (it is not part of the [pendingEdits] registry, since a
-  /// difficulty write is its own multi-target command), so this flag is the
-  /// signal the profile-switch guard uses to refuse switching mid-edit. Cleared
-  /// on a successful difficulty write and whenever a new inspection lands.
-  final bool difficultyDirty;
+  /// The pending (unsaved) difficulty edit, or null when difficulty is at the
+  /// selected save's stored value with no propagation requested. It is held as
+  /// a typed field rather than in [pendingEdits] because a difficulty write is
+  /// its own multi-target `write_difficulty` command (not a `write_save` edit
+  /// object). It participates in [hasUnsavedEdits], [pendingEditCount] (so the
+  /// global "Unsaved (N)" badge counts it and Save enables), the global
+  /// [saveAllPending], and the global Reset. Cleared on a save switch, refresh,
+  /// and whenever the user reverts the controls back to the stored value.
+  final PendingDifficulty? pendingDifficulty;
 
   /// True when there are any unsaved edits anywhere — pending registry edits or
-  /// a dirty difficulty draft. The profile-switch guard blocks on this so a
-  /// difficulty draft is protected exactly like a pending field edit.
-  bool get hasUnsavedEdits => pendingEdits.isNotEmpty || difficultyDirty;
+  /// a pending difficulty edit. The profile-switch guard blocks on this so a
+  /// difficulty edit is protected exactly like a pending field edit.
+  bool get hasUnsavedEdits =>
+      pendingEdits.isNotEmpty || pendingDifficulty != null;
 
   /// True once the user ran a successful codec round-trip verification this
   /// session for an executable the probe could not auto-trust (a pattern-
@@ -133,9 +136,12 @@ class EditorState {
   final String? codecError;
   final String? lastWriteMessage;
 
-  /// Total number of edit objects across all pending keys.
+  /// Total number of edit objects across all pending keys, plus the pending
+  /// difficulty edit (counted as one) so the global "Unsaved (N)" badge and the
+  /// Save/Reset buttons reflect a pending difficulty just like any field edit.
   int get pendingEditCount =>
-      pendingEdits.values.fold(0, (n, e) => n + e.edits.length);
+      pendingEdits.values.fold(0, (n, e) => n + e.edits.length) +
+      (pendingDifficulty != null ? 1 : 0);
 
   SaveSlot? get selectedSave {
     for (final save in saves) {
@@ -183,6 +189,21 @@ class EditorState {
     return null;
   }
 
+  /// The profile of the SAVE currently under edit (the inspected/selected save),
+  /// resolved from its `persistentProfileId`. This is what difficulty
+  /// propagation must bind to — distinct from [activeProfile], which describes
+  /// the sidebar's effective filter profile and can differ from the edited
+  /// save's own profile. Null when the selected save has no profile id or no
+  /// matching profile exists (propagation is then disabled).
+  ProfileSummary? get editedSaveProfile {
+    final profileId = selectedSave?.persistentProfileId;
+    if (profileId == null) return null;
+    for (final profile in profiles) {
+      if (profile.profileId == profileId) return profile;
+    }
+    return null;
+  }
+
   EditorState copyWith({
     String? saveDir,
     String? codecHostPath,
@@ -202,7 +223,7 @@ class EditorState {
     String? codecError,
     String? lastWriteMessage,
     Map<String, PendingSaveEdit>? pendingEdits,
-    bool? difficultyDirty,
+    Object? pendingDifficulty = _unchanged,
     bool clearInspection = false,
     bool clearBackups = false,
     bool clearError = false,
@@ -242,7 +263,15 @@ class EditorState {
       pendingEdits: clearPendingEdits
           ? const {}
           : pendingEdits ?? this.pendingEdits,
-      difficultyDirty: difficultyDirty ?? this.difficultyDirty,
+      // A pending difficulty edit is cleared on the same events that clear the
+      // pending-edit registry (slot switch, refresh, fresh inspection landing),
+      // so honour clearPendingEdits for it too. Otherwise apply the explicit
+      // value (passing null clears it; the _unchanged sentinel keeps it).
+      pendingDifficulty: clearPendingEdits
+          ? null
+          : (identical(pendingDifficulty, _unchanged)
+                ? this.pendingDifficulty
+                : pendingDifficulty as PendingDifficulty?),
     );
   }
 }
@@ -310,11 +339,13 @@ class EditorNotifier extends StateNotifier<EditorState> {
     }
   }
 
-  /// Run a write request (`write_save` by default) as a tracked load, then
-  /// rescan on success. Returns true only when the core accepted the write; a
-  /// rejected write sets `state.error` and returns false so callers can skip
-  /// success-only follow-ups. The post-success `refresh()` rescans saves AND
-  /// profiles, so difficulty writes targeting the profile are reflected too.
+  /// Run a single write request (`write_save` by default) as a tracked load,
+  /// then rescan on success. Returns true only when the core accepted the
+  /// write; a rejected write sets `state.error` and returns false so callers
+  /// can skip success-only follow-ups. The post-success `refresh()` rescans
+  /// saves AND profiles. Used by [restoreBackup] and [applyMemoryEventEdit];
+  /// the global [saveAllPending] orchestrates its writes inline so it can do a
+  /// slot write_save and a write_difficulty with a single trailing refresh.
   Future<bool> _runWrite({
     required Map<String, Object?> payload,
     required String Function(Map<String, Object?> data) message,
@@ -335,48 +366,67 @@ class EditorNotifier extends StateNotifier<EditorState> {
     return ok;
   }
 
-  /// Write a difficulty configuration to the given save files and, optionally,
-  /// the profile's `PersistentDataList.sav`. Dispatched through [_runWrite] so
-  /// the overlay shows, errors surface, and a successful write rescans saves +
-  /// profiles (so the sidebar difficulty badge and the card both update).
+  /// Resolve the `write_difficulty` targets for [edit] against the current
+  /// state, binding propagation to the EDITED SAVE's profile (not the sidebar's
+  /// filter profile). Returns the assembled command payload, or null when there
+  /// is no selected save to target.
+  ///
+  /// - The current save is always a target.
+  /// - `allSaves`: every save whose `persistentProfileId` matches the edited
+  ///   save's profile id (current save always included).
+  /// - `alsoProfile`: the profile's `PersistentDataList.sav`
+  ///   (`dirname(currentSavePath)/PersistentDataList.sav`) with that profile id.
   ///
   /// The `binaryHost` codec host is attached exactly as the `write_save` path
   /// does (via [_codecPayload]) — the private-payload edit on save targets
   /// requires the codec host, and the core errors without it.
-  Future<bool> writeDifficulty({
-    required Map<String, Object?> difficulty,
-    required List<String> savePaths,
-    ({String path, int profileId})? profile,
-  }) async {
+  Map<String, Object?>? _buildDifficultyPayload(PendingDifficulty edit) {
+    final path = state.selectedPath;
+    if (path == null) return null;
+
+    // The profile of the SAVE under edit (not state.activeProfile, which is the
+    // sidebar's effective filter profile and can differ). Resolve it from the
+    // selected save's persistentProfileId.
+    final editedProfileId = state.selectedSave?.persistentProfileId;
+    ProfileSummary? editedProfile;
+    if (editedProfileId != null) {
+      for (final profile in state.profiles) {
+        if (profile.profileId == editedProfileId) {
+          editedProfile = profile;
+          break;
+        }
+      }
+    }
+
+    final savePaths = <String>[path];
+    if (edit.allSaves && editedProfile != null) {
+      savePaths
+        ..clear()
+        ..addAll(
+          state.saves
+              .where((s) => s.persistentProfileId == editedProfile!.profileId)
+              .map((s) => s.path),
+        );
+      // The current save is always a target, even if its persistentProfileId is
+      // null or mismatched.
+      if (!savePaths.contains(path)) savePaths.add(path);
+    }
+
     final targets = <String, Object?>{
       'saves': savePaths,
-      if (profile != null)
-        'profile': {'path': profile.path, 'profileId': profile.profileId},
+      if (edit.alsoProfile && editedProfile != null)
+        'profile': {
+          'path': p.join(p.dirname(path), 'PersistentDataList.sav'),
+          'profileId': editedProfile.profileId,
+        },
     };
-    final n = savePaths.length + (profile != null ? 1 : 0);
-    final ok = await _runWrite(
-      command: 'write_difficulty',
-      payload: {
-        'difficulty': difficulty,
-        'targets': targets,
-        'backup': true,
-        ..._codecPayload(),
-      },
-      // The core returns { targetsWritten, paths } (no backup-path fields), so
-      // report the count directly rather than via _backupMessage.
-      message: (data) {
-        final written = (data['targetsWritten'] as num?)?.toInt() ?? n;
-        if (written == 0) return 'No difficulty changes to write';
-        return 'Difficulty written to $written '
-            'target${written == 1 ? '' : 's'} (backup created)';
-      },
-    );
-    // On success the draft now matches what was written. The post-success
-    // refresh()/_inspect already clears difficultyDirty when the fresh
-    // inspection lands, but clear it explicitly too so the flag drops even if
-    // that re-inspect were to fail (the write itself succeeded on disk).
-    if (ok) setDifficultyDirty(false);
-    return ok;
+
+    return {
+      'difficulty': edit.difficulty,
+      'targets': targets,
+      'backup': true,
+      ..._codecPayload(),
+    };
   }
 
   /// Serializes all core calls. The native layer runs each command in its own
@@ -502,25 +552,37 @@ class EditorNotifier extends StateNotifier<EditorState> {
     state = state.copyWith(pendingEdits: updated);
   }
 
-  /// Set whether the Difficulty card holds an unsaved draft. Called by the card
-  /// as its draft becomes dirty/clean and on save/reset. Drives the
-  /// profile-switch guard via [EditorState.hasUnsavedEdits].
-  void setDifficultyDirty(bool dirty) {
-    if (state.difficultyDirty == dirty) return;
-    state = state.copyWith(difficultyDirty: dirty);
+  /// Upsert the pending difficulty edit. Called by the Difficulty card as its
+  /// controls change (or a propagation box is ticked). Participates in
+  /// [EditorState.hasUnsavedEdits], [EditorState.pendingEditCount] (so the
+  /// global Save/Reset reflect it), and is written by [saveAllPending].
+  void setPendingDifficulty(PendingDifficulty edit) {
+    state = state.copyWith(pendingDifficulty: edit);
   }
 
-  /// Clear all pending edits.
+  /// Clear the pending difficulty edit (e.g. the card reverts to the stored
+  /// value with no propagation requested).
+  void clearPendingDifficulty() {
+    if (state.pendingDifficulty == null) return;
+    state = state.copyWith(pendingDifficulty: null);
+  }
+
+  /// Clear all pending edits (registry and the pending difficulty edit).
   void clearAllPendingEdits() {
-    if (state.pendingEdits.isEmpty) return;
+    if (state.pendingEdits.isEmpty && state.pendingDifficulty == null) return;
     state = state.copyWith(clearPendingEdits: true);
   }
 
-  /// Save all pending edits in one write_save call. No-op when empty.
+  /// Save all pending edits: the slot edits in one `write_save` and the pending
+  /// difficulty edit in one `write_difficulty`. When both exist, both core
+  /// writes run sequentially against the current save's `.sav` (each re-reads
+  /// the file, so order is safe — slot write_save first, then write_difficulty),
+  /// then the state refreshes ONCE at the end. No-op when nothing is pending.
   /// Re-entry-safe: bails immediately if a load is already in flight.
   /// Returns true on success (or when nothing to save), false on failure.
   Future<bool> saveAllPending() async {
-    if (state.pendingEdits.isEmpty) return true;
+    final difficultyEdit = state.pendingDifficulty;
+    if (state.pendingEdits.isEmpty && difficultyEdit == null) return true;
     if (state.isLoading) return false;
     final savePath = state.selectedPath;
     if (savePath == null) return false;
@@ -583,29 +645,91 @@ class EditorNotifier extends StateNotifier<EditorState> {
       return false;
     }
 
+    // Difficulty rewrites the private payload of each target save, so it needs
+    // a compress-ready codec — surface the same error the other private writes
+    // use rather than silently skipping it.
+    if (difficultyEdit != null && !state.codecCompressReady) {
+      state = state.copyWith(
+        error:
+            'Saving difficulty needs a verified G1R codec host '
+            '(it rewrites the private payload of each targeted save).',
+      );
+      return false;
+    }
+
+    final difficultyPayload = difficultyEdit == null
+        ? null
+        : _buildDifficultyPayload(difficultyEdit);
+
     final n = allEdits.length;
-    final ok = await _runWrite(
-      payload: {
-        'path': savePath,
-        'backup': true,
-        if (syncPersistent) 'syncPersistentDataList': true,
-        'edits': allEdits,
-        ..._codecPayload(),
-      },
-      message: (data) => _backupMessage(
-        '$n change${n == 1 ? '' : 's'} saved with backup',
-        data,
-      ),
-    );
+    var ok = false;
+    await _withLoading(() async {
+      final messages = <String>[];
+
+      // 1) Slot edits (write_save), if any.
+      if (allEdits.isNotEmpty) {
+        final response = await _execute(
+          'write_save',
+          payload: {
+            'path': savePath,
+            'backup': true,
+            if (syncPersistent) 'syncPersistentDataList': true,
+            'edits': allEdits,
+            ..._codecPayload(),
+          },
+        );
+        if (response['ok'] != true) {
+          state = state.copyWith(error: _errorMessage(response));
+          return;
+        }
+        final data = (response['data'] as Map).cast<String, Object?>();
+        messages.add(
+          _backupMessage('$n change${n == 1 ? '' : 's'} saved with backup', data),
+        );
+      }
+
+      // 2) Difficulty (write_difficulty), if pending. Each write re-reads the
+      // file, so running it after the slot write is safe.
+      if (difficultyPayload != null) {
+        final response = await _execute(
+          'write_difficulty',
+          payload: difficultyPayload,
+        );
+        if (response['ok'] != true) {
+          state = state.copyWith(error: _errorMessage(response));
+          return;
+        }
+        final data = (response['data'] as Map).cast<String, Object?>();
+        final targetsList = (difficultyPayload['targets'] as Map);
+        final saveTargets = (targetsList['saves'] as List?)?.length ?? 1;
+        final profileTarget = targetsList.containsKey('profile') ? 1 : 0;
+        final written =
+            (data['targetsWritten'] as num?)?.toInt() ??
+            (saveTargets + profileTarget);
+        messages.add(
+          written == 0
+              ? 'No difficulty changes to write'
+              : 'Difficulty written to $written '
+                    'target${written == 1 ? '' : 's'} (backup created)',
+        );
+      }
+
+      // Both writes accepted — report and refresh ONCE.
+      state = state.copyWith(lastWriteMessage: messages.join('; '));
+      await refresh();
+      ok = true;
+    });
+
     if (ok) {
-      // Clear exactly the snapshot keys. The _runWrite → refresh() call has
-      // already triggered a central clearAllPendingEdits() (refresh always
-      // clears all pending), so this is a belt-and-suspenders guard for the
-      // case where a mid-write keystroke registered a new key after the
-      // snapshot was taken but before refresh ran.
+      // Clear exactly the snapshot keys plus the difficulty edit. The
+      // _withLoading → refresh() call has already triggered a central
+      // clearPendingEdits (refresh always clears all pending), so this is a
+      // belt-and-suspenders guard for the case where a mid-write keystroke
+      // registered a new key after the snapshot was taken but before refresh ran.
       for (final key in snapshotKeys) {
         clearPendingEdit(key);
       }
+      clearPendingDifficulty();
     }
     return ok;
   }
@@ -733,9 +857,6 @@ class EditorNotifier extends StateNotifier<EditorState> {
         clearInspection: selectedPath == null,
         clearBackups: selectedPath == null,
         clearPendingEdits: selectedPath == null,
-        // Nothing selected → no card → no draft. When a save remains selected,
-        // the follow-up _inspect clears this when the fresh inspection lands.
-        difficultyDirty: selectedPath == null ? false : null,
       );
       if (selectedPath != null) {
         await _inspect(selectedPath);
@@ -774,10 +895,6 @@ class EditorNotifier extends StateNotifier<EditorState> {
       // fields still show the drafts and the registry must keep matching
       // them so the user can retry the save.
       clearPendingEdits: switchingSlot,
-      // Same rationale for the difficulty draft: a slot switch must not carry
-      // a draft into a different save. A same-save re-inspect clears it when
-      // the fresh inspection lands (below).
-      difficultyDirty: switchingSlot ? false : null,
     );
     try {
       final payload = <String, Object?>{
@@ -805,13 +922,11 @@ class EditorNotifier extends StateNotifier<EditorState> {
       // discarded in the same state change — never earlier (see above).
       state = state.copyWith(
         inspection: SaveInspection.fromJson(data),
+        // The fresh inspection re-seeds every editor, so discard all pending
+        // edits — including any pending difficulty edit, which clearPendingEdits
+        // also clears. The card re-seeds its controls from the new inspection's
+        // stored difficulty.
         clearPendingEdits: true,
-        // A slot switch must not carry a difficulty draft into a different
-        // save, so drop it. A same-save re-inspect (e.g. a confirmed rescan, or
-        // an incidental refresh after a hero/inventory save) must PRESERVE a
-        // dirty draft — the card re-seeds itself only when the save identity
-        // changes — so leave the flag untouched here.
-        difficultyDirty: switchingSlot ? false : null,
       );
       final backupSnapshot = await _loadBackups(path, seq);
       if (backupSnapshot == null) return;

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -366,6 +366,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
       // report the count directly rather than via _backupMessage.
       message: (data) {
         final written = (data['targetsWritten'] as num?)?.toInt() ?? n;
+        if (written == 0) return 'No difficulty changes to write';
         return 'Difficulty written to $written '
             'target${written == 1 ? '' : 's'} (backup created)';
       },

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -1344,7 +1344,11 @@ class EditorNotifier extends StateNotifier<EditorState> {
       );
       return false;
     }
-    if (state.pendingEdits.isNotEmpty) {
+    // Guard on hasUnsavedEdits (pendingEdits OR a pending difficulty), matching
+    // selectProfile/refresh: removing or duplicating a memory event writes the
+    // file immediately and its success path re-seeds the editors, which would
+    // silently discard a pending difficulty edit just as it would pending edits.
+    if (state.hasUnsavedEdits) {
       state = state.copyWith(
         error:
             'Save or reset your unsaved changes first — removing or '

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -412,11 +412,21 @@ class EditorNotifier extends StateNotifier<EditorState> {
       if (!savePaths.contains(path)) savePaths.add(path);
     }
 
+    // The save `path`s here carry the on-disk style of the save folder, which
+    // is Windows-style for these saves even when the host (e.g. Linux CI) is
+    // POSIX. `package:path`'s top-level functions use the HOST style, so on a
+    // POSIX host `p.dirname('C:\\...\\G1R-001.sav')` collapses to '.'. Pick a
+    // Context matching the SAVE path's style so dirname/join stay correct on any
+    // host. Treat a backslash or an `X:` drive prefix as Windows-style.
+    final isWindowsStyle =
+        path.contains('\\') || RegExp(r'^[A-Za-z]:').hasMatch(path);
+    final ctx = isWindowsStyle ? p.Context(style: p.Style.windows) : p.posix;
+
     final targets = <String, Object?>{
       'saves': savePaths,
       if (edit.alsoProfile && editedProfile != null)
         'profile': {
-          'path': p.join(p.dirname(path), 'PersistentDataList.sav'),
+          'path': ctx.join(ctx.dirname(path), 'PersistentDataList.sav'),
           'profileId': editedProfile.profileId,
         },
     };
@@ -703,30 +713,41 @@ class EditorNotifier extends StateNotifier<EditorState> {
       // 2) Difficulty (write_difficulty), if pending. Each write re-reads the
       // file, so running it after the slot write is safe.
       if (difficultyPayload != null) {
-        final response = await _execute(
-          'write_difficulty',
-          payload: difficultyPayload,
-        );
-        if (response['ok'] != true) {
-          // The slot edits are already committed to disk, but the difficulty
-          // write failed. Record the error and fall through to refresh +
-          // converge: we must NOT keep the committed slot edits pending.
-          difficultyError = _errorMessage(response);
-        } else {
-          difficultyCommitted = true;
-          final data = (response['data'] as Map).cast<String, Object?>();
-          final targetsList = (difficultyPayload['targets'] as Map);
-          final saveTargets = (targetsList['saves'] as List?)?.length ?? 1;
-          final profileTarget = targetsList.containsKey('profile') ? 1 : 0;
-          final written =
-              (data['targetsWritten'] as num?)?.toInt() ??
-              (saveTargets + profileTarget);
-          messages.add(
-            written == 0
-                ? 'No difficulty changes to write'
-                : 'Difficulty written to $written '
-                      'target${written == 1 ? '' : 's'} (backup created)',
+        try {
+          final response = await _execute(
+            'write_difficulty',
+            payload: difficultyPayload,
           );
+          if (response['ok'] != true) {
+            // The slot edits are already committed to disk, but the difficulty
+            // write failed. Record the error and fall through to refresh +
+            // converge: we must NOT keep the committed slot edits pending.
+            difficultyError = _errorMessage(response);
+          } else {
+            difficultyCommitted = true;
+            final data = (response['data'] as Map).cast<String, Object?>();
+            final targetsList = (difficultyPayload['targets'] as Map);
+            final saveTargets = (targetsList['saves'] as List?)?.length ?? 1;
+            final profileTarget = targetsList.containsKey('profile') ? 1 : 0;
+            final written =
+                (data['targetsWritten'] as num?)?.toInt() ??
+                (saveTargets + profileTarget);
+            messages.add(
+              written == 0
+                  ? 'No difficulty changes to write'
+                  : 'Difficulty written to $written '
+                        'target${written == 1 ? '' : 's'} (backup created)',
+            );
+          }
+        } catch (error) {
+          // A THROWN difficulty dispatch (e.g. malformed native JSON from the
+          // core) must be treated as a difficulty failure for convergence, not
+          // swallowed by _withLoading's generic catch — otherwise difficultyError
+          // stays null and the convergence branch would clearPendingDifficulty(),
+          // silently discarding an edit that never landed on disk. Setting
+          // difficultyError (with difficultyCommitted false) routes us to the
+          // "keep pendingDifficulty + surface error" branch.
+          difficultyError = 'Unexpected error: $error';
         }
       }
 

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -662,6 +662,14 @@ class EditorNotifier extends StateNotifier<EditorState> {
         : _buildDifficultyPayload(difficultyEdit);
 
     final n = allEdits.length;
+    // Outcome tracking. The two core commands write the same .sav independently,
+    // so there is no atomic cross-command rollback: if write_save commits but
+    // write_difficulty then fails, the slot bytes are ALREADY on disk. We must
+    // therefore converge editor state with disk (no divergence) rather than
+    // pretend nothing happened — see the convergence block after the writes.
+    var slotEditsCommitted = false; // write_save succeeded (or no slot edits)
+    var difficultyCommitted = false; // write_difficulty succeeded
+    String? difficultyError; // set when write_difficulty failed after a slot commit
     var ok = false;
     await _withLoading(() async {
       final messages = <String>[];
@@ -679,6 +687,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
           },
         );
         if (response['ok'] != true) {
+          // write_save failed: nothing committed. Keep ALL pending edits.
           state = state.copyWith(error: _errorMessage(response));
           return;
         }
@@ -687,6 +696,9 @@ class EditorNotifier extends StateNotifier<EditorState> {
           _backupMessage('$n change${n == 1 ? '' : 's'} saved with backup', data),
         );
       }
+      // Either there were no slot edits, or write_save succeeded — the slot
+      // edits in the snapshot are now on disk.
+      slotEditsCommitted = true;
 
       // 2) Difficulty (write_difficulty), if pending. Each write re-reads the
       // file, so running it after the slot write is safe.
@@ -696,40 +708,73 @@ class EditorNotifier extends StateNotifier<EditorState> {
           payload: difficultyPayload,
         );
         if (response['ok'] != true) {
-          state = state.copyWith(error: _errorMessage(response));
-          return;
+          // The slot edits are already committed to disk, but the difficulty
+          // write failed. Record the error and fall through to refresh +
+          // converge: we must NOT keep the committed slot edits pending.
+          difficultyError = _errorMessage(response);
+        } else {
+          difficultyCommitted = true;
+          final data = (response['data'] as Map).cast<String, Object?>();
+          final targetsList = (difficultyPayload['targets'] as Map);
+          final saveTargets = (targetsList['saves'] as List?)?.length ?? 1;
+          final profileTarget = targetsList.containsKey('profile') ? 1 : 0;
+          final written =
+              (data['targetsWritten'] as num?)?.toInt() ??
+              (saveTargets + profileTarget);
+          messages.add(
+            written == 0
+                ? 'No difficulty changes to write'
+                : 'Difficulty written to $written '
+                      'target${written == 1 ? '' : 's'} (backup created)',
+          );
         }
-        final data = (response['data'] as Map).cast<String, Object?>();
-        final targetsList = (difficultyPayload['targets'] as Map);
-        final saveTargets = (targetsList['saves'] as List?)?.length ?? 1;
-        final profileTarget = targetsList.containsKey('profile') ? 1 : 0;
-        final written =
-            (data['targetsWritten'] as num?)?.toInt() ??
-            (saveTargets + profileTarget);
-        messages.add(
-          written == 0
-              ? 'No difficulty changes to write'
-              : 'Difficulty written to $written '
-                    'target${written == 1 ? '' : 's'} (backup created)',
-        );
       }
 
-      // Both writes accepted — report and refresh ONCE.
-      state = state.copyWith(lastWriteMessage: messages.join('; '));
+      // Report the slot/difficulty messages that did land, then refresh ONCE so
+      // the re-inspect reflects exactly what is on disk. The error (if any) is
+      // re-applied after refresh, since refresh clears it.
+      if (messages.isNotEmpty) {
+        state = state.copyWith(lastWriteMessage: messages.join('; '));
+      }
       await refresh();
-      ok = true;
+      // Overall success only when nothing failed.
+      ok = difficultyError == null;
     });
 
-    if (ok) {
-      // Clear exactly the snapshot keys plus the difficulty edit. The
-      // _withLoading → refresh() call has already triggered a central
-      // clearPendingEdits (refresh always clears all pending), so this is a
-      // belt-and-suspenders guard for the case where a mid-write keystroke
-      // registered a new key after the snapshot was taken but before refresh ran.
+    // Converge editor state with disk. After this returns, the pending set
+    // reflects exactly what is NOT yet on disk.
+    if (slotEditsCommitted) {
+      // The snapshot slot edits ARE on disk now — clear them regardless of the
+      // difficulty outcome. Leaving them pending is the divergence bug (the
+      // editor would still think on-disk changes are unsaved, and a retry would
+      // double-apply). refresh()'s _inspect already clears all pending on a
+      // successful re-inspect, but a failed re-inspect keeps them — so clear the
+      // committed keys explicitly here to guarantee convergence either way.
       for (final key in snapshotKeys) {
         clearPendingEdit(key);
       }
-      clearPendingDifficulty();
+      if (difficultyCommitted) {
+        // Difficulty is on disk too — nothing left pending for it.
+        clearPendingDifficulty();
+      } else if (difficultyError != null) {
+        // Slot edits landed but difficulty did NOT. Keep ONLY the difficulty
+        // edit pending so the user can retry just the difficulty, and surface a
+        // clear, honest error. Re-assert the pending difficulty in case the
+        // post-write refresh re-seeded/cleared it.
+        if (difficultyEdit != null) {
+          state = state.copyWith(pendingDifficulty: difficultyEdit);
+        }
+        // Only claim the slot changes were saved when there actually were any —
+        // a difficulty-only save that fails has nothing committed to report.
+        state = state.copyWith(
+          error: allEdits.isEmpty
+              ? 'Difficulty failed: $difficultyError'
+              : 'Slot changes saved, but difficulty failed: $difficultyError',
+        );
+      } else {
+        // No difficulty edit was pending — slot-only save. Nothing else to do.
+        clearPendingDifficulty();
+      }
     }
     return ok;
   }

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -69,6 +69,7 @@ class EditorState {
     this.codecError,
     this.lastWriteMessage,
     this.pendingEdits = const {},
+    this.difficultyDirty = false,
   });
 
   final String saveDir;
@@ -94,6 +95,19 @@ class EditorState {
   /// 'inventory', 'typed:&lt;joined path&gt;'). Cleared on save, refresh to a
   /// different save, or selection change.
   final Map<String, PendingSaveEdit> pendingEdits;
+
+  /// True when the Difficulty card holds an unsaved draft that differs from the
+  /// selected save's stored difficulty. The Difficulty card manages its draft in
+  /// widget-local state (it is not part of the [pendingEdits] registry, since a
+  /// difficulty write is its own multi-target command), so this flag is the
+  /// signal the profile-switch guard uses to refuse switching mid-edit. Cleared
+  /// on a successful difficulty write and whenever a new inspection lands.
+  final bool difficultyDirty;
+
+  /// True when there are any unsaved edits anywhere — pending registry edits or
+  /// a dirty difficulty draft. The profile-switch guard blocks on this so a
+  /// difficulty draft is protected exactly like a pending field edit.
+  bool get hasUnsavedEdits => pendingEdits.isNotEmpty || difficultyDirty;
 
   /// True once the user ran a successful codec round-trip verification this
   /// session for an executable the probe could not auto-trust (a pattern-
@@ -188,6 +202,7 @@ class EditorState {
     String? codecError,
     String? lastWriteMessage,
     Map<String, PendingSaveEdit>? pendingEdits,
+    bool? difficultyDirty,
     bool clearInspection = false,
     bool clearBackups = false,
     bool clearError = false,
@@ -227,6 +242,7 @@ class EditorState {
       pendingEdits: clearPendingEdits
           ? const {}
           : pendingEdits ?? this.pendingEdits,
+      difficultyDirty: difficultyDirty ?? this.difficultyDirty,
     );
   }
 }
@@ -338,7 +354,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
         'profile': {'path': profile.path, 'profileId': profile.profileId},
     };
     final n = savePaths.length + (profile != null ? 1 : 0);
-    return _runWrite(
+    final ok = await _runWrite(
       command: 'write_difficulty',
       payload: {
         'difficulty': difficulty,
@@ -354,6 +370,12 @@ class EditorNotifier extends StateNotifier<EditorState> {
             'target${written == 1 ? '' : 's'} (backup created)';
       },
     );
+    // On success the draft now matches what was written. The post-success
+    // refresh()/_inspect already clears difficultyDirty when the fresh
+    // inspection lands, but clear it explicitly too so the flag drops even if
+    // that re-inspect were to fail (the write itself succeeded on disk).
+    if (ok) setDifficultyDirty(false);
+    return ok;
   }
 
   /// Serializes all core calls. The native layer runs each command in its own
@@ -392,7 +414,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
   /// visible save is selected (triggering [_inspect]); if there are none,
   /// the selection is cleared.
   Future<void> selectProfile(int? profileId) async {
-    if (state.pendingEdits.isNotEmpty) {
+    if (state.hasUnsavedEdits) {
       state = state.copyWith(
         error:
             'Save or reset your unsaved changes first — switching profiles '
@@ -477,6 +499,14 @@ class EditorNotifier extends StateNotifier<EditorState> {
     final updated = Map<String, PendingSaveEdit>.from(state.pendingEdits);
     updated.remove(key);
     state = state.copyWith(pendingEdits: updated);
+  }
+
+  /// Set whether the Difficulty card holds an unsaved draft. Called by the card
+  /// as its draft becomes dirty/clean and on save/reset. Drives the
+  /// profile-switch guard via [EditorState.hasUnsavedEdits].
+  void setDifficultyDirty(bool dirty) {
+    if (state.difficultyDirty == dirty) return;
+    state = state.copyWith(difficultyDirty: dirty);
   }
 
   /// Clear all pending edits.
@@ -702,6 +732,9 @@ class EditorNotifier extends StateNotifier<EditorState> {
         clearInspection: selectedPath == null,
         clearBackups: selectedPath == null,
         clearPendingEdits: selectedPath == null,
+        // Nothing selected → no card → no draft. When a save remains selected,
+        // the follow-up _inspect clears this when the fresh inspection lands.
+        difficultyDirty: selectedPath == null ? false : null,
       );
       if (selectedPath != null) {
         await _inspect(selectedPath);
@@ -740,6 +773,10 @@ class EditorNotifier extends StateNotifier<EditorState> {
       // fields still show the drafts and the registry must keep matching
       // them so the user can retry the save.
       clearPendingEdits: switchingSlot,
+      // Same rationale for the difficulty draft: a slot switch must not carry
+      // a draft into a different save. A same-save re-inspect clears it when
+      // the fresh inspection lands (below).
+      difficultyDirty: switchingSlot ? false : null,
     );
     try {
       final payload = <String, Object?>{
@@ -768,6 +805,9 @@ class EditorNotifier extends StateNotifier<EditorState> {
       state = state.copyWith(
         inspection: SaveInspection.fromJson(data),
         clearPendingEdits: true,
+        // A fresh inspection re-seeds the Difficulty card from the stored
+        // value, so any prior draft is no longer dirty.
+        difficultyDirty: false,
       );
       final backupSnapshot = await _loadBackups(path, seq);
       if (backupSnapshot == null) return;

--- a/apps/goresave/lib/features/editor/domain/pending_edits.dart
+++ b/apps/goresave/lib/features/editor/domain/pending_edits.dart
@@ -9,3 +9,30 @@ class PendingSaveEdit {
   final List<Map<String, Object?>> edits;
   final bool syncPersistentDataList;
 }
+
+/// A pending (unsaved) difficulty edit. Unlike [PendingSaveEdit], difficulty is
+/// not a `write_save` edit object — it is its own multi-target
+/// `write_difficulty` command (current save, optionally the profile's
+/// `PersistentDataList.sav`, optionally every save of the profile). It is held
+/// as a typed field on `EditorState` and saved as part of the global
+/// `saveAllPending` flow.
+///
+/// The `difficulty` map is exactly the payload the core's `write_difficulty`
+/// command expects (preset + optional custom sub-levels + flowHelper +
+/// permadeath). The propagation flags drive which targets the save assembles.
+class PendingDifficulty {
+  const PendingDifficulty({
+    required this.difficulty,
+    this.alsoProfile = false,
+    this.allSaves = false,
+  });
+
+  final Map<String, Object?> difficulty;
+
+  /// Also write the resolved profile's `PersistentDataList.sav`.
+  final bool alsoProfile;
+
+  /// Apply to every save attributed to the resolved profile (current save
+  /// always included).
+  final bool allSaves;
+}

--- a/apps/goresave/lib/features/editor/ui/difficulty_card.dart
+++ b/apps/goresave/lib/features/editor/ui/difficulty_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:goresave/features/editor/domain/editor_models.dart';
 import 'package:goresave/features/editor/domain/editor_notifier.dart';
-import 'package:path/path.dart' as p;
+import 'package:goresave/features/editor/domain/pending_edits.dart';
 
 /// The four difficulty presets, in the order the in-game screen lists them.
 /// These are the exact label strings the core maps back to its class names
@@ -27,9 +27,18 @@ String _impliedLevelForPreset(String preset) {
 }
 
 /// Editable difficulty form mirroring the in-game difficulty screen, bound to
-/// the selected save's stored difficulty. Writes through
-/// [EditorNotifier.writeDifficulty] with optional propagation to the profile
-/// and to all of the profile's saves (always with a backup).
+/// the selected save's stored difficulty.
+///
+/// Difficulty is a normal **pending edit**: changing a control registers (or
+/// updates) a [PendingDifficulty] on the notifier; reverting to the stored
+/// value with no propagation box ticked clears it. It is saved by the GLOBAL
+/// toolbar Save (`saveAllPending` dispatches `write_difficulty`) and discarded
+/// by the GLOBAL Reset — exactly like hero/inventory/metadata edits. The card
+/// therefore has no own Save/Reset buttons.
+///
+/// The displayed control values come from `pendingDifficulty ?? stored`, so a
+/// global Reset (which clears `pendingDifficulty`) makes the card show the
+/// saved values again, and switching saves re-seeds correctly.
 ///
 /// Difficulty is stored redundantly: in each save (gameplay-relevant), and in
 /// the profile's `PersistentDataList.sav` (the new-game menu default). Editing
@@ -47,14 +56,18 @@ class DifficultyCard extends StatefulWidget {
   final SaveInspection inspection;
   final EditorNotifier notifier;
 
-  /// The effective profile (`EditorState.activeProfile`). Null when no profile
-  /// is resolved — the propagation checkboxes are then disabled because there
-  /// is no profile to write to.
+  /// The profile of the SAVE under edit (resolved from the selected save's
+  /// `persistentProfileId`). Null when the edited save has no resolvable profile
+  /// — the propagation checkboxes are then disabled because there is no profile
+  /// to write to. NOTE: this is the edited save's profile, NOT the sidebar's
+  /// effective filter profile.
   final ProfileSummary? profile;
 
   /// Whether the codec host is compress-ready. Difficulty lives in the private
   /// payload of each targeted save, so writing it recompresses the payload and
   /// requires a verified/trusted codec — same gate as the other private edits.
+  /// The card no longer blocks on this (the global Save surfaces the codec
+  /// error); it is kept for a non-blocking hint.
   final bool canCompress;
 
   @override
@@ -62,212 +75,161 @@ class DifficultyCard extends StatefulWidget {
 }
 
 class _DifficultyCardState extends State<DifficultyCard> {
-  // Collapsed by default so the Overview panel opens to the same compact
-  // layout as before — the editing form (and its own Reset/Save buttons)
-  // appears only when the user expands the card.
-  bool _expanded = false;
+  // Expanded by default so the editing form is visible on load.
+  bool _expanded = true;
 
-  // Draft state — label strings ('Novice'/'Gothic'/'Hard'/'Custom').
-  late String _preset;
-  late String _combat;
-  late String _resources;
-  late String _progression;
-  late bool _flow;
-  late bool _perma;
+  EditorState get _state => widget.notifier.state;
 
-  // Propagation checkboxes (default OFF).
-  bool _alsoProfile = false;
-  bool _allSaves = false;
+  PendingDifficulty? get _pending => _state.pendingDifficulty;
 
-  // Identity of the save the draft was seeded from (the inspection path), so we
-  // re-seed only when a DIFFERENT save lands — not on every incidental
-  // re-inspect of the same save. A null path (no save) is its own identity.
-  Object? _seededFromPath;
+  // --- Stored (saved) values, normalised to UI labels --------------------
 
-  bool _saving = false;
+  String get _storedPreset => _normalizePreset(widget.inspection.difficulty?.presetLabel);
 
-  @override
-  void initState() {
-    super.initState();
-    _seed();
+  bool get _storedFlow => widget.inspection.difficulty?.flowHelper ?? false;
+
+  bool get _storedPerma {
+    return _storedPreset == 'Novice'
+        ? false
+        : (widget.inspection.difficulty?.permadeath ?? false);
   }
 
-  @override
-  void didUpdateWidget(covariant DifficultyCard oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // Re-seed only when a DIFFERENT save lands (path changed), when the current
-    // draft has no unsaved work, OR when the notifier reports the difficulty is
-    // no longer dirty. The notifier is the source of truth for "keep this
-    // draft": it preserves difficultyDirty across an incidental re-inspect of
-    // the SAME save (e.g. a toolbar Save of hero edits) so the draft survives,
-    // but clears it on a genuine save switch, after a successful difficulty
-    // write, and when the user confirms a discard-and-rescan — in which case we
-    // re-seed to the stored value. We must NOT call setDifficultyDirty from
-    // here (it would mutate the provider during build/didUpdateWidget).
-    final samePath = widget.inspection.path == _seededFromPath;
-    final notifierDirty = widget.notifier.state.difficultyDirty;
-    if (!samePath || !_hasWork || !notifierDirty) {
-      _seed();
-      // If the re-seed lands on a draft with no work but the notifier flag is
-      // still set, the flag is now stale (the card shows no "Unsaved" state),
-      // and it would wedge the profile-switch / rescan guards until restart.
-      // Clear it safely AFTER this frame — mutating the provider during
-      // build/didUpdateWidget is not allowed. Only clear when there is genuinely
-      // no work, so a still-dirty same-save draft is never silently dropped.
-      if (!_hasWork && widget.notifier.state.difficultyDirty) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted && !_hasWork) widget.notifier.setDifficultyDirty(false);
-        });
-      }
+  // --- Displayed values: pending edit when present, else stored ----------
+
+  String get _preset {
+    final d = _pending?.difficulty;
+    if (d == null) return _storedPreset;
+    // The card stores 'preset' as a UI label ('Novice'/'Gothic'/'Hard'/
+    // 'Custom') — exactly what the core's write_difficulty expects.
+    return _normalizePreset(d['preset'] as String?);
+  }
+
+  bool get _flow {
+    final d = _pending?.difficulty;
+    if (d == null) return _storedFlow;
+    return (d['flowHelper'] as bool?) ?? false;
+  }
+
+  bool get _perma {
+    final d = _pending?.difficulty;
+    if (d == null) return _storedPerma;
+    if (_preset == 'Novice') return false;
+    return (d['permadeath'] as bool?) ?? false;
+  }
+
+  /// Sub-level for a Custom picker. When a pending Custom edit exists, read its
+  /// stored level; otherwise fall back to the saved value normalised against
+  /// the preset.
+  String _customLevel(String field) {
+    final d = _pending?.difficulty;
+    if (d != null && d[field] is String) {
+      return _normalizeLevel(d[field] as String, 'Custom');
     }
+    final stored = widget.inspection.difficulty;
+    final label = switch (field) {
+      'combat' => stored?.combatLabel,
+      'resources' => stored?.resourcesLabel,
+      _ => stored?.progressionLabel,
+    };
+    return _normalizeLevel(label, _storedPreset);
   }
 
-  /// Seed (or reset) the draft from the stored difficulty. Falls back to a
-  /// Gothic baseline when the save has no difficulty block at all.
-  void _seed() {
-    final d = widget.inspection.difficulty;
-    final preset = _normalizePreset(d?.presetLabel);
-    setState(() {
-      _seededFromPath = widget.inspection.path;
-      _preset = preset;
-      _combat = _normalizeLevel(d?.combatLabel, preset);
-      _resources = _normalizeLevel(d?.resourcesLabel, preset);
-      _progression = _normalizeLevel(d?.progressionLabel, preset);
-      _flow = d?.flowHelper ?? false;
-      // Novice forces permadeath off; otherwise honour the stored value.
-      _perma = preset == 'Novice' ? false : (d?.permadeath ?? false);
-      _alsoProfile = false;
-      _allSaves = false;
-    });
-  }
+  bool get _alsoProfile => _pending?.alsoProfile ?? false;
+  bool get _allSaves => _pending?.allSaves ?? false;
 
-  String _normalizePreset(String? label) {
-    return _presets.contains(label) ? label! : 'Gothic';
-  }
+  // --- Label/normalisation helpers ---------------------------------------
+
+  String _normalizePreset(String? label) =>
+      _presets.contains(label) ? label! : 'Gothic';
 
   String _normalizeLevel(String? label, String preset) {
     if (_levels.contains(label)) return label!;
-    // No usable stored sub-level: derive from the preset so locked pickers show
-    // a sensible value.
     return preset == 'Custom' ? 'Gothic' : _impliedLevelForPreset(preset);
   }
 
   /// The level a picker should DISPLAY: the draft value when Custom (pickers
   /// editable), otherwise the level implied by the preset (pickers locked).
-  String _displayedLevel(String draftLevel) {
-    return _preset == 'Custom' ? draftLevel : _impliedLevelForPreset(_preset);
+  String _displayedLevel(String field) {
+    return _preset == 'Custom'
+        ? _customLevel(field)
+        : _impliedLevelForPreset(_preset);
   }
 
-  /// Effective permadeath for dirty-comparison and save: forced off on Novice.
-  bool get _effectivePerma => _preset == 'Novice' ? false : _perma;
+  // --- Pending-edit registration -----------------------------------------
 
-  /// Whether the draft differs from the stored value (drives Save/Reset).
-  bool get _dirty {
-    final d = widget.inspection.difficulty;
-    final storedPreset = _normalizePreset(d?.presetLabel);
-    if (_preset != storedPreset) return true;
-    if (_flow != (d?.flowHelper ?? false)) return true;
-    final storedPerma = storedPreset == 'Novice'
-        ? false
-        : (d?.permadeath ?? false);
-    if (_effectivePerma != storedPerma) return true;
-    // Sub-levels only matter when Custom — for the other presets the level is
-    // fully implied by the preset, so a stored sub-level mismatch is not a
-    // user-visible difference.
-    if (_preset == 'Custom') {
-      if (_combat != _normalizeLevel(d?.combatLabel, storedPreset)) return true;
-      if (_resources != _normalizeLevel(d?.resourcesLabel, storedPreset)) {
-        return true;
-      }
-      if (_progression != _normalizeLevel(d?.progressionLabel, storedPreset)) {
-        return true;
-      }
+  /// Recompute the pending difficulty from a candidate set of control values
+  /// and the current propagation flags, then either register it or — when it
+  /// matches the stored value AND no propagation box is ticked — clear it.
+  void _apply({
+    String? preset,
+    bool? flow,
+    bool? perma,
+    String? combat,
+    String? resources,
+    String? progression,
+    bool? alsoProfile,
+    bool? allSaves,
+  }) {
+    final nextPreset = preset ?? _preset;
+    // Novice forces permadeath off; otherwise carry the explicit toggle or the
+    // current displayed value.
+    final nextPerma = nextPreset == 'Novice' ? false : (perma ?? _perma);
+    final nextFlow = flow ?? _flow;
+
+    // Custom sub-levels: only meaningful (and editable) on Custom. When leaving
+    // Custom, snap them to the implied preset level so a later return to Custom
+    // starts coherent.
+    final String nextCombat;
+    final String nextResources;
+    final String nextProgression;
+    if (nextPreset == 'Custom') {
+      nextCombat = combat ?? _customLevel('combat');
+      nextResources = resources ?? _customLevel('resources');
+      nextProgression = progression ?? _customLevel('progression');
+    } else {
+      final implied = _impliedLevelForPreset(nextPreset);
+      nextCombat = implied;
+      nextResources = implied;
+      nextProgression = implied;
     }
-    return false;
-  }
 
-  /// True when there is work to save: a changed field OR a ticked propagation
-  /// box (the user may want to push the current, unchanged difficulty to the
-  /// profile / other saves). Drives Save enablement and the unsaved-edits guard.
-  bool get _hasWork => _dirty || _alsoProfile || _allSaves;
+    final nextAlsoProfile =
+        (alsoProfile ?? _alsoProfile) && widget.profile != null;
+    final nextAllSaves = (allSaves ?? _allSaves) && widget.profile != null;
 
-  void _syncDirty() {
-    // Report "has work" (not just field-dirty) so the profile-switch /
-    // rescan guard also protects a propagation-only intent.
-    widget.notifier.setDifficultyDirty(_hasWork);
-  }
+    // Does this match the stored value with no propagation? Then there is no
+    // pending work — clear it. Sub-levels only matter on Custom.
+    final matchesStored =
+        nextPreset == _storedPreset &&
+        nextFlow == _storedFlow &&
+        nextPerma == _storedPerma &&
+        (nextPreset != 'Custom' ||
+            (nextCombat == _customLevel('combat') &&
+                nextResources == _customLevel('resources') &&
+                nextProgression == _customLevel('progression')));
 
-  void _onPresetChanged(String preset) {
-    setState(() {
-      _preset = preset;
-      if (preset == 'Novice') _perma = false;
-      // Leaving Custom: snap the displayed sub-levels to the preset so the
-      // locked pickers reflect it. Entering Custom keeps the current values as
-      // the editable starting point.
-      if (preset != 'Custom') {
-        final implied = _impliedLevelForPreset(preset);
-        _combat = implied;
-        _resources = implied;
-        _progression = implied;
-      }
-    });
-    _syncDirty();
-  }
-
-  void _reset() {
-    _seed();
-    widget.notifier.setDifficultyDirty(false);
-  }
-
-  Future<void> _save() async {
-    final path = widget.inspection.path;
-    if (path == null) return;
-    final profile = widget.profile;
-
-    final savePaths = <String>[path];
-    if (_allSaves && profile != null) {
-      savePaths
-        ..clear()
-        ..addAll(
-          widget.notifier.state.saves
-              .where((s) => s.persistentProfileId == profile.profileId)
-              .map((s) => s.path),
-        );
-      // Ensure the current save is included even if its persistentProfileId is
-      // null or mismatched.
-      if (!savePaths.contains(path)) savePaths.add(path);
+    if (matchesStored && !nextAlsoProfile && !nextAllSaves) {
+      widget.notifier.clearPendingDifficulty();
+      setState(() {});
+      return;
     }
 
     final difficulty = <String, Object?>{
-      'preset': _preset,
-      if (_preset == 'Custom') 'combat': _combat,
-      if (_preset == 'Custom') 'resources': _resources,
-      if (_preset == 'Custom') 'progression': _progression,
-      'flowHelper': _flow,
-      'permadeath': _effectivePerma,
+      'preset': nextPreset,
+      if (nextPreset == 'Custom') 'combat': nextCombat,
+      if (nextPreset == 'Custom') 'resources': nextResources,
+      if (nextPreset == 'Custom') 'progression': nextProgression,
+      'flowHelper': nextFlow,
+      'permadeath': nextPerma,
     };
-
-    final ({String path, int profileId})? target =
-        (_alsoProfile && profile != null)
-        ? (path: _persistentDataListPath(path), profileId: profile.profileId)
-        : null;
-
-    setState(() => _saving = true);
-    try {
-      await widget.notifier.writeDifficulty(
+    widget.notifier.setPendingDifficulty(
+      PendingDifficulty(
         difficulty: difficulty,
-        savePaths: savePaths,
-        profile: target,
-      );
-    } finally {
-      if (mounted) setState(() => _saving = false);
-    }
-  }
-
-  /// The profile's `PersistentDataList.sav` lives next to the save files, in
-  /// the same directory. Derive it from the current save's directory.
-  String _persistentDataListPath(String savePath) {
-    return p.join(p.dirname(savePath), 'PersistentDataList.sav');
+        alsoProfile: nextAlsoProfile,
+        allSaves: nextAllSaves,
+      ),
+    );
+    setState(() {});
   }
 
   @override
@@ -275,28 +237,13 @@ class _DifficultyCardState extends State<DifficultyCard> {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
     final hasProfile = widget.profile != null;
-    final hasWork = _hasWork;
-    // A difficulty write does a full re-inspect that re-seeds every editor and
-    // clears the pending-edit registry, which would silently discard unrelated
-    // unsaved hero/inventory/metadata edits. Mirror the app's "mutually
-    // exclusive edits" pattern (see structural inventory edits): block the
-    // Difficulty save while other pending edits exist, with a clear hint.
-    final blockingPending = widget.notifier.state.pendingEditCount > 0;
-    // Difficulty is a private-payload edit on every targeted save, so writing
-    // needs a compress-ready codec — disable Save with a hint otherwise,
-    // matching the other private editors.
+    final hasWork = _pending != null;
     final canWrite = widget.canCompress;
-    // Save is enabled for a changed field OR a propagation-only intent (ticking
-    // a box to push the current difficulty to the profile / all saves).
-    final canSave = hasWork &&
-        canWrite &&
-        !blockingPending &&
-        !_saving &&
-        !widget.notifier.state.isLoading;
+    final busy = _state.isLoading;
 
-    final presetEnabled = !_saving;
-    final permaEnabled = _preset != 'Novice' && !_saving;
-    final levelsEnabled = _preset == 'Custom' && !_saving;
+    final presetEnabled = !busy;
+    final permaEnabled = _preset != 'Novice' && !busy;
+    final levelsEnabled = _preset == 'Custom' && !busy;
 
     return Card(
       child: Padding(
@@ -357,7 +304,7 @@ class _DifficultyCardState extends State<DifficultyCard> {
                 selected: {_preset},
                 showSelectedIcon: false,
                 onSelectionChanged: presetEnabled
-                    ? (selection) => _onPresetChanged(selection.first)
+                    ? (selection) => _apply(preset: selection.first)
                     : null,
               ),
               const SizedBox(height: 8),
@@ -367,12 +314,9 @@ class _DifficultyCardState extends State<DifficultyCard> {
                 dense: true,
                 title: const Text('Close Combat Flow Helper'),
                 value: _flow,
-                onChanged: _saving
+                onChanged: busy
                     ? null
-                    : (value) {
-                        setState(() => _flow = value);
-                        _syncDirty();
-                      },
+                    : (value) => _apply(flow: value),
               ),
               SwitchListTile(
                 contentPadding: EdgeInsets.zero,
@@ -381,44 +325,32 @@ class _DifficultyCardState extends State<DifficultyCard> {
                 subtitle: _preset == 'Novice'
                     ? const Text('Not available on Novice')
                     : null,
-                value: _effectivePerma,
+                value: _perma,
                 onChanged: permaEnabled
-                    ? (value) {
-                        setState(() => _perma = value);
-                        _syncDirty();
-                      }
+                    ? (value) => _apply(perma: value)
                     : null,
               ),
               const SizedBox(height: 8),
               // Level pickers.
               _LevelPicker(
                 label: 'Combat',
-                value: _displayedLevel(_combat),
+                value: _displayedLevel('combat'),
                 enabled: levelsEnabled,
-                onChanged: (value) {
-                  setState(() => _combat = value);
-                  _syncDirty();
-                },
+                onChanged: (value) => _apply(combat: value),
               ),
               const SizedBox(height: 8),
               _LevelPicker(
                 label: 'Resources',
-                value: _displayedLevel(_resources),
+                value: _displayedLevel('resources'),
                 enabled: levelsEnabled,
-                onChanged: (value) {
-                  setState(() => _resources = value);
-                  _syncDirty();
-                },
+                onChanged: (value) => _apply(resources: value),
               ),
               const SizedBox(height: 8),
               _LevelPicker(
                 label: 'Progression',
-                value: _displayedLevel(_progression),
+                value: _displayedLevel('progression'),
                 enabled: levelsEnabled,
-                onChanged: (value) {
-                  setState(() => _progression = value);
-                  _syncDirty();
-                },
+                onChanged: (value) => _apply(progression: value),
               ),
               const SizedBox(height: 16),
               // Explanation.
@@ -432,12 +364,13 @@ class _DifficultyCardState extends State<DifficultyCard> {
                   'Difficulty is stored in this save (gameplay-relevant), in the '
                   'profile (the new-game menu default), and separately in every '
                   'other save. Editing here changes only the current save unless '
-                  'you tick the options below.',
+                  'you tick the options below. Use the toolbar Save to write your '
+                  'changes.',
                   style: theme.textTheme.bodySmall,
                 ),
               ),
               const SizedBox(height: 8),
-              // Propagation checkboxes.
+              // Propagation checkboxes (bound to the EDITED SAVE's profile).
               CheckboxListTile(
                 contentPadding: EdgeInsets.zero,
                 dense: true,
@@ -447,11 +380,8 @@ class _DifficultyCardState extends State<DifficultyCard> {
                     ? null
                     : const Text('No resolved profile to update'),
                 value: _alsoProfile,
-                onChanged: hasProfile && !_saving
-                    ? (value) {
-                        setState(() => _alsoProfile = value ?? false);
-                        _syncDirty();
-                      }
+                onChanged: hasProfile && !busy
+                    ? (value) => _apply(alsoProfile: value ?? false)
                     : null,
               ),
               CheckboxListTile(
@@ -463,17 +393,13 @@ class _DifficultyCardState extends State<DifficultyCard> {
                     ? null
                     : const Text('No resolved profile to apply to'),
                 value: _allSaves,
-                onChanged: hasProfile && !_saving
-                    ? (value) {
-                        setState(() => _allSaves = value ?? false);
-                        _syncDirty();
-                      }
+                onChanged: hasProfile && !busy
+                    ? (value) => _apply(allSaves: value ?? false)
                     : null,
               ),
-              const SizedBox(height: 12),
-              if (!canWrite)
+              if (hasWork && !canWrite)
                 Padding(
-                  padding: const EdgeInsets.only(bottom: 8),
+                  padding: const EdgeInsets.only(top: 8),
                   child: Text(
                     'Saving difficulty needs a verified G1R codec host '
                     '(it rewrites the private payload of each targeted save).',
@@ -482,33 +408,6 @@ class _DifficultyCardState extends State<DifficultyCard> {
                     ),
                   ),
                 ),
-              if (canWrite && blockingPending)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 8),
-                  child: Text(
-                    'Save or reset your other pending changes first — a '
-                    'difficulty save reloads the file and would discard them.',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: scheme.error,
-                    ),
-                  ),
-                ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  OutlinedButton.icon(
-                    icon: const Icon(Icons.undo),
-                    label: const Text('Reset'),
-                    onPressed: hasWork && !_saving ? _reset : null,
-                  ),
-                  const SizedBox(width: 8),
-                  FilledButton.icon(
-                    icon: const Icon(Icons.save_outlined),
-                    label: const Text('Save'),
-                    onPressed: canSave ? _save : null,
-                  ),
-                ],
-              ),
             ],
           ],
         ),

--- a/apps/goresave/lib/features/editor/ui/difficulty_card.dart
+++ b/apps/goresave/lib/features/editor/ui/difficulty_card.dart
@@ -94,6 +94,20 @@ class _DifficultyCardState extends State<DifficultyCard> {
         : (widget.inspection.difficulty?.permadeath ?? false);
   }
 
+  /// The SAVED (on-disk) sub-level for a field, normalised to a UI label and
+  /// independent of any pending draft. Used to decide whether a candidate
+  /// matches what is actually on disk — never read the pending draft here, or
+  /// reverting/propagation toggles could clear a still-divergent Custom edit.
+  String _storedLevel(String field) {
+    final stored = widget.inspection.difficulty;
+    final label = switch (field) {
+      'combat' => stored?.combatLabel,
+      'resources' => stored?.resourcesLabel,
+      _ => stored?.progressionLabel,
+    };
+    return _normalizeLevel(label, _storedPreset);
+  }
+
   // --- Displayed values: pending edit when present, else stored ----------
 
   String get _preset {
@@ -197,16 +211,21 @@ class _DifficultyCardState extends State<DifficultyCard> {
         (alsoProfile ?? _alsoProfile) && widget.profile != null;
     final nextAllSaves = (allSaves ?? _allSaves) && widget.profile != null;
 
-    // Does this match the stored value with no propagation? Then there is no
-    // pending work — clear it. Sub-levels only matter on Custom.
+    // Does this match the SAVED (on-disk) value with no propagation? Then there
+    // is no pending work — clear it. The comparison must be against the stored
+    // difficulty, NOT the pending draft: comparing Custom sub-levels via
+    // `_customLevel` (which reads the draft) would let a propagation toggle (or
+    // any later `_apply`) clear `pendingDifficulty` while the sub-levels still
+    // differ from disk, silently dropping the unsaved level change. Sub-levels
+    // only matter on Custom.
     final matchesStored =
         nextPreset == _storedPreset &&
         nextFlow == _storedFlow &&
         nextPerma == _storedPerma &&
         (nextPreset != 'Custom' ||
-            (nextCombat == _customLevel('combat') &&
-                nextResources == _customLevel('resources') &&
-                nextProgression == _customLevel('progression')));
+            (nextCombat == _storedLevel('combat') &&
+                nextResources == _storedLevel('resources') &&
+                nextProgression == _storedLevel('progression')));
 
     if (matchesStored && !nextAlsoProfile && !nextAllSaves) {
       widget.notifier.clearPendingDifficulty();

--- a/apps/goresave/lib/features/editor/ui/difficulty_card.dart
+++ b/apps/goresave/lib/features/editor/ui/difficulty_card.dart
@@ -8,6 +8,14 @@ import 'package:goresave/features/editor/domain/pending_edits.dart';
 /// (Novice→_Easy, Gothic→_Standard, Hard→_Hard, Custom→_Custom).
 const _presets = ['Novice', 'Gothic', 'Hard', 'Custom'];
 
+/// Sentinel for a stored preset that is missing or not one of the four known
+/// UI presets (e.g. an unmapped raw core class name). Must NEVER be treated as
+/// a concrete preset: when it is the active value the selector shows nothing
+/// selected and the card refuses to build a saveable candidate, so a global
+/// Save can never silently write a guessed preset. Resolved only when the user
+/// explicitly picks a known preset.
+const _unknownPreset = '';
+
 /// The three sub-level options shown for Combat / Resources / Progression.
 const _levels = ['Novice', 'Gothic', 'Hard'];
 
@@ -153,8 +161,11 @@ class _DifficultyCardState extends State<DifficultyCard> {
 
   // --- Label/normalisation helpers ---------------------------------------
 
+  /// Resolve a stored/draft preset label to a known UI preset, or the
+  /// [_unknownPreset] sentinel when it is missing or not one of the four
+  /// presets. Never falls back to a concrete preset — see [_unknownPreset].
   String _normalizePreset(String? label) =>
-      _presets.contains(label) ? label! : 'Gothic';
+      _presets.contains(label) ? label! : _unknownPreset;
 
   String _normalizeLevel(String? label, String preset) {
     if (_levels.contains(label)) return label!;
@@ -185,6 +196,19 @@ class _DifficultyCardState extends State<DifficultyCard> {
     bool? allSaves,
   }) {
     final nextPreset = preset ?? _preset;
+
+    // The stored preset is unknown (missing or an unmapped class name) and the
+    // user has not explicitly picked one yet. Do NOT build a saveable candidate
+    // from a guessed preset — that would let a propagation toggle or a global
+    // Save write a difficulty (historically Gothic) the user never chose. Any
+    // edit only becomes saveable once the user explicitly selects a preset
+    // (which arrives here as a non-null `preset`).
+    if (nextPreset == _unknownPreset) {
+      widget.notifier.clearPendingDifficulty();
+      setState(() {});
+      return;
+    }
+
     // Novice forces permadeath off; otherwise carry the explicit toggle or the
     // current displayed value.
     final nextPerma = nextPreset == 'Novice' ? false : (perma ?? _perma);
@@ -289,7 +313,13 @@ class _DifficultyCardState extends State<DifficultyCard> {
                             style: theme.textTheme.titleMedium,
                           ),
                           Text(
-                            _preset,
+                            // Show the raw stored label for an unknown preset
+                            // so diagnostics still surface the on-disk value;
+                            // the selector below stays unselected until the
+                            // user picks a known preset.
+                            _preset == _unknownPreset
+                                ? 'Unknown (${widget.inspection.difficulty?.presetLabel ?? 'none'})'
+                                : _preset,
                             style: theme.textTheme.bodySmall,
                           ),
                         ],
@@ -320,7 +350,12 @@ class _DifficultyCardState extends State<DifficultyCard> {
                   for (final preset in _presets)
                     ButtonSegment<String>(value: preset, label: Text(preset)),
                 ],
-                selected: {_preset},
+                // An unknown stored preset shows NOTHING selected — the user
+                // must explicitly pick one before any difficulty is saveable.
+                emptySelectionAllowed: _preset == _unknownPreset,
+                selected: _preset == _unknownPreset
+                    ? const <String>{}
+                    : {_preset},
                 showSelectedIcon: false,
                 onSelectionChanged: presetEnabled
                     ? (selection) => _apply(preset: selection.first)

--- a/apps/goresave/lib/features/editor/ui/difficulty_card.dart
+++ b/apps/goresave/lib/features/editor/ui/difficulty_card.dart
@@ -108,6 +108,17 @@ class _DifficultyCardState extends State<DifficultyCard> {
     final notifierDirty = widget.notifier.state.difficultyDirty;
     if (!samePath || !_hasWork || !notifierDirty) {
       _seed();
+      // If the re-seed lands on a draft with no work but the notifier flag is
+      // still set, the flag is now stale (the card shows no "Unsaved" state),
+      // and it would wedge the profile-switch / rescan guards until restart.
+      // Clear it safely AFTER this frame — mutating the provider during
+      // build/didUpdateWidget is not allowed. Only clear when there is genuinely
+      // no work, so a still-dirty same-save draft is never silently dropped.
+      if (!_hasWork && widget.notifier.state.difficultyDirty) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && !_hasWork) widget.notifier.setDifficultyDirty(false);
+        });
+      }
     }
   }
 

--- a/apps/goresave/lib/features/editor/ui/difficulty_card.dart
+++ b/apps/goresave/lib/features/editor/ui/difficulty_card.dart
@@ -1,0 +1,504 @@
+import 'package:flutter/material.dart';
+import 'package:goresave/features/editor/domain/editor_models.dart';
+import 'package:goresave/features/editor/domain/editor_notifier.dart';
+import 'package:path/path.dart' as p;
+
+/// The four difficulty presets, in the order the in-game screen lists them.
+/// These are the exact label strings the core maps back to its class names
+/// (Novice→_Easy, Gothic→_Standard, Hard→_Hard, Custom→_Custom).
+const _presets = ['Novice', 'Gothic', 'Hard', 'Custom'];
+
+/// The three sub-level options shown for Combat / Resources / Progression.
+const _levels = ['Novice', 'Gothic', 'Hard'];
+
+/// Maps a preset to the implied sub-level shown when the pickers are locked
+/// (i.e. preset != Custom). Custom has no implied level — the pickers stay at
+/// whatever the user/draft holds.
+String _impliedLevelForPreset(String preset) {
+  switch (preset) {
+    case 'Novice':
+      return 'Novice';
+    case 'Hard':
+      return 'Hard';
+    case 'Gothic':
+    default:
+      return 'Gothic';
+  }
+}
+
+/// Editable difficulty form mirroring the in-game difficulty screen, bound to
+/// the selected save's stored difficulty. Writes through
+/// [EditorNotifier.writeDifficulty] with optional propagation to the profile
+/// and to all of the profile's saves (always with a backup).
+///
+/// Difficulty is stored redundantly: in each save (gameplay-relevant), and in
+/// the profile's `PersistentDataList.sav` (the new-game menu default). Editing
+/// here changes only the current save unless the propagation checkboxes are
+/// ticked.
+class DifficultyCard extends StatefulWidget {
+  const DifficultyCard({
+    super.key,
+    required this.inspection,
+    required this.notifier,
+    required this.profile,
+    required this.canCompress,
+  });
+
+  final SaveInspection inspection;
+  final EditorNotifier notifier;
+
+  /// The effective profile (`EditorState.activeProfile`). Null when no profile
+  /// is resolved — the propagation checkboxes are then disabled because there
+  /// is no profile to write to.
+  final ProfileSummary? profile;
+
+  /// Whether the codec host is compress-ready. Difficulty lives in the private
+  /// payload of each targeted save, so writing it recompresses the payload and
+  /// requires a verified/trusted codec — same gate as the other private edits.
+  final bool canCompress;
+
+  @override
+  State<DifficultyCard> createState() => _DifficultyCardState();
+}
+
+class _DifficultyCardState extends State<DifficultyCard> {
+  // Collapsed by default so the Overview panel opens to the same compact
+  // layout as before — the editing form (and its own Reset/Save buttons)
+  // appears only when the user expands the card.
+  bool _expanded = false;
+
+  // Draft state — label strings ('Novice'/'Gothic'/'Hard'/'Custom').
+  late String _preset;
+  late String _combat;
+  late String _resources;
+  late String _progression;
+  late bool _flow;
+  late bool _perma;
+
+  // Propagation checkboxes (default OFF).
+  bool _alsoProfile = false;
+  bool _allSaves = false;
+
+  // Identity of the inspection the draft was seeded from, so we re-seed only
+  // when a new inspection actually lands (not on every rebuild).
+  Object? _seededFrom;
+
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _seed();
+  }
+
+  @override
+  void didUpdateWidget(covariant DifficultyCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A new SaveInspection instance (refresh / save / slot switch) re-seeds the
+    // draft from the stored value. The notifier centrally clears difficultyDirty
+    // when the fresh inspection lands, so we must NOT call setDifficultyDirty
+    // from here (it would mutate the provider during build).
+    if (!identical(widget.inspection, _seededFrom)) {
+      _seed();
+    }
+  }
+
+  /// Seed (or reset) the draft from the stored difficulty. Falls back to a
+  /// Gothic baseline when the save has no difficulty block at all.
+  void _seed() {
+    final d = widget.inspection.difficulty;
+    final preset = _normalizePreset(d?.presetLabel);
+    setState(() {
+      _seededFrom = widget.inspection;
+      _preset = preset;
+      _combat = _normalizeLevel(d?.combatLabel, preset);
+      _resources = _normalizeLevel(d?.resourcesLabel, preset);
+      _progression = _normalizeLevel(d?.progressionLabel, preset);
+      _flow = d?.flowHelper ?? false;
+      // Novice forces permadeath off; otherwise honour the stored value.
+      _perma = preset == 'Novice' ? false : (d?.permadeath ?? false);
+      _alsoProfile = false;
+      _allSaves = false;
+    });
+  }
+
+  String _normalizePreset(String? label) {
+    return _presets.contains(label) ? label! : 'Gothic';
+  }
+
+  String _normalizeLevel(String? label, String preset) {
+    if (_levels.contains(label)) return label!;
+    // No usable stored sub-level: derive from the preset so locked pickers show
+    // a sensible value.
+    return preset == 'Custom' ? 'Gothic' : _impliedLevelForPreset(preset);
+  }
+
+  /// The level a picker should DISPLAY: the draft value when Custom (pickers
+  /// editable), otherwise the level implied by the preset (pickers locked).
+  String _displayedLevel(String draftLevel) {
+    return _preset == 'Custom' ? draftLevel : _impliedLevelForPreset(_preset);
+  }
+
+  /// Effective permadeath for dirty-comparison and save: forced off on Novice.
+  bool get _effectivePerma => _preset == 'Novice' ? false : _perma;
+
+  /// Whether the draft differs from the stored value (drives Save/Reset).
+  bool get _dirty {
+    final d = widget.inspection.difficulty;
+    final storedPreset = _normalizePreset(d?.presetLabel);
+    if (_preset != storedPreset) return true;
+    if (_flow != (d?.flowHelper ?? false)) return true;
+    final storedPerma = storedPreset == 'Novice'
+        ? false
+        : (d?.permadeath ?? false);
+    if (_effectivePerma != storedPerma) return true;
+    // Sub-levels only matter when Custom — for the other presets the level is
+    // fully implied by the preset, so a stored sub-level mismatch is not a
+    // user-visible difference.
+    if (_preset == 'Custom') {
+      if (_combat != _normalizeLevel(d?.combatLabel, storedPreset)) return true;
+      if (_resources != _normalizeLevel(d?.resourcesLabel, storedPreset)) {
+        return true;
+      }
+      if (_progression != _normalizeLevel(d?.progressionLabel, storedPreset)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void _syncDirty() {
+    widget.notifier.setDifficultyDirty(_dirty);
+  }
+
+  void _onPresetChanged(String preset) {
+    setState(() {
+      _preset = preset;
+      if (preset == 'Novice') _perma = false;
+      // Leaving Custom: snap the displayed sub-levels to the preset so the
+      // locked pickers reflect it. Entering Custom keeps the current values as
+      // the editable starting point.
+      if (preset != 'Custom') {
+        final implied = _impliedLevelForPreset(preset);
+        _combat = implied;
+        _resources = implied;
+        _progression = implied;
+      }
+    });
+    _syncDirty();
+  }
+
+  void _reset() {
+    _seed();
+    widget.notifier.setDifficultyDirty(false);
+  }
+
+  Future<void> _save() async {
+    final path = widget.inspection.path;
+    if (path == null) return;
+    final profile = widget.profile;
+
+    final savePaths = <String>[path];
+    if (_allSaves && profile != null) {
+      savePaths
+        ..clear()
+        ..addAll(
+          widget.notifier.state.saves
+              .where((s) => s.persistentProfileId == profile.profileId)
+              .map((s) => s.path),
+        );
+      // Ensure the current save is included even if its persistentProfileId is
+      // null or mismatched.
+      if (!savePaths.contains(path)) savePaths.add(path);
+    }
+
+    final difficulty = <String, Object?>{
+      'preset': _preset,
+      if (_preset == 'Custom') 'combat': _combat,
+      if (_preset == 'Custom') 'resources': _resources,
+      if (_preset == 'Custom') 'progression': _progression,
+      'flowHelper': _flow,
+      'permadeath': _effectivePerma,
+    };
+
+    final ({String path, int profileId})? target =
+        (_alsoProfile && profile != null)
+        ? (path: _persistentDataListPath(path), profileId: profile.profileId)
+        : null;
+
+    setState(() => _saving = true);
+    try {
+      await widget.notifier.writeDifficulty(
+        difficulty: difficulty,
+        savePaths: savePaths,
+        profile: target,
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  /// The profile's `PersistentDataList.sav` lives next to the save files, in
+  /// the same directory. Derive it from the current save's directory.
+  String _persistentDataListPath(String savePath) {
+    return p.join(p.dirname(savePath), 'PersistentDataList.sav');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final hasProfile = widget.profile != null;
+    final dirty = _dirty;
+    // Difficulty is a private-payload edit on every targeted save, so writing
+    // needs a compress-ready codec — disable Save with a hint otherwise,
+    // matching the other private editors.
+    final canWrite = widget.canCompress;
+    final canSave = dirty && canWrite && !_saving && !widget.notifier.state.isLoading;
+
+    final presetEnabled = !_saving;
+    final permaEnabled = _preset != 'Novice' && !_saving;
+    final levelsEnabled = _preset == 'Custom' && !_saving;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            InkWell(
+              onTap: () => setState(() => _expanded = !_expanded),
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    const Icon(Icons.local_fire_department_outlined),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            'Difficulty',
+                            style: theme.textTheme.titleMedium,
+                          ),
+                          Text(
+                            _preset,
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (dirty)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Text(
+                          'Unsaved',
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: scheme.primary,
+                          ),
+                        ),
+                      ),
+                    Icon(_expanded ? Icons.expand_less : Icons.expand_more),
+                  ],
+                ),
+              ),
+            ),
+            if (_expanded) ...[
+              const SizedBox(height: 8),
+              // Preset selector.
+              Text('Preset', style: theme.textTheme.labelLarge),
+              const SizedBox(height: 6),
+              SegmentedButton<String>(
+                segments: [
+                  for (final preset in _presets)
+                    ButtonSegment<String>(value: preset, label: Text(preset)),
+                ],
+                selected: {_preset},
+                showSelectedIcon: false,
+                onSelectionChanged: presetEnabled
+                    ? (selection) => _onPresetChanged(selection.first)
+                    : null,
+              ),
+              const SizedBox(height: 8),
+              // Toggles.
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+                title: const Text('Close Combat Flow Helper'),
+                value: _flow,
+                onChanged: _saving
+                    ? null
+                    : (value) {
+                        setState(() => _flow = value);
+                        _syncDirty();
+                      },
+              ),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+                title: const Text('Permadeath'),
+                subtitle: _preset == 'Novice'
+                    ? const Text('Not available on Novice')
+                    : null,
+                value: _effectivePerma,
+                onChanged: permaEnabled
+                    ? (value) {
+                        setState(() => _perma = value);
+                        _syncDirty();
+                      }
+                    : null,
+              ),
+              const SizedBox(height: 8),
+              // Level pickers.
+              _LevelPicker(
+                label: 'Combat',
+                value: _displayedLevel(_combat),
+                enabled: levelsEnabled,
+                onChanged: (value) {
+                  setState(() => _combat = value);
+                  _syncDirty();
+                },
+              ),
+              const SizedBox(height: 8),
+              _LevelPicker(
+                label: 'Resources',
+                value: _displayedLevel(_resources),
+                enabled: levelsEnabled,
+                onChanged: (value) {
+                  setState(() => _resources = value);
+                  _syncDirty();
+                },
+              ),
+              const SizedBox(height: 8),
+              _LevelPicker(
+                label: 'Progression',
+                value: _displayedLevel(_progression),
+                enabled: levelsEnabled,
+                onChanged: (value) {
+                  setState(() => _progression = value);
+                  _syncDirty();
+                },
+              ),
+              const SizedBox(height: 16),
+              // Explanation.
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: scheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  'Difficulty is stored in this save (gameplay-relevant), in the '
+                  'profile (the new-game menu default), and separately in every '
+                  'other save. Editing here changes only the current save unless '
+                  'you tick the options below.',
+                  style: theme.textTheme.bodySmall,
+                ),
+              ),
+              const SizedBox(height: 8),
+              // Propagation checkboxes.
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+                controlAffinity: ListTileControlAffinity.leading,
+                title: const Text('Also update the profile'),
+                subtitle: hasProfile
+                    ? null
+                    : const Text('No resolved profile to update'),
+                value: _alsoProfile,
+                onChanged: hasProfile && !_saving
+                    ? (value) => setState(() => _alsoProfile = value ?? false)
+                    : null,
+              ),
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+                controlAffinity: ListTileControlAffinity.leading,
+                title: const Text('Apply to all saves of this profile'),
+                subtitle: hasProfile
+                    ? null
+                    : const Text('No resolved profile to apply to'),
+                value: _allSaves,
+                onChanged: hasProfile && !_saving
+                    ? (value) => setState(() => _allSaves = value ?? false)
+                    : null,
+              ),
+              const SizedBox(height: 12),
+              if (!canWrite)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Text(
+                    'Saving difficulty needs a verified G1R codec host '
+                    '(it rewrites the private payload of each targeted save).',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: scheme.error,
+                    ),
+                  ),
+                ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  OutlinedButton.icon(
+                    icon: const Icon(Icons.undo),
+                    label: const Text('Reset'),
+                    onPressed: dirty && !_saving ? _reset : null,
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton.icon(
+                    icon: const Icon(Icons.save_outlined),
+                    label: const Text('Save'),
+                    onPressed: canSave ? _save : null,
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// One labelled Novice/Gothic/Hard segmented picker. Disabled state reflects
+/// the value but ignores taps.
+class _LevelPicker extends StatelessWidget {
+  const _LevelPicker({
+    required this.label,
+    required this.value,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final String label;
+  final String value;
+  final bool enabled;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        SizedBox(
+          width: 110,
+          child: Text(label, style: theme.textTheme.bodyMedium),
+        ),
+        Expanded(
+          child: SegmentedButton<String>(
+            segments: [
+              for (final level in _levels)
+                ButtonSegment<String>(value: level, label: Text(level)),
+            ],
+            selected: {value},
+            showSelectedIcon: false,
+            onSelectionChanged:
+                enabled ? (selection) => onChanged(selection.first) : null,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/goresave/lib/features/editor/ui/difficulty_card.dart
+++ b/apps/goresave/lib/features/editor/ui/difficulty_card.dart
@@ -79,9 +79,10 @@ class _DifficultyCardState extends State<DifficultyCard> {
   bool _alsoProfile = false;
   bool _allSaves = false;
 
-  // Identity of the inspection the draft was seeded from, so we re-seed only
-  // when a new inspection actually lands (not on every rebuild).
-  Object? _seededFrom;
+  // Identity of the save the draft was seeded from (the inspection path), so we
+  // re-seed only when a DIFFERENT save lands — not on every incidental
+  // re-inspect of the same save. A null path (no save) is its own identity.
+  Object? _seededFromPath;
 
   bool _saving = false;
 
@@ -94,11 +95,18 @@ class _DifficultyCardState extends State<DifficultyCard> {
   @override
   void didUpdateWidget(covariant DifficultyCard oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // A new SaveInspection instance (refresh / save / slot switch) re-seeds the
-    // draft from the stored value. The notifier centrally clears difficultyDirty
-    // when the fresh inspection lands, so we must NOT call setDifficultyDirty
-    // from here (it would mutate the provider during build).
-    if (!identical(widget.inspection, _seededFrom)) {
+    // Re-seed only when a DIFFERENT save lands (path changed), when the current
+    // draft has no unsaved work, OR when the notifier reports the difficulty is
+    // no longer dirty. The notifier is the source of truth for "keep this
+    // draft": it preserves difficultyDirty across an incidental re-inspect of
+    // the SAME save (e.g. a toolbar Save of hero edits) so the draft survives,
+    // but clears it on a genuine save switch, after a successful difficulty
+    // write, and when the user confirms a discard-and-rescan — in which case we
+    // re-seed to the stored value. We must NOT call setDifficultyDirty from
+    // here (it would mutate the provider during build/didUpdateWidget).
+    final samePath = widget.inspection.path == _seededFromPath;
+    final notifierDirty = widget.notifier.state.difficultyDirty;
+    if (!samePath || !_hasWork || !notifierDirty) {
       _seed();
     }
   }
@@ -109,7 +117,7 @@ class _DifficultyCardState extends State<DifficultyCard> {
     final d = widget.inspection.difficulty;
     final preset = _normalizePreset(d?.presetLabel);
     setState(() {
-      _seededFrom = widget.inspection;
+      _seededFromPath = widget.inspection.path;
       _preset = preset;
       _combat = _normalizeLevel(d?.combatLabel, preset);
       _resources = _normalizeLevel(d?.resourcesLabel, preset);
@@ -167,8 +175,15 @@ class _DifficultyCardState extends State<DifficultyCard> {
     return false;
   }
 
+  /// True when there is work to save: a changed field OR a ticked propagation
+  /// box (the user may want to push the current, unchanged difficulty to the
+  /// profile / other saves). Drives Save enablement and the unsaved-edits guard.
+  bool get _hasWork => _dirty || _alsoProfile || _allSaves;
+
   void _syncDirty() {
-    widget.notifier.setDifficultyDirty(_dirty);
+    // Report "has work" (not just field-dirty) so the profile-switch /
+    // rescan guard also protects a propagation-only intent.
+    widget.notifier.setDifficultyDirty(_hasWork);
   }
 
   void _onPresetChanged(String preset) {
@@ -249,12 +264,24 @@ class _DifficultyCardState extends State<DifficultyCard> {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
     final hasProfile = widget.profile != null;
-    final dirty = _dirty;
+    final hasWork = _hasWork;
+    // A difficulty write does a full re-inspect that re-seeds every editor and
+    // clears the pending-edit registry, which would silently discard unrelated
+    // unsaved hero/inventory/metadata edits. Mirror the app's "mutually
+    // exclusive edits" pattern (see structural inventory edits): block the
+    // Difficulty save while other pending edits exist, with a clear hint.
+    final blockingPending = widget.notifier.state.pendingEditCount > 0;
     // Difficulty is a private-payload edit on every targeted save, so writing
     // needs a compress-ready codec — disable Save with a hint otherwise,
     // matching the other private editors.
     final canWrite = widget.canCompress;
-    final canSave = dirty && canWrite && !_saving && !widget.notifier.state.isLoading;
+    // Save is enabled for a changed field OR a propagation-only intent (ticking
+    // a box to push the current difficulty to the profile / all saves).
+    final canSave = hasWork &&
+        canWrite &&
+        !blockingPending &&
+        !_saving &&
+        !widget.notifier.state.isLoading;
 
     final presetEnabled = !_saving;
     final permaEnabled = _preset != 'Novice' && !_saving;
@@ -291,7 +318,7 @@ class _DifficultyCardState extends State<DifficultyCard> {
                         ],
                       ),
                     ),
-                    if (dirty)
+                    if (hasWork)
                       Padding(
                         padding: const EdgeInsets.only(right: 8),
                         child: Text(
@@ -410,7 +437,10 @@ class _DifficultyCardState extends State<DifficultyCard> {
                     : const Text('No resolved profile to update'),
                 value: _alsoProfile,
                 onChanged: hasProfile && !_saving
-                    ? (value) => setState(() => _alsoProfile = value ?? false)
+                    ? (value) {
+                        setState(() => _alsoProfile = value ?? false);
+                        _syncDirty();
+                      }
                     : null,
               ),
               CheckboxListTile(
@@ -423,7 +453,10 @@ class _DifficultyCardState extends State<DifficultyCard> {
                     : const Text('No resolved profile to apply to'),
                 value: _allSaves,
                 onChanged: hasProfile && !_saving
-                    ? (value) => setState(() => _allSaves = value ?? false)
+                    ? (value) {
+                        setState(() => _allSaves = value ?? false);
+                        _syncDirty();
+                      }
                     : null,
               ),
               const SizedBox(height: 12),
@@ -438,13 +471,24 @@ class _DifficultyCardState extends State<DifficultyCard> {
                     ),
                   ),
                 ),
+              if (canWrite && blockingPending)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Text(
+                    'Save or reset your other pending changes first — a '
+                    'difficulty save reloads the file and would discard them.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: scheme.error,
+                    ),
+                  ),
+                ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
                   OutlinedButton.icon(
                     icon: const Icon(Icons.undo),
                     label: const Text('Reset'),
-                    onPressed: dirty && !_saving ? _reset : null,
+                    onPressed: hasWork && !_saving ? _reset : null,
                   ),
                   const SizedBox(width: 8),
                   FilledButton.icon(

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -16,6 +16,7 @@ import 'package:goresave/features/editor/domain/pending_edits.dart';
 import 'package:goresave/providers/data_providers.dart';
 import 'package:intl/intl.dart';
 import 'add_inventory_item_dialog.dart';
+import 'difficulty_card.dart';
 import 'hero_stats_card.dart';
 import 'progression_panel.dart';
 
@@ -685,7 +686,7 @@ class _EditorWorkspace extends StatelessWidget {
                     child: _OverviewPanel(
                       inspection: inspection,
                       notifier: notifier,
-                      selectedSave: state.selectedSave,
+                      state: state,
                     ),
                   ),
                   _KeepAliveTab(
@@ -802,21 +803,26 @@ class _OverviewPanel extends StatelessWidget {
   const _OverviewPanel({
     required this.inspection,
     required this.notifier,
-    required this.selectedSave,
+    required this.state,
   });
 
   final SaveInspection inspection;
   final EditorNotifier notifier;
-  final SaveSlot? selectedSave;
+  final EditorState state;
 
   @override
   Widget build(BuildContext context) {
     return ListView(
       padding: const EdgeInsets.all(20),
       children: [
-        _HeaderCard(inspection: inspection, save: selectedSave),
+        _HeaderCard(inspection: inspection, save: state.selectedSave),
         const SizedBox(height: 16),
-        _DifficultyCard(inspection: inspection),
+        DifficultyCard(
+          inspection: inspection,
+          notifier: notifier,
+          profile: state.activeProfile,
+          canCompress: state.codecCompressReady,
+        ),
         const SizedBox(height: 16),
         _MetadataEditor(inspection: inspection, notifier: notifier),
         const SizedBox(height: 16),
@@ -979,51 +985,6 @@ class _OverviewDiagnosticsState extends State<_OverviewDiagnostics> {
                     ),
                   ),
                 ],
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _DifficultyCard extends StatefulWidget {
-  const _DifficultyCard({required this.inspection});
-  final SaveInspection inspection;
-  @override
-  State<_DifficultyCard> createState() => _DifficultyCardState();
-}
-
-class _DifficultyCardState extends State<_DifficultyCard> {
-  bool _expanded = false;
-  @override
-  Widget build(BuildContext context) {
-    final d = widget.inspection.difficulty;
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _CollapsibleCardHeader(
-              icon: Icons.local_fire_department_outlined,
-              title: 'Difficulty',
-              subtitle: d?.presetLabel ?? 'Unknown',
-              expanded: _expanded,
-              onToggle: () => setState(() => _expanded = !_expanded),
-            ),
-            if (_expanded && d != null) ...[
-              const SizedBox(height: 8),
-              _MetricGrid(
-                metrics: {
-                  'Preset': d.presetLabel,
-                  'Close Combat Flow Helper': d.flowHelper == true ? 'On' : 'Off',
-                  'Permadeath': d.permadeath == true ? 'On' : 'Off',
-                  'Combat': d.combatLabel,
-                  'Resources': d.resourcesLabel,
-                  'Progression': d.progressionLabel,
-                },
               ),
             ],
           ],

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -816,6 +816,8 @@ class _OverviewPanel extends StatelessWidget {
       children: [
         _HeaderCard(inspection: inspection, save: selectedSave),
         const SizedBox(height: 16),
+        _DifficultyCard(inspection: inspection),
+        const SizedBox(height: 16),
         _MetadataEditor(inspection: inspection, notifier: notifier),
         const SizedBox(height: 16),
         _OverviewDiagnostics(inspection: inspection),
@@ -977,6 +979,51 @@ class _OverviewDiagnosticsState extends State<_OverviewDiagnostics> {
                     ),
                   ),
                 ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DifficultyCard extends StatefulWidget {
+  const _DifficultyCard({required this.inspection});
+  final SaveInspection inspection;
+  @override
+  State<_DifficultyCard> createState() => _DifficultyCardState();
+}
+
+class _DifficultyCardState extends State<_DifficultyCard> {
+  bool _expanded = false;
+  @override
+  Widget build(BuildContext context) {
+    final d = widget.inspection.difficulty;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _CollapsibleCardHeader(
+              icon: Icons.local_fire_department_outlined,
+              title: 'Difficulty',
+              subtitle: d?.presetLabel ?? 'Unknown',
+              expanded: _expanded,
+              onToggle: () => setState(() => _expanded = !_expanded),
+            ),
+            if (_expanded && d != null) ...[
+              const SizedBox(height: 8),
+              _MetricGrid(
+                metrics: {
+                  'Preset': d.presetLabel,
+                  'Close Combat Flow Helper': d.flowHelper == true ? 'On' : 'Off',
+                  'Permadeath': d.permadeath == true ? 'On' : 'Off',
+                  'Combat': d.combatLabel,
+                  'Resources': d.resourcesLabel,
+                  'Progression': d.progressionLabel,
+                },
               ),
             ],
           ],

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -288,23 +288,21 @@ class _ProfileHeader extends StatelessWidget {
   }
 
   /// Rescanning re-inspects the selected slot, which clears the global
-  /// pending-edit registry AND would re-seed the Difficulty card — never
-  /// silently discard unsaved drafts. Guard on the same `hasUnsavedEdits`
-  /// signal the profile-switch guard uses (pending registry edits OR a dirty
-  /// difficulty draft), not just the pending count.
+  /// pending-edit registry (including any pending difficulty edit) and re-seeds
+  /// every editor — never silently discard unsaved changes. Guard on the same
+  /// `hasUnsavedEdits` signal the profile-switch guard uses (pending registry
+  /// edits OR a pending difficulty edit).
   Future<void> _confirmRefresh(BuildContext context) async {
     if (notifier.state.hasUnsavedEdits) {
       final pendingCount = notifier.pendingEditCount;
-      final detail = pendingCount > 0
-          ? 'Rescanning reloads every save and discards your $pendingCount '
-                'unsaved change${pendingCount == 1 ? '' : 's'}.'
-          : 'Rescanning reloads every save and discards your unsaved '
-                'difficulty changes.';
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (context) => AlertDialog(
           title: const Text('Discard unsaved changes?'),
-          content: Text(detail),
+          content: Text(
+            'Rescanning reloads every save and discards your $pendingCount '
+            'unsaved change${pendingCount == 1 ? '' : 's'}.',
+          ),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(false),
@@ -318,11 +316,8 @@ class _ProfileHeader extends StatelessWidget {
         ),
       );
       if (confirmed != true) return;
-      // The user chose to discard. Clear the difficulty draft signal so the
-      // card re-seeds to the stored value on the upcoming re-inspect (the
-      // notifier otherwise preserves a dirty draft across a same-save
-      // re-inspect). Pending registry edits are cleared by the refresh itself.
-      notifier.setDifficultyDirty(false);
+      // The user chose to discard. refresh() centrally clears all pending edits
+      // (registry + the pending difficulty edit) and re-seeds the editors.
     }
     await notifier.refresh();
   }
@@ -827,14 +822,16 @@ class _OverviewPanel extends StatelessWidget {
       children: [
         _HeaderCard(inspection: inspection, save: state.selectedSave),
         const SizedBox(height: 16),
+        _MetadataEditor(inspection: inspection, notifier: notifier),
+        const SizedBox(height: 16),
         DifficultyCard(
           inspection: inspection,
           notifier: notifier,
-          profile: state.activeProfile,
+          // Propagation binds to the EDITED SAVE's profile, not the sidebar's
+          // effective filter profile (which can differ).
+          profile: state.editedSaveProfile,
           canCompress: state.codecCompressReady,
         ),
-        const SizedBox(height: 16),
-        _MetadataEditor(inspection: inspection, notifier: notifier),
         const SizedBox(height: 16),
         _OverviewDiagnostics(inspection: inspection),
         const SizedBox(height: 16),
@@ -1945,6 +1942,12 @@ class _PrivateInventorySummaryCardState
     // count as plain text but the delete action may still apply.
     return Row(
       mainAxisSize: MainAxisSize.min,
+      // Top-align so the count field's error line ('Min 1') has room to render
+      // below the field without growing the row or shoving the delete button —
+      // the field reserves constant vertical space for that line (see
+      // _InventoryItemCountEditor.helperText), and the delete button sits at the
+      // top next to the field, not vertically centred against the taller field.
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (countEditable)
           _InventoryItemCountEditor(
@@ -2113,12 +2116,20 @@ class _InventoryItemCountEditorState extends State<_InventoryItemCountEditor> {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 120,
+      width: 132,
       child: TextField(
         controller: _controller,
         keyboardType: TextInputType.number,
         onChanged: _onCountTextChanged,
-        decoration: InputDecoration(labelText: 'Count', errorText: _error),
+        decoration: InputDecoration(
+          labelText: 'Count',
+          errorText: _error,
+          // Reserve a constant line below the field with a blank helper so that
+          // showing the 'Min 1' error swaps in place of the helper rather than
+          // adding a new line — the field height stays stable, so it never
+          // grows inside the trailing Row when the user types 0.
+          helperText: ' ',
+        ),
       ),
     );
   }

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -288,18 +288,23 @@ class _ProfileHeader extends StatelessWidget {
   }
 
   /// Rescanning re-inspects the selected slot, which clears the global
-  /// pending-edit registry — never silently discard unsaved drafts.
+  /// pending-edit registry AND would re-seed the Difficulty card — never
+  /// silently discard unsaved drafts. Guard on the same `hasUnsavedEdits`
+  /// signal the profile-switch guard uses (pending registry edits OR a dirty
+  /// difficulty draft), not just the pending count.
   Future<void> _confirmRefresh(BuildContext context) async {
-    final pendingCount = notifier.pendingEditCount;
-    if (pendingCount > 0) {
+    if (notifier.state.hasUnsavedEdits) {
+      final pendingCount = notifier.pendingEditCount;
+      final detail = pendingCount > 0
+          ? 'Rescanning reloads every save and discards your $pendingCount '
+                'unsaved change${pendingCount == 1 ? '' : 's'}.'
+          : 'Rescanning reloads every save and discards your unsaved '
+                'difficulty changes.';
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (context) => AlertDialog(
           title: const Text('Discard unsaved changes?'),
-          content: Text(
-            'Rescanning reloads every save and discards your $pendingCount '
-            'unsaved change${pendingCount == 1 ? '' : 's'}.',
-          ),
+          content: Text(detail),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(false),
@@ -313,6 +318,11 @@ class _ProfileHeader extends StatelessWidget {
         ),
       );
       if (confirmed != true) return;
+      // The user chose to discard. Clear the difficulty draft signal so the
+      // card re-seeds to the stored value on the upcoming re-inspect (the
+      // notifier otherwise preserves a dirty draft across a same-save
+      // re-inspect). Pending registry edits are cleared by the refresh itself.
+      notifier.setDifficultyDirty(false);
     }
     await notifier.refresh();
   }

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -1961,17 +1961,26 @@ class _PrivateInventorySummaryCardState
             '×${item.count ?? '?'}',
             style: theme.textTheme.bodyMedium,
           ),
-        if (canRemove && item.path.isNotEmpty && item.removable) ...[
+        if (canRemove && item.path.isNotEmpty) ...[
           const SizedBox(width: 4),
           Tooltip(
-            message: removeBlocked
+            message: !item.removable
+                ? "Can't delete: this item is likely equipped or "
+                    'assigned to a hotkey slot'
+                : removeBlocked
                 ? 'Save or reset your pending inventory changes first — '
                     'an add or remove must be saved on its own'
                 : 'Remove item from inventory',
             child: IconButton(
               icon: const Icon(Icons.delete_outline),
-              onPressed:
-                  removeBlocked ? null : () => _queueRemove(item),
+              // A non-removable item shows the trash icon disabled (its asset
+              // path occurs in more than one container — e.g. also equipped or
+              // in a quickslot — so the core can't unambiguously remove it). A
+              // removable item is disabled only while a structural/count edit
+              // is pending; otherwise it queues the remove.
+              onPressed: (!item.removable || removeBlocked)
+                  ? null
+                  : () => _queueRemove(item),
             ),
           ),
         ],

--- a/apps/goresave/lib/features/editor/ui/editor_page.dart
+++ b/apps/goresave/lib/features/editor/ui/editor_page.dart
@@ -517,9 +517,9 @@ String _saveSlotSubtitle(SaveSlot save) {
   if (timePlayed != '-') {
     parts.add(timePlayed);
   }
-  final mapName = save.mapName;
-  if (mapName != null && mapName.isNotEmpty) {
-    parts.add(mapName);
+  final difficulty = save.difficulty?.presetLabel;
+  if (difficulty != null && difficulty != '-') {
+    parts.add(difficulty);
   }
   return parts.join(' | ');
 }
@@ -935,8 +935,9 @@ class _OverviewDiagnosticsState extends State<_OverviewDiagnostics> {
                         'Slot': inspection.slot ?? '-',
                         if (inspection.chapterId != null)
                           'Chapter': inspection.chapterId.toString(),
-                        if (inspection.mapName != null)
-                          'Map': inspection.mapName!,
+                        if (inspection.difficulty?.presetLabel != null &&
+                            inspection.difficulty!.presetLabel != '-')
+                          'Difficulty': inspection.difficulty!.presetLabel,
                         if (inspection.timePlayedSeconds != null)
                           'Time played': _formatDurationSeconds(
                             inspection.timePlayedSeconds,
@@ -1065,10 +1066,11 @@ class _HeaderCard extends StatelessWidget {
                                   inspection.timePlayedSeconds,
                                 ),
                               ),
-                            if (inspection.mapName != null)
+                            if (inspection.difficulty?.presetLabel != null &&
+                                inspection.difficulty!.presetLabel != '-')
                               _InfoPill(
-                                icon: Icons.map_outlined,
-                                label: inspection.mapName!,
+                                icon: Icons.local_fire_department_outlined,
+                                label: inspection.difficulty!.presetLabel,
                               ),
                           ];
                           if (pills.isEmpty) return const SizedBox.shrink();

--- a/apps/goresave/test/difficulty_card_test.dart
+++ b/apps/goresave/test/difficulty_card_test.dart
@@ -3,14 +3,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:goresave/features/editor/domain/core_service.dart';
 import 'package:goresave/features/editor/domain/editor_models.dart';
 import 'package:goresave/features/editor/domain/editor_notifier.dart';
-import 'package:goresave/features/editor/domain/pending_edits.dart';
 import 'package:goresave/features/editor/ui/difficulty_card.dart';
 
 /// Minimal core stub: every command resolves to an empty ok response so the
 /// EditorNotifier constructor (which fires refresh + checkCodec) settles
 /// without errors. The Difficulty card never issues a write in this test — it
-/// only reads notifier.state and calls setDifficultyDirty — so no command
-/// needs real data.
+/// only reads notifier.state and registers/clears the pending difficulty edit —
+/// so no command needs real data.
 class _StubCoreService implements GoresaveCoreService {
   @override
   bool get isAvailable => true;
@@ -53,6 +52,13 @@ SwitchListTile _switchByTitle(WidgetTester tester, String title) {
       .firstWhere((s) => (s.title as Text).data == title);
 }
 
+/// The preset SegmentedButton is the only one carrying a 'Custom' segment.
+Finder _presetPicker() => find.byWidgetPredicate(
+  (w) =>
+      w is SegmentedButton<String> &&
+      w.segments.any((s) => (s.label as Text).data == 'Custom'),
+);
+
 void main() {
   late EditorNotifier notifier;
 
@@ -69,6 +75,7 @@ void main() {
     WidgetTester tester, {
     ProfileSummary? profile,
     SaveInspection? inspection,
+    bool canCompress = true,
   }) async {
     await tester.binding.setSurfaceSize(const Size(900, 1200));
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -80,61 +87,54 @@ void main() {
               inspection: inspection ?? _customInspection(),
               notifier: notifier,
               profile: profile,
-              canCompress: true,
+              canCompress: canCompress,
             ),
           ),
         ),
       ),
     );
     await tester.pumpAndSettle();
-    // The card opens collapsed; expand it to reveal the editing form.
-    await tester.tap(find.text('Difficulty'));
-    await tester.pumpAndSettle();
-  }
-
-  /// Resolve the Save FilledButton (the only FilledButton containing 'Save').
-  FilledButton saveButton(WidgetTester tester) {
-    final finder = find.ancestor(
-      of: find.text('Save'),
-      matching: find.byType(FilledButton),
-    );
-    return tester.widget<FilledButton>(finder);
-  }
-
-  /// Tap the 'Also update the profile' checkbox tile.
-  Future<void> tickAlsoProfile(WidgetTester tester) async {
-    await tester.tap(find.text('Also update the profile'));
-    await tester.pumpAndSettle();
+    // The card now opens EXPANDED by default — no need to tap to reveal it.
   }
 
   const profile = ProfileSummary(profileId: 1, profileName: 'Nameless Hero');
+
+  testWidgets('the card is expanded by default (form visible on load)', (
+    tester,
+  ) async {
+    await pumpCard(tester);
+    // The preset selector (and its 'Custom' segment) is visible without any tap.
+    expect(_presetPicker(), findsOneWidget);
+    expect(find.text('Combat'), findsOneWidget);
+  });
+
+  testWidgets('the card has no own Save/Reset buttons', (tester) async {
+    await pumpCard(tester, profile: profile);
+    // No card-local Save/Reset (those live on the global toolbar now).
+    expect(find.widgetWithText(FilledButton, 'Save'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, 'Reset'), findsNothing);
+  });
 
   testWidgets(
     'Custom preset enables Permadeath and all three level pickers',
     (tester) async {
       await pumpCard(tester);
 
-      // Custom-preset save seeds Custom: pickers and Permadeath are editable.
       expect(_switchByTitle(tester, 'Permadeath').onChanged, isNotNull);
       for (final label in ['Combat', 'Resources', 'Progression']) {
         expect(find.text(label), findsOneWidget);
       }
-      // The three level pickers are the SegmentedButtons whose options are
-      // exactly Novice/Gothic/Hard (no 'Custom' segment). There are three of
-      // them and all are enabled.
       final levelPickers = tester
           .widgetList<SegmentedButton<String>>(
             find.byType(SegmentedButton<String>),
           )
-          .where((b) => b.segments.every((s) => (s.label as Text).data != 'Custom'))
+          .where(
+            (b) => b.segments.every((s) => (s.label as Text).data != 'Custom'),
+          )
           .toList();
       expect(levelPickers, hasLength(3));
       for (final picker in levelPickers) {
-        expect(
-          picker.onSelectionChanged,
-          isNotNull,
-          reason: 'Custom preset must enable every level picker',
-        );
+        expect(picker.onSelectionChanged, isNotNull);
       }
     },
   );
@@ -144,42 +144,28 @@ void main() {
     (tester) async {
       await pumpCard(tester);
 
-      // Switch the preset to Novice. The preset picker is the only
-      // SegmentedButton that carries a 'Custom' segment, so it is uniquely
-      // addressable; tap its 'Novice' option (a 'Novice' label also exists in
-      // the level pickers, hence the scoped finder).
-      final presetPicker = find.byWidgetPredicate(
-        (w) =>
-            w is SegmentedButton<String> &&
-            w.segments.any((s) => (s.label as Text).data == 'Custom'),
-      );
       await tester.tap(
-        find.descendant(of: presetPicker, matching: find.text('Novice')),
+        find.descendant(of: _presetPicker(), matching: find.text('Novice')),
       );
       await tester.pumpAndSettle();
 
-      // Permadeath is disabled and forced off on Novice.
       final perma = _switchByTitle(tester, 'Permadeath');
       expect(perma.onChanged, isNull, reason: 'Novice disables Permadeath');
       expect(perma.value, isFalse, reason: 'Novice forces Permadeath off');
 
-      // Every level picker is now locked.
       final levelPickers = tester
           .widgetList<SegmentedButton<String>>(
             find.byType(SegmentedButton<String>),
           )
-          .where((b) => b.segments.every((s) => (s.label as Text).data != 'Custom'))
+          .where(
+            (b) => b.segments.every((s) => (s.label as Text).data != 'Custom'),
+          )
           .toList();
       expect(levelPickers, hasLength(3));
       for (final picker in levelPickers) {
-        expect(
-          picker.onSelectionChanged,
-          isNull,
-          reason: 'Novice must disable every level picker',
-        );
+        expect(picker.onSelectionChanged, isNull);
       }
 
-      // Flow Helper stays enabled regardless of preset.
       expect(
         _switchByTitle(tester, 'Close Combat Flow Helper').onChanged,
         isNotNull,
@@ -188,97 +174,108 @@ void main() {
   );
 
   testWidgets(
-    'propagation-only: ticking a box enables Save and marks dirty (Report #5)',
+    'changing a control registers a pending difficulty edit the GLOBAL count '
+    'reflects',
     (tester) async {
       await pumpCard(tester, profile: profile);
 
-      // No field changed yet → Save disabled, not dirty.
-      expect(saveButton(tester).onPressed, isNull);
-      expect(notifier.state.difficultyDirty, isFalse);
+      // Nothing pending initially.
+      expect(notifier.state.pendingDifficulty, isNull);
+      expect(notifier.state.pendingEditCount, 0);
 
-      // Tick "Also update the profile" without changing any field.
-      await tickAlsoProfile(tester);
+      // Switch preset Custom → Novice: a real difficulty change.
+      await tester.tap(
+        find.descendant(of: _presetPicker(), matching: find.text('Novice')),
+      );
+      await tester.pumpAndSettle();
 
-      // Save is now enabled for the propagation-only write, and the dirty
-      // signal flips so the unsaved-edits guard would prompt.
-      expect(
-        saveButton(tester).onPressed,
-        isNotNull,
-        reason: 'A ticked propagation box is work — Save must enable',
+      // A pending difficulty edit is now registered and the GLOBAL count/badge
+      // reflect it.
+      expect(notifier.state.pendingDifficulty, isNotNull);
+      expect(notifier.state.pendingEditCount, 1);
+      expect(notifier.state.hasUnsavedEdits, isTrue);
+      expect(notifier.state.pendingDifficulty!.difficulty['preset'], 'Novice');
+      // The card shows the 'Unsaved' badge.
+      expect(find.text('Unsaved'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'reverting a control back to the stored value clears the pending edit',
+    (tester) async {
+      await pumpCard(tester, profile: profile);
+
+      // Stored flowHelper is true. Toggle it off (pending), then back on.
+      final flowFinder = find.ancestor(
+        of: find.text('Close Combat Flow Helper'),
+        matching: find.byType(SwitchListTile),
       );
-      expect(
-        notifier.state.difficultyDirty,
-        isTrue,
-        reason: 'A propagation-only intent must register as unsaved work',
-      );
+      await tester.tap(flowFinder);
+      await tester.pumpAndSettle();
+      expect(notifier.state.pendingDifficulty, isNotNull);
+
+      await tester.tap(flowFinder);
+      await tester.pumpAndSettle();
+      // Back at the stored value with no propagation → no pending work.
+      expect(notifier.state.pendingDifficulty, isNull);
+      expect(notifier.state.pendingEditCount, 0);
+      expect(find.text('Unsaved'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'propagation-only: ticking a box registers a pending edit (no field change)',
+    (tester) async {
+      await pumpCard(tester, profile: profile);
+
+      expect(notifier.state.pendingDifficulty, isNull);
+
+      await tester.tap(find.text('Also update the profile'));
+      await tester.pumpAndSettle();
+
+      // A ticked propagation box is work even without a field change.
+      expect(notifier.state.pendingDifficulty, isNotNull);
+      expect(notifier.state.pendingDifficulty!.alsoProfile, isTrue);
       expect(notifier.state.hasUnsavedEdits, isTrue);
     },
   );
 
   testWidgets(
-    'difficulty Save is blocked while unrelated pending edits exist (Report #2)',
+    'no resolvable profile disables both propagation checkboxes',
     (tester) async {
-      // Register an unrelated pending edit before pumping the card.
-      notifier.setPendingEdit(
-        'publicName',
-        const PendingSaveEdit(
-          edits: [
-            {'path': 'public.name.set', 'value': 'Renamed'},
-          ],
-        ),
-      );
-      await pumpCard(tester, profile: profile);
+      // profile == null models a save with no resolvable profile.
+      await pumpCard(tester, profile: null);
 
-      // Make a real difficulty change so the only thing keeping Save disabled
-      // is the blocking pending edit.
-      await tester.tap(
-        find.descendant(
-          of: find.byWidgetPredicate(
-            (w) =>
-                w is SegmentedButton<String> &&
-                w.segments.any((s) => (s.label as Text).data == 'Custom'),
-          ),
-          matching: find.text('Hard'),
-        ),
+      final boxes = tester.widgetList<CheckboxListTile>(
+        find.byType(CheckboxListTile),
       );
-      await tester.pumpAndSettle();
-
-      expect(
-        saveButton(tester).onPressed,
-        isNull,
-        reason: 'Difficulty Save must be blocked while other edits are pending',
-      );
-      // The blocking hint is shown.
-      expect(
-        find.textContaining('Save or reset your other pending changes first'),
-        findsOneWidget,
-      );
+      expect(boxes, hasLength(2));
+      for (final box in boxes) {
+        expect(
+          box.onChanged,
+          isNull,
+          reason: 'Cannot propagate without a resolved profile',
+        );
+      }
     },
   );
 
   testWidgets(
-    'dirty difficulty draft survives an incidental same-save re-inspect '
-    '(Report #1 / behavior B)',
+    'a global Reset (pendingDifficulty cleared) makes the card show stored '
+    'values again',
     (tester) async {
       await pumpCard(tester, profile: profile);
 
-      // Make the draft dirty: switch preset Custom → Novice.
+      // Make the draft Novice.
       await tester.tap(
-        find.descendant(
-          of: find.byWidgetPredicate(
-            (w) =>
-                w is SegmentedButton<String> &&
-                w.segments.any((s) => (s.label as Text).data == 'Custom'),
-          ),
-          matching: find.text('Novice'),
-        ),
+        find.descendant(of: _presetPicker(), matching: find.text('Novice')),
       );
       await tester.pumpAndSettle();
-      expect(notifier.state.difficultyDirty, isTrue);
+      expect(notifier.state.pendingDifficulty, isNotNull);
 
-      // Simulate an incidental re-inspect of the SAME save: a brand-new
-      // SaveInspection instance with the same path lands in the widget tree.
-      // (The notifier preserves difficultyDirty for a same-save re-inspect.)
+      // Simulate the global Reset clearing the pending difficulty, then a
+      // parent rebuild of the card (same save).
+      notifier.clearPendingDifficulty();
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -295,118 +292,33 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Draft must still be Novice (preserved), and still marked unsaved.
+      // The card renders the stored Custom preset again.
       final presetPicker = tester.widget<SegmentedButton<String>>(
-        find.byWidgetPredicate(
-          (w) =>
-              w is SegmentedButton<String> &&
-              w.segments.any((s) => (s.label as Text).data == 'Custom'),
-        ),
+        _presetPicker(),
       );
-      expect(
-        presetPicker.selected,
-        {'Novice'},
-        reason: 'A dirty draft must survive a same-save re-inspect',
-      );
-      expect(notifier.state.difficultyDirty, isTrue);
+      expect(presetPicker.selected, {'Custom'});
+      expect(find.text('Unsaved'), findsNothing);
     },
   );
 
   testWidgets(
-    'stale difficultyDirty is cleared when a re-seed lands on a no-work draft '
-    '(Report #1 — stuck guard)',
+    'a non-blocking codec hint shows when an edit is pending but the codec is '
+    'not compress-ready',
     (tester) async {
-      await pumpCard(tester, profile: profile);
+      await pumpCard(tester, profile: profile, canCompress: false);
 
-      // Drive the notifier flag dirty directly, leaving the local draft at its
-      // freshly-seeded (no-work) state. This models the regression: the flag is
-      // set but the card has nothing to save, so the "Unsaved" badge is hidden
-      // yet the profile-switch / rescan guards stay wedged.
-      notifier.setDifficultyDirty(true);
-      expect(notifier.state.difficultyDirty, isTrue);
+      // No hint until there is pending work.
+      expect(find.textContaining('verified G1R codec host'), findsNothing);
 
-      // A re-inspect of the SAME save lands (new instance, same path). Because
-      // the draft has no work, didUpdateWidget re-seeds and must schedule a
-      // clear of the stale flag after the frame.
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SingleChildScrollView(
-              child: DifficultyCard(
-                inspection: _customInspection(),
-                notifier: notifier,
-                profile: profile,
-                canCompress: true,
-              ),
-            ),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      // The post-frame callback has run: the stale flag is cleared, so
-      // hasUnsavedEdits reflects reality and the guards are no longer stuck.
-      expect(
-        notifier.state.difficultyDirty,
-        isFalse,
-        reason: 'A re-seed to a no-work draft must clear the stale dirty flag',
-      );
-      expect(notifier.state.hasUnsavedEdits, isFalse);
-    },
-  );
-
-  testWidgets(
-    'draft re-seeds when the notifier clears difficultyDirty (discard path)',
-    (tester) async {
-      await pumpCard(tester, profile: profile);
-
-      // Make the draft dirty.
       await tester.tap(
-        find.descendant(
-          of: find.byWidgetPredicate(
-            (w) =>
-                w is SegmentedButton<String> &&
-                w.segments.any((s) => (s.label as Text).data == 'Custom'),
-          ),
-          matching: find.text('Novice'),
-        ),
-      );
-      await tester.pumpAndSettle();
-      expect(notifier.state.difficultyDirty, isTrue);
-
-      // The discard-and-rescan path clears the dirty signal before refresh.
-      // The real app rebuilds the card when notifier state changes; simulate
-      // that parent rebuild by re-pumping the same widget (same save path).
-      notifier.setDifficultyDirty(false);
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SingleChildScrollView(
-              child: DifficultyCard(
-                inspection: _customInspection(),
-                notifier: notifier,
-                profile: profile,
-                canCompress: true,
-              ),
-            ),
-          ),
-        ),
+        find.descendant(of: _presetPicker(), matching: find.text('Novice')),
       );
       await tester.pumpAndSettle();
 
-      // The card re-seeds to the stored Custom preset.
-      final presetPicker = tester.widget<SegmentedButton<String>>(
-        find.byWidgetPredicate(
-          (w) =>
-              w is SegmentedButton<String> &&
-              w.segments.any((s) => (s.label as Text).data == 'Custom'),
-        ),
-      );
-      expect(
-        presetPicker.selected,
-        {'Custom'},
-        reason: 'Clearing difficultyDirty must re-seed the draft to stored',
-      );
+      // The hint appears, but the controls remain enabled — the global Save
+      // surfaces the actual error; the card no longer gates.
+      expect(find.textContaining('verified G1R codec host'), findsOneWidget);
+      expect(notifier.state.pendingDifficulty, isNotNull);
     },
   );
 }

--- a/apps/goresave/test/difficulty_card_test.dart
+++ b/apps/goresave/test/difficulty_card_test.dart
@@ -45,6 +45,24 @@ SaveInspection _customInspection() {
   });
 }
 
+/// A SaveInspection whose stored difficulty preset is an UNMAPPED core class
+/// name. `presetLabel` therefore passes the raw string through, which is not
+/// one of the four UI presets, so the card must treat it as "unknown" — never
+/// silently as Gothic.
+SaveInspection _unknownPresetInspection() {
+  return SaveInspection.fromJson({
+    'format': 'G1R',
+    'path': r'C:\tmp\saves\G1R-002.sav',
+    'size': 1024,
+    'sha1': 'def',
+    'difficulty': {
+      'preset': 'EDifficulty_SomeFutureMode',
+      'flowHelper': true,
+      'permadeath': true,
+    },
+  });
+}
+
 /// Resolve a SwitchListTile by its title text.
 SwitchListTile _switchByTitle(WidgetTester tester, String title) {
   return tester
@@ -380,6 +398,89 @@ void main() {
       );
       expect(presetPicker.selected, {'Custom'});
       expect(find.text('Unsaved'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'an unknown stored preset shows NOTHING selected and registers no pending '
+    'difficulty until the user explicitly picks a preset',
+    (tester) async {
+      await pumpCard(
+        tester,
+        profile: profile,
+        inspection: _unknownPresetInspection(),
+      );
+
+      // The preset selector highlights nothing — the unmapped class name is
+      // NOT silently treated as Gothic (or any concrete preset).
+      final presetPicker = tester.widget<SegmentedButton<String>>(
+        _presetPicker(),
+      );
+      expect(presetPicker.selected, isEmpty);
+      expect(presetPicker.emptySelectionAllowed, isTrue);
+
+      // Nothing pending: a global Save must not write a guessed preset.
+      expect(notifier.state.pendingDifficulty, isNull);
+      expect(notifier.state.pendingEditCount, 0);
+      expect(notifier.state.hasUnsavedEdits, isFalse);
+
+      // Toggling a non-preset control (flow helper) while the preset is still
+      // unknown must NOT manufacture a saveable candidate from a guessed
+      // preset — there is still nothing pending.
+      await tester.tap(
+        find.ancestor(
+          of: find.text('Close Combat Flow Helper'),
+          matching: find.byType(SwitchListTile),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        notifier.state.pendingDifficulty,
+        isNull,
+        reason: 'no explicit preset chosen yet → no saveable difficulty',
+      );
+
+      // Ticking a propagation box while the preset is unknown likewise must not
+      // produce a candidate that would write a guessed difficulty.
+      await tester.tap(find.text('Also update the profile'));
+      await tester.pumpAndSettle();
+      expect(
+        notifier.state.pendingDifficulty,
+        isNull,
+        reason: 'propagation cannot write difficulty without a chosen preset',
+      );
+    },
+  );
+
+  testWidgets(
+    'after the user explicitly picks a preset, an unknown-stored save '
+    'registers a pending difficulty normally',
+    (tester) async {
+      await pumpCard(
+        tester,
+        profile: profile,
+        inspection: _unknownPresetInspection(),
+      );
+      expect(notifier.state.pendingDifficulty, isNull);
+
+      // Explicitly choose Hard. The stored preset (unknown) != Hard, so this is
+      // a real change and registers a pending difficulty with that preset.
+      await tester.tap(
+        find.descendant(of: _presetPicker(), matching: find.text('Hard')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(notifier.state.pendingDifficulty, isNotNull);
+      expect(notifier.state.pendingEditCount, 1);
+      expect(notifier.state.hasUnsavedEdits, isTrue);
+      expect(notifier.state.pendingDifficulty!.difficulty['preset'], 'Hard');
+
+      // The selector now highlights the explicitly-chosen preset.
+      final presetPicker = tester.widget<SegmentedButton<String>>(
+        _presetPicker(),
+      );
+      expect(presetPicker.selected, {'Hard'});
+      expect(find.text('Unsaved'), findsOneWidget);
     },
   );
 

--- a/apps/goresave/test/difficulty_card_test.dart
+++ b/apps/goresave/test/difficulty_card_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/core_service.dart';
+import 'package:goresave/features/editor/domain/editor_models.dart';
+import 'package:goresave/features/editor/domain/editor_notifier.dart';
+import 'package:goresave/features/editor/ui/difficulty_card.dart';
+
+/// Minimal core stub: every command resolves to an empty ok response so the
+/// EditorNotifier constructor (which fires refresh + checkCodec) settles
+/// without errors. The Difficulty card never issues a write in this test — it
+/// only reads notifier.state and calls setDifficultyDirty — so no command
+/// needs real data.
+class _StubCoreService implements GoresaveCoreService {
+  @override
+  bool get isAvailable => true;
+
+  @override
+  String get description => 'stub';
+
+  @override
+  Future<Map<String, Object?>> execute(
+    String command, {
+    Map<String, Object?> payload = const {},
+  }) async {
+    return {'ok': true, 'data': const <String, Object?>{}};
+  }
+}
+
+/// A SaveInspection seeded with a Custom-preset difficulty block. Custom maps
+/// the level suffixes to labels: _Custom→Custom, _Hard→Hard, _Standard→Gothic.
+SaveInspection _customInspection() {
+  return SaveInspection.fromJson({
+    'format': 'G1R',
+    'path': r'C:\tmp\saves\G1R-001.sav',
+    'size': 1024,
+    'sha1': 'abc',
+    'difficulty': {
+      'preset': 'EDifficulty_Custom',
+      'combat': 'ECombat_Hard',
+      'resources': 'EResources_Standard',
+      'progression': 'EProgression_Easy',
+      'flowHelper': true,
+      'permadeath': true,
+    },
+  });
+}
+
+/// Resolve a SwitchListTile by its title text.
+SwitchListTile _switchByTitle(WidgetTester tester, String title) {
+  return tester
+      .widgetList<SwitchListTile>(find.byType(SwitchListTile))
+      .firstWhere((s) => (s.title as Text).data == title);
+}
+
+void main() {
+  late EditorNotifier notifier;
+
+  setUp(() {
+    notifier = EditorNotifier(
+      _StubCoreService(),
+      saveDir: r'C:\tmp\saves',
+      codecHostPath: r'C:\tools\codec.exe',
+      gameExePath: r'C:\games\G1R-Win64-Shipping.exe',
+    );
+  });
+
+  Future<void> pumpCard(WidgetTester tester, {ProfileSummary? profile}) async {
+    await tester.binding.setSurfaceSize(const Size(900, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: DifficultyCard(
+              inspection: _customInspection(),
+              notifier: notifier,
+              profile: profile,
+              canCompress: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    // The card opens collapsed; expand it to reveal the editing form.
+    await tester.tap(find.text('Difficulty'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+    'Custom preset enables Permadeath and all three level pickers',
+    (tester) async {
+      await pumpCard(tester);
+
+      // Custom-preset save seeds Custom: pickers and Permadeath are editable.
+      expect(_switchByTitle(tester, 'Permadeath').onChanged, isNotNull);
+      for (final label in ['Combat', 'Resources', 'Progression']) {
+        expect(find.text(label), findsOneWidget);
+      }
+      // The three level pickers are the SegmentedButtons whose options are
+      // exactly Novice/Gothic/Hard (no 'Custom' segment). There are three of
+      // them and all are enabled.
+      final levelPickers = tester
+          .widgetList<SegmentedButton<String>>(
+            find.byType(SegmentedButton<String>),
+          )
+          .where((b) => b.segments.every((s) => (s.label as Text).data != 'Custom'))
+          .toList();
+      expect(levelPickers, hasLength(3));
+      for (final picker in levelPickers) {
+        expect(
+          picker.onSelectionChanged,
+          isNotNull,
+          reason: 'Custom preset must enable every level picker',
+        );
+      }
+    },
+  );
+
+  testWidgets(
+    'Novice preset disables Permadeath and all three level pickers',
+    (tester) async {
+      await pumpCard(tester);
+
+      // Switch the preset to Novice. The preset picker is the only
+      // SegmentedButton that carries a 'Custom' segment, so it is uniquely
+      // addressable; tap its 'Novice' option (a 'Novice' label also exists in
+      // the level pickers, hence the scoped finder).
+      final presetPicker = find.byWidgetPredicate(
+        (w) =>
+            w is SegmentedButton<String> &&
+            w.segments.any((s) => (s.label as Text).data == 'Custom'),
+      );
+      await tester.tap(
+        find.descendant(of: presetPicker, matching: find.text('Novice')),
+      );
+      await tester.pumpAndSettle();
+
+      // Permadeath is disabled and forced off on Novice.
+      final perma = _switchByTitle(tester, 'Permadeath');
+      expect(perma.onChanged, isNull, reason: 'Novice disables Permadeath');
+      expect(perma.value, isFalse, reason: 'Novice forces Permadeath off');
+
+      // Every level picker is now locked.
+      final levelPickers = tester
+          .widgetList<SegmentedButton<String>>(
+            find.byType(SegmentedButton<String>),
+          )
+          .where((b) => b.segments.every((s) => (s.label as Text).data != 'Custom'))
+          .toList();
+      expect(levelPickers, hasLength(3));
+      for (final picker in levelPickers) {
+        expect(
+          picker.onSelectionChanged,
+          isNull,
+          reason: 'Novice must disable every level picker',
+        );
+      }
+
+      // Flow Helper stays enabled regardless of preset.
+      expect(
+        _switchByTitle(tester, 'Close Combat Flow Helper').onChanged,
+        isNotNull,
+      );
+    },
+  );
+}

--- a/apps/goresave/test/difficulty_card_test.dart
+++ b/apps/goresave/test/difficulty_card_test.dart
@@ -319,6 +319,30 @@ void main() {
   );
 
   testWidgets(
+    'with no resolvable profile, a field edit never sets alsoProfile/allSaves '
+    'on the candidate (defense-in-depth against a stale tick)',
+    (tester) async {
+      // profile == null models a save with no resolvable profile. Changing a
+      // control fires _apply, which must force the propagation flags false so
+      // a pending difficulty can never carry propagation the save-path could
+      // not honour.
+      await pumpCard(tester, profile: null);
+
+      // Tap the Novice segment within the PRESET picker specifically (the
+      // 'Novice' label also appears in the level pickers). This diverges from
+      // the stored Custom preset, so _apply registers a pending difficulty.
+      await tester.tap(
+        find.descendant(of: _presetPicker(), matching: find.text('Novice')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(notifier.state.pendingDifficulty, isNotNull);
+      expect(notifier.state.pendingDifficulty!.alsoProfile, isFalse);
+      expect(notifier.state.pendingDifficulty!.allSaves, isFalse);
+    },
+  );
+
+  testWidgets(
     'a global Reset (pendingDifficulty cleared) makes the card show stored '
     'values again',
     (tester) async {

--- a/apps/goresave/test/difficulty_card_test.dart
+++ b/apps/goresave/test/difficulty_card_test.dart
@@ -313,6 +313,49 @@ void main() {
   );
 
   testWidgets(
+    'stale difficultyDirty is cleared when a re-seed lands on a no-work draft '
+    '(Report #1 — stuck guard)',
+    (tester) async {
+      await pumpCard(tester, profile: profile);
+
+      // Drive the notifier flag dirty directly, leaving the local draft at its
+      // freshly-seeded (no-work) state. This models the regression: the flag is
+      // set but the card has nothing to save, so the "Unsaved" badge is hidden
+      // yet the profile-switch / rescan guards stay wedged.
+      notifier.setDifficultyDirty(true);
+      expect(notifier.state.difficultyDirty, isTrue);
+
+      // A re-inspect of the SAME save lands (new instance, same path). Because
+      // the draft has no work, didUpdateWidget re-seeds and must schedule a
+      // clear of the stale flag after the frame.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: DifficultyCard(
+                inspection: _customInspection(),
+                notifier: notifier,
+                profile: profile,
+                canCompress: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The post-frame callback has run: the stale flag is cleared, so
+      // hasUnsavedEdits reflects reality and the guards are no longer stuck.
+      expect(
+        notifier.state.difficultyDirty,
+        isFalse,
+        reason: 'A re-seed to a no-work draft must clear the stale dirty flag',
+      );
+      expect(notifier.state.hasUnsavedEdits, isFalse);
+    },
+  );
+
+  testWidgets(
     'draft re-seeds when the notifier clears difficultyDirty (discard path)',
     (tester) async {
       await pumpCard(tester, profile: profile);

--- a/apps/goresave/test/difficulty_card_test.dart
+++ b/apps/goresave/test/difficulty_card_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:goresave/features/editor/domain/core_service.dart';
 import 'package:goresave/features/editor/domain/editor_models.dart';
 import 'package:goresave/features/editor/domain/editor_notifier.dart';
+import 'package:goresave/features/editor/domain/pending_edits.dart';
 import 'package:goresave/features/editor/ui/difficulty_card.dart';
 
 /// Minimal core stub: every command resolves to an empty ok response so the
@@ -64,7 +65,11 @@ void main() {
     );
   });
 
-  Future<void> pumpCard(WidgetTester tester, {ProfileSummary? profile}) async {
+  Future<void> pumpCard(
+    WidgetTester tester, {
+    ProfileSummary? profile,
+    SaveInspection? inspection,
+  }) async {
     await tester.binding.setSurfaceSize(const Size(900, 1200));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     await tester.pumpWidget(
@@ -72,7 +77,7 @@ void main() {
         home: Scaffold(
           body: SingleChildScrollView(
             child: DifficultyCard(
-              inspection: _customInspection(),
+              inspection: inspection ?? _customInspection(),
               notifier: notifier,
               profile: profile,
               canCompress: true,
@@ -86,6 +91,23 @@ void main() {
     await tester.tap(find.text('Difficulty'));
     await tester.pumpAndSettle();
   }
+
+  /// Resolve the Save FilledButton (the only FilledButton containing 'Save').
+  FilledButton saveButton(WidgetTester tester) {
+    final finder = find.ancestor(
+      of: find.text('Save'),
+      matching: find.byType(FilledButton),
+    );
+    return tester.widget<FilledButton>(finder);
+  }
+
+  /// Tap the 'Also update the profile' checkbox tile.
+  Future<void> tickAlsoProfile(WidgetTester tester) async {
+    await tester.tap(find.text('Also update the profile'));
+    await tester.pumpAndSettle();
+  }
+
+  const profile = ProfileSummary(profileId: 1, profileName: 'Nameless Hero');
 
   testWidgets(
     'Custom preset enables Permadeath and all three level pickers',
@@ -161,6 +183,186 @@ void main() {
       expect(
         _switchByTitle(tester, 'Close Combat Flow Helper').onChanged,
         isNotNull,
+      );
+    },
+  );
+
+  testWidgets(
+    'propagation-only: ticking a box enables Save and marks dirty (Report #5)',
+    (tester) async {
+      await pumpCard(tester, profile: profile);
+
+      // No field changed yet → Save disabled, not dirty.
+      expect(saveButton(tester).onPressed, isNull);
+      expect(notifier.state.difficultyDirty, isFalse);
+
+      // Tick "Also update the profile" without changing any field.
+      await tickAlsoProfile(tester);
+
+      // Save is now enabled for the propagation-only write, and the dirty
+      // signal flips so the unsaved-edits guard would prompt.
+      expect(
+        saveButton(tester).onPressed,
+        isNotNull,
+        reason: 'A ticked propagation box is work — Save must enable',
+      );
+      expect(
+        notifier.state.difficultyDirty,
+        isTrue,
+        reason: 'A propagation-only intent must register as unsaved work',
+      );
+      expect(notifier.state.hasUnsavedEdits, isTrue);
+    },
+  );
+
+  testWidgets(
+    'difficulty Save is blocked while unrelated pending edits exist (Report #2)',
+    (tester) async {
+      // Register an unrelated pending edit before pumping the card.
+      notifier.setPendingEdit(
+        'publicName',
+        const PendingSaveEdit(
+          edits: [
+            {'path': 'public.name.set', 'value': 'Renamed'},
+          ],
+        ),
+      );
+      await pumpCard(tester, profile: profile);
+
+      // Make a real difficulty change so the only thing keeping Save disabled
+      // is the blocking pending edit.
+      await tester.tap(
+        find.descendant(
+          of: find.byWidgetPredicate(
+            (w) =>
+                w is SegmentedButton<String> &&
+                w.segments.any((s) => (s.label as Text).data == 'Custom'),
+          ),
+          matching: find.text('Hard'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        saveButton(tester).onPressed,
+        isNull,
+        reason: 'Difficulty Save must be blocked while other edits are pending',
+      );
+      // The blocking hint is shown.
+      expect(
+        find.textContaining('Save or reset your other pending changes first'),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'dirty difficulty draft survives an incidental same-save re-inspect '
+    '(Report #1 / behavior B)',
+    (tester) async {
+      await pumpCard(tester, profile: profile);
+
+      // Make the draft dirty: switch preset Custom → Novice.
+      await tester.tap(
+        find.descendant(
+          of: find.byWidgetPredicate(
+            (w) =>
+                w is SegmentedButton<String> &&
+                w.segments.any((s) => (s.label as Text).data == 'Custom'),
+          ),
+          matching: find.text('Novice'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(notifier.state.difficultyDirty, isTrue);
+
+      // Simulate an incidental re-inspect of the SAME save: a brand-new
+      // SaveInspection instance with the same path lands in the widget tree.
+      // (The notifier preserves difficultyDirty for a same-save re-inspect.)
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: DifficultyCard(
+                inspection: _customInspection(),
+                notifier: notifier,
+                profile: profile,
+                canCompress: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Draft must still be Novice (preserved), and still marked unsaved.
+      final presetPicker = tester.widget<SegmentedButton<String>>(
+        find.byWidgetPredicate(
+          (w) =>
+              w is SegmentedButton<String> &&
+              w.segments.any((s) => (s.label as Text).data == 'Custom'),
+        ),
+      );
+      expect(
+        presetPicker.selected,
+        {'Novice'},
+        reason: 'A dirty draft must survive a same-save re-inspect',
+      );
+      expect(notifier.state.difficultyDirty, isTrue);
+    },
+  );
+
+  testWidgets(
+    'draft re-seeds when the notifier clears difficultyDirty (discard path)',
+    (tester) async {
+      await pumpCard(tester, profile: profile);
+
+      // Make the draft dirty.
+      await tester.tap(
+        find.descendant(
+          of: find.byWidgetPredicate(
+            (w) =>
+                w is SegmentedButton<String> &&
+                w.segments.any((s) => (s.label as Text).data == 'Custom'),
+          ),
+          matching: find.text('Novice'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(notifier.state.difficultyDirty, isTrue);
+
+      // The discard-and-rescan path clears the dirty signal before refresh.
+      // The real app rebuilds the card when notifier state changes; simulate
+      // that parent rebuild by re-pumping the same widget (same save path).
+      notifier.setDifficultyDirty(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: DifficultyCard(
+                inspection: _customInspection(),
+                notifier: notifier,
+                profile: profile,
+                canCompress: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The card re-seeds to the stored Custom preset.
+      final presetPicker = tester.widget<SegmentedButton<String>>(
+        find.byWidgetPredicate(
+          (w) =>
+              w is SegmentedButton<String> &&
+              w.segments.any((s) => (s.label as Text).data == 'Custom'),
+        ),
+      );
+      expect(
+        presetPicker.selected,
+        {'Custom'},
+        reason: 'Clearing difficultyDirty must re-seed the draft to stored',
       );
     },
   );

--- a/apps/goresave/test/difficulty_card_test.dart
+++ b/apps/goresave/test/difficulty_card_test.dart
@@ -224,6 +224,64 @@ void main() {
   );
 
   testWidgets(
+    'Custom: a changed sub-level stays pending across a later _apply '
+    '(propagation toggle) — compared against STORED, not the draft',
+    (tester) async {
+      await pumpCard(tester, profile: profile);
+
+      // Stored Custom combat is Hard. Change it to Novice → a real edit.
+      // Target the Combat picker's SegmentedButton (the Row that holds the
+      // 'Combat' label).
+      final combatRow = find.ancestor(
+        of: find.text('Combat'),
+        matching: find.byType(Row),
+      );
+      final combatNovice = find.descendant(
+        of: combatRow,
+        matching: find.text('Novice'),
+      );
+      await tester.tap(combatNovice);
+      await tester.pumpAndSettle();
+      expect(notifier.state.pendingDifficulty, isNotNull);
+      expect(notifier.state.pendingDifficulty!.difficulty['combat'], 'Novice');
+
+      // Now toggle a propagation box ON then OFF. Each fires _apply. With the
+      // bug, the second toggle would compare the changed combat against the
+      // PENDING DRAFT (also Novice) → match → wrongly clear, dropping the
+      // unsaved sub-level change. The fix compares against STORED (Hard).
+      await tester.tap(find.text('Also update the profile'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Also update the profile'));
+      await tester.pumpAndSettle();
+
+      // The combat sub-level still differs from stored → still pending.
+      expect(
+        notifier.state.pendingDifficulty,
+        isNotNull,
+        reason: 'a sub-level differing from STORED must keep the edit pending',
+      );
+      expect(notifier.state.pendingDifficulty!.difficulty['combat'], 'Novice');
+      expect(notifier.state.pendingDifficulty!.alsoProfile, isFalse);
+
+      // Reverting combat back to STORED (Hard) with no propagation clears it.
+      final combatHard = find.descendant(
+        of: find.ancestor(
+          of: find.text('Combat'),
+          matching: find.byType(Row),
+        ),
+        matching: find.text('Hard'),
+      );
+      await tester.tap(combatHard);
+      await tester.pumpAndSettle();
+      expect(
+        notifier.state.pendingDifficulty,
+        isNull,
+        reason: 'all sub-levels back to STORED + no propagation → cleared',
+      );
+    },
+  );
+
+  testWidgets(
     'propagation-only: ticking a box registers a pending edit (no field change)',
     (tester) async {
       await pumpCard(tester, profile: profile);

--- a/apps/goresave/test/difficulty_settings_test.dart
+++ b/apps/goresave/test/difficulty_settings_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/editor_models.dart';
+
+void main() {
+  test('DifficultySettings.fromJson maps fields and label', () {
+    final d = DifficultySettings.fromJson({
+      'preset': 'DifficultyPreset_Custom',
+      'combat': 'CombatDifficultySettings_Hard',
+      'flowHelper': true,
+      'permadeath': false,
+    });
+    expect(d.presetLabel, 'Custom');
+    expect(d.combatLabel, 'Hard');
+    expect(d.flowHelper, true);
+    expect(d.permadeath, false);
+  });
+
+  test('presetLabel maps Easy to Novice and Standard to Gothic', () {
+    expect(DifficultySettings(preset: 'DifficultyPreset_Easy').presetLabel, 'Novice');
+    expect(DifficultySettings(preset: 'DifficultyPreset_Standard').presetLabel, 'Gothic');
+  });
+}

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -575,6 +575,65 @@ void main() {
   );
 
   test(
+    'thrown write_difficulty converges: write_save succeeds, write_difficulty '
+    'THROWS — slot edits cleared, difficulty KEPT (not discarded), error surfaced',
+    () async {
+      final core = _ThrowingDifficultyWriteCoreService(
+        scanData: difficultyScanData(),
+      );
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      notifier.setPendingEdit(
+        'publicName',
+        const PendingSaveEdit(
+          edits: [
+            {'path': 'public.m_PlayerSaveName', 'value': 'Renamed'},
+          ],
+        ),
+      );
+      const pendingDifficulty = PendingDifficulty(
+        difficulty: {'preset': 'Hard', 'flowHelper': false, 'permadeath': true},
+      );
+      notifier.setPendingDifficulty(pendingDifficulty);
+
+      final ok = await notifier.saveAllPending();
+
+      expect(
+        ok,
+        isFalse,
+        reason: 'overall save failed (difficulty threw, did not land)',
+      );
+      // write_save ran (and succeeded) before the throwing write_difficulty.
+      final writeCommands = core.requests
+          .map((r) => r.command)
+          .where((c) => c == 'write_save' || c == 'write_difficulty')
+          .toList();
+      expect(writeCommands, ['write_save', 'write_difficulty']);
+      // Committed slot edits are on disk — they MUST NOT stay pending.
+      expect(
+        notifier.state.pendingEdits.containsKey('publicName'),
+        isFalse,
+        reason: 'committed slot edits cleared (converged with disk)',
+      );
+      // The thrown difficulty write never landed — it MUST be retained, not
+      // discarded by clearPendingDifficulty().
+      expect(
+        notifier.state.pendingDifficulty,
+        pendingDifficulty,
+        reason: 'a thrown difficulty write keeps the pending edit',
+      );
+      // An honest error is surfaced (not silently swallowed).
+      expect(notifier.state.error, isNotNull);
+      expect(
+        notifier.state.error,
+        contains('Slot changes saved, but difficulty failed'),
+      );
+    },
+  );
+
+  test(
     'global Reset (refresh) clears a pending difficulty edit',
     () async {
       final core = _RecordingCoreService(scanData: difficultyScanData());
@@ -1921,6 +1980,27 @@ class _FailingDifficultyWriteCoreService extends _RecordingCoreService {
         'ok': false,
         'error': {'message': 'difficulty write failed'},
       };
+    }
+    return super.execute(command, payload: payload);
+  }
+}
+
+/// write_save succeeds, but write_difficulty THROWS (e.g. malformed native
+/// JSON from the core) instead of returning an error result — exercises the
+/// thrown-write convergence path (the difficulty edit must be KEPT pending).
+class _ThrowingDifficultyWriteCoreService extends _RecordingCoreService {
+  _ThrowingDifficultyWriteCoreService({super.scanData});
+
+  @override
+  Future<Map<String, Object?>> execute(
+    String command, {
+    Map<String, Object?> payload = const {},
+  }) async {
+    if (command == 'write_difficulty') {
+      requests.add(
+        _RecordedRequest(command, Map<String, Object?>.from(payload)),
+      );
+      throw const FormatException('malformed native difficulty response');
     }
     return super.execute(command, payload: payload);
   }

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -522,6 +522,59 @@ void main() {
   );
 
   test(
+    'partial commit converges: write_save succeeds, write_difficulty fails — '
+    'slot edits cleared (committed), difficulty kept, honest error',
+    () async {
+      final core = _FailingDifficultyWriteCoreService(
+        scanData: difficultyScanData(),
+      );
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      notifier.setPendingEdit(
+        'publicName',
+        const PendingSaveEdit(
+          edits: [
+            {'path': 'public.m_PlayerSaveName', 'value': 'Renamed'},
+          ],
+        ),
+      );
+      const pendingDifficulty = PendingDifficulty(
+        difficulty: {'preset': 'Hard', 'flowHelper': false, 'permadeath': true},
+      );
+      notifier.setPendingDifficulty(pendingDifficulty);
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isFalse, reason: 'overall save failed (difficulty did not land)');
+      // write_save ran (and succeeded) before the failing write_difficulty.
+      final writeCommands = core.requests
+          .map((r) => r.command)
+          .where((c) => c == 'write_save' || c == 'write_difficulty')
+          .toList();
+      expect(writeCommands, ['write_save', 'write_difficulty']);
+      // The committed slot edits are now on disk — they MUST NOT stay pending
+      // (that would be the divergence bug + a double-apply on retry).
+      expect(
+        notifier.state.pendingEdits.containsKey('publicName'),
+        isFalse,
+        reason: 'committed slot edits cleared regardless of difficulty outcome',
+      );
+      // The difficulty did NOT land — keep ONLY it pending so the user can
+      // retry just the difficulty.
+      expect(notifier.state.pendingDifficulty, isNotNull);
+      expect(notifier.state.pendingDifficulty, pendingDifficulty);
+      // Honest, specific error surfaced.
+      expect(
+        notifier.state.error,
+        contains('Slot changes saved, but difficulty failed'),
+      );
+      expect(notifier.state.error, contains('difficulty write failed'));
+    },
+  );
+
+  test(
     'global Reset (refresh) clears a pending difficulty edit',
     () async {
       final core = _RecordingCoreService(scanData: difficultyScanData());
@@ -1797,6 +1850,30 @@ class _FailingWriteCoreService extends _RecordingCoreService {
       return {
         'ok': false,
         'error': {'message': 'write failed'},
+      };
+    }
+    return super.execute(command, payload: payload);
+  }
+}
+
+/// write_save succeeds, but write_difficulty always fails — used to exercise
+/// the partial-commit convergence path (slot edits land on disk, difficulty
+/// does not).
+class _FailingDifficultyWriteCoreService extends _RecordingCoreService {
+  _FailingDifficultyWriteCoreService({super.scanData});
+
+  @override
+  Future<Map<String, Object?>> execute(
+    String command, {
+    Map<String, Object?> payload = const {},
+  }) async {
+    if (command == 'write_difficulty') {
+      requests.add(
+        _RecordedRequest(command, Map<String, Object?>.from(payload)),
+      );
+      return {
+        'ok': false,
+        'error': {'message': 'difficulty write failed'},
       };
     }
     return super.execute(command, payload: payload);

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -353,6 +353,265 @@ void main() {
     expect(countAfter, countBefore);
   });
 
+  // ---------------------------------------------------------------------------
+  // Pending difficulty edit folded into the global Save/Reset flow
+  // ---------------------------------------------------------------------------
+
+  /// A scan with one save attributed to profile 7, so selectedSave and
+  /// editedSaveProfile resolve.
+  Map<String, Object?> difficultyScanData() => {
+    'saves': [
+      {
+        'path': r'C:\tmp\saves\G1R-001.sav',
+        'slot': 'G1R-001',
+        'format': 'GSAV',
+        'fileSize': 100,
+        'sha1': 'a',
+        'status': 'ok',
+        'playerSaveName': 'Save A',
+        'persistentProfileId': 7,
+      },
+      {
+        'path': r'C:\tmp\saves\G1R-002.sav',
+        'slot': 'G1R-002',
+        'format': 'GSAV',
+        'fileSize': 100,
+        'sha1': 'b',
+        'status': 'ok',
+        'playerSaveName': 'Save B',
+        'persistentProfileId': 7,
+      },
+    ],
+    'profiles': [
+      {
+        'profileId': 7,
+        'profileName': 'Nameless Hero',
+        'quickSaveSlots': <String>[],
+        'autoSaveSlots': <String>[],
+        'savedSlots': ['G1R-001', 'G1R-002'],
+      },
+    ],
+    'activeProfileId': 7,
+  };
+
+  EditorNotifier difficultyNotifier(_RecordingCoreService core) {
+    return EditorNotifier(
+      core,
+      saveDir: r'C:\tmp\saves',
+      codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+      gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+    );
+  }
+
+  test(
+    'pending difficulty edit counts in pendingEditCount/hasUnsavedEdits and '
+    'enables the global Save',
+    () async {
+      final core = _RecordingCoreService(scanData: difficultyScanData());
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+
+      expect(notifier.state.pendingEditCount, 0);
+      expect(notifier.state.hasUnsavedEdits, isFalse);
+
+      notifier.setPendingDifficulty(
+        const PendingDifficulty(
+          difficulty: {
+            'preset': 'Hard',
+            'flowHelper': false,
+            'permadeath': true,
+          },
+        ),
+      );
+
+      // The global badge counts the difficulty edit as one unsaved change.
+      expect(notifier.state.pendingEditCount, 1);
+      expect(notifier.state.hasUnsavedEdits, isTrue);
+    },
+  );
+
+  test(
+    'global saveAllPending dispatches write_difficulty and clears the edit',
+    () async {
+      final core = _RecordingCoreService(scanData: difficultyScanData());
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+      // Select the first save so it is the edited save.
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      notifier.setPendingDifficulty(
+        const PendingDifficulty(
+          difficulty: {
+            'preset': 'Hard',
+            'flowHelper': false,
+            'permadeath': true,
+          },
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isTrue);
+      final writes = core.requests
+          .where((r) => r.command == 'write_difficulty')
+          .toList();
+      expect(writes, hasLength(1), reason: 'exactly one write_difficulty');
+      final payload = writes.single.payload;
+      expect(payload['difficulty'], {
+        'preset': 'Hard',
+        'flowHelper': false,
+        'permadeath': true,
+      });
+      // Only the current save targeted (no propagation), profile not written.
+      final targets = payload['targets'] as Map;
+      expect(targets['saves'], [r'C:\tmp\saves\G1R-001.sav']);
+      expect(targets.containsKey('profile'), isFalse);
+      expect(payload['backup'], isTrue);
+      // Codec host attached (private-payload edit).
+      expect(payload['binaryHost'], isNotNull);
+      // Edit cleared after success.
+      expect(notifier.state.pendingDifficulty, isNull);
+      expect(notifier.state.hasUnsavedEdits, isFalse);
+    },
+  );
+
+  test(
+    'global saveAllPending performs BOTH write_save and write_difficulty with '
+    'a single refresh',
+    () async {
+      final core = _RecordingCoreService(scanData: difficultyScanData());
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+      final scansBefore = core.requests
+          .where((r) => r.command == 'scan_save_dir')
+          .length;
+
+      notifier.setPendingEdit(
+        'publicName',
+        const PendingSaveEdit(
+          edits: [
+            {'path': 'public.m_PlayerSaveName', 'value': 'Renamed'},
+          ],
+        ),
+      );
+      notifier.setPendingDifficulty(
+        const PendingDifficulty(
+          difficulty: {'preset': 'Gothic', 'flowHelper': true, 'permadeath': false},
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isTrue);
+      // Both core writes issued, write_save before write_difficulty.
+      final writeCommands = core.requests
+          .map((r) => r.command)
+          .where((c) => c == 'write_save' || c == 'write_difficulty')
+          .toList();
+      expect(writeCommands, ['write_save', 'write_difficulty']);
+      // Exactly ONE refresh (scan_save_dir) at the end.
+      final scansAfter = core.requests
+          .where((r) => r.command == 'scan_save_dir')
+          .length;
+      expect(scansAfter - scansBefore, 1, reason: 'refresh runs once');
+      // Everything cleared.
+      expect(notifier.state.pendingEdits, isEmpty);
+      expect(notifier.state.pendingDifficulty, isNull);
+    },
+  );
+
+  test(
+    'global Reset (refresh) clears a pending difficulty edit',
+    () async {
+      final core = _RecordingCoreService(scanData: difficultyScanData());
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      notifier.setPendingDifficulty(
+        const PendingDifficulty(
+          difficulty: {'preset': 'Hard', 'flowHelper': false, 'permadeath': true},
+        ),
+      );
+      expect(notifier.state.pendingDifficulty, isNotNull);
+
+      // Global Reset re-scans/re-inspects, which clears all pending edits.
+      await notifier.refresh();
+
+      expect(notifier.state.pendingDifficulty, isNull);
+      expect(notifier.state.hasUnsavedEdits, isFalse);
+    },
+  );
+
+  test(
+    'difficulty propagation binds to the EDITED SAVE profile (allSaves + '
+    'profile targets resolved from selectedSave)',
+    () async {
+      final core = _RecordingCoreService(scanData: difficultyScanData());
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      notifier.setPendingDifficulty(
+        const PendingDifficulty(
+          difficulty: {'preset': 'Hard', 'flowHelper': false, 'permadeath': true},
+          alsoProfile: true,
+          allSaves: true,
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+      expect(ok, isTrue);
+
+      final write = core.requests.lastWhere(
+        (r) => r.command == 'write_difficulty',
+      );
+      final targets = write.payload['targets'] as Map;
+      // allSaves → every save of profile 7 (both G1R-001 and G1R-002).
+      expect(
+        (targets['saves'] as List).toSet(),
+        {r'C:\tmp\saves\G1R-001.sav', r'C:\tmp\saves\G1R-002.sav'},
+      );
+      // alsoProfile → PersistentDataList.sav next to the current save, profile 7.
+      final profileTarget = targets['profile'] as Map;
+      expect(profileTarget['path'], r'C:\tmp\saves\PersistentDataList.sav');
+      expect(profileTarget['profileId'], 7);
+    },
+  );
+
+  test(
+    'global saveAllPending surfaces the codec error when difficulty is pending '
+    'but the codec is not compress-ready',
+    () async {
+      final core = _RecordingCoreService(
+        scanData: difficultyScanData(),
+        codecCanCompress: false,
+      );
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      notifier.setPendingDifficulty(
+        const PendingDifficulty(
+          difficulty: {'preset': 'Hard', 'flowHelper': false, 'permadeath': true},
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isFalse);
+      expect(notifier.state.error, contains('verified G1R codec host'));
+      // No write was issued.
+      expect(
+        core.requests.where((r) => r.command == 'write_difficulty'),
+        isEmpty,
+      );
+      // The pending edit is kept so the user can verify the codec and retry.
+      expect(notifier.state.pendingDifficulty, isNotNull);
+    },
+  );
+
   test('saveAllPending keeps pending edits on failure', () async {
     final core = _FailingWriteCoreService();
     final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
@@ -1449,6 +1708,17 @@ class _RecordingCoreService implements GoresaveCoreService {
                   r'C:\tmp\saves\PersistentDataList.sav.bak.2',
               'persistentBytesChanged': true,
             },
+          },
+        };
+      case 'write_difficulty':
+        final targets = (payload['targets'] as Map?) ?? const {};
+        final saveCount = (targets['saves'] as List?)?.length ?? 0;
+        final profileCount = targets.containsKey('profile') ? 1 : 0;
+        return {
+          'ok': true,
+          'data': {
+            'targetsWritten': saveCount + profileCount,
+            'paths': targets['saves'],
           },
         };
       case 'search_typed_properties':

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -724,6 +724,69 @@ void main() {
     },
   );
 
+  test(
+    'global saveAllPending fails loudly and keeps the pending difficulty when '
+    'propagation is requested but the edited save profile cannot be resolved',
+    () async {
+      // A scan where the selected save\'s persistentProfileId (99) matches no
+      // profile in state.profiles, so editedSaveProfile is null — propagation
+      // cannot bind to a profile.
+      final core = _RecordingCoreService(
+        scanData: {
+          'saves': [
+            {
+              'path': r'C:\tmp\saves\G1R-001.sav',
+              'slot': 'G1R-001',
+              'format': 'GSAV',
+              'fileSize': 100,
+              'sha1': 'a',
+              'status': 'ok',
+              'playerSaveName': 'Save A',
+              'persistentProfileId': 99,
+            },
+          ],
+          'profiles': [
+            {
+              'profileId': 7,
+              'profileName': 'Nameless Hero',
+              'quickSaveSlots': <String>[],
+              'autoSaveSlots': <String>[],
+              'savedSlots': ['G1R-001'],
+            },
+          ],
+          'activeProfileId': 7,
+        },
+      );
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      // Sanity: the edited save\'s profile is genuinely unresolvable.
+      expect(notifier.state.editedSaveProfile, isNull);
+
+      notifier.setPendingDifficulty(
+        const PendingDifficulty(
+          difficulty: {'preset': 'Hard', 'flowHelper': false, 'permadeath': true},
+          alsoProfile: true,
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      // Fails loudly with a clear error.
+      expect(ok, isFalse);
+      expect(notifier.state.error, contains('could not be resolved'));
+      // No write was issued — the current-slot save must not slip through.
+      expect(
+        core.requests.where((r) => r.command == 'write_difficulty'),
+        isEmpty,
+      );
+      // The pending edit is KEPT so nothing is silently lost.
+      expect(notifier.state.pendingDifficulty, isNotNull);
+      expect(notifier.state.pendingDifficulty!.alsoProfile, isTrue);
+    },
+  );
+
   test('saveAllPending keeps pending edits on failure', () async {
     final core = _FailingWriteCoreService();
     final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -1390,6 +1390,52 @@ void main() {
     },
   );
 
+  test(
+    'applyMemoryEventEdit is blocked and preserves a pending difficulty edit',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(
+        core,
+        saveDir: r'C:\tmp\saves',
+        codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+        gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+      );
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      // Seed an unsaved difficulty edit (lives in pendingDifficulty, NOT
+      // pendingEdits) — a memory-event write would otherwise refresh and
+      // silently discard it.
+      notifier.setPendingDifficulty(
+        const PendingDifficulty(
+          difficulty: {
+            'preset': 'Hard',
+            'flowHelper': false,
+            'permadeath': true,
+          },
+        ),
+      );
+      expect(notifier.state.hasUnsavedEdits, isTrue);
+
+      final writesBefore = core.requests
+          .where((r) => r.command == 'write_save')
+          .length;
+
+      final result = await notifier.applyMemoryEventEdit(
+        MemoryEventEdit.remove(arrayPath: const ['MemorizedEvents'], index: 0),
+      );
+
+      expect(result, isFalse);
+      expect(notifier.state.error, isNotNull);
+      // No write_save must have been issued.
+      final writesAfter = core.requests
+          .where((r) => r.command == 'write_save')
+          .length;
+      expect(writesAfter, writesBefore);
+      // The pending difficulty edit must still be intact (not silently dropped).
+      expect(notifier.state.pendingDifficulty, isNotNull);
+    },
+  );
+
   // ---------------------------------------------------------------------------
   // Profile switcher (selectProfile)
   // ---------------------------------------------------------------------------

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -725,6 +725,58 @@ void main() {
   );
 
   test(
+    'global saveAllPending rejects when a pending difficulty edit conflicts '
+    'with a typed All-data edit targeting a difficulty property',
+    () async {
+      final core = _RecordingCoreService(scanData: difficultyScanData());
+      final notifier = difficultyNotifier(core);
+      await pumpEventQueue();
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      // A typed "All data" edit targeting the difficulty preset...
+      notifier.setPendingEdit(
+        'typed:m_difficultyPreset',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {
+                'path': ['m_difficultyPreset'],
+                'value': '/Script/Angelscript.DifficultyPreset_Hard',
+              },
+            },
+          ],
+        ),
+      );
+      // ...and a Difficulty-card edit, both pending at once.
+      notifier.setPendingDifficulty(
+        const PendingDifficulty(
+          difficulty: {'preset': 'Easy', 'flowHelper': false, 'permadeath': true},
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      // Refuses loudly with a conflict error.
+      expect(ok, isFalse);
+      expect(notifier.state.error, contains('Conflicting difficulty edits'));
+      // No writes issued at all.
+      expect(
+        core.requests.where(
+          (r) => r.command == 'write_save' || r.command == 'write_difficulty',
+        ),
+        isEmpty,
+      );
+      // BOTH pending sets are retained so the user can resolve the conflict.
+      expect(
+        notifier.state.pendingEdits.containsKey('typed:m_difficultyPreset'),
+        isTrue,
+      );
+      expect(notifier.state.pendingDifficulty, isNotNull);
+    },
+  );
+
+  test(
     'global saveAllPending fails loudly and keeps the pending difficulty when '
     'propagation is requested but the edited save profile cannot be resolved',
     () async {

--- a/apps/goresave/test/widget_test.dart
+++ b/apps/goresave/test/widget_test.dart
@@ -484,6 +484,69 @@ void main() {
 
     expect(find.bySemanticsLabel('Loading editor data'), findsNothing);
   });
+
+  testWidgets(
+      'non-removable inventory item shows a disabled trash button with an '
+      'explanatory tooltip', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1400, 1000));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final core = _RemovableInventoryCoreService();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          coreServiceProvider.overrideWithValue(core),
+          editorSettingsStoreProvider.overrideWithValue(
+            const NoopEditorSettingsStore(),
+          ),
+        ],
+        child: const GoresaveApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(Tab, 'Inventory'));
+    await tester.pumpAndSettle();
+
+    // Food is the first category, so the non-removable Cheese stack is visible.
+    final cheeseRow = find.ancestor(
+      of: find.text('ItFo_Cheese'),
+      matching: find.byType(ListTile),
+    );
+    expect(cheeseRow, findsOneWidget);
+    // The trash button renders even though the item is non-removable, but it is
+    // disabled and explains why via its tooltip.
+    final cheeseDeleteTooltip = find.descendant(
+      of: cheeseRow,
+      matching: find.byTooltip(
+        "Can't delete: this item is likely equipped or "
+        'assigned to a hotkey slot',
+      ),
+    );
+    expect(cheeseDeleteTooltip, findsOneWidget);
+    final cheeseDelete = tester.widget<IconButton>(
+      find.descendant(of: cheeseDeleteTooltip, matching: find.byType(IconButton)),
+    );
+    expect(cheeseDelete.onPressed, isNull);
+
+    // Switch to the removable Orenugget stack: its trash button is enabled with
+    // the standard remove tooltip.
+    await tester.tap(find.text('Miscellaneous (1)'));
+    await tester.pumpAndSettle();
+
+    final oreRow = find.ancestor(
+      of: find.text('ItMi_Orenugget'),
+      matching: find.byType(ListTile),
+    );
+    final oreDeleteTooltip = find.descendant(
+      of: oreRow,
+      matching: find.byTooltip('Remove item from inventory'),
+    );
+    expect(oreDeleteTooltip, findsOneWidget);
+    final oreDelete = tester.widget<IconButton>(
+      find.descendant(of: oreDeleteTooltip, matching: find.byType(IconButton)),
+    );
+    expect(oreDelete.onPressed, isNotNull);
+  });
 }
 
 class _RecordedRequest {
@@ -846,6 +909,41 @@ class _FakeCoreService implements GoresaveCoreService {
           'error': {'message': 'Unhandled fake command $command'},
         };
     }
+  }
+}
+
+/// A fake core that enables the inventory remove (trash) UI: it verifies the
+/// typed parse, advertises `private.inventory.removeItem`, and marks the
+/// Orenugget stack removable while the Cheese stack is NOT removable (its asset
+/// path occurs in more than one container — e.g. also equipped / in a
+/// quickslot — so the core can't unambiguously remove it).
+class _RemovableInventoryCoreService extends _FakeCoreService {
+  @override
+  Future<Map<String, Object?>> execute(
+    String command, {
+    Map<String, Object?> payload = const {},
+  }) async {
+    final result = await super.execute(command, payload: payload);
+    if (command != 'inspect_save') return result;
+    final data = (result['data'] as Map).cast<String, Object?>();
+    final private = (data['private'] as Map).cast<String, Object?>();
+    // Mark the typed parse verified so addItem/removeItem are gated open.
+    private['typedParse'] = {'status': 'ok', 'propertyCount': 1, 'maxDepth': 1};
+    final inventory = (private['inventory'] as Map).cast<String, Object?>();
+    inventory['writable'] = const [
+      'private.inventory.setItemCount',
+      'private.inventory.removeItem',
+    ];
+    final items = (inventory['items'] as List)
+        .map((e) => (e as Map).cast<String, Object?>())
+        .toList();
+    for (final item in items) {
+      // Orenugget is uniquely in the MainContainer → removable; Cheese also
+      // lives in another container → not removable (trash disabled).
+      item['removable'] = item['id'] == 'ItMi_Orenugget';
+    }
+    inventory['items'] = items;
+    return result;
   }
 }
 

--- a/apps/goresave/test/widget_test.dart
+++ b/apps/goresave/test/widget_test.dart
@@ -33,10 +33,10 @@ void main() {
     expect(find.text('Die Welt der Verurteilten'), findsAtLeastNWidgets(1));
     expect(find.text('Overview'), findsOneWidget);
     expect(find.text('Public save name'), findsOneWidget);
-    // Header pills summarise chapter, time played and map for the save.
+    // Header pills summarise chapter, time played and difficulty for the save.
     expect(find.text('Chapter 1'), findsOneWidget);
     expect(find.text('1h 56m'), findsOneWidget);
-    expect(find.text('MainMap'), findsAtLeastNWidgets(1));
+    expect(find.text('Custom'), findsAtLeastNWidgets(1));
     expect(find.text('Profile 0'), findsOneWidget);
 
     // Format/save-kind details live in the collapsed diagnostics card.
@@ -48,17 +48,19 @@ void main() {
     expect(find.text('Auto save'), findsOneWidget);
     expect(find.bySemanticsLabel('Screenshot for G1R-001'), findsWidgets);
 
-    // Inspection JSON card exists and is collapsed by default.
-    expect(find.text('Inspection JSON'), findsOneWidget);
-    expect(find.text('Raw save inspection data'), findsOneWidget);
     // JSON content is not visible until expanded.
     expect(find.text('"format"'), findsNothing);
-    // Expand the card and confirm JSON content appears.
+    // Scroll the Inspection JSON card into view (the lazy ListView only builds
+    // children near the viewport).
     await tester.scrollUntilVisible(
       find.text('Inspection JSON'),
       120,
       scrollable: find.byType(Scrollable).last,
     );
+    // Inspection JSON card exists and is collapsed by default.
+    expect(find.text('Inspection JSON'), findsOneWidget);
+    expect(find.text('Raw save inspection data'), findsOneWidget);
+    // Expand the card and confirm JSON content appears.
     await tester.tap(find.text('Inspection JSON'));
     await tester.pumpAndSettle();
     expect(find.textContaining('"format"'), findsOneWidget);
@@ -570,6 +572,7 @@ class _FakeCoreService implements GoresaveCoreService {
               'slotName': 'G1R-001',
               'playerSaveName': 'Die Welt der Verurteilten',
             },
+            'difficulty': {'preset': 'DifficultyPreset_Custom'},
             'persistent': {
               'playerSaveName': 'Die Welt der Verurteilten, Tag 1, 13:07',
               'chapterId': 1,

--- a/apps/goresave/test/widget_test.dart
+++ b/apps/goresave/test/widget_test.dart
@@ -41,6 +41,11 @@ void main() {
 
     // Format/save-kind details live in the collapsed diagnostics card.
     expect(find.text('Format'), findsNothing);
+    // The Difficulty card now opens expanded by default, pushing the diagnostics
+    // card down. Collapse it so the compact Overview lays out as before and the
+    // diagnostics card is reachable.
+    await tester.tap(find.text('Difficulty'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Diagnostics & details'));
     await tester.pumpAndSettle();
     expect(find.text('Format'), findsOneWidget);

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2180,6 +2180,32 @@ fn read_bool_property_in_range(
     read_bool_property_at(payload, refs, name_idx)
 }
 
+fn write_bool_property_in_range(
+    payload: &mut [u8],
+    refs: &[FStringRef],
+    start_idx: usize,
+    end_idx: usize,
+    name: &str,
+    value: bool,
+) -> Result<(), CoreError> {
+    let name_idx = find_ref_in_range(refs, start_idx, end_idx, name)
+        .ok_or_else(|| CoreError::Parse(format!("property {name} was not found")))?;
+    let type_ref = refs
+        .get(name_idx + 1)
+        .ok_or_else(|| CoreError::Parse(format!("type for {name} was not found")))?;
+    if type_ref.value != "BoolProperty" {
+        return Err(CoreError::Parse(format!(
+            "property {name} is not a BoolProperty"
+        )));
+    }
+    let offset = type_ref.len_offset + type_ref.total_len + 8;
+    *payload
+        .get_mut(offset)
+        .ok_or_else(|| CoreError::Parse(format!("bool value for {name} is out of range")))? =
+        if value { 1 } else { 0 };
+    Ok(())
+}
+
 fn find_ref_in_range(
     refs: &[FStringRef],
     start_idx: usize,
@@ -6527,6 +6553,25 @@ mod tests {
         out.extend_from_slice(value.as_bytes());
         out.push(0);
         out
+    }
+
+    #[test]
+    fn write_bool_property_in_range_flips_value_byte() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&fstring("m_PermanentDeath"));
+        payload.extend_from_slice(&fstring("BoolProperty"));
+        payload.extend_from_slice(&[0u8; 8]);
+        payload.push(0); // value byte
+
+        let refs = scan_fstrings(&payload, 0);
+        write_bool_property_in_range(&mut payload, &refs, 0, refs.len(), "m_PermanentDeath", true)
+            .unwrap();
+
+        let refs2 = scan_fstrings(&payload, 0);
+        assert_eq!(
+            read_bool_property_in_range(&payload, &refs2, 0, refs2.len(), "m_PermanentDeath"),
+            Some(true),
+        );
     }
 
     #[test]

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -6838,9 +6838,12 @@ fn replace_class_or_str_property_in_range(
     let type_ref = refs
         .get(name_idx + 1)
         .ok_or_else(|| CoreError::Parse(format!("type for {property_name} was not found")))?;
-    if type_ref.value != "StrProperty" && type_ref.value != "ClassProperty" {
+    if type_ref.value != "StrProperty"
+        && type_ref.value != "ClassProperty"
+        && type_ref.value != "ObjectProperty"
+    {
         return Err(CoreError::Parse(format!(
-            "property {property_name} is not a StrProperty/ClassProperty"
+            "property {property_name} is not a StrProperty/ClassProperty/ObjectProperty"
         )));
     }
     let value_ref = refs
@@ -7342,6 +7345,37 @@ mod tests {
         let mut payload = Vec::new();
         payload.extend_from_slice(&fstring("m_difficultyPreset"));
         payload.extend_from_slice(&fstring("ClassProperty"));
+        payload.extend_from_slice(&[0u8; 4]); // flags
+        payload.extend_from_slice(&0u32.to_le_bytes()); // size (rewritten)
+        payload.push(0); // tag
+        payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+
+        let refs = scan_fstrings(&payload, 0);
+        replace_class_or_str_property_in_range(
+            &mut payload,
+            &refs,
+            0,
+            refs.len(),
+            "m_difficultyPreset",
+            "/Script/Angelscript.DifficultyPreset_Easy",
+        )
+        .unwrap();
+
+        let refs2 = scan_fstrings(&payload, 0);
+        assert_eq!(
+            value_after_property_in_range(&refs2, 0, refs2.len(), "m_difficultyPreset").as_deref(),
+            Some("/Script/Angelscript.DifficultyPreset_Easy"),
+        );
+    }
+
+    #[test]
+    fn replace_object_property_value_in_range_rewrites_path() {
+        // Real on-disk saves serialize m_difficultyPreset as an ObjectProperty
+        // (asset path is the object reference) with the same header layout as
+        // Str/ClassProperty: [4 bytes flags][4-byte size][1 byte tag][value FString].
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&fstring("m_difficultyPreset"));
+        payload.extend_from_slice(&fstring("ObjectProperty"));
         payload.extend_from_slice(&[0u8; 4]); // flags
         payload.extend_from_slice(&0u32.to_le_bytes()); // size (rewritten)
         payload.push(0); // tag

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::ffi::{CStr, CString, c_char};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -6685,10 +6686,26 @@ fn write_difficulty_internal(
     let mut plans: Vec<DifficultyWritePlan> = Vec::new();
 
     if let Some(saves) = targets.get("saves").and_then(Value::as_array) {
+        // Dedup save paths up front: the staging/replace loop reuses each
+        // target's *.tmp-goresave (and *.replaced-goresave aside) path, so two
+        // plans for the SAME file would collide — the first begin_replace
+        // consumes the temp file, the second moves the just-replaced target
+        // aside (clobbering the first aside) then fails because the temp is
+        // gone, and rollback can leave the save MISSING. Keep the first
+        // occurrence; silently drop later duplicates (the Dart caller may
+        // legitimately include the current save in an "all saves" set).
+        let mut seen: HashSet<PathBuf> = HashSet::new();
         for save in saves {
             let path = PathBuf::from(save.as_str().ok_or_else(|| {
                 CoreError::InvalidRequest("targets.saves entries must be strings".to_string())
             })?);
+            // Normalize via canonicalize when possible so the same file
+            // referenced two ways (e.g. relative vs absolute) is also caught;
+            // fall back to the raw path when the file can't be canonicalized.
+            let key = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            if !seen.insert(key) {
+                continue;
+            }
             let original = fs::read(&path)?;
             // Edit the PUBLIC payload first, then route the PRIVATE difficulty
             // edit through the same codec-backed path write_save uses. The
@@ -7425,6 +7442,81 @@ mod tests {
             !pdl_backup.exists(),
             "no PersistentDataList backup shares the slot's suffix, so \
              prepare_paired_persistent_data_list_restore finds no companion to pair",
+        );
+    }
+
+    #[test]
+    fn write_difficulty_internal_dedups_duplicate_save_targets() {
+        // Regression: if targets.saves lists the SAME path twice, the old code
+        // built two plans for one file. Staging reused the same *.tmp-goresave
+        // and begin_replace ran twice on the same target: the first consumed the
+        // temp file, the second moved the (already-replaced) target aside —
+        // removing the first replace's aside — then FAILED because the temp file
+        // was gone, and rollback could leave the save file MISSING. Dedup must
+        // keep exactly one plan per save path so the write succeeds and the file
+        // is never lost.
+        let dir = tempdir().unwrap();
+        let save_path = dir.path().join("G1R-001.sav");
+
+        let private_payload = difficulty_private_payload();
+        let seed_compressed = b"seed-compressed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        let original_bytes =
+            build_gsav(2, &difficulty_public_payload(), &stream, &[0, 0, 0, 0]);
+        fs::write(&save_path, &original_bytes).unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let req = DifficultyRequest {
+            preset: "Hard".into(),
+            combat: None,
+            resources: None,
+            progression: None,
+            flow_helper: None,
+            permadeath: None,
+        };
+        // Same save path listed TWICE.
+        let path_str = save_path.display().to_string();
+        let targets = json!({
+            "saves": [path_str.clone(), path_str],
+        });
+
+        let response =
+            write_difficulty_internal(&req, &targets, true, Some(&backend)).unwrap();
+        // Exactly one target written despite the duplicate entry.
+        assert_eq!(response["targetsWritten"], 1);
+
+        // The save still exists and was edited to Hard (NOT lost to rollback).
+        assert!(save_path.exists(), "save file must not be lost");
+        let written_save = fs::read(&save_path).unwrap();
+        let d = difficulty_for_gsav_bytes(&written_save).unwrap();
+        assert_eq!(d.preset.as_deref(), Some("DifficultyPreset_Hard"));
+        assert_ne!(written_save, original_bytes, "save must reflect the edit");
+
+        // Only one backup/replace happened: a single backup for this path, and
+        // no leftover staging artifacts (tmp / replaced-aside) that a second,
+        // colliding replace would have orphaned.
+        let backups = dir.path().join("goresave_backups");
+        let backup_count = fs::read_dir(&backups)
+            .unwrap()
+            .filter(|e| {
+                e.as_ref()
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("G1R-001.sav.bak.")
+            })
+            .count();
+        assert_eq!(backup_count, 1, "exactly one backup for the deduped path");
+        assert!(
+            !save_path.with_extension("sav.tmp-goresave").exists(),
+            "no leftover staging temp file",
+        );
+        assert!(
+            !save_path.with_extension("sav.replaced-goresave").exists(),
+            "no leftover moved-aside original",
         );
     }
 

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2283,9 +2283,7 @@ fn apply_save_difficulty(payload: &mut Vec<u8>, req: &DifficultyRequest) -> Resu
     if let Some(perma) = req.resolved_permadeath() {
         let refs = scan_fstrings(payload, 0);
         let end = refs.len();
-        if find_ref_in_range(&refs, 0, end, "m_PermanentDeath").is_some() {
-            write_bool_property_in_range(payload, &refs, 0, end, "m_PermanentDeath", perma)?;
-        }
+        write_permadeath_in_range(payload, &refs, 0, end, perma)?;
     }
     if let Some(flow) = req.flow_helper {
         let refs = scan_fstrings(payload, 0);
@@ -2352,16 +2350,22 @@ fn write_profile_difficulty(
             )?;
         }
     }
-    for (name, val) in [
-        ("m_PermanentDeath", req.resolved_permadeath()),
-        ("m_FakeSloppyCombos", req.flow_helper),
-    ] {
-        let Some(v) = val else { continue };
+    // Permadeath: write to whichever spelling (m_PermanentDeath / m_PermaDeath)
+    // is present in the profile range. Re-scan + re-locate first (earlier splices
+    // shift offsets), exactly like the per-field pattern below.
+    if let Some(perma) = req.resolved_permadeath() {
         let refs = scan_fstrings(data, 0);
         let (s, e) = profile_range_by_id(&refs, profile_id, data)
             .ok_or_else(|| CoreError::Validation(format!("profile {profile_id} not found")))?;
-        if find_ref_in_range(&refs, s, e, name).is_some() {
-            write_bool_property_in_range(data, &refs, s, e, name, v)?;
+        write_permadeath_in_range(data, &refs, s, e, perma)?;
+    }
+    // Flow helper (no alternate spelling).
+    if let Some(flow) = req.flow_helper {
+        let refs = scan_fstrings(data, 0);
+        let (s, e) = profile_range_by_id(&refs, profile_id, data)
+            .ok_or_else(|| CoreError::Validation(format!("profile {profile_id} not found")))?;
+        if find_ref_in_range(&refs, s, e, "m_FakeSloppyCombos").is_some() {
+            write_bool_property_in_range(data, &refs, s, e, "m_FakeSloppyCombos", flow)?;
         }
     }
     Ok(())
@@ -2429,6 +2433,29 @@ fn write_bool_property_in_range(
         .get_mut(offset)
         .ok_or_else(|| CoreError::Parse(format!("bool value for {name} is out of range")))? =
         if value { 1 } else { 0 };
+    Ok(())
+}
+
+/// Permadeath may be stored under either spelling depending on save version.
+/// The read path falls back from `m_PermanentDeath` to `m_PermaDeath`
+/// (see `parse_profile_summaries`); the write path mirrors that here.
+const PERMADEATH_NAMES: [&str; 2] = ["m_PermanentDeath", "m_PermaDeath"];
+
+/// Write `value` to whichever permadeath spelling is present in `[s, e)`.
+/// If neither is present, skip silently (matches the existing absent-field
+/// behavior at both write sites).
+fn write_permadeath_in_range(
+    payload: &mut [u8],
+    refs: &[FStringRef],
+    s: usize,
+    e: usize,
+    value: bool,
+) -> Result<(), CoreError> {
+    for name in PERMADEATH_NAMES {
+        if find_ref_in_range(refs, s, e, name).is_some() {
+            return write_bool_property_in_range(payload, refs, s, e, name, value);
+        }
+    }
     Ok(())
 }
 
@@ -7046,6 +7073,55 @@ mod tests {
             .any(|p| p.ends_with("DifficultyPreset_Custom")));
         assert!(presets.iter().any(|p| p.ends_with("DifficultyPreset_Hard")));
         assert!(!presets.iter().any(|p| p.ends_with("DifficultyPreset_Easy")));
+    }
+
+    #[test]
+    fn write_profile_difficulty_writes_permadeath_under_alternate_spelling() {
+        // A 2-profile buffer where the TARGET profile (id 1) stores permadeath
+        // under the alternate spelling `m_PermaDeath` (the read parser already
+        // supports this fallback; the write path must mirror it).
+        let mut data = b"GVAS".to_vec();
+        data.extend_from_slice(&fstring("m_Profiles"));
+        // profile 0 (untouched)
+        data.extend_from_slice(&fstring("m_ProfileName"));
+        data.extend_from_slice(&fstring("m_ProfileId"));
+        data.extend_from_slice(&fstring("IntProperty"));
+        data.extend_from_slice(&[0u8; 4]);
+        data.extend_from_slice(&4u32.to_le_bytes());
+        data.push(0);
+        data.extend_from_slice(&0i32.to_le_bytes());
+        // profile 1 (target) — permadeath stored as `m_PermaDeath`, currently true.
+        data.extend_from_slice(&fstring("m_ProfileName"));
+        data.extend_from_slice(&fstring("m_ProfileId"));
+        data.extend_from_slice(&fstring("IntProperty"));
+        data.extend_from_slice(&[0u8; 4]);
+        data.extend_from_slice(&4u32.to_le_bytes());
+        data.push(0);
+        data.extend_from_slice(&1i32.to_le_bytes());
+        data.extend_from_slice(&fstring("m_PermaDeath"));
+        data.extend_from_slice(&fstring("BoolProperty"));
+        data.extend_from_slice(&[0u8; 8]);
+        data.push(1); // currently on
+        data.extend_from_slice(&fstring("SavedDataVersion"));
+
+        // Novice forces permadeath off (resolved_permadeath() => Some(false)).
+        let req = DifficultyRequest {
+            preset: "Novice".into(),
+            combat: None,
+            resources: None,
+            progression: None,
+            flow_helper: None,
+            permadeath: Some(true),
+        };
+        write_profile_difficulty(&mut data, 1, &req).unwrap();
+
+        let refs = scan_fstrings(&data, 0);
+        let (s, e) = profile_range_by_id(&refs, 1, &data).unwrap();
+        assert_eq!(
+            read_bool_property_in_range(&data, &refs, s, e, "m_PermaDeath"),
+            Some(false),
+            "Novice-forced permadeath-off must be written even under the m_PermaDeath spelling",
+        );
     }
 
     #[test]

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -6418,6 +6418,40 @@ fn replace_str_property_fstring_in_range(
     write_str_property_value(payload, size_offset, value_ref, new_value)
 }
 
+/// Like `replace_str_property_fstring_in_range`, but also accepts
+/// `ClassProperty`. A ClassProperty's value is serialized as an inline FString
+/// with the identical layout to a StrProperty, so the same size-aware splice
+/// rewrites asset-path values (e.g. a DifficultyPreset class path) in place.
+fn replace_class_or_str_property_in_range(
+    payload: &mut Vec<u8>,
+    refs: &[FStringRef],
+    start_idx: usize,
+    end_idx: usize,
+    property_name: &str,
+    new_value: &str,
+) -> Result<(), CoreError> {
+    let name_idx = find_ref_in_range(refs, start_idx, end_idx, property_name)
+        .ok_or_else(|| CoreError::Parse(format!("property {property_name} was not found")))?;
+    let type_ref = refs
+        .get(name_idx + 1)
+        .ok_or_else(|| CoreError::Parse(format!("type for {property_name} was not found")))?;
+    if type_ref.value != "StrProperty" && type_ref.value != "ClassProperty" {
+        return Err(CoreError::Parse(format!(
+            "property {property_name} is not a StrProperty/ClassProperty"
+        )));
+    }
+    let value_ref = refs
+        .get(name_idx + 2)
+        .ok_or_else(|| CoreError::Parse(format!("value for {property_name} was not found")))?;
+    if value_ref.utf16 {
+        return Err(CoreError::UnsupportedEdit(
+            "UTF-16 FString replacement is not implemented yet".to_string(),
+        ));
+    }
+    let size_offset = type_ref.len_offset + type_ref.total_len + 4;
+    write_str_property_value(payload, size_offset, value_ref, new_value)
+}
+
 fn sha1_hex(data: &[u8]) -> String {
     let mut hasher = Sha1::new();
     hasher.update(data);
@@ -6493,6 +6527,34 @@ mod tests {
         out.extend_from_slice(value.as_bytes());
         out.push(0);
         out
+    }
+
+    #[test]
+    fn replace_class_property_value_in_range_rewrites_path() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&fstring("m_difficultyPreset"));
+        payload.extend_from_slice(&fstring("ClassProperty"));
+        payload.extend_from_slice(&[0u8; 4]); // flags
+        payload.extend_from_slice(&0u32.to_le_bytes()); // size (rewritten)
+        payload.push(0); // tag
+        payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+
+        let refs = scan_fstrings(&payload, 0);
+        replace_class_or_str_property_in_range(
+            &mut payload,
+            &refs,
+            0,
+            refs.len(),
+            "m_difficultyPreset",
+            "/Script/Angelscript.DifficultyPreset_Easy",
+        )
+        .unwrap();
+
+        let refs2 = scan_fstrings(&payload, 0);
+        assert_eq!(
+            value_after_property_in_range(&refs2, 0, refs2.len(), "m_difficultyPreset").as_deref(),
+            Some("/Script/Angelscript.DifficultyPreset_Easy"),
+        );
     }
 
     fn minimal_stream() -> Vec<u8> {

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -6918,6 +6918,11 @@ fn replace_class_or_str_property_in_range(
 ) -> Result<(), CoreError> {
     let name_idx = find_ref_in_range(refs, start_idx, end_idx, property_name)
         .ok_or_else(|| CoreError::Parse(format!("property {property_name} was not found")))?;
+    if name_idx + 2 >= end_idx {
+        return Err(CoreError::Parse(format!(
+            "value for {property_name} was not found"
+        )));
+    }
     let type_ref = refs
         .get(name_idx + 1)
         .ok_or_else(|| CoreError::Parse(format!("type for {property_name} was not found")))?;
@@ -7624,6 +7629,48 @@ mod tests {
             value_after_property_in_range(&refs2, 0, refs2.len(), "m_difficultyPreset").as_deref(),
             Some("/Script/Angelscript.DifficultyPreset_Easy"),
         );
+    }
+
+    #[test]
+    fn replace_class_or_str_property_does_not_splice_past_end_idx() {
+        // The matched property name is the LAST ref inside the selected range
+        // (end_idx). Its type/value refs live AFTER end_idx, in the FOLLOWING
+        // field/profile. Without the range guard the helper would read
+        // refs[name_idx + 2] (= the next field's value) and corrupt bytes
+        // outside the selected profile. With the guard it must fail cleanly and
+        // leave the following field's bytes untouched.
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&fstring("m_difficultyPreset"));
+        // --- everything below belongs to the NEXT field, outside the range ---
+        payload.extend_from_slice(&fstring("ObjectProperty"));
+        payload.extend_from_slice(&[0u8; 4]); // flags
+        payload.extend_from_slice(&0u32.to_le_bytes()); // size
+        payload.push(0); // tag
+        payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+
+        let before = payload.clone();
+        let refs = scan_fstrings(&payload, 0);
+        // end_idx bounds the search to ONLY the property-name ref. The type ref
+        // (name_idx + 1) and value ref (name_idx + 2) fall at/beyond end_idx.
+        let end_idx = 1;
+        let err = replace_class_or_str_property_in_range(
+            &mut payload,
+            &refs,
+            0,
+            end_idx,
+            "m_difficultyPreset",
+            "/Script/Angelscript.DifficultyPreset_Easy",
+        )
+        .unwrap_err();
+        match &err {
+            CoreError::Parse(msg) => assert!(
+                msg.contains("value for m_difficultyPreset was not found"),
+                "unexpected error message: {msg}",
+            ),
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+        // The out-of-range following field must be byte-for-byte untouched.
+        assert_eq!(payload, before, "bytes outside the selected range were modified");
     }
 
     fn minimal_stream() -> Vec<u8> {

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2247,6 +2247,76 @@ fn apply_save_difficulty(payload: &mut Vec<u8>, req: &DifficultyRequest) -> Resu
     Ok(())
 }
 
+fn profile_range_by_id(refs: &[FStringRef], profile_id: i32, payload: &[u8]) -> Option<(usize, usize)> {
+    let profiles_idx = refs.iter().position(|r| r.value == "m_Profiles")?;
+    let profiles_end = refs
+        .iter()
+        .enumerate()
+        .skip(profiles_idx + 1)
+        .find(|(_, r)| r.value == "SavedDataVersion")
+        .map(|(i, _)| i)
+        .unwrap_or(refs.len());
+    let starts: Vec<usize> = refs
+        .iter()
+        .enumerate()
+        .take(profiles_end)
+        .skip(profiles_idx + 1)
+        .filter_map(|(i, r)| (r.value == "m_ProfileName").then_some(i))
+        .collect();
+    for (ord, &start) in starts.iter().enumerate() {
+        let end = starts.get(ord + 1).copied().unwrap_or(profiles_end);
+        let id = read_i32_property_in_range(payload, refs, start, end, "m_ProfileId")
+            .unwrap_or(ord as i32);
+        if id == profile_id {
+            return Some((start, end));
+        }
+    }
+    None
+}
+
+fn write_profile_difficulty(
+    data: &mut Vec<u8>,
+    profile_id: i32,
+    req: &DifficultyRequest,
+) -> Result<(), CoreError> {
+    if !data.starts_with(b"GVAS") {
+        return Err(CoreError::Parse(
+            "PersistentDataList.sav is not a GVAS file".into(),
+        ));
+    }
+    // Apply field-by-field, re-locating the profile range after each splice
+    // (reuses the same resolution helpers as apply_save_difficulty for consistency).
+    for (name, class) in req.class_edits()? {
+        let refs = scan_fstrings(data, 0);
+        let (s, e) = profile_range_by_id(&refs, profile_id, data)
+            .ok_or_else(|| CoreError::Validation(format!("profile {profile_id} not found")))?;
+        // Skip silently if a field is absent in this profile range.
+        if find_ref_in_range(&refs, s, e, name).is_some() {
+            replace_class_or_str_property_in_range(
+                data,
+                &refs,
+                s,
+                e,
+                name,
+                &format!("{ANGELSCRIPT}{class}"),
+            )?;
+        }
+    }
+    for (name, val) in [
+        ("m_PermanentDeath", req.resolved_permadeath()),
+        ("m_FakeSloppyCombos", req.flow_helper),
+    ] {
+        let Some(v) = val else { continue };
+        let refs = scan_fstrings(data, 0);
+        let (s, e) = profile_range_by_id(&refs, profile_id, data)
+            .ok_or_else(|| CoreError::Validation(format!("profile {profile_id} not found")))?;
+        if find_ref_in_range(&refs, s, e, name).is_some() {
+            write_bool_property_in_range(data, &refs, s, e, name, v)?;
+        }
+    }
+    Ok(())
+}
+
 fn read_i32_after_property(payload: &[u8], refs: &[FStringRef], name: &str) -> Option<i32> {
     let name_idx = refs.iter().position(|r| r.value == name)?;
     read_i32_property_at(payload, refs, name_idx)
@@ -6710,6 +6780,63 @@ mod tests {
             read_bool_property_in_range(&payload, &refs2, 0, refs2.len(), "m_PermanentDeath"),
             Some(true),
         );
+    }
+
+    #[test]
+    fn write_profile_difficulty_targets_only_the_named_profile() {
+        let mut data = b"GVAS".to_vec();
+        data.extend_from_slice(&fstring("m_Profiles"));
+        // profile 0
+        data.extend_from_slice(&fstring("m_ProfileName"));
+        data.extend_from_slice(&fstring("m_ProfileId"));
+        data.extend_from_slice(&fstring("IntProperty"));
+        data.extend_from_slice(&[0u8; 4]);
+        data.extend_from_slice(&4u32.to_le_bytes());
+        data.push(0);
+        data.extend_from_slice(&0i32.to_le_bytes());
+        data.extend_from_slice(&fstring("m_difficultyPreset"));
+        data.extend_from_slice(&fstring("ClassProperty"));
+        data.extend_from_slice(&[0u8; 4]);
+        data.extend_from_slice(&0u32.to_le_bytes());
+        data.push(0);
+        data.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+        // profile 1
+        data.extend_from_slice(&fstring("m_ProfileName"));
+        data.extend_from_slice(&fstring("m_ProfileId"));
+        data.extend_from_slice(&fstring("IntProperty"));
+        data.extend_from_slice(&[0u8; 4]);
+        data.extend_from_slice(&4u32.to_le_bytes());
+        data.push(0);
+        data.extend_from_slice(&1i32.to_le_bytes());
+        data.extend_from_slice(&fstring("m_difficultyPreset"));
+        data.extend_from_slice(&fstring("ClassProperty"));
+        data.extend_from_slice(&[0u8; 4]);
+        data.extend_from_slice(&0u32.to_le_bytes());
+        data.push(0);
+        data.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Easy"));
+        data.extend_from_slice(&fstring("SavedDataVersion"));
+
+        let req = DifficultyRequest {
+            preset: "Hard".into(),
+            combat: None,
+            resources: None,
+            progression: None,
+            flow_helper: None,
+            permadeath: None,
+        };
+        write_profile_difficulty(&mut data, 1, &req).unwrap();
+
+        let refs = scan_fstrings(&data, 0);
+        let presets: Vec<_> = refs
+            .iter()
+            .filter(|r| r.value.contains("DifficultyPreset_"))
+            .map(|r| r.value.clone())
+            .collect();
+        assert!(presets
+            .iter()
+            .any(|p| p.ends_with("DifficultyPreset_Custom")));
+        assert!(presets.iter().any(|p| p.ends_with("DifficultyPreset_Hard")));
+        assert!(!presets.iter().any(|p| p.ends_with("DifficultyPreset_Easy")));
     }
 
     #[test]

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2155,7 +2155,7 @@ fn level_suffix(label: &str) -> Result<&'static str, CoreError> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DifficultyRequest {
     preset: String, // Novice|Gothic|Hard|Custom
@@ -4247,6 +4247,9 @@ fn apply_private_edits(
             "private.typed.setValue" => {
                 parse_private_typed_set_value_edit(edit).map(PrivateEdit::TypedSetValue)
             }
+            "private.difficulty.set" => {
+                parse_private_difficulty_edit(edit).map(PrivateEdit::Difficulty)
+            }
             // Index-addressed edits (arrayRemove/arrayDuplicate) target indices
             // that shift after each structural change within the same batch;
             // callers must submit at most one structural array edit per write.
@@ -4400,6 +4403,7 @@ enum PrivateEdit {
     InventoryRemoveItem(PrivateInventoryRemoveItemEdit),
     TypedSetValue(PrivateTypedSetValueEdit),
     TypedContainer(PrivateTypedContainerEdit),
+    Difficulty(DifficultyRequest),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -4439,6 +4443,11 @@ fn parse_typed_edit_path(
         )));
     }
     properties::parse_path(&segments)
+}
+
+fn parse_private_difficulty_edit(edit: &Edit) -> Result<DifficultyRequest, CoreError> {
+    serde_json::from_value::<DifficultyRequest>(edit.value.clone())
+        .map_err(|e| CoreError::InvalidRequest(e.to_string()))
 }
 
 fn parse_private_typed_set_value_edit(edit: &Edit) -> Result<PrivateTypedSetValueEdit, CoreError> {
@@ -5060,6 +5069,7 @@ fn apply_private_edit_to_payload(
         PrivateEdit::TypedContainer(edit) => {
             apply_private_typed_container_edit_to_payload(payload, edit)
         }
+        PrivateEdit::Difficulty(req) => apply_save_difficulty(payload, req),
     }
 }
 
@@ -6500,6 +6510,28 @@ fn replace_public_fstring(
     Ok(())
 }
 
+/// Splice a difficulty change into a save's uncompressed public payload
+/// (`SaveGamePublicData`), leaving the compressed private stream and trailer
+/// untouched. The private payload is updated separately via the
+/// `private.difficulty.set` edit kind.
+fn write_difficulty_into_save_public(
+    data: &[u8],
+    req: &DifficultyRequest,
+) -> Result<Vec<u8>, CoreError> {
+    let parts = split_gsav(data)?;
+    let mut public_payload = parts.public_payload.to_vec();
+    let compressed_stream = parts.compressed_stream.to_vec();
+    let trailer = parts.trailer.to_vec();
+    let version = parts.version;
+    apply_save_difficulty(&mut public_payload, req)?;
+    Ok(build_gsav(
+        version,
+        &public_payload,
+        &compressed_stream,
+        &trailer,
+    ))
+}
+
 fn replace_str_property_fstring(
     payload: &mut Vec<u8>,
     property_name: &str,
@@ -6729,6 +6761,81 @@ mod tests {
             read_bool_property_in_range(&payload, &refs, 0, end, "m_PermanentDeath"),
             Some(true),
         );
+    }
+
+    #[test]
+    fn apply_save_difficulty_non_custom_mirrors_preset_and_locks_permadeath() {
+        let mut payload = Vec::new();
+        for name in ["m_difficultyPreset", "m_customCombatSettings"] {
+            payload.extend_from_slice(&fstring(name));
+            payload.extend_from_slice(&fstring("ClassProperty"));
+            payload.extend_from_slice(&[0u8; 4]);
+            payload.extend_from_slice(&0u32.to_le_bytes());
+            payload.push(0);
+            payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+        }
+        payload.extend_from_slice(&fstring("m_PermanentDeath"));
+        payload.extend_from_slice(&fstring("BoolProperty"));
+        payload.extend_from_slice(&[0u8; 8]);
+        payload.push(1); // currently true
+
+        // Novice should mirror all sub-settings to Easy AND force permadeath off,
+        // even though permadeath: Some(true) was requested.
+        let req = DifficultyRequest {
+            preset: "Novice".into(),
+            combat: None,
+            resources: None,
+            progression: None,
+            flow_helper: None,
+            permadeath: Some(true),
+        };
+        apply_save_difficulty(&mut payload, &req).unwrap();
+        let refs = scan_fstrings(&payload, 0);
+        let end = refs.len();
+        assert_eq!(
+            value_after_property_in_range(&refs, 0, end, "m_difficultyPreset").as_deref(),
+            Some("/Script/Angelscript.DifficultyPreset_Easy"),
+        );
+        assert_eq!(
+            value_after_property_in_range(&refs, 0, end, "m_customCombatSettings").as_deref(),
+            Some("/Script/Angelscript.CombatDifficultySettings_Easy"),
+        );
+        assert_eq!(
+            read_bool_property_in_range(&payload, &refs, 0, end, "m_PermanentDeath"),
+            Some(false),
+        );
+    }
+
+    #[test]
+    fn write_difficulty_into_save_updates_public_payload() {
+        let mut public = Vec::new();
+        public.extend_from_slice(&fstring("m_difficultyPreset"));
+        public.extend_from_slice(&fstring("ClassProperty"));
+        public.extend_from_slice(&[0u8; 4]);
+        public.extend_from_slice(&0u32.to_le_bytes());
+        public.push(0);
+        public.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+        public.extend_from_slice(&fstring("m_PermanentDeath"));
+        public.extend_from_slice(&fstring("BoolProperty"));
+        public.extend_from_slice(&[0u8; 8]);
+        public.push(1);
+
+        // minimal_stream()/[0,0,0,0] trailer mirror the other GSAV tests: an empty
+        // compressed stream would make split_gsav -> parse_compressed_stream fail
+        // (it requires the size prefix + method fstring + PACKAGE_FILE_TAG header).
+        let gsav = build_gsav(2, &public, &minimal_stream(), &[0, 0, 0, 0]);
+        let req = DifficultyRequest {
+            preset: "Novice".into(),
+            combat: None,
+            resources: None,
+            progression: None,
+            flow_helper: None,
+            permadeath: Some(true),
+        };
+        let out = write_difficulty_into_save_public(&gsav, &req).unwrap();
+        let d = difficulty_for_gsav_bytes(&out).unwrap();
+        assert_eq!(d.preset.as_deref(), Some("DifficultyPreset_Easy"));
+        assert_eq!(d.permadeath, Some(false)); // Novice forces off
     }
 
     #[test]

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -167,6 +167,17 @@ pub struct ProfileSummary {
 
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DifficultySettings {
+    pub preset: Option<String>,
+    pub combat: Option<String>,
+    pub resources: Option<String>,
+    pub progression: Option<String>,
+    pub flow_helper: Option<bool>,
+    pub permadeath: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SaveDirSummary {
     pub saves: Vec<SaveListItem>,
     pub profiles: Vec<ProfileSummary>,
@@ -2097,6 +2108,26 @@ fn value_after_property_in_range(
         .map(|r| r.value.clone())
 }
 
+fn short_class_name(path: &str) -> String {
+    path.rsplit('.').next().unwrap_or(path).to_string()
+}
+
+pub fn parse_difficulty_settings(payload: &[u8]) -> DifficultySettings {
+    let refs = scan_fstrings(payload, 0);
+    let end = refs.len();
+    let class = |name: &str| {
+        value_after_property_in_range(&refs, 0, end, name).map(|v| short_class_name(&v))
+    };
+    DifficultySettings {
+        preset: class("m_difficultyPreset"),
+        combat: class("m_customCombatSettings"),
+        resources: class("m_customResourcesSettings"),
+        progression: class("m_customProgressionSettings"),
+        flow_helper: read_bool_property_in_range(payload, &refs, 0, end, "m_FakeSloppyCombos"),
+        permadeath: read_bool_property_in_range(payload, &refs, 0, end, "m_PermanentDeath"),
+    }
+}
+
 fn read_i32_after_property(payload: &[u8], refs: &[FStringRef], name: &str) -> Option<i32> {
     let name_idx = refs.iter().position(|r| r.value == name)?;
     read_i32_property_at(payload, refs, name_idx)
@@ -3480,6 +3511,7 @@ fn is_property_type_name(value: &str) -> bool {
             | "ByteProperty"
             | "EnumProperty"
             | "DoubleProperty"
+            | "ClassProperty"
     )
 }
 
@@ -11599,5 +11631,30 @@ mod tests {
             err.to_string().contains("at most one structural array edit"),
             "unexpected error message: {err}"
         );
+    }
+
+    #[test]
+    fn parse_difficulty_settings_reads_preset_and_bools() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&fstring("m_difficultyPreset"));
+        payload.extend_from_slice(&fstring("ClassProperty"));
+        payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+        payload.extend_from_slice(&fstring("m_customCombatSettings"));
+        payload.extend_from_slice(&fstring("ClassProperty"));
+        payload.extend_from_slice(&fstring("/Script/Angelscript.CombatDifficultySettings_Hard"));
+        payload.extend_from_slice(&fstring("m_FakeSloppyCombos"));
+        payload.extend_from_slice(&fstring("BoolProperty"));
+        payload.extend_from_slice(&[0u8; 8]); // array_index + size
+        payload.push(1); // bool value byte
+        payload.extend_from_slice(&fstring("m_PermanentDeath"));
+        payload.extend_from_slice(&fstring("BoolProperty"));
+        payload.extend_from_slice(&[0u8; 8]);
+        payload.push(0);
+
+        let d = parse_difficulty_settings(&payload);
+        assert_eq!(d.preset.as_deref(), Some("DifficultyPreset_Custom"));
+        assert_eq!(d.combat.as_deref(), Some("CombatDifficultySettings_Hard"));
+        assert_eq!(d.flow_helper, Some(true));
+        assert_eq!(d.permadeath, Some(false));
     }
 }

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2432,10 +2432,17 @@ fn write_bool_property_in_range(
     }
     // value byte sits 8 bytes past the type ref (4 flags + 4 size), mirroring read_bool_property_at
     let offset = type_ref.len_offset + type_ref.total_len + 8;
-    *payload
+    // A GVAS BoolProperty's value lives in the tag_flags byte as bit 0x10
+    // (properties::TAG_FLAG_BOOL_TRUE). Set/clear only that bit so the strict
+    // parser / the game read it correctly and other tag-flag bits survive.
+    let byte = payload
         .get_mut(offset)
-        .ok_or_else(|| CoreError::Parse(format!("bool value for {name} is out of range")))? =
-        if value { 1 } else { 0 };
+        .ok_or_else(|| CoreError::Parse(format!("bool value for {name} is out of range")))?;
+    if value {
+        *byte |= properties::TAG_FLAG_BOOL_TRUE;
+    } else {
+        *byte &= !properties::TAG_FLAG_BOOL_TRUE;
+    }
     Ok(())
 }
 
@@ -7029,17 +7036,33 @@ mod tests {
         payload.extend_from_slice(&fstring("m_PermanentDeath"));
         payload.extend_from_slice(&fstring("BoolProperty"));
         payload.extend_from_slice(&[0u8; 8]);
-        payload.push(0); // value byte
+        // Seed an unrelated tag-flag bit (0x08) so we can confirm it survives.
+        payload.push(properties::TAG_FLAG_NATIVE_SERIALIZE); // value/tag byte
 
         let refs = scan_fstrings(&payload, 0);
+        // Locate the value byte the writer targets so we can assert on the bit.
+        let name_idx = find_ref_in_range(&refs, 0, refs.len(), "m_PermanentDeath").unwrap();
+        let type_ref = &refs[name_idx + 1];
+        let value_offset = type_ref.len_offset + type_ref.total_len + 8;
+
         write_bool_property_in_range(&mut payload, &refs, 0, refs.len(), "m_PermanentDeath", true)
             .unwrap();
+        // A true BoolProperty must set the 0x10 bit, not overwrite the byte with 0x01.
+        assert_ne!(payload[value_offset] & properties::TAG_FLAG_BOOL_TRUE, 0);
+        // The unrelated 0x08 bit must survive.
+        assert_ne!(payload[value_offset] & properties::TAG_FLAG_NATIVE_SERIALIZE, 0);
 
         let refs2 = scan_fstrings(&payload, 0);
         assert_eq!(
             read_bool_property_in_range(&payload, &refs2, 0, refs2.len(), "m_PermanentDeath"),
             Some(true),
         );
+
+        // Writing false clears the 0x10 bit but preserves the unrelated 0x08 bit.
+        write_bool_property_in_range(&mut payload, &refs2, 0, refs2.len(), "m_PermanentDeath", false)
+            .unwrap();
+        assert_eq!(payload[value_offset] & properties::TAG_FLAG_BOOL_TRUE, 0);
+        assert_ne!(payload[value_offset] & properties::TAG_FLAG_NATIVE_SERIALIZE, 0);
     }
 
     #[test]
@@ -7125,7 +7148,7 @@ mod tests {
         data.extend_from_slice(&fstring("m_PermaDeath"));
         data.extend_from_slice(&fstring("BoolProperty"));
         data.extend_from_slice(&[0u8; 8]);
-        data.push(1); // currently on
+        data.push(properties::TAG_FLAG_BOOL_TRUE); // currently on (game stores true as 0x10)
         data.extend_from_slice(&fstring("SavedDataVersion"));
 
         // Novice forces permadeath off (resolved_permadeath() => Some(false)).
@@ -7213,7 +7236,7 @@ mod tests {
         payload.extend_from_slice(&fstring("m_PermanentDeath"));
         payload.extend_from_slice(&fstring("BoolProperty"));
         payload.extend_from_slice(&[0u8; 8]);
-        payload.push(1); // currently true
+        payload.push(properties::TAG_FLAG_BOOL_TRUE); // currently true (game stores true as 0x10)
 
         // Novice should mirror all sub-settings to Easy AND force permadeath off,
         // even though permadeath: Some(true) was requested.
@@ -7254,7 +7277,7 @@ mod tests {
         public.extend_from_slice(&fstring("m_PermanentDeath"));
         public.extend_from_slice(&fstring("BoolProperty"));
         public.extend_from_slice(&[0u8; 8]);
-        public.push(1);
+        public.push(properties::TAG_FLAG_BOOL_TRUE); // game stores true as 0x10
 
         // minimal_stream()/[0,0,0,0] trailer mirror the other GSAV tests: an empty
         // compressed stream would make split_gsav -> parse_compressed_stream fail

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2142,6 +2142,111 @@ fn difficulty_for_gsav_bytes(data: &[u8]) -> Option<DifficultySettings> {
     Some(parse_difficulty_settings(parts.public_payload))
 }
 
+const ANGELSCRIPT: &str = "/Script/Angelscript.";
+
+fn level_suffix(label: &str) -> Result<&'static str, CoreError> {
+    match label {
+        "Novice" => Ok("Easy"),
+        "Gothic" => Ok("Standard"),
+        "Hard" => Ok("Hard"),
+        other => Err(CoreError::InvalidRequest(format!(
+            "unknown difficulty level {other}"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DifficultyRequest {
+    preset: String, // Novice|Gothic|Hard|Custom
+    #[serde(default)]
+    combat: Option<String>,
+    #[serde(default)]
+    resources: Option<String>,
+    #[serde(default)]
+    progression: Option<String>,
+    #[serde(default)]
+    flow_helper: Option<bool>,
+    #[serde(default)]
+    permadeath: Option<bool>,
+}
+
+impl DifficultyRequest {
+    /// Resolved short class names (no package prefix).
+    fn class_edits(&self) -> Result<Vec<(&'static str, String)>, CoreError> {
+        let preset = if self.preset == "Custom" {
+            "DifficultyPreset_Custom".to_string()
+        } else {
+            format!("DifficultyPreset_{}", level_suffix(&self.preset)?)
+        };
+        let lvl = |explicit: &Option<String>| -> Result<&'static str, CoreError> {
+            if self.preset == "Custom" {
+                level_suffix(explicit.as_deref().unwrap_or("Gothic"))
+            } else {
+                level_suffix(&self.preset)
+            }
+        };
+        Ok(vec![
+            ("m_difficultyPreset", preset),
+            (
+                "m_customCombatSettings",
+                format!("CombatDifficultySettings_{}", lvl(&self.combat)?),
+            ),
+            (
+                "m_customResourcesSettings",
+                format!("ResourcesDifficultySettings_{}", lvl(&self.resources)?),
+            ),
+            (
+                "m_customProgressionSettings",
+                format!("ProgressionDifficultySettings_{}", lvl(&self.progression)?),
+            ),
+        ])
+    }
+
+    /// Permadeath is locked off for Novice.
+    fn resolved_permadeath(&self) -> Option<bool> {
+        if self.preset == "Novice" {
+            Some(false)
+        } else {
+            self.permadeath
+        }
+    }
+}
+
+fn apply_save_difficulty(payload: &mut Vec<u8>, req: &DifficultyRequest) -> Result<(), CoreError> {
+    // Class properties: re-scan before each splice (lengths shift).
+    for (name, class) in req.class_edits()? {
+        let refs = scan_fstrings(payload, 0);
+        let end = refs.len();
+        if find_ref_in_range(&refs, 0, end, name).is_some() {
+            replace_class_or_str_property_in_range(
+                payload,
+                &refs,
+                0,
+                end,
+                name,
+                &format!("{ANGELSCRIPT}{class}"),
+            )?;
+        }
+    }
+    // Bools: guard each write so an absent property is skipped, not errored.
+    if let Some(perma) = req.resolved_permadeath() {
+        let refs = scan_fstrings(payload, 0);
+        let end = refs.len();
+        if find_ref_in_range(&refs, 0, end, "m_PermanentDeath").is_some() {
+            write_bool_property_in_range(payload, &refs, 0, end, "m_PermanentDeath", perma)?;
+        }
+    }
+    if let Some(flow) = req.flow_helper {
+        let refs = scan_fstrings(payload, 0);
+        let end = refs.len();
+        if find_ref_in_range(&refs, 0, end, "m_FakeSloppyCombos").is_some() {
+            write_bool_property_in_range(payload, &refs, 0, end, "m_FakeSloppyCombos", flow)?;
+        }
+    }
+    Ok(())
+}
+
 fn read_i32_after_property(payload: &[u8], refs: &[FStringRef], name: &str) -> Option<i32> {
     let name_idx = refs.iter().position(|r| r.value == name)?;
     read_i32_property_at(payload, refs, name_idx)
@@ -2198,6 +2303,7 @@ fn write_bool_property_in_range(
             "property {name} is not a BoolProperty"
         )));
     }
+    // value byte sits 8 bytes past the type ref (4 flags + 4 size), mirroring read_bool_property_at
     let offset = type_ref.len_offset + type_ref.total_len + 8;
     *payload
         .get_mut(offset)
@@ -6570,6 +6676,57 @@ mod tests {
         let refs2 = scan_fstrings(&payload, 0);
         assert_eq!(
             read_bool_property_in_range(&payload, &refs2, 0, refs2.len(), "m_PermanentDeath"),
+            Some(true),
+        );
+    }
+
+    #[test]
+    fn apply_save_difficulty_sets_preset_and_subsettings() {
+        let mut payload = Vec::new();
+        for name in [
+            "m_difficultyPreset",
+            "m_customCombatSettings",
+            "m_customResourcesSettings",
+            "m_customProgressionSettings",
+        ] {
+            payload.extend_from_slice(&fstring(name));
+            payload.extend_from_slice(&fstring("ClassProperty"));
+            payload.extend_from_slice(&[0u8; 4]);
+            payload.extend_from_slice(&0u32.to_le_bytes());
+            payload.push(0);
+            payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Easy"));
+        }
+        payload.extend_from_slice(&fstring("m_PermanentDeath"));
+        payload.extend_from_slice(&fstring("BoolProperty"));
+        payload.extend_from_slice(&[0u8; 8]);
+        payload.push(0);
+
+        let req = DifficultyRequest {
+            preset: "Custom".to_string(),
+            combat: Some("Hard".to_string()),
+            resources: None,
+            progression: None,
+            flow_helper: None,
+            permadeath: Some(true),
+        };
+        apply_save_difficulty(&mut payload, &req).unwrap();
+
+        let refs = scan_fstrings(&payload, 0);
+        let end = refs.len();
+        assert_eq!(
+            value_after_property_in_range(&refs, 0, end, "m_difficultyPreset").as_deref(),
+            Some("/Script/Angelscript.DifficultyPreset_Custom"),
+        );
+        assert_eq!(
+            value_after_property_in_range(&refs, 0, end, "m_customCombatSettings").as_deref(),
+            Some("/Script/Angelscript.CombatDifficultySettings_Hard"),
+        );
+        assert_eq!(
+            value_after_property_in_range(&refs, 0, end, "m_customResourcesSettings").as_deref(),
+            Some("/Script/Angelscript.ResourcesDifficultySettings_Standard"),
+        );
+        assert_eq!(
+            read_bool_property_in_range(&payload, &refs, 0, end, "m_PermanentDeath"),
             Some(true),
         );
     }

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -135,6 +135,8 @@ pub struct SaveListItem {
     pub auto_save: Option<bool>,
     pub persistent_profile_id: Option<i32>,
     pub screenshot: Option<ScreenshotSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub difficulty: Option<DifficultySettings>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -601,6 +603,7 @@ fn scan_save_dir_summary_with_codec_backend(
                     auto_save: persistent.and_then(|metadata| metadata.auto_save),
                     persistent_profile_id: persistent.and_then(|metadata| metadata.profile_id),
                     screenshot: screenshot.clone(),
+                    difficulty: difficulty_for_gsav_bytes(&data),
                 });
             }
             Err(err) => saves.push(SaveListItem {
@@ -624,6 +627,7 @@ fn scan_save_dir_summary_with_codec_backend(
                 auto_save: persistent.and_then(|metadata| metadata.auto_save),
                 persistent_profile_id: persistent.and_then(|metadata| metadata.profile_id),
                 screenshot: screenshot.clone(),
+                difficulty: None,
             }),
         }
     }
@@ -1859,6 +1863,8 @@ fn inspect_bytes_with_codec_backend(
             value["persistent"] =
                 serde_json::to_value(metadata).map_err(|e| CoreError::Parse(e.to_string()))?;
         }
+        value["difficulty"] = serde_json::to_value(difficulty_for_gsav_bytes(data))
+            .map_err(|e| CoreError::Parse(e.to_string()))?;
         Ok(value)
     } else if data.starts_with(b"GVAS") {
         Ok(parse_gvas(data, path))
@@ -2126,6 +2132,14 @@ pub fn parse_difficulty_settings(payload: &[u8]) -> DifficultySettings {
         flow_helper: read_bool_property_in_range(payload, &refs, 0, end, "m_FakeSloppyCombos"),
         permadeath: read_bool_property_in_range(payload, &refs, 0, end, "m_PermanentDeath"),
     }
+}
+
+fn difficulty_for_gsav_bytes(data: &[u8]) -> Option<DifficultySettings> {
+    if !data.starts_with(b"GSAV") {
+        return None;
+    }
+    let parts = split_gsav(data).ok()?;
+    Some(parse_difficulty_settings(parts.public_payload))
 }
 
 fn read_i32_after_property(payload: &[u8], refs: &[FStringRef], name: &str) -> Option<i32> {
@@ -11656,5 +11670,10 @@ mod tests {
         assert_eq!(d.combat.as_deref(), Some("CombatDifficultySettings_Hard"));
         assert_eq!(d.flow_helper, Some(true));
         assert_eq!(d.permadeath, Some(false));
+    }
+
+    #[test]
+    fn difficulty_for_gsav_bytes_none_for_non_gsav() {
+        assert!(difficulty_for_gsav_bytes(b"NOPE").is_none());
     }
 }

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2180,7 +2180,9 @@ pub fn parse_difficulty_settings(payload: &[u8]) -> DifficultySettings {
         resources: class("m_customResourcesSettings"),
         progression: class("m_customProgressionSettings"),
         flow_helper: read_bool_property_in_range(payload, &refs, 0, end, "m_FakeSloppyCombos"),
-        permadeath: read_bool_property_in_range(payload, &refs, 0, end, "m_PermanentDeath"),
+        permadeath: PERMADEATH_NAMES
+            .iter()
+            .find_map(|n| read_bool_property_in_range(payload, &refs, 0, end, n)),
     }
 }
 
@@ -12707,6 +12709,22 @@ mod tests {
         assert_eq!(d.combat.as_deref(), Some("CombatDifficultySettings_Hard"));
         assert_eq!(d.flow_helper, Some(true));
         assert_eq!(d.permadeath, Some(false));
+    }
+
+    #[test]
+    fn parse_difficulty_settings_reads_permadeath_alternate_spelling() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&fstring("m_difficultyPreset"));
+        payload.extend_from_slice(&fstring("ClassProperty"));
+        payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+        // Permadeath stored under the alternate spelling `m_PermaDeath`.
+        payload.extend_from_slice(&fstring("m_PermaDeath"));
+        payload.extend_from_slice(&fstring("BoolProperty"));
+        payload.extend_from_slice(&[0u8; 8]); // array_index + size
+        payload.push(1); // bool value byte (true)
+
+        let d = parse_difficulty_settings(&payload);
+        assert_eq!(d.permadeath, Some(true));
     }
 
     #[test]

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -503,6 +503,30 @@ fn execute_json_inner(input: &str) -> Result<Value, CoreError> {
                 sync_persistent_data_list,
             )?)
         }
+        "write_difficulty" => {
+            let req: DifficultyRequest = serde_json::from_value(
+                payload.get("difficulty").cloned().unwrap_or(Value::Null),
+            )
+            .map_err(|e| CoreError::InvalidRequest(e.to_string()))?;
+            let backup = payload
+                .get("backup")
+                .and_then(Value::as_bool)
+                .unwrap_or(true);
+            let codec_backend = payload
+                .get("binaryHost")
+                .map(binary_host_backend_from_config)
+                .transpose()?;
+            let codec_backend = codec_backend
+                .as_ref()
+                .map(|backend| backend as &dyn codec_backend::CodecBackend);
+            let targets = payload.get("targets").cloned().unwrap_or(Value::Null);
+            Ok(write_difficulty_internal(
+                &req,
+                &targets,
+                backup,
+                codec_backend,
+            )?)
+        }
         other => Err(CoreError::InvalidRequest(format!(
             "unknown command {other:?}"
         ))),
@@ -6584,6 +6608,151 @@ fn replace_public_fstring(
 /// (`SaveGamePublicData`), leaving the compressed private stream and trailer
 /// untouched. The private payload is updated separately via the
 /// `private.difficulty.set` edit kind.
+/// One save or profile file the difficulty write will touch, captured up front
+/// so backups, staging, and the atomic replace operate on already-validated
+/// bytes — never on a partially-edited buffer.
+struct DifficultyWritePlan {
+    path: PathBuf,
+    original: Vec<u8>,
+    edited: Vec<u8>,
+}
+
+/// Orchestrate a difficulty write across any combination of save slots and a
+/// PersistentDataList profile, mirroring `write_save_internal`'s
+/// edit -> validate -> backup -> stage -> atomic-replace pipeline so a failure
+/// at any step leaves every target untouched.
+fn write_difficulty_internal(
+    req: &DifficultyRequest,
+    targets: &Value,
+    backup: bool,
+    codec_backend: Option<&dyn codec_backend::CodecBackend>,
+) -> Result<Value, CoreError> {
+    let mut plans: Vec<DifficultyWritePlan> = Vec::new();
+
+    if let Some(saves) = targets.get("saves").and_then(Value::as_array) {
+        for save in saves {
+            let path = PathBuf::from(save.as_str().ok_or_else(|| {
+                CoreError::InvalidRequest("targets.saves entries must be strings".to_string())
+            })?);
+            let original = fs::read(&path)?;
+            // Edit the PUBLIC payload first, then route the PRIVATE difficulty
+            // edit through the same codec-backed path write_save uses. The
+            // private edit REQUIRES a codec backend; apply_private_edits errors
+            // with a clear message if none is configured.
+            let public_done = write_difficulty_into_save_public(&original, req)?;
+            let edit = Edit {
+                path: "private.difficulty.set".to_string(),
+                value: serde_json::to_value(req)
+                    .map_err(|e| CoreError::InvalidRequest(e.to_string()))?,
+            };
+            let edited = apply_private_edits(&public_done, &[&edit], codec_backend)?;
+            // Validate exactly as write_save_internal does: parse the edited
+            // bytes, and for GSAV confirm a byte-identical rebuild so the
+            // compressed stream / trailer were preserved.
+            inspect_bytes(&edited, None, false)?;
+            if edited.starts_with(b"GSAV") {
+                let rebuilt = rebuild_gsav_preserving_stream(&edited)?;
+                if rebuilt != edited {
+                    return Err(CoreError::Validation(
+                        "edited GSAV does not rebuild byte-identically".to_string(),
+                    ));
+                }
+            }
+            plans.push(DifficultyWritePlan {
+                path,
+                original,
+                edited,
+            });
+        }
+    }
+
+    if let Some(profile) = targets.get("profile").filter(|v| !v.is_null()) {
+        let path = PathBuf::from(profile.get("path").and_then(Value::as_str).ok_or_else(|| {
+            CoreError::InvalidRequest("targets.profile.path is required".to_string())
+        })?);
+        let profile_id = profile
+            .get("profileId")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| {
+                CoreError::InvalidRequest("targets.profile.profileId is required".to_string())
+            })? as i32;
+        let original = fs::read(&path)?;
+        let mut edited = original.clone();
+        write_profile_difficulty(&mut edited, profile_id, req)?;
+        plans.push(DifficultyWritePlan {
+            path,
+            original,
+            edited,
+        });
+    }
+
+    if plans.is_empty() {
+        return Err(CoreError::InvalidRequest(
+            "write_difficulty requires at least one target".to_string(),
+        ));
+    }
+
+    // Only touch files whose bytes actually changed; an unchanged target needs
+    // no backup, no staging, and no replace.
+    let changed: Vec<&DifficultyWritePlan> =
+        plans.iter().filter(|p| p.original != p.edited).collect();
+
+    // Back up every changed target under ONE shared suffix BEFORE writing
+    // anything, so a restore can pair save + profile by suffix.
+    if backup {
+        let paths: Vec<&Path> = changed.iter().map(|p| p.path.as_path()).collect();
+        if !paths.is_empty() {
+            let suffix = shared_backup_suffix(&paths);
+            for p in &changed {
+                create_backup_with_suffix(&p.path, &suffix)?;
+            }
+        }
+    }
+
+    // Stage every edited buffer to a tmp file and validate it on disk before
+    // any target is replaced.
+    let mut tmps: Vec<(PathBuf, PathBuf)> = Vec::new();
+    for p in &changed {
+        let tmp = p.path.with_extension("sav.tmp-goresave");
+        fs::write(&tmp, &p.edited)?;
+        inspect_save(&tmp, false)?;
+        tmps.push((p.path.clone(), tmp));
+    }
+
+    // Atomic replace: begin each (move-aside + rename-in). If any begin_replace
+    // fails, roll back the ones already begun so no target is left swapped.
+    // Mirrors write_save_internal's PendingReplace ownership: commit/rollback
+    // each consume the value, so we collect by value and drain.
+    let mut committed: Vec<PendingReplace> = Vec::new();
+    for (target, tmp) in &tmps {
+        match begin_replace(target, tmp) {
+            Ok(pending) => committed.push(pending),
+            Err(err) => {
+                for pending in committed {
+                    pending.rollback();
+                }
+                return Err(err);
+            }
+        }
+    }
+    for pending in committed {
+        pending.commit();
+    }
+
+    // The bytes on disk changed; drop any cached decoded payloads.
+    for (target, _) in &tmps {
+        invalidate_decoded_payload_cache(target);
+    }
+
+    Ok(json!({
+        "targetsWritten": changed.len(),
+        "paths": changed
+            .iter()
+            .map(|p| p.path.display().to_string())
+            .collect::<Vec<_>>(),
+    }))
+}
+
 fn write_difficulty_into_save_public(
     data: &[u8],
     req: &DifficultyRequest,
@@ -6963,6 +7132,209 @@ mod tests {
         let d = difficulty_for_gsav_bytes(&out).unwrap();
         assert_eq!(d.preset.as_deref(), Some("DifficultyPreset_Easy"));
         assert_eq!(d.permadeath, Some(false)); // Novice forces off
+    }
+
+    /// Build a private payload that carries an editable `m_difficultyPreset`
+    /// ClassProperty plus an `m_PermanentDeath` BoolProperty, so the
+    /// `private.difficulty.set` edit (which reuses `apply_save_difficulty`) has
+    /// something to splice.
+    fn difficulty_private_payload() -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&fstring("m_difficultyPreset"));
+        out.extend_from_slice(&fstring("ClassProperty"));
+        out.extend_from_slice(&[0u8; 4]);
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.push(0);
+        out.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+        out.extend_from_slice(&fstring("m_PermanentDeath"));
+        out.extend_from_slice(&fstring("BoolProperty"));
+        out.extend_from_slice(&[0u8; 8]);
+        out.push(1);
+        out.extend_from_slice(&fstring("None"));
+        out
+    }
+
+    /// Build a public payload that carries an editable `m_difficultyPreset`
+    /// ClassProperty plus `m_PermanentDeath`, so `write_difficulty_into_save_public`
+    /// can splice it.
+    fn difficulty_public_payload() -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&fstring("m_difficultyPreset"));
+        out.extend_from_slice(&fstring("ClassProperty"));
+        out.extend_from_slice(&[0u8; 4]);
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.push(0);
+        out.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+        out.extend_from_slice(&fstring("m_PermanentDeath"));
+        out.extend_from_slice(&fstring("BoolProperty"));
+        out.extend_from_slice(&[0u8; 8]);
+        out.push(1);
+        out.extend_from_slice(&fstring("None"));
+        out
+    }
+
+    /// Build a 2-profile PersistentDataList.sav buffer (profile 0 = Custom,
+    /// profile 1 = Easy), mirroring the buffer used by
+    /// `write_profile_difficulty_targets_only_the_named_profile`.
+    fn difficulty_persistent_profiles() -> Vec<u8> {
+        let mut data = b"GVAS".to_vec();
+        data.extend_from_slice(&fstring("m_Profiles"));
+        for (id, preset) in [(0i32, "DifficultyPreset_Custom"), (1i32, "DifficultyPreset_Easy")] {
+            data.extend_from_slice(&fstring("m_ProfileName"));
+            data.extend_from_slice(&fstring("m_ProfileId"));
+            data.extend_from_slice(&fstring("IntProperty"));
+            data.extend_from_slice(&[0u8; 4]);
+            data.extend_from_slice(&4u32.to_le_bytes());
+            data.push(0);
+            data.extend_from_slice(&id.to_le_bytes());
+            data.extend_from_slice(&fstring("m_difficultyPreset"));
+            data.extend_from_slice(&fstring("ClassProperty"));
+            data.extend_from_slice(&[0u8; 4]);
+            data.extend_from_slice(&0u32.to_le_bytes());
+            data.push(0);
+            data.extend_from_slice(&fstring(&format!("/Script/Angelscript.{preset}")));
+        }
+        data.extend_from_slice(&fstring("SavedDataVersion"));
+        data
+    }
+
+    #[test]
+    fn write_difficulty_internal_writes_save_and_profile_under_one_backup_suffix() {
+        let dir = tempdir().unwrap();
+        let save_path = dir.path().join("G1R-001.sav");
+        let profile_path = dir.path().join("PersistentDataList.sav");
+
+        // Save: public difficulty + a private difficulty payload behind the
+        // test codec backend.
+        let private_payload = difficulty_private_payload();
+        let seed_compressed = b"seed-compressed".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &save_path,
+            build_gsav(2, &difficulty_public_payload(), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        // Profile target: 2-profile PersistentDataList, editing only profile 1.
+        fs::write(&profile_path, difficulty_persistent_profiles()).unwrap();
+
+        let req = DifficultyRequest {
+            preset: "Hard".into(),
+            combat: None,
+            resources: None,
+            progression: None,
+            flow_helper: None,
+            permadeath: None,
+        };
+        let targets = json!({
+            "saves": [save_path.display().to_string()],
+            "profile": { "path": profile_path.display().to_string(), "profileId": 1 },
+        });
+
+        let response =
+            write_difficulty_internal(&req, &targets, true, Some(&backend)).unwrap();
+        assert_eq!(response["targetsWritten"], 2);
+
+        // The save's PUBLIC payload now reports Hard (re-read + parse).
+        let written_save = fs::read(&save_path).unwrap();
+        let d = difficulty_for_gsav_bytes(&written_save).unwrap();
+        assert_eq!(d.preset.as_deref(), Some("DifficultyPreset_Hard"));
+
+        // The save's PRIVATE payload was also edited to Hard.
+        let parts = split_gsav(&written_save).unwrap();
+        let written_stream =
+            parse_compressed_stream(&written_save, 13 + parts.public_payload.len()).unwrap();
+        let decoded =
+            decompress_private_payload(&written_save, &written_stream, &backend).unwrap();
+        let private_refs = scan_fstrings(&decoded, 0);
+        assert_eq!(
+            value_after_property_in_range(
+                &private_refs,
+                0,
+                private_refs.len(),
+                "m_difficultyPreset"
+            )
+            .as_deref(),
+            Some("/Script/Angelscript.DifficultyPreset_Hard"),
+        );
+
+        // Profile 1 became Hard; profile 0 (Custom) was left untouched.
+        let written_profile = fs::read(&profile_path).unwrap();
+        let presets: Vec<_> = scan_fstrings(&written_profile, 0)
+            .into_iter()
+            .filter(|r| r.value.contains("DifficultyPreset_"))
+            .map(|r| r.value)
+            .collect();
+        assert!(presets.iter().any(|p| p.ends_with("DifficultyPreset_Custom")));
+        assert!(presets.iter().any(|p| p.ends_with("DifficultyPreset_Hard")));
+        assert!(!presets.iter().any(|p| p.ends_with("DifficultyPreset_Easy")));
+
+        // Both targets were backed up under ONE shared suffix.
+        let backups = dir.path().join("goresave_backups");
+        let mut save_suffix = None;
+        let mut profile_suffix = None;
+        for entry in fs::read_dir(&backups).unwrap() {
+            let name = entry.unwrap().file_name().to_string_lossy().into_owned();
+            if let Some(rest) = name.strip_prefix("G1R-001.sav.bak.") {
+                save_suffix = Some(rest.to_string());
+            } else if let Some(rest) = name.strip_prefix("PersistentDataList.sav.bak.") {
+                profile_suffix = Some(rest.to_string());
+            }
+        }
+        let save_suffix = save_suffix.expect("save backup created");
+        let profile_suffix = profile_suffix.expect("profile backup created");
+        assert_eq!(save_suffix, profile_suffix, "shared backup suffix");
+    }
+
+    #[test]
+    fn write_difficulty_internal_requires_at_least_one_target() {
+        let req = DifficultyRequest {
+            preset: "Hard".into(),
+            combat: None,
+            resources: None,
+            progression: None,
+            flow_helper: None,
+            permadeath: None,
+        };
+        let err = write_difficulty_internal(&req, &json!({}), false, None).unwrap_err();
+        assert!(matches!(err, CoreError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn write_difficulty_internal_profile_only_needs_no_codec() {
+        let dir = tempdir().unwrap();
+        let profile_path = dir.path().join("PersistentDataList.sav");
+        fs::write(&profile_path, difficulty_persistent_profiles()).unwrap();
+
+        let req = DifficultyRequest {
+            preset: "Hard".into(),
+            combat: None,
+            resources: None,
+            progression: None,
+            flow_helper: None,
+            permadeath: None,
+        };
+        let targets = json!({
+            "profile": { "path": profile_path.display().to_string(), "profileId": 1 },
+        });
+
+        // No codec backend supplied: the profile-only path must not require one.
+        let response = write_difficulty_internal(&req, &targets, true, None).unwrap();
+        assert_eq!(response["targetsWritten"], 1);
+
+        let written = fs::read(&profile_path).unwrap();
+        let presets: Vec<_> = scan_fstrings(&written, 0)
+            .into_iter()
+            .filter(|r| r.value.contains("DifficultyPreset_"))
+            .map(|r| r.value)
+            .collect();
+        assert!(presets.iter().any(|p| p.ends_with("DifficultyPreset_Hard")));
+        assert!(!presets.iter().any(|p| p.ends_with("DifficultyPreset_Easy")));
+        assert!(dir.path().join("goresave_backups").exists());
     }
 
     #[test]

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -1737,6 +1737,32 @@ fn create_backup_copy(path: &Path) -> Result<PathBuf, CoreError> {
     Ok(backup_path)
 }
 
+/// Back up `path` with a suffix that is free on disk for this file AND not in
+/// `avoid`. Used when backing up several independent files in one round: each
+/// file gets a distinct suffix so the paired-restore heuristic
+/// ([`prepare_paired_persistent_data_list_restore`]) never auto-couples them,
+/// even when their names differ (a per-file existence check alone would not
+/// stop two differently-named files from sharing the same timestamp suffix).
+fn create_unique_backup_avoiding(path: &Path, avoid: &[String]) -> Result<PathBuf, CoreError> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let mut suffix = format!("{timestamp}");
+    let mut attempt = 0u32;
+    while avoid.iter().any(|s| s == &suffix)
+        || backup_path_with_suffix(path, &suffix).exists()
+    {
+        attempt += 1;
+        suffix = format!("{timestamp}.{attempt}");
+        if attempt >= 1_000_000 {
+            suffix = format!("{timestamp}.overflow");
+            break;
+        }
+    }
+    create_backup_with_suffix(path, &suffix)
+}
+
 fn unique_backup_path(path: &Path) -> PathBuf {
     let suffix = shared_backup_suffix(std::slice::from_ref(&path));
     backup_path_with_suffix(path, &suffix)
@@ -6697,14 +6723,25 @@ fn write_difficulty_internal(
     let changed: Vec<&DifficultyWritePlan> =
         plans.iter().filter(|p| p.original != p.edited).collect();
 
-    // Back up every changed target under ONE shared suffix BEFORE writing
-    // anything, so a restore can pair save + profile by suffix.
+    // Back up every changed target with its OWN unique suffix BEFORE writing
+    // anything. Difficulty edits to separate files (slot saves, profile) are
+    // logically independent and must each restore on their own — they must NOT
+    // be coupled by a shared suffix, or prepare_paired_persistent_data_list_restore
+    // would auto-roll-back the profile when a single slot is restored.
     if backup {
-        let paths: Vec<&Path> = changed.iter().map(|p| p.path.as_path()).collect();
-        if !paths.is_empty() {
-            let suffix = shared_backup_suffix(&paths);
-            for p in &changed {
-                create_backup_with_suffix(&p.path, &suffix)?;
+        // Track the suffixes already chosen in this batch so two files with
+        // different names (e.g. G1R-001.sav and PersistentDataList.sav) never
+        // land on the same suffix — create_backup_copy only checks its own
+        // file's backup path for collisions, not its siblings'.
+        let mut used_suffixes: Vec<String> = Vec::new();
+        for p in &changed {
+            let backup_path = create_unique_backup_avoiding(&p.path, &used_suffixes)?;
+            if let Some(name) = backup_path.file_name().and_then(|n| n.to_str()) {
+                if let Ok(prefix) = backup_file_prefix(&p.path) {
+                    if let Some(suffix) = name.strip_prefix(&prefix) {
+                        used_suffixes.push(suffix.to_string());
+                    }
+                }
             }
         }
     }
@@ -7202,7 +7239,7 @@ mod tests {
     }
 
     #[test]
-    fn write_difficulty_internal_writes_save_and_profile_under_one_backup_suffix() {
+    fn write_difficulty_internal_writes_save_and_profile_under_distinct_backup_suffixes() {
         let dir = tempdir().unwrap();
         let save_path = dir.path().join("G1R-001.sav");
         let profile_path = dir.path().join("PersistentDataList.sav");
@@ -7276,7 +7313,10 @@ mod tests {
         assert!(presets.iter().any(|p| p.ends_with("DifficultyPreset_Hard")));
         assert!(!presets.iter().any(|p| p.ends_with("DifficultyPreset_Easy")));
 
-        // Both targets were backed up under ONE shared suffix.
+        // Each target was backed up under its OWN distinct suffix, so the
+        // paired-restore heuristic (prepare_paired_persistent_data_list_restore,
+        // which matches when the companion's suffix equals the slot's suffix)
+        // does NOT auto-couple a single slot restore to the profile rollback.
         let backups = dir.path().join("goresave_backups");
         let mut save_suffix = None;
         let mut profile_suffix = None;
@@ -7290,7 +7330,24 @@ mod tests {
         }
         let save_suffix = save_suffix.expect("save backup created");
         let profile_suffix = profile_suffix.expect("profile backup created");
-        assert_eq!(save_suffix, profile_suffix, "shared backup suffix");
+        assert_ne!(
+            save_suffix, profile_suffix,
+            "save and profile backups must have DISTINCT suffixes so a single \
+             slot restore is not coupled to the profile rollback",
+        );
+
+        // Confirm the suffixes really would not pair: the slot suffix must not
+        // match the companion-prefixed name (the exact check restore performs).
+        assert_ne!(
+            format!("PersistentDataList.sav.bak.{save_suffix}"),
+            format!("PersistentDataList.sav.bak.{profile_suffix}"),
+        );
+        let pdl_backup = backups.join(format!("PersistentDataList.sav.bak.{save_suffix}"));
+        assert!(
+            !pdl_backup.exists(),
+            "no PersistentDataList backup shares the slot's suffix, so \
+             prepare_paired_persistent_data_list_restore finds no companion to pair",
+        );
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-06-14-difficulty-editor.md
+++ b/docs/superpowers/plans/2026-06-14-difficulty-editor.md
@@ -1,0 +1,1327 @@
+# Difficulty Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show each savegame's difficulty (Novice/Gothic/Hard/Custom) in place of the useless "MainMap" badge, and let the user edit difficulty from a collapsible card in the Overview tab — writing the current save, and optionally the profile and all of the profile's saves, with mandatory backups.
+
+**Architecture:** Difficulty is stored per-save in both the uncompressed public payload (`SaveGamePublicData`) and the compressed private payload (`SaveDataPayload`), and also in `PersistentDataList.sav` (`ProfileData`). The private save copy is authoritative for gameplay. Phase 1 surfaces the per-save difficulty (read-only) from the public payload and replaces the map badges. Phase 2 adds an all-or-nothing multi-file write via a new `write_difficulty` core command, reusing the existing GVAS fstring-splice, GSAV rebuild, private-edit/Kraken, and backup/atomic-replace machinery.
+
+**Tech Stack:** Rust core (`crates/goresave_core`), Flutter + Riverpod app (`apps/goresave`). Tests: Rust `#[cfg(test)]` unit tests with synthetic GVAS buffers (`fstring()` helper); Flutter `flutter_test` widget tests.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-14-profile-difficulty-tab-design.md`
+
+---
+
+## Background facts (verified)
+
+- Asset-path prefix: `/Script/Angelscript.`
+- Preset values: `DifficultyPreset_{Easy,Standard,Hard,Custom}`; sub-settings
+  `CombatDifficultySettings_{Easy,Standard,Hard}`, `ResourcesDifficultySettings_{…}`,
+  `ProgressionDifficultySettings_{…}`.
+- UI label mapping: `Easy`→Novice, `Standard`→Gothic, `Hard`→Hard, `Custom`→Custom.
+- Properties: `m_difficultyPreset`, `m_customCombatSettings`,
+  `m_customResourcesSettings`, `m_customProgressionSettings` are **ClassProperty**
+  (value is an inline FString asset path). `m_FakeSloppyCombos` (Flow Helper),
+  `m_PermanentDeath` (Permadeath) are **BoolProperty**.
+- All difficulty properties are serialized on every save and every profile, so all
+  edits are in-place splices (no structural insertion).
+- Existing helpers to reuse:
+  - `scan_fstrings(data, 0) -> Vec<FStringRef>` (fields: `value`, `utf16`,
+    `len_offset`, `total_len`).
+  - `value_after_property_in_range(refs, start, end, name) -> Option<String>`
+    (lib.rs:2086).
+  - `read_bool_property_in_range(payload, refs, start, end, name) -> Option<bool>`
+    (lib.rs:2127).
+  - `find_ref_in_range(refs, start, end, value) -> Option<usize>` (lib.rs:2138).
+  - `replace_str_property_fstring_in_range(payload, refs, start, end, name, value)`
+    (lib.rs:6334) — currently rejects non-`StrProperty`.
+  - `write_str_property_value(payload, size_offset, value_ref, new_value)` (lib.rs:6077).
+  - `split_gsav` / `build_gsav` / `replace_public_fstring` (lib.rs:6305).
+  - `apply_private_edits` dispatch (lib.rs:4025); `apply_public_edit` (lib.rs:3994).
+  - `write_save_internal` pipeline (lib.rs:3762): `create_backup_with_suffix`
+    (lib.rs:1717), `shared_backup_suffix` (lib.rs:1729), `begin_replace` (lib.rs:1666),
+    `PendingReplace::{commit,rollback}`.
+  - Bool value byte location: `type_ref.len_offset + type_ref.total_len + 8`
+    (from `read_bool_property_at`, lib.rs:3349).
+  - Command dispatch match arm lives in `execute_json`'s handler near lib.rs:458.
+
+---
+
+# PHASE 1 — Surface & display difficulty (read-only, shippable)
+
+## Task 1: Core — parse per-save difficulty from a GVAS payload
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add near the other parsing tests in the `tests` module (after lib.rs:6410):
+
+```rust
+#[test]
+fn parse_difficulty_settings_reads_preset_and_bools() {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&fstring("m_difficultyPreset"));
+    payload.extend_from_slice(&fstring("ClassProperty"));
+    payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+    payload.extend_from_slice(&fstring("m_customCombatSettings"));
+    payload.extend_from_slice(&fstring("ClassProperty"));
+    payload.extend_from_slice(&fstring("/Script/Angelscript.CombatDifficultySettings_Hard"));
+    payload.extend_from_slice(&fstring("m_FakeSloppyCombos"));
+    payload.extend_from_slice(&fstring("BoolProperty"));
+    payload.extend_from_slice(&[0u8; 8]); // array_index + size
+    payload.push(1); // bool value byte
+    payload.extend_from_slice(&fstring("m_PermanentDeath"));
+    payload.extend_from_slice(&fstring("BoolProperty"));
+    payload.extend_from_slice(&[0u8; 8]);
+    payload.push(0);
+
+    let d = parse_difficulty_settings(&payload);
+    assert_eq!(d.preset.as_deref(), Some("DifficultyPreset_Custom"));
+    assert_eq!(d.combat.as_deref(), Some("CombatDifficultySettings_Hard"));
+    assert_eq!(d.flow_helper, Some(true));
+    assert_eq!(d.permadeath, Some(false));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core parse_difficulty_settings_reads_preset_and_bools`
+Expected: FAIL — `cannot find function parse_difficulty_settings` / `DifficultySettings`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the struct (near `ProfileSummary`, lib.rs:150) and the parser (near
+`value_after_property_in_range`). The struct stores the **short class name** (the
+substring after the last `.`), so the UI maps it without knowing the package prefix.
+
+```rust
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DifficultySettings {
+    pub preset: Option<String>,
+    pub combat: Option<String>,
+    pub resources: Option<String>,
+    pub progression: Option<String>,
+    pub flow_helper: Option<bool>,
+    pub permadeath: Option<bool>,
+}
+
+fn short_class_name(path: &str) -> String {
+    path.rsplit('.').next().unwrap_or(path).to_string()
+}
+
+fn parse_difficulty_settings(payload: &[u8]) -> DifficultySettings {
+    let refs = scan_fstrings(payload, 0);
+    let end = refs.len();
+    let class = |name: &str| {
+        value_after_property_in_range(&refs, 0, end, name).map(|v| short_class_name(&v))
+    };
+    DifficultySettings {
+        preset: class("m_difficultyPreset"),
+        combat: class("m_customCombatSettings"),
+        resources: class("m_customResourcesSettings"),
+        progression: class("m_customProgressionSettings"),
+        flow_helper: read_bool_property_in_range(payload, &refs, 0, end, "m_FakeSloppyCombos"),
+        permadeath: read_bool_property_in_range(payload, &refs, 0, end, "m_PermanentDeath"),
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core parse_difficulty_settings_reads_preset_and_bools`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): parse per-save difficulty settings from a GVAS payload"
+```
+
+## Task 2: Core — expose difficulty on inspect_save and list_saves
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+
+The save's public payload bytes come from `split_gsav(data).public_payload`. Add a small
+helper that extracts difficulty from a full GSAV file, returning `None` for non-GSAV.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn difficulty_for_gsav_bytes_none_for_non_gsav() {
+    assert!(difficulty_for_gsav_bytes(b"NOPE").is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core difficulty_for_gsav_bytes_none_for_non_gsav`
+Expected: FAIL — `cannot find function difficulty_for_gsav_bytes`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+fn difficulty_for_gsav_bytes(data: &[u8]) -> Option<DifficultySettings> {
+    if !data.starts_with(b"GSAV") {
+        return None;
+    }
+    let parts = split_gsav(data).ok()?;
+    Some(parse_difficulty_settings(parts.public_payload))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core difficulty_for_gsav_bytes_none_for_non_gsav`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into list_saves (SaveListItem)**
+
+In the `SaveListItem` struct (search `struct SaveListItem`), add:
+```rust
+    #[serde(skip_serializing_if = "Option::is_none")]
+    difficulty: Option<DifficultySettings>,
+```
+In the scan builder (lib.rs:554, the `Ok(info)` arm), compute once before `saves.push`:
+```rust
+                let difficulty = difficulty_for_gsav_bytes(&data);
+```
+and add `difficulty,` to the `SaveListItem { … }`. In the `Err` arm add `difficulty: None,`.
+
+- [ ] **Step 6: Wire into inspect output**
+
+Find where `inspect_save` / `inspect_bytes` builds its returned JSON object (the object
+that includes `"public"`). Add a top-level field:
+```rust
+        "difficulty": difficulty_for_gsav_bytes(data),
+```
+(Use the in-scope full-file byte slice; in `inspect_bytes` that is the `data` param.)
+
+- [ ] **Step 7: Build & run the core test suite**
+
+Run: `cargo test -p goresave_core`
+Expected: PASS (no regressions).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): expose per-save difficulty on inspect_save and list_saves"
+```
+
+## Task 3: Dart — difficulty model + fields on SaveSlot/SaveInspection
+
+**Files:**
+- Modify: `apps/goresave/lib/features/editor/domain/editor_models.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/goresave/test/difficulty_settings_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/editor_models.dart';
+
+void main() {
+  test('DifficultySettings.fromJson maps fields and label', () {
+    final d = DifficultySettings.fromJson({
+      'preset': 'DifficultyPreset_Custom',
+      'combat': 'CombatDifficultySettings_Hard',
+      'flowHelper': true,
+      'permadeath': false,
+    });
+    expect(d.presetLabel, 'Custom');
+    expect(d.combatLabel, 'Hard');
+    expect(d.flowHelper, true);
+    expect(d.permadeath, false);
+  });
+
+  test('presetLabel maps Easy to Novice and Standard to Gothic', () {
+    expect(DifficultySettings(preset: 'DifficultyPreset_Easy').presetLabel, 'Novice');
+    expect(DifficultySettings(preset: 'DifficultyPreset_Standard').presetLabel, 'Gothic');
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/goresave && flutter test test/difficulty_settings_test.dart`
+Expected: FAIL — `DifficultySettings` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `editor_models.dart` (top-level, near `ProfileSummary`):
+
+```dart
+/// Maps a difficulty class short-name suffix to its UI label.
+String _difficultyLevelLabel(String? className) {
+  if (className == null) return '-';
+  if (className.endsWith('_Easy')) return 'Novice';
+  if (className.endsWith('_Standard')) return 'Gothic';
+  if (className.endsWith('_Hard')) return 'Hard';
+  if (className.endsWith('_Custom')) return 'Custom';
+  return className;
+}
+
+class DifficultySettings {
+  const DifficultySettings({
+    this.preset,
+    this.combat,
+    this.resources,
+    this.progression,
+    this.flowHelper,
+    this.permadeath,
+  });
+
+  factory DifficultySettings.fromJson(Map<String, Object?> json) {
+    return DifficultySettings(
+      preset: json['preset'] as String?,
+      combat: json['combat'] as String?,
+      resources: json['resources'] as String?,
+      progression: json['progression'] as String?,
+      flowHelper: json['flowHelper'] as bool?,
+      permadeath: json['permadeath'] as bool?,
+    );
+  }
+
+  static DifficultySettings? maybeFromJson(Object? json) =>
+      json is Map ? DifficultySettings.fromJson(json.cast<String, Object?>()) : null;
+
+  final String? preset;
+  final String? combat;
+  final String? resources;
+  final String? progression;
+  final bool? flowHelper;
+  final bool? permadeath;
+
+  String get presetLabel => _difficultyLevelLabel(preset);
+  String get combatLabel => _difficultyLevelLabel(combat);
+  String get resourcesLabel => _difficultyLevelLabel(resources);
+  String get progressionLabel => _difficultyLevelLabel(progression);
+}
+```
+
+Add `final DifficultySettings? difficulty;` plus `this.difficulty` to the constructors
+of **both** `SaveSlot` (lib line ~168) and `SaveInspection`, and in each `fromJson`:
+```dart
+      difficulty: DifficultySettings.maybeFromJson(json['difficulty']),
+```
+(For `SaveInspection.fromJson` the difficulty is a top-level key, same as `format`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/goresave && flutter test test/difficulty_settings_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/domain/editor_models.dart apps/goresave/test/difficulty_settings_test.dart
+git commit -m "feat(app): add DifficultySettings model and fields on SaveSlot/SaveInspection"
+```
+
+## Task 4: Dart — replace map badges with difficulty label
+
+**Files:**
+- Modify: `apps/goresave/lib/features/editor/ui/editor_page.dart`
+
+- [ ] **Step 1: Replace the sidebar subtitle (editor_page.dart:520-523)**
+
+```dart
+  final difficulty = save.difficulty?.presetLabel;
+  if (difficulty != null && difficulty != '-') {
+    parts.add(difficulty);
+  }
+```
+(Delete the previous `mapName` block.)
+
+- [ ] **Step 2: Replace the header pill (editor_page.dart:1068-1072)**
+
+```dart
+                            if (inspection.difficulty?.presetLabel != null &&
+                                inspection.difficulty!.presetLabel != '-')
+                              _InfoPill(
+                                icon: Icons.local_fire_department_outlined,
+                                label: inspection.difficulty!.presetLabel,
+                              ),
+```
+
+- [ ] **Step 3: Replace the diagnostics metric (editor_page.dart:938-939)**
+
+```dart
+                        if (inspection.difficulty?.presetLabel != null &&
+                            inspection.difficulty!.presetLabel != '-')
+                          'Difficulty': inspection.difficulty!.presetLabel,
+```
+
+- [ ] **Step 4: Verify it compiles / analyzer clean**
+
+Run: `cd apps/goresave && flutter analyze lib/features/editor/ui/editor_page.dart`
+Expected: No issues (no remaining references to `save.mapName` / `inspection.mapName`
+in these three spots).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/ui/editor_page.dart
+git commit -m "feat(app): show per-save difficulty in place of the MainMap badge"
+```
+
+## Task 5: Dart — read-only Difficulty card in Overview
+
+**Files:**
+- Modify: `apps/goresave/lib/features/editor/ui/editor_page.dart`
+
+Mirror the existing `_CollapsibleCardHeader` card (the "Diagnostics & details" card,
+~lib.939). Read the Overview panel build method first to find the column where cards are
+listed, and insert the new card just below the header card.
+
+- [ ] **Step 1: Add the card widget**
+
+```dart
+class _DifficultyCard extends StatefulWidget {
+  const _DifficultyCard({required this.inspection});
+  final SaveInspection inspection;
+  @override
+  State<_DifficultyCard> createState() => _DifficultyCardState();
+}
+
+class _DifficultyCardState extends State<_DifficultyCard> {
+  bool _expanded = false;
+  @override
+  Widget build(BuildContext context) {
+    final d = widget.inspection.difficulty;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _CollapsibleCardHeader(
+              icon: Icons.local_fire_department_outlined,
+              title: 'Difficulty',
+              subtitle: d?.presetLabel ?? 'Unknown',
+              expanded: _expanded,
+              onToggle: () => setState(() => _expanded = !_expanded),
+            ),
+            if (_expanded && d != null) ...[
+              const SizedBox(height: 8),
+              _MetricGrid(
+                metrics: {
+                  'Preset': d.presetLabel,
+                  'Close Combat Flow Helper': d.flowHelper == true ? 'On' : 'Off',
+                  'Permadeath': d.permadeath == true ? 'On' : 'Off',
+                  'Combat': d.combatLabel,
+                  'Resources': d.resourcesLabel,
+                  'Progression': d.progressionLabel,
+                },
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Insert it in the Overview panel**
+
+In the Overview panel's `Column`/`ListView` children, add below the header card:
+```dart
+            _DifficultyCard(inspection: inspection),
+```
+(Use the `inspection` variable already in scope in that panel.)
+
+- [ ] **Step 3: Verify**
+
+Run: `cd apps/goresave && flutter analyze lib/features/editor/ui/editor_page.dart`
+Expected: No issues.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/ui/editor_page.dart
+git commit -m "feat(app): add read-only Difficulty card to the Overview tab"
+```
+
+**Phase 1 checkpoint:** Build and run the app (`/run` or `flutter run -d windows` in
+`apps/goresave`), open a save, confirm the sidebar/header show Novice/Gothic/Hard/Custom
+and the Difficulty card shows correct values. This phase is shippable on its own.
+
+---
+
+# PHASE 2 — Edit difficulty (writes)
+
+## Task 6: Core — generalize the fstring splice to ClassProperty
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn replace_class_property_value_in_range_rewrites_path() {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&fstring("m_difficultyPreset"));
+    payload.extend_from_slice(&fstring("ClassProperty"));
+    payload.extend_from_slice(&[0u8; 4]); // flags
+    payload.extend_from_slice(&0u32.to_le_bytes()); // size (rewritten)
+    payload.push(0); // tag
+    payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+
+    let refs = scan_fstrings(&payload, 0);
+    replace_class_or_str_property_in_range(
+        &mut payload, &refs, 0, refs.len(),
+        "m_difficultyPreset",
+        "/Script/Angelscript.DifficultyPreset_Easy",
+    )
+    .unwrap();
+
+    let refs2 = scan_fstrings(&payload, 0);
+    assert_eq!(
+        value_after_property_in_range(&refs2, 0, refs2.len(), "m_difficultyPreset").as_deref(),
+        Some("/Script/Angelscript.DifficultyPreset_Easy"),
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core replace_class_property_value_in_range_rewrites_path`
+Expected: FAIL — `cannot find function replace_class_or_str_property_in_range`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Copy `replace_str_property_fstring_in_range` (lib.rs:6334) to a new function that accepts
+`StrProperty` or `ClassProperty` (value layout is identical):
+
+```rust
+fn replace_class_or_str_property_in_range(
+    payload: &mut Vec<u8>,
+    refs: &[FStringRef],
+    start_idx: usize,
+    end_idx: usize,
+    property_name: &str,
+    new_value: &str,
+) -> Result<(), CoreError> {
+    let name_idx = find_ref_in_range(refs, start_idx, end_idx, property_name)
+        .ok_or_else(|| CoreError::Parse(format!("property {property_name} was not found")))?;
+    let type_ref = refs
+        .get(name_idx + 1)
+        .ok_or_else(|| CoreError::Parse(format!("type for {property_name} was not found")))?;
+    if type_ref.value != "StrProperty" && type_ref.value != "ClassProperty" {
+        return Err(CoreError::Parse(format!(
+            "property {property_name} is not a StrProperty/ClassProperty"
+        )));
+    }
+    let value_ref = refs
+        .get(name_idx + 2)
+        .ok_or_else(|| CoreError::Parse(format!("value for {property_name} was not found")))?;
+    if value_ref.utf16 {
+        return Err(CoreError::UnsupportedEdit(
+            "UTF-16 FString replacement is not implemented yet".to_string(),
+        ));
+    }
+    let size_offset = type_ref.len_offset + type_ref.total_len + 4;
+    write_str_property_value(payload, size_offset, value_ref, new_value)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core replace_class_property_value_in_range_rewrites_path`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): in-place splice for ClassProperty asset-path values"
+```
+
+## Task 7: Core — in-place BoolProperty writer
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn write_bool_property_in_range_flips_value_byte() {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&fstring("m_PermanentDeath"));
+    payload.extend_from_slice(&fstring("BoolProperty"));
+    payload.extend_from_slice(&[0u8; 8]);
+    payload.push(0); // value byte
+
+    let refs = scan_fstrings(&payload, 0);
+    write_bool_property_in_range(&mut payload, &refs, 0, refs.len(), "m_PermanentDeath", true)
+        .unwrap();
+
+    let refs2 = scan_fstrings(&payload, 0);
+    assert_eq!(
+        read_bool_property_in_range(&payload, &refs2, 0, refs2.len(), "m_PermanentDeath"),
+        Some(true),
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core write_bool_property_in_range_flips_value_byte`
+Expected: FAIL — `cannot find function write_bool_property_in_range`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+fn write_bool_property_in_range(
+    payload: &mut [u8],
+    refs: &[FStringRef],
+    start_idx: usize,
+    end_idx: usize,
+    name: &str,
+    value: bool,
+) -> Result<(), CoreError> {
+    let name_idx = find_ref_in_range(refs, start_idx, end_idx, name)
+        .ok_or_else(|| CoreError::Parse(format!("property {name} was not found")))?;
+    let type_ref = refs
+        .get(name_idx + 1)
+        .ok_or_else(|| CoreError::Parse(format!("type for {name} was not found")))?;
+    if type_ref.value != "BoolProperty" {
+        return Err(CoreError::Parse(format!("property {name} is not a BoolProperty")));
+    }
+    let offset = type_ref.len_offset + type_ref.total_len + 8;
+    *payload
+        .get_mut(offset)
+        .ok_or_else(|| CoreError::Parse(format!("bool value for {name} is out of range")))? =
+        if value { 1 } else { 0 };
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core write_bool_property_in_range_flips_value_byte`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): in-place BoolProperty value writer"
+```
+
+## Task 8: Core — apply a difficulty change to a GVAS payload (range)
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+
+This is the shared mutator for a **single-record GVAS payload** (a save's public payload
+or its decoded private payload — each holds one `SaveGamePublicData`/`SaveDataPayload`
+record). It applies only the requested fields, mapping UI levels to asset paths, and
+re-scans before each splice because splices shift byte offsets. The multi-profile
+`PersistentDataList` case is handled separately in Task 10.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn apply_save_difficulty_sets_preset_and_subsettings() {
+    let mut payload = Vec::new();
+    for name in ["m_difficultyPreset", "m_customCombatSettings",
+                 "m_customResourcesSettings", "m_customProgressionSettings"] {
+        payload.extend_from_slice(&fstring(name));
+        payload.extend_from_slice(&fstring("ClassProperty"));
+        payload.extend_from_slice(&[0u8; 4]);
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        payload.push(0);
+        payload.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Easy"));
+    }
+    payload.extend_from_slice(&fstring("m_PermanentDeath"));
+    payload.extend_from_slice(&fstring("BoolProperty"));
+    payload.extend_from_slice(&[0u8; 8]);
+    payload.push(0);
+
+    let req = DifficultyRequest {
+        preset: "Custom".to_string(),
+        combat: Some("Hard".to_string()),
+        resources: None,
+        progression: None,
+        flow_helper: None,
+        permadeath: Some(true),
+    };
+    apply_save_difficulty(&mut payload, &req).unwrap();
+
+    let refs = scan_fstrings(&payload, 0);
+    let end = refs.len();
+    assert_eq!(
+        value_after_property_in_range(&refs, 0, end, "m_difficultyPreset").as_deref(),
+        Some("/Script/Angelscript.DifficultyPreset_Custom"),
+    );
+    assert_eq!(
+        value_after_property_in_range(&refs, 0, end, "m_customCombatSettings").as_deref(),
+        Some("/Script/Angelscript.CombatDifficultySettings_Hard"),
+    );
+    // Resources/Progression had no explicit level -> default to Gothic (Standard) for Custom.
+    assert_eq!(
+        value_after_property_in_range(&refs, 0, end, "m_customResourcesSettings").as_deref(),
+        Some("/Script/Angelscript.ResourcesDifficultySettings_Standard"),
+    );
+    assert_eq!(
+        read_bool_property_in_range(&payload, &refs, 0, end, "m_PermanentDeath"),
+        Some(true),
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core apply_save_difficulty_sets_preset_and_subsettings`
+Expected: FAIL — `DifficultyRequest` / `apply_save_difficulty` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+const ANGELSCRIPT: &str = "/Script/Angelscript.";
+
+fn level_suffix(label: &str) -> Result<&'static str, CoreError> {
+    match label {
+        "Novice" => Ok("Easy"),
+        "Gothic" => Ok("Standard"),
+        "Hard" => Ok("Hard"),
+        other => Err(CoreError::InvalidRequest(format!("unknown difficulty level {other}"))),
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DifficultyRequest {
+    preset: String, // Novice|Gothic|Hard|Custom
+    #[serde(default)] combat: Option<String>,
+    #[serde(default)] resources: Option<String>,
+    #[serde(default)] progression: Option<String>,
+    #[serde(default)] flow_helper: Option<bool>,
+    #[serde(default)] permadeath: Option<bool>,
+}
+
+impl DifficultyRequest {
+    /// Resolved short class names (no package prefix).
+    fn class_edits(&self) -> Result<Vec<(&'static str, String)>, CoreError> {
+        let preset = if self.preset == "Custom" {
+            "DifficultyPreset_Custom".to_string()
+        } else {
+            format!("DifficultyPreset_{}", level_suffix(&self.preset)?)
+        };
+        // Sub-setting levels: explicit for Custom (default Gothic); mirror preset otherwise.
+        let lvl = |explicit: &Option<String>| -> Result<&'static str, CoreError> {
+            if self.preset == "Custom" {
+                level_suffix(explicit.as_deref().unwrap_or("Gothic"))
+            } else {
+                level_suffix(&self.preset)
+            }
+        };
+        Ok(vec![
+            ("m_difficultyPreset", preset),
+            ("m_customCombatSettings", format!("CombatDifficultySettings_{}", lvl(&self.combat)?)),
+            ("m_customResourcesSettings", format!("ResourcesDifficultySettings_{}", lvl(&self.resources)?)),
+            ("m_customProgressionSettings", format!("ProgressionDifficultySettings_{}", lvl(&self.progression)?)),
+        ])
+    }
+    /// Permadeath is locked off for Novice.
+    fn resolved_permadeath(&self) -> Option<bool> {
+        if self.preset == "Novice" { Some(false) } else { self.permadeath }
+    }
+}
+
+fn apply_save_difficulty(payload: &mut Vec<u8>, req: &DifficultyRequest) -> Result<(), CoreError> {
+    // Class properties: re-scan before each splice (lengths shift).
+    for (name, class) in req.class_edits()? {
+        let refs = scan_fstrings(payload, 0);
+        let end = refs.len();
+        if find_ref_in_range(&refs, 0, end, name).is_some() {
+            replace_class_or_str_property_in_range(
+                payload, &refs, 0, end, name, &format!("{ANGELSCRIPT}{class}"),
+            )?;
+        }
+    }
+    // Bools.
+    if let Some(perma) = req.resolved_permadeath() {
+        let refs = scan_fstrings(payload, 0);
+        write_bool_property_in_range(payload, &refs, 0, refs.len(), "m_PermanentDeath", perma)?;
+    }
+    if let Some(flow) = req.flow_helper {
+        let refs = scan_fstrings(payload, 0);
+        write_bool_property_in_range(payload, &refs, 0, refs.len(), "m_FakeSloppyCombos", flow)?;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core apply_save_difficulty_sets_preset_and_subsettings`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): apply a difficulty request to a single-record GVAS payload"
+```
+
+## Task 9: Core — write difficulty into one save (public + private)
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+
+Public payload: splice via `split_gsav`/`build_gsav` (like `replace_public_fstring`).
+Private payload: route through `apply_private_edits` with a new edit kind.
+
+- [ ] **Step 1: Add a private edit arm**
+
+In `apply_private_edits`'s match (lib.rs:4044), add:
+```rust
+            "private.difficulty.set" => {
+                parse_private_difficulty_edit(edit).map(PrivateEdit::Difficulty)
+            }
+```
+Add a `Difficulty(DifficultyRequest)` variant to the `PrivateEdit` enum, a
+`parse_private_difficulty_edit(edit) -> Result<DifficultyRequest, CoreError>` that
+deserializes `edit.value` into `DifficultyRequest`, and in the payload-mutation step
+(where each `PrivateEdit` is applied to the decoded private payload) handle
+`PrivateEdit::Difficulty(req) => apply_save_difficulty(payload, &req)?`.
+(Find the apply loop by searching `PrivateEdit::TypedSetValue` in the mutation function.)
+
+- [ ] **Step 2: Add the public + private orchestrator with a test**
+
+Test (uses the GSAV test scaffolding already present — search for an existing
+`build_gsav`-based test to copy the public/stream/trailer setup):
+
+```rust
+#[test]
+fn write_difficulty_into_save_updates_public_payload() {
+    // Build a GSAV whose public payload carries a Custom preset, then set Novice.
+    let mut public = Vec::new();
+    public.extend_from_slice(&fstring("m_difficultyPreset"));
+    public.extend_from_slice(&fstring("ClassProperty"));
+    public.extend_from_slice(&[0u8; 4]);
+    public.extend_from_slice(&0u32.to_le_bytes());
+    public.push(0);
+    public.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+    public.extend_from_slice(&fstring("m_PermanentDeath"));
+    public.extend_from_slice(&fstring("BoolProperty"));
+    public.extend_from_slice(&[0u8; 8]);
+    public.push(1);
+
+    let gsav = build_gsav(2, &public, &[], &[]);
+    let req = DifficultyRequest {
+        preset: "Novice".into(), combat: None, resources: None,
+        progression: None, flow_helper: None, permadeath: Some(true),
+    };
+    let out = write_difficulty_into_save_public(&gsav, &req).unwrap();
+    let d = difficulty_for_gsav_bytes(&out).unwrap();
+    assert_eq!(d.preset.as_deref(), Some("DifficultyPreset_Easy"));
+    assert_eq!(d.permadeath, Some(false)); // Novice forces off
+}
+```
+
+Implementation:
+```rust
+fn write_difficulty_into_save_public(
+    data: &[u8],
+    req: &DifficultyRequest,
+) -> Result<Vec<u8>, CoreError> {
+    let parts = split_gsav(data)?;
+    let mut public_payload = parts.public_payload.to_vec();
+    let compressed_stream = parts.compressed_stream.to_vec();
+    let trailer = parts.trailer.to_vec();
+    let version = parts.version;
+    apply_save_difficulty(&mut public_payload, req)?;
+    Ok(build_gsav(version, &public_payload, &compressed_stream, &trailer))
+}
+```
+
+(The private side is exercised through `apply_private_edits` in Task 11's command test,
+which needs the codec backend; keep the unit test here to the public path.)
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p goresave_core write_difficulty_into_save_updates_public_payload`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): write difficulty into a save's public payload + private edit kind"
+```
+
+## Task 10: Core — write difficulty into a profile range in PersistentDataList
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+
+Reuse the profile boundary logic from `parse_profile_summaries` (lib.rs:904): locate the
+target profile's `[start_idx, end_idx)` ref range by `m_ProfileId`, then splice within it.
+Because splices shift bytes, re-scan and re-derive the range bound after each edit.
+
+- [ ] **Step 1: Write the failing test** (synthetic two-profile buffer)
+
+```rust
+#[test]
+fn write_profile_difficulty_targets_only_the_named_profile() {
+    let mut data = b"GVAS".to_vec();
+    data.extend_from_slice(&fstring("m_Profiles"));
+    // profile 0
+    data.extend_from_slice(&fstring("m_ProfileName"));
+    data.extend_from_slice(&fstring("m_ProfileId"));
+    data.extend_from_slice(&fstring("IntProperty"));
+    data.extend_from_slice(&[0u8; 4]);
+    data.extend_from_slice(&4u32.to_le_bytes());
+    data.push(0);
+    data.extend_from_slice(&0i32.to_le_bytes());
+    data.extend_from_slice(&fstring("m_difficultyPreset"));
+    data.extend_from_slice(&fstring("ClassProperty"));
+    data.extend_from_slice(&[0u8; 4]);
+    data.extend_from_slice(&0u32.to_le_bytes());
+    data.push(0);
+    data.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Custom"));
+    // profile 1
+    data.extend_from_slice(&fstring("m_ProfileName"));
+    data.extend_from_slice(&fstring("m_ProfileId"));
+    data.extend_from_slice(&fstring("IntProperty"));
+    data.extend_from_slice(&[0u8; 4]);
+    data.extend_from_slice(&4u32.to_le_bytes());
+    data.push(0);
+    data.extend_from_slice(&1i32.to_le_bytes());
+    data.extend_from_slice(&fstring("m_difficultyPreset"));
+    data.extend_from_slice(&fstring("ClassProperty"));
+    data.extend_from_slice(&[0u8; 4]);
+    data.extend_from_slice(&0u32.to_le_bytes());
+    data.push(0);
+    data.extend_from_slice(&fstring("/Script/Angelscript.DifficultyPreset_Easy"));
+    data.extend_from_slice(&fstring("SavedDataVersion"));
+
+    let req = DifficultyRequest {
+        preset: "Hard".into(), combat: None, resources: None,
+        progression: None, flow_helper: None, permadeath: None,
+    };
+    write_profile_difficulty(&mut data, 1, &req).unwrap();
+
+    // Profile 1 changed, profile 0 untouched.
+    let refs = scan_fstrings(&data, 0);
+    let presets: Vec<_> = refs.iter().filter(|r| r.value.contains("DifficultyPreset_")).map(|r| r.value.clone()).collect();
+    assert!(presets.iter().any(|p| p.ends_with("DifficultyPreset_Custom")));
+    assert!(presets.iter().any(|p| p.ends_with("DifficultyPreset_Hard")));
+    assert!(!presets.iter().any(|p| p.ends_with("DifficultyPreset_Easy")));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core write_profile_difficulty_targets_only_the_named_profile`
+Expected: FAIL — `write_profile_difficulty` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+fn profile_range_by_id(refs: &[FStringRef], profile_id: i32, payload: &[u8]) -> Option<(usize, usize)> {
+    let profiles_idx = refs.iter().position(|r| r.value == "m_Profiles")?;
+    let profiles_end = refs.iter().enumerate().skip(profiles_idx + 1)
+        .find(|(_, r)| r.value == "SavedDataVersion").map(|(i, _)| i)
+        .unwrap_or(refs.len());
+    let starts: Vec<usize> = refs.iter().enumerate().take(profiles_end).skip(profiles_idx + 1)
+        .filter_map(|(i, r)| (r.value == "m_ProfileName").then_some(i)).collect();
+    for (ord, &start) in starts.iter().enumerate() {
+        let end = starts.get(ord + 1).copied().unwrap_or(profiles_end);
+        let id = read_i32_property_in_range(payload, refs, start, end, "m_ProfileId")
+            .unwrap_or(ord as i32);
+        if id == profile_id {
+            return Some((start, end));
+        }
+    }
+    None
+}
+
+fn write_profile_difficulty(
+    data: &mut Vec<u8>,
+    profile_id: i32,
+    req: &DifficultyRequest,
+) -> Result<(), CoreError> {
+    if !data.starts_with(b"GVAS") {
+        return Err(CoreError::Parse("PersistentDataList.sav is not a GVAS file".into()));
+    }
+    // Apply field-by-field, re-locating the profile range after each splice
+    // (reuses the same resolution helpers as apply_save_difficulty for consistency).
+    for (name, class) in req.class_edits()? {
+        let refs = scan_fstrings(data, 0);
+        let (s, e) = profile_range_by_id(&refs, profile_id, data)
+            .ok_or_else(|| CoreError::Validation(format!("profile {profile_id} not found")))?;
+        // Skip silently if a field is absent in this profile range.
+        if find_ref_in_range(&refs, s, e, name).is_some() {
+            replace_class_or_str_property_in_range(data, &refs, s, e, name, &format!("{ANGELSCRIPT}{class}"))?;
+        }
+    }
+    for (name, val) in [("m_PermanentDeath", req.resolved_permadeath()), ("m_FakeSloppyCombos", req.flow_helper)] {
+        let Some(v) = val else { continue };
+        let refs = scan_fstrings(data, 0);
+        let (s, e) = profile_range_by_id(&refs, profile_id, data)
+            .ok_or_else(|| CoreError::Validation(format!("profile {profile_id} not found")))?;
+        if find_ref_in_range(&refs, s, e, name).is_some() {
+            write_bool_property_in_range(data, &refs, s, e, name, v)?;
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core write_profile_difficulty_targets_only_the_named_profile`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): write difficulty into a single profile range in PersistentDataList"
+```
+
+## Task 11: Core — `write_difficulty` command (multi-target, backed up, atomic)
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs`
+
+Payload:
+```json
+{
+  "command": "write_difficulty",
+  "difficulty": { "preset": "...", "combat": "...", "resources": "...",
+                  "progression": "...", "flowHelper": true, "permadeath": false },
+  "targets": { "saves": ["<path>", ...], "profile": { "path": "<PersistentDataList.sav>", "profileId": 1 } },
+  "binaryHost": { ... },
+  "backup": true
+}
+```
+
+- [ ] **Step 1: Add the dispatch arm**
+
+In `execute_json`'s match (after the `"write_save"` arm, lib.rs:458):
+```rust
+        "write_difficulty" => {
+            let req: DifficultyRequest = serde_json::from_value(
+                payload.get("difficulty").cloned().unwrap_or(Value::Null),
+            ).map_err(|e| CoreError::InvalidRequest(e.to_string()))?;
+            let backup = payload.get("backup").and_then(Value::as_bool).unwrap_or(true);
+            let codec_backend = payload.get("binaryHost").map(binary_host_backend_from_config).transpose()?;
+            let codec_backend = codec_backend.as_ref().map(|b| b as &dyn codec_backend::CodecBackend);
+            let targets = payload.get("targets").cloned().unwrap_or(Value::Null);
+            Ok(write_difficulty_internal(&req, &targets, backup, codec_backend)?)
+        }
+```
+
+- [ ] **Step 2: Write the orchestrator with a multi-target file test**
+
+Test (writes two temp GSAV saves + a temp PersistentDataList, runs the orchestrator,
+asserts all three updated and `.bak` backups exist). Use `tempfile::tempdir` like
+existing write tests; reuse a GSAV save built as in Task 9 and a PersistentDataList as in
+Task 10. Assert: each target's difficulty re-parses to the new preset, and a backup file
+was created next to each.
+
+Implementation:
+```rust
+struct DifficultyWritePlan {
+    path: PathBuf,
+    original: Vec<u8>,
+    edited: Vec<u8>,
+}
+
+fn write_difficulty_internal(
+    req: &DifficultyRequest,
+    targets: &Value,
+    backup: bool,
+    codec_backend: Option<&dyn codec_backend::CodecBackend>,
+) -> Result<Value, CoreError> {
+    let mut plans: Vec<DifficultyWritePlan> = Vec::new();
+
+    // Saves: edit public payload + private payload.
+    if let Some(saves) = targets.get("saves").and_then(Value::as_array) {
+        for save in saves {
+            let path = PathBuf::from(save.as_str().ok_or_else(|| {
+                CoreError::InvalidRequest("targets.saves entries must be strings".into())
+            })?);
+            let original = fs::read(&path)?;
+            let public_done = write_difficulty_into_save_public(&original, req)?;
+            // Private payload via the existing private-edit pipeline.
+            let edit = Edit {
+                path: "private.difficulty.set".to_string(),
+                value: serde_json::to_value(req).map_err(|e| CoreError::InvalidRequest(e.to_string()))?,
+            };
+            let edited = apply_private_edits(&public_done, &[&edit], codec_backend)?;
+            inspect_bytes(&edited, None, false)?;
+            if edited.starts_with(b"GSAV") {
+                let rebuilt = rebuild_gsav_preserving_stream(&edited)?;
+                if rebuilt != edited {
+                    return Err(CoreError::Validation(
+                        "edited GSAV does not rebuild byte-identically".into(),
+                    ));
+                }
+            }
+            plans.push(DifficultyWritePlan { path, original, edited });
+        }
+    }
+
+    // Profile: edit PersistentDataList range.
+    if let Some(profile) = targets.get("profile").filter(|v| !v.is_null()) {
+        let path = PathBuf::from(profile.get("path").and_then(Value::as_str).ok_or_else(|| {
+            CoreError::InvalidRequest("targets.profile.path is required".into())
+        })?);
+        let profile_id = profile.get("profileId").and_then(Value::as_i64).ok_or_else(|| {
+            CoreError::InvalidRequest("targets.profile.profileId is required".into())
+        })? as i32;
+        let original = fs::read(&path)?;
+        let mut edited = original.clone();
+        write_profile_difficulty(&mut edited, profile_id, req)?;
+        plans.push(DifficultyWritePlan { path, original, edited });
+    }
+
+    if plans.is_empty() {
+        return Err(CoreError::InvalidRequest("write_difficulty requires at least one target".into()));
+    }
+
+    // One shared backup suffix across every target.
+    let changed: Vec<&DifficultyWritePlan> = plans.iter().filter(|p| p.original != p.edited).collect();
+    if backup {
+        let paths: Vec<&Path> = changed.iter().map(|p| p.path.as_path()).collect();
+        if !paths.is_empty() {
+            let suffix = shared_backup_suffix(&paths);
+            for p in &changed {
+                create_backup_with_suffix(&p.path, &suffix)?;
+            }
+        }
+    }
+
+    // Stage tmp files + validate each by re-parsing.
+    let mut tmps = Vec::new();
+    for p in &changed {
+        let tmp = p.path.with_extension("sav.tmp-goresave");
+        fs::write(&tmp, &p.edited)?;
+        inspect_save(&tmp, false)?;
+        tmps.push((p.path.clone(), tmp));
+    }
+    // Atomic replace all; rollback everything if any fails.
+    let mut committed: Vec<PendingReplace> = Vec::new();
+    for (target, tmp) in &tmps {
+        match begin_replace(target, tmp) {
+            Ok(pending) => committed.push(pending),
+            Err(err) => {
+                for p in committed { p.rollback(); }
+                return Err(err);
+            }
+        }
+    }
+    for p in committed { p.commit(); }
+
+    for (target, _) in &tmps {
+        invalidate_decoded_payload_cache(target);
+    }
+    Ok(json!({
+        "targetsWritten": changed.len(),
+        "paths": changed.iter().map(|p| p.path.display().to_string()).collect::<Vec<_>>(),
+    }))
+}
+```
+
+(`DifficultyRequest` already derives both `Serialize` and `Deserialize` from Task 8, so
+`serde_json::to_value(req)` for the private edit works.)
+
+> NOTE: `begin_replace` returns a `PendingReplace`; confirm its `commit`/`rollback`
+> signatures (lib.rs:1666) and that `commit` consumes `self`. Adjust the loop if
+> `PendingReplace` is not `Send`/movable as written — the `write_save_internal` pattern
+> at lib.rs:3854 is the reference.
+
+- [ ] **Step 3: Run the test + full suite**
+
+Run: `cargo test -p goresave_core`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): write_difficulty command — multi-target, backed up, atomic"
+```
+
+## Task 12: Manual authority check (verification, not code)
+
+- [ ] Edit one real save's difficulty via the new command (e.g. a small CLI/test
+  harness or the app once Task 14 lands), launch the game, load that save, and confirm
+  the difficulty changed in-game. If only the public or only the private copy matters,
+  note it in the spec and narrow `write_difficulty_into_save_public` / the private edit
+  accordingly. Record the result in the spec's "Authority note".
+
+## Task 13: Dart — notifier method for write_difficulty
+
+**Files:**
+- Modify: `apps/goresave/lib/features/editor/domain/editor_notifier.dart`
+
+- [ ] **Step 1: Add the method**
+
+Mirror the existing `write_save` tracked-execute (`editor_notifier.dart:297-320`):
+```dart
+  Future<void> writeDifficulty({
+    required Map<String, Object?> difficulty,
+    required List<String> savePaths,
+    ({String path, int profileId})? profile,
+  }) async {
+    final targets = <String, Object?>{
+      'saves': savePaths,
+      if (profile != null)
+        'profile': {'path': profile.path, 'profileId': profile.profileId},
+    };
+    await _runTrackedWrite('write_difficulty', payload: {
+      'difficulty': difficulty,
+      'targets': targets,
+      'backup': true,
+      // include binaryHost the same way write_save does (copy that wiring)
+    });
+  }
+```
+(Use whatever helper `write_save` uses to attach `binaryHost`; copy it verbatim.)
+
+- [ ] **Step 2: Analyze**
+
+Run: `cd apps/goresave && flutter analyze lib/features/editor/domain/editor_notifier.dart`
+Expected: No issues.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/domain/editor_notifier.dart
+git commit -m "feat(app): EditorNotifier.writeDifficulty dispatch"
+```
+
+## Task 14: Dart — make the Difficulty card editable
+
+**Files:**
+- Modify: `apps/goresave/lib/features/editor/ui/editor_page.dart`
+
+Convert `_DifficultyCard` to an editing form with its own buffer.
+
+- [ ] **Step 1: Replace the card body with editable controls**
+
+State fields: `String _preset; bool _flow; bool _perma; String _combat/_resources/_progression;`
+initialized from `widget.inspection.difficulty` (labels), plus `bool _alsoProfile=false,
+_allSaves=false; bool _dirty=false;`.
+
+Build:
+- Preset selector: `SegmentedButton`/`ChoiceChip`s for `['Novice','Gothic','Hard','Custom']`.
+- Custom block enabled only when `_preset=='Custom'`:
+  - two `SwitchListTile`s — "Close Combat Flow Helper" (`_flow`), "Permadeath"
+    (`_perma`, disabled when `_preset=='Novice'`).
+  - three level pickers (Combat/Resources/Progression) over `['Novice','Gothic','Hard']`,
+    enabled only for Custom.
+- Editability per the matrix: Flow always enabled; Permadeath enabled unless Novice;
+  sub-pickers enabled only for Custom.
+- An explanation `Text` block: "Difficulty is stored in this save (gameplay), in the
+  profile (menu default), and in every other save. This edits only the current save
+  unless you tick the boxes below."
+- Two `CheckboxListTile`s: "Also update the profile", "Apply to all saves of this
+  profile".
+- A Save and a Reset `FilledButton`/`TextButton`, enabled when `_dirty`.
+
+- [ ] **Step 2: Wire Save**
+
+On Save, assemble the difficulty map and targets and call the notifier. The card needs
+the `EditorNotifier`, the current save path, the resolved profile, and the profile's save
+paths — pass them in via constructor from the Overview panel (which has `notifier`,
+`state.selectedSave`, `state.activeProfile`, and `state.saves`). Compute:
+```dart
+final savePaths = <String>[inspection.path!];
+if (_allSaves && profile != null) {
+  savePaths
+    ..clear()
+    ..addAll(profileSavePaths); // all SaveSlot.path where persistentProfileId == profile.profileId
+}
+final difficulty = {
+  'preset': _preset,
+  if (_preset == 'Custom') 'combat': _combat,
+  if (_preset == 'Custom') 'resources': _resources,
+  if (_preset == 'Custom') 'progression': _progression,
+  'flowHelper': _flow,
+  'permadeath': _preset == 'Novice' ? false : _perma,
+};
+await notifier.writeDifficulty(
+  difficulty: difficulty,
+  savePaths: savePaths,
+  profile: _alsoProfile && profile != null
+      ? (path: persistentDataListPath, profileId: profile.profileId)
+      : null,
+);
+```
+`persistentDataListPath`: derive from the save directory + `PersistentDataList.sav`
+(the save path's parent). `profileSavePaths`: filter `state.saves` by
+`persistentProfileId == profile.profileId`, take `.path`.
+
+- [ ] **Step 3: Guard unsaved difficulty edits on profile/save switch**
+
+In `editor_notifier.dart` the profile-switch guard (lib.rs:347) blocks on
+`hasUnsavedEdits`. Ensure the card's dirty state participates: simplest is to keep the
+card's edits in the notifier's pending-edit set, OR add a lightweight
+`difficultyDirty` flag to `EditorState` that the card toggles via a notifier setter and
+that the guard checks. Implement the flag approach:
+- add `bool difficultyDirty` to `EditorState` (+ copyWith), default false;
+- add `EditorNotifier.setDifficultyDirty(bool)`;
+- include it in the guard's "unsaved" condition;
+- clear it after a successful `writeDifficulty` and on `inspect`.
+
+- [ ] **Step 4: Analyze + widget test**
+
+Create `apps/goresave/test/difficulty_card_test.dart` with a widget test that pumps the
+card with a Custom inspection, taps preset = Novice, and asserts the Permadeath switch is
+disabled and the sub-pickers are disabled. (Use `ProviderScope` overrides or a fake
+notifier; follow an existing widget test in `apps/goresave/test` for the harness.)
+
+Run: `cd apps/goresave && flutter analyze && flutter test test/difficulty_card_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/ui/editor_page.dart apps/goresave/lib/features/editor/domain/editor_notifier.dart apps/goresave/test/difficulty_card_test.dart
+git commit -m "feat(app): editable Difficulty card with profile/all-saves propagation"
+```
+
+## Task 15: End-to-end verification
+
+- [ ] Run the full suites: `cargo test -p goresave_core` and
+  `cd apps/goresave && flutter test`. Expected: all PASS.
+- [ ] `/run` the app: change a save's difficulty (Custom→Novice), Save, reopen — confirm
+  the card, sidebar badge, and header pill reflect the change and a backup exists.
+- [ ] Tick "all saves" + "profile", Save, confirm every slot + PersistentDataList updated
+  and each has a backup under one shared suffix.
+
+---
+
+## Self-review notes (addressed)
+
+- **Spec coverage:** read/display (Tasks 1-5), per-save public+private write (Tasks 6-9),
+  profile write (Task 10), multi-target/backups/atomic (Task 11), badge replacement
+  (Task 4), editability matrix (Task 14), authority check (Task 12). Covered.
+- **Type consistency:** `DifficultyRequest` (Rust, Serialize+Deserialize),
+  `DifficultySettings` (Rust read struct + Dart model),
+  `replace_class_or_str_property_in_range`, `write_bool_property_in_range`,
+  `apply_difficulty_to_range`, `write_profile_difficulty`, `write_difficulty_internal`,
+  `EditorNotifier.writeDifficulty` used consistently.
+- **Known implementer checkpoints (not placeholders — verify against real code):**
+  `PendingReplace` commit/rollback ownership (Task 11 note); the exact private-edit
+  apply loop location for `PrivateEdit::Difficulty` (Task 9); `binaryHost` wiring in the
+  notifier (Task 13). Each names the reference site to copy.

--- a/docs/superpowers/specs/2026-06-14-profile-difficulty-tab-design.md
+++ b/docs/superpowers/specs/2026-06-14-profile-difficulty-tab-design.md
@@ -1,4 +1,4 @@
-# Profil tab — view + edit profile difficulty
+# Difficulty editor tab — per-save, with optional profile / all-saves propagation
 
 Date: 2026-06-14
 Status: Design approved by user (pending spec review)
@@ -6,51 +6,58 @@ Status: Design approved by user (pending spec review)
 ## Problem
 
 The game lets the player choose a difficulty (Novice / Gothic / Hard / Custom) only
-once, at profile creation, and never again. The difficulty actually lives in the
-profile, which the editor already parses read-only (`ProfileSummary`). We want a new
-**"Profil" tab** that displays profile overview data and lets the user edit the
-difficulty settings of an existing profile.
+once, at profile creation, and never again in-game. We want an editor tab to change
+the difficulty of an existing playthrough.
+
+Investigation showed difficulty is **not** profile-only — it is stored in three places:
+
+1. `PersistentDataList.sav` -> `/Script/G1R.ProfileData` (profile level).
+2. Each savegame's **public payload** -> `/Script/G1R.SaveGamePublicData` (uncompressed
+   GVAS, verified at `public_properties` in the inspect output).
+3. Each savegame's **private payload** -> `/Script/G1R.SaveDataPayload` (inside the
+   compressed stream; verified in `work/decompressed/*.bin`).
+
+The savegame's own copy (private payload, driving `DifficultyManagerSubsystem` on load)
+is the authoritative gameplay value. The profile copy is the menu default / display for
+new saves. So **editing only the profile would not change an existing save's
+difficulty** — the edit has to target the savegame itself.
 
 ## Decisions (from brainstorming)
 
-- **Placement:** a new editor tab **"Profil"** at **position 2**, immediately right of
-  Overview (tab index 1). The remaining tabs shift right.
-- **Binding:** the tab is bound to the **effective profile**
-  (`EditorState.activeProfile` / `effectiveProfileId`), NOT to the selected savegame.
-  This is the smart resolution of the cross-save problem: the profile is already
-  resolved app-wide (sidebar profile selector + the current save's profile), so the
-  tab reads that shared state instead of `SaveInspection`. The other 7 tabs stay
-  bound to the selected save; only Profil is profile-scoped.
-- **Edit scope:** difficulty only (full). Profile overview fields (name, id, slot
-  counts, MaxQuick/MaxAuto) are shown **read-only**. Editing those is out of scope v1.
-- **Core write op:** a dedicated command `write_profile_difficulty` targeting
-  `PersistentDataList.sav` (keeps `write_save`'s slot/private logic clean).
+- The editor is **per-save**: a new tab bound to the currently selected savegame
+  (`SaveInspection`), like the other editor tabs. This dissolves the original cross-save
+  concern — the authoritative edit is per-save.
+- Tab **position 2**, immediately right of Overview (index 1); remaining tabs shift
+  right. Working name **"Schwierigkeit"** (shows profile overview read-only as context
+  plus the editable difficulty). Final tab label TBD with user; not blocking.
+- Editing a save writes difficulty into **both** the save's public payload and its
+  private payload (the authoritative copy), so menu display and gameplay stay
+  consistent.
+- **Two opt-in checkboxes**, both default OFF:
+  - *"Auch das Profil aktualisieren"* — also write the difficulty into the profile's
+    `ProfileData` in `PersistentDataList.sav`.
+  - *"Auf ALLE Savegames dieses Profils anwenden"* — also write every other savegame
+    belonging to the same profile.
+- **UI must explain** the three-place storage and what each checkbox does, so the user
+  understands why editing one save does not by itself change others or the profile.
+- **Backups are mandatory** for every file written, under one shared backup suffix, with
+  atomic replace and rollback if any target fails. No partial writes.
+- Edit scope: difficulty only. Profile/save overview fields stay read-only.
 
-## Verified facts (from live PersistentDataList.sav + UE4SS dump)
+## Verified facts
 
-The difficulty fields are `ClassProperty`/`BoolProperty` members of
-`/Script/G1R.ProfileData`, stored per profile inside `PersistentDataList.sav` (GVAS),
-in the profile's ref range located by `parse_profile_summaries`
-(`crates/goresave_core/src/lib.rs:904`).
+Difficulty fields are `ClassProperty` / `BoolProperty` members. Confirmed values:
 
-Confirmed against the user's live file (two profiles present):
+- Live `PersistentDataList.sav`: profile 0 = `DifficultyPreset_Custom` (sub-settings
+  `*_Standard`); profile 1 = `DifficultyPreset_Easy` (all sub-settings present and
+  `*_Easy`, plus the bools). So **all difficulty properties are always serialized**
+  on every profile and every save -> all edits are in-place splices, no structural
+  property insertion needed.
+- Inspect output of a real save: difficulty present in `public_properties`
+  (uncompressed) and again in the decoded private payload.
 
-- Profile 0 (Custom): `m_difficultyPreset = DifficultyPreset_Custom`, sub-settings all
-  `*_Standard`.
-- Profile 1 (Novice): `m_difficultyPreset = DifficultyPreset_Easy`, **and all three
-  sub-settings are present and = `*_Easy`**, plus the bools.
-
-Two assumptions therefore hold:
-
-1. **Preset mapping** — Novice = `Easy`, Gothic = `Standard`, Hard = `Hard`, Custom =
-   `Custom`.
-2. **All difficulty properties are always serialized** on every profile, regardless of
-   preset (offsets are contiguous `0x40–0x68` on `ProfileData`). So switching any
-   profile to/from Custom is a pure **in-place edit** — no structural property
-   insertion needed. This removes the main implementation risk.
-
-The game mirrors the sub-settings to the preset level (a Novice profile stores all
-`_Easy` sub-settings). We replicate that: see Behavior below.
+Preset mapping (confirmed): Novice = `Easy`, Gothic = `Standard`, Hard = `Hard`,
+Custom = `Custom`.
 
 ## Field mapping
 
@@ -65,16 +72,13 @@ Asset-path prefix: `/Script/Angelscript.`
 | Close Combat Flow Helper | `m_FakeSloppyCombos` | BoolProperty | on/off |
 | Permadeath | `m_PermanentDeath` | BoolProperty | on/off |
 
-Sub-setting level labels follow the same Novice/Gothic/Hard naming as the preset
-(`Easy`/`Standard`/`Hard`).
+Left untouched (present but not in the in-game difficulty screen): `m_Survival`,
+`m_PermanentDeathGameOver`, `m_MaxQuick`, `m_MaxAuto`.
 
-Left untouched (present on `ProfileData` but not in the in-game difficulty screen):
-`m_Survival`, `m_PermanentDeathGameOver`, `m_MaxQuick`, `m_MaxAuto`.
+## Editability behavior
 
-## Behavior
-
-Per-control editability mirrors the in-game difficulty screen (confirmed from the four
-preset screenshots — orange = editable, grey = locked):
+Mirrors the in-game difficulty screen (confirmed from the four preset screenshots —
+orange = editable, grey = locked):
 
 | Control | Novice | Gothic | Hard | Custom |
 | --- | --- | --- | --- | --- |
@@ -84,70 +88,98 @@ preset screenshots — orange = editable, grey = locked):
 
 Rules:
 
-- **Flow Helper** is always editable and independent of the preset — never force it.
-  In-game default is on for every preset.
-- **Permadeath** is editable for Gothic / Hard / Custom (default off). For Novice it is
-  locked off: when the editor sets preset = Novice, force `m_PermanentDeath = false`
-  and disable the toggle.
-- **Sub-settings** (Combat / Resources / Progression) are editable only for Custom. For
-  Novice / Gothic / Hard, on save rewrite all three to the matching level (mirrors the
-  game: a Novice profile stores `*_Easy`, etc.) and show them disabled. Custom defaults
-  the three to Gothic (`*_Standard`) when first switched, but otherwise preserves
-  whatever is stored.
-- Editing difficulty rewrites the whole profile and affects all of its saves — show a
-  one-line note to that effect near the Save action.
+- **Flow Helper** always editable, independent of preset (in-game default on). Never
+  forced.
+- **Permadeath** editable for Gothic / Hard / Custom (default off). For Novice it is
+  locked off: when preset = Novice, force `m_PermanentDeath = false`.
+- **Sub-settings** editable only for Custom. For Novice / Gothic / Hard, on save rewrite
+  all three to the matching level (mirrors the game) and show them disabled. Custom
+  defaults the three to Gothic (`*_Standard`) on first switch, otherwise preserves
+  stored values.
 
 ## Core (Rust) — `crates/goresave_core/src/lib.rs`
 
-New command `write_profile_difficulty`:
+Single command **`write_difficulty`** so the all-or-nothing backup/rollback guarantee
+lives in one place:
 
-- Payload: `{ path, profileId, difficulty: { preset, combat?, resources?,
-  progression?, flowHelper?, permadeath? } }` where `path` resolves to the save
-  directory / `PersistentDataList.sav`.
-- Locate the profile's ref range via the same boundary logic as
-  `parse_profile_summaries` (`m_ProfileName` start, next-profile / `SavedDataVersion`
-  end). Match `profileId` via `m_ProfileId`.
-- ClassProperty string edits: a ClassProperty-aware variant of
-  `replace_str_property_fstring_in_range` (`lib.rs:3958`). Verify the on-disk
-  ClassProperty layout against the fixture (TDD, byte-exact) — it may differ from
-  `StrProperty`.
-- Bool edits: in-place single byte (reuse the bool read path's offset logic).
-- Safety pipeline mirrors `write_save_internal` (`lib.rs:3762`): backup, write tmp,
-  re-parse + validate (round-trip the written values back through
-  `parse_profile_summaries` and assert they match), atomic `begin_replace`/commit.
-- Reject if a targeted property is not found in the profile range (defensive; not
-  expected given the always-present finding).
+```
+{
+  difficulty: { preset, combat?, resources?, progression?, flowHelper?, permadeath? },
+  targets: {
+    saves:   ["<slot path>", ...],          // each gets public + private edits
+    profile: { path: "<PersistentDataList.sav>", profileId } | null
+  },
+  backup: true
+}
+```
+
+Per-save difficulty write (one helper, used for every entry in `targets.saves`):
+
+- **Public payload:** ClassProperty / Bool splices on the uncompressed GVAS region.
+  Extend `apply_public_edit` (`lib.rs:3994`) with the difficulty paths; reuse a
+  ClassProperty-aware variant of the existing fstring splice.
+- **Private payload:** same edits inside `SaveDataPayload`, applied through the existing
+  private-edit + Kraken recompress pipeline (`apply_private_edits`, `lib.rs:3789`) that
+  inventory edits already use.
+
+Profile difficulty write (when `targets.profile` set): locate the profile range via the
+same boundary logic as `parse_profile_summaries` (`lib.rs:904`), splice
+`ProfileData` ClassProperty / Bool members in place.
+
+Orchestration + safety:
+
+- Validate ClassProperty on-disk layout against fixtures (TDD, byte-exact) — it may
+  differ from `StrProperty`.
+- Back up **every** target file under one `shared_backup_suffix` (`lib.rs` existing
+  helper, today used for slot+companion). Write each to a `.tmp-goresave`, re-inspect /
+  re-parse each to confirm the written value, then `begin_replace` all and commit; if
+  any replace fails, roll back every already-committed target. Reuse the
+  begin_replace / commit / rollback pattern from `write_save_internal` (`lib.rs:3854`).
+- GSAV saves must still rebuild byte-identically except for the intended edit
+  (`rebuild_gsav_preserving_stream`).
 
 ## Frontend (Flutter / Riverpod)
 
-- New `_ProfilePanel` widget, added to the `TabBar` tabs and `TabBarView` children at
-  index 1 in `apps/goresave/lib/features/editor/ui/editor_page.dart` (bump the
-  `TabController` length 7 -> 8). Wrap in `_KeepAliveTab`. Icon e.g.
-  `Icons.badge_outlined` / `Icons.person_pin_outlined`, label "Profil".
-- Reads `state.activeProfile`. Empty state ("Kein Profil ausgewählt") when none
-  resolves.
-- Layout mirrors the in-game difficulty screen: a preset selector (4 options) and a
-  Custom block with two toggles (Flow Helper, Permadeath) and three 3-way pickers
-  (Combat, Resources, Progression) that enable only for Custom. Read-only profile
-  overview (name, id, slot counts) above.
-- **Own edit buffer + Save/Reset** inside the tab, independent of the save-scoped
-  pending-edit buffer. Save dispatches `_core.execute('write_profile_difficulty', …)`
-  via `EditorNotifier`, then refreshes profiles.
-- Extend the unsaved-edits / profile-switch guard
-  (`editor_notifier.dart:347`) so Profil edits block profile/save switches the same way
-  save edits do.
+- New `_DifficultyPanel`, added to the `TabBar` tabs and `TabBarView` children at index 1
+  in `apps/goresave/lib/features/editor/ui/editor_page.dart` (bump `TabController`
+  length 7 -> 8, wrap in `_KeepAliveTab`).
+- Bound to the selected save's `SaveInspection` (current save's difficulty is the edit
+  subject). Shows the resolved profile overview (`state.activeProfile`) read-only as
+  context.
+- Layout mirrors the in-game screen: preset selector (4 options); a Custom block with
+  two toggles (Flow Helper, Permadeath) and three 3-way pickers (Combat, Resources,
+  Progression) enabled per the editability matrix.
+- An **explanation block** stating: difficulty is stored in this save (gameplay-
+  relevant), in the profile (menu default), and separately in every other save; this
+  editor changes only the current save unless the checkboxes below are ticked.
+- **Two checkboxes** (default off): update profile; apply to all saves of this profile.
+- Own edit buffer + Save / Reset inside the tab. Save assembles `targets`
+  (always the current save; + all profile slots if checked; + profile if checked) and
+  dispatches `write_difficulty` via `EditorNotifier`, then refreshes.
+- Extend the unsaved-edits / profile-switch guard (`editor_notifier.dart:347`) to cover
+  dirty difficulty edits.
+
+## Authority note (verify before relying on save edits)
+
+Strongly inferred that the private `SaveDataPayload` drives loaded-game difficulty.
+Recommend one empirical check during implementation: edit one save's difficulty, load
+it in-game, confirm the change takes effect. If only public or only private matters,
+narrow the per-save write accordingly.
 
 ## Testing
 
-- **Core:** parse + write round-trip test on a `PersistentDataList.sav` fixture (copy a
-  sanitized snapshot of the live file into `fixtures/`). Cases: Custom→Novice,
-  Novice→Custom, toggle each bool, change each sub-setting. Assert byte-exact GVAS
-  re-serialization elsewhere and that re-parse returns the written values.
-- **Frontend:** widget test for preset→Custom enable/disable, buffer Save/Reset, and
-  the profile-switch guard with dirty Profil edits.
+- **Core:** round-trip tests on (a) a `PersistentDataList.sav` fixture and (b) a real
+  save fixture (`work/decompressed` payloads + a slot file). Cases: each preset switch,
+  each bool toggle, each sub-setting; assert byte-exact re-serialization elsewhere and
+  re-parse returns the written values, for public and private. Multi-target test:
+  current save + profile + all saves all written and backed up; induced failure rolls
+  everything back.
+- **Frontend:** widget tests for the editability matrix (enable/disable per preset),
+  checkbox-driven `targets` assembly, buffer Save/Reset, and the dirty-edit switch
+  guard.
 
 ## Out of scope (v1)
 
 - Editing `m_MaxQuick` / `m_MaxAuto`, `m_Survival`, `m_PermanentDeathGameOver`.
-- Editing profile name / overview fields.
+- Editing profile/save names or other overview fields.
 - Creating, deleting, or batch-editing profiles.

--- a/docs/superpowers/specs/2026-06-14-profile-difficulty-tab-design.md
+++ b/docs/superpowers/specs/2026-06-14-profile-difficulty-tab-design.md
@@ -1,4 +1,4 @@
-# Difficulty editor tab — per-save, with optional profile / all-saves propagation
+# Difficulty editor — Overview card, per-save, with optional profile / all-saves propagation
 
 Date: 2026-06-14
 Status: Design approved by user (pending spec review)
@@ -6,7 +6,7 @@ Status: Design approved by user (pending spec review)
 ## Problem
 
 The game lets the player choose a difficulty (Novice / Gothic / Hard / Custom) only
-once, at profile creation, and never again in-game. We want an editor tab to change
+once, at profile creation, and never again in-game. We want an editor control to change
 the difficulty of an existing playthrough.
 
 Investigation showed difficulty is **not** profile-only — it is stored in three places:
@@ -24,12 +24,20 @@ difficulty** — the edit has to target the savegame itself.
 
 ## Decisions (from brainstorming)
 
-- The editor is **per-save**: a new tab bound to the currently selected savegame
-  (`SaveInspection`), like the other editor tabs. This dissolves the original cross-save
-  concern — the authoritative edit is per-save.
-- Tab **position 2**, immediately right of Overview (index 1); remaining tabs shift
-  right. Working name **"Schwierigkeit"** (shows profile overview read-only as context
-  plus the editable difficulty). Final tab label TBD with user; not blocking.
+- The editor is **per-save**, bound to the currently selected savegame
+  (`SaveInspection`). This dissolves the original cross-save concern — the authoritative
+  edit is per-save.
+- **No new tab.** The difficulty editor is a **collapsible "Difficulty" card** inside
+  the existing **Overview** tab, reusing the `_CollapsibleCardHeader` pattern (as
+  "Diagnostics & details" does).
+- **No profile overview data** is shown (dropped from scope).
+- **Replace the location/map badges with the difficulty.** "MainMap" is the only map in
+  the game (verified: every save's `mapName` is `MainMap`), so the map label carries no
+  information. Replace it at all three render sites with the save's difficulty preset
+  label (Novice / Gothic / Hard / Custom):
+  - sidebar subtitle `_saveSlotSubtitle` (`editor_page.dart:520`)
+  - header `_InfoPill` (`editor_page.dart:1068`)
+  - "Diagnostics & details" metric grid `'Map'` entry (`editor_page.dart:938`)
 - Editing a save writes difficulty into **both** the save's public payload and its
   private payload (the authoritative copy), so menu display and gameplay stay
   consistent.
@@ -99,7 +107,18 @@ Rules:
 
 ## Core (Rust) — `crates/goresave_core/src/lib.rs`
 
-Single command **`write_difficulty`** so the all-or-nothing backup/rollback guarantee
+**Surface per-save difficulty (read path).** The save's own difficulty lives in its
+public payload (`SaveGamePublicData`) and private payload (`SaveDataPayload`). Parse the
+preset + sub-settings + bools from the public payload and add them to:
+
+- `inspect_save` output / `SaveInspection` (drives the Difficulty card).
+- `list_saves` output / `SaveSlot` (drives the sidebar subtitle badge) — read from the
+  small uncompressed public payload during scan, alongside the existing chapter/map
+  read; no decompression needed, so scan cost stays low.
+
+The profile copy in `ProfileSummary` (already parsed) stays as-is and is not shown.
+
+**Write path — single command `write_difficulty`** so the all-or-nothing backup/rollback guarantee
 lives in one place:
 
 ```
@@ -140,12 +159,14 @@ Orchestration + safety:
 
 ## Frontend (Flutter / Riverpod)
 
-- New `_DifficultyPanel`, added to the `TabBar` tabs and `TabBarView` children at index 1
-  in `apps/goresave/lib/features/editor/ui/editor_page.dart` (bump `TabController`
-  length 7 -> 8, wrap in `_KeepAliveTab`).
-- Bound to the selected save's `SaveInspection` (current save's difficulty is the edit
-  subject). Shows the resolved profile overview (`state.activeProfile`) read-only as
-  context.
+All in `apps/goresave/lib/features/editor/ui/editor_page.dart`.
+
+**Difficulty card (Overview tab):**
+
+- New `_DifficultyCard`, a collapsible card in the Overview panel's column, using the
+  existing `_CollapsibleCardHeader` (title "Difficulty", icon e.g.
+  `Icons.local_fire_department_outlined`). Bound to the selected save's
+  `SaveInspection`.
 - Layout mirrors the in-game screen: preset selector (4 options); a Custom block with
   two toggles (Flow Helper, Permadeath) and three 3-way pickers (Combat, Resources,
   Progression) enabled per the editability matrix.
@@ -153,11 +174,19 @@ Orchestration + safety:
   relevant), in the profile (menu default), and separately in every other save; this
   editor changes only the current save unless the checkboxes below are ticked.
 - **Two checkboxes** (default off): update profile; apply to all saves of this profile.
-- Own edit buffer + Save / Reset inside the tab. Save assembles `targets`
+- Own edit buffer + Save / Reset inside the card. Save assembles `targets`
   (always the current save; + all profile slots if checked; + profile if checked) and
   dispatches `write_difficulty` via `EditorNotifier`, then refreshes.
 - Extend the unsaved-edits / profile-switch guard (`editor_notifier.dart:347`) to cover
   dirty difficulty edits.
+
+**Map badge -> difficulty replacement:**
+
+- Add a `difficultyLabel` helper mapping the save's preset
+  (`Easy/Standard/Hard/Custom` -> `Novice/Gothic/Hard/Custom`).
+- Replace the three `mapName` render sites (subtitle, header pill, diagnostics metric)
+  with the difficulty label. The header pill keeps a fitting icon
+  (e.g. `Icons.local_fire_department_outlined`); the metric key becomes `'Difficulty'`.
 
 ## Authority note (verify before relying on save edits)
 


### PR DESCRIPTION
## Summary
Adds the ability to view and edit a savegame's difficulty (Novice / Gothic / Hard / Custom), which the game otherwise locks at profile creation.

- **Read/display:** core parses per-save difficulty from the uncompressed public payload (`SaveGamePublicData`) and surfaces it on `inspect_save` and `list_saves`. The useless "MainMap" location badge (the game has one map) is replaced everywhere by the difficulty preset label (sidebar, header pill, diagnostics).
- **Edit:** a collapsible **Difficulty** card in the Overview tab, bound to the selected save. Mirrors the in-game screen — preset selector, Close Combat Flow Helper + Permadeath toggles, and Combat/Resources/Progression level pickers — with the same editability rules (Flow Helper always editable; Permadeath locked off on Novice; sub-settings editable only for Custom).
- **Where it writes:** difficulty is stored in three places — the save's public payload, the save's private/compressed payload (`SaveDataPayload`, authoritative for gameplay), and the profile (`PersistentDataList.sav`, menu default). The editor writes both save payloads, with two opt-in checkboxes to also update the profile and to apply the change to all of the profile's saves.
- **Safety:** a single `write_difficulty` core command owns an all-or-nothing write — every target file is backed up under one shared suffix before any write, staged to a temp file, validated (byte-identical GSAV rebuild), then atomically replaced with rollback if any target fails.

Design + plan: `docs/superpowers/specs/2026-06-14-profile-difficulty-tab-design.md`, `docs/superpowers/plans/2026-06-14-difficulty-editor.md`.

## Test Plan
- [x] Core unit tests: `cargo test -p goresave_core` — 226 passed (parse, ClassProperty/Bool splice, single-record + profile-range mutation, full `write_difficulty` multi-target round-trip incl. private payload via codec mock, profile isolation, backup-suffix pairing).
- [x] App tests: `flutter test` — 119 passed (model mapping, editability matrix, shell rendering).
- [x] `flutter analyze` — only pre-existing `notifier.state` warnings.
- [ ] Manual in-game: edit a save's difficulty, load in Gothic Remake, confirm the change takes effect (authoritative-copy check — feature writes both public+private so it is correct regardless).
- [ ] Manual: tick "all saves" + "profile", save, confirm every slot + PersistentDataList updated and each has a backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Rewrites compressed private save payloads and can touch many `.sav` files plus profile data; non-atomic split between write_save and write_difficulty can leave slot changes committed if difficulty fails (handled in UI but still on-disk risk).
> 
> **Overview**
> Adds **end-to-end difficulty editing** in the Gothic Remake save editor: the core exposes parsed difficulty on scan/inspect, a new **`write_difficulty`** command mutates save public + private payloads and optional **`PersistentDataList.sav`** profile rows, and the Flutter app adds an Overview **Difficulty** card wired into the global Save/Reset flow.
> 
> **Core (`goresave_core`):** Parses `DifficultySettings` from GSAV public data; implements preset/sub-level class-path rewrites, bool writes (permadeath alternate spellings, flow helper), profile-scoped GVAS edits, and **`private.difficulty.set`** alongside existing private edit plumbing. **`write_difficulty_internal`** validates, dedupes save paths, backs up each changed file with **distinct** backup suffixes (avoids paired-restore coupling), stages, and atomically replaces with rollback.
> 
> **Flutter:** `PendingDifficulty` + `hasUnsavedEdits`/`saveAllPending` orchestrate sequential **`write_save`** then **`write_difficulty`** with partial-failure convergence (committed slot edits cleared, difficulty kept for retry). Guards cover codec readiness, typed All-data conflicts, and unresolvable profile propagation. UI shows difficulty in sidebar/header/diagnostics instead of map name; **`DifficultyCard`** handles unknown presets safely and optional propagate-to-profile / all-saves checkboxes bound to the **edited save’s** profile.
> 
> **Smaller UI fixes:** Inventory delete shows disabled trash + tooltip for non-removable items; count field layout stabilized.
> 
> **Tests:** Extensive Rust unit tests for splice/write paths; Flutter widget/notifier tests for the card and save orchestration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405f6fe0de04de9e648ca70763d0a0fffc872ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->