### PR TITLE
feat: full NPC + knowledge-entry catalogs for the Knowledge tab

### DIFF
--- a/apps/goresave/assets/knowledge_catalog.json
+++ b/apps/goresave/assets/knowledge_catalog.json
@@ -1,0 +1,15654 @@
+[
+  {
+    "category": "choice",
+    "id": "Choice62749"
+  },
+  {
+    "category": "choice",
+    "id": "Choice63019"
+  },
+  {
+    "category": "choice",
+    "id": "Choice63035"
+  },
+  {
+    "category": "choice",
+    "id": "Choice66465"
+  },
+  {
+    "category": "choice",
+    "id": "Choice66956"
+  },
+  {
+    "category": "choice",
+    "id": "Choice66972"
+  },
+  {
+    "category": "choice",
+    "id": "Choice67313"
+  },
+  {
+    "category": "choice",
+    "id": "Choice67329"
+  },
+  {
+    "category": "choice",
+    "id": "Choice67373"
+  },
+  {
+    "category": "choice",
+    "id": "Choice67718"
+  },
+  {
+    "category": "choice",
+    "id": "Choice67734"
+  },
+  {
+    "category": "choice",
+    "id": "Choice845Exit"
+  },
+  {
+    "category": "choice",
+    "id": "Choice845Hello"
+  },
+  {
+    "category": "choice",
+    "id": "Choice846Exit"
+  },
+  {
+    "category": "choice",
+    "id": "Choice846Hello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceAidanExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceAidanHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceArtoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceArtoHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceArtoPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceArtoWhat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceAsghan144609"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceAsghan92345"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceAsghan92765"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalcadar113694"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalcadar145962"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalcadarExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalcadarNotalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalcadarNotalkHi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalcadarNotalkImp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalcadarNotalkSleeper"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalcadarSleepspell"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalisidroDrink"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalisidroExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalisidroGimmekraut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalisidroHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalisidroProblem"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalisidroRunning"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalisidroThinkagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalisidroTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkagan106785"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganGimmekraut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganOrderhelp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccessErz"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccessJoin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccessTakescrolls"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccessTakescrollsCharme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccessTakescrollsPyrokinese"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccessTakescrollsSchlaf"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccessTakescrollsTelekinese"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccessTakescrollsWindfaust"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganSuccessWhatspells"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganWannahelp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganWasdrin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalkaganWhyhere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor105182"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor105182_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor105182_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor105182_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor105182_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor105182_4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor105928"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor144281"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor197143"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor84850"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor91958"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor91996"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor92243"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor92808"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukor94713"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorAltar"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorDead"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorFirstscroll"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorFirstwait"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorFoundnone"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorFoundone"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorHelp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorMeet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorRunes"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorSecondwait"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorSummoning"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaallukorTeleport"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamib146019"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamib157249"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamib157265"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamib220561"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamib220684"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamibExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamibFirsttalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamibFirsttalkMute"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamibFirsttalkSleeper"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamibNotalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamibNotalkHi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamibNotalkImp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalnamibNotalkSleeper"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorun131138"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorun131281"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorun131286"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorun131306"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorun131332"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorun131364"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorun134478"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorun135517"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorun135930"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunFirsttalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunFirsttalkMuteende"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunFirsttalkWhere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunGotweed"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunNotalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunNotalkHi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunNotalkImp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunNotalkSleeper"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalorunWeedatkaloms"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvez219711"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvez219732"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvez219759"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvez219779"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvez219799"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvez219821"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvez219841"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvez219863"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvez219883"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvezAtpsi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvezExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvezGotopsi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvezGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvezMyadvantage"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvezPsimagic"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvezRightway"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvezSleeper"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaalparvezSleepersaid"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranBeweis"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranBruderschaft"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranFreiheit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranIntocastle"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranIntocastleExactly"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranIntocastleForgetit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranIntocastleLetter"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranIntocastleMage"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranIntocastleMeetsomeone"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranLehre"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltaranWaytost"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondral157207"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondral157223"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondralDustysuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondralExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondralFanaticteacher"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondralLoyality"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondralMuteexit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondralNewmember"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondralNewmember2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondralSendtokalom"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltondralYoutalked"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltyon157291"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltyonExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltyonNotalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltyonNotalkHi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltyonNotalkImp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltyonNotalkSleeper"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltyonSpecialjoint"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBaaltyonVision"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalor147501"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorFetchweed"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorRipoff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorSellunder"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorSellunderComeon"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorSellunderForgetit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorSellunderHalfhalf"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorTelldealer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorTelldealerForgetit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBalorTelldealerPay"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit119943"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit119959"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit121294"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit121600"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit121738"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit121827"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit122174"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit134683"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit135597"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit135877"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit181790"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBandit452441"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBartholo221528"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBartholoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBartholoHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBartholoKrautbote"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer116639"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer116655"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer116832"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer116858"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer117010"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer117462"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer117520"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer117602"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer118084"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer118280"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer118280_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer119206"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBlackmailer119206_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwyn106913"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwyn107802"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwyn107820"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwyn108210"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynDoch"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynExitSchutzgeld"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynHelloForgetit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynHelloHowmuch"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynHelloNotnow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynHelloOktakeit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynHelloSolldrohungsein"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynPayday"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynPaydayPayagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynPaydayPaynomore"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBloodwynPayforjesse"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok119214"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok119230"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok119637"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120201"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120204"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120207"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120210"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120213"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120216"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120278"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120398"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120739"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok120763"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok122565"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBrannok146365"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBullit109127"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBullit139992"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBullit145942"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBullitAufsmaul"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBullitExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBullitFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBuster215041"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceBuster78171"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceButch84921"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceButchExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceButchHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCaine144631"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCaineAddinfokalom"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCaineExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCaineHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCaineHalloJa"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCaineHalloNein"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCaineJob"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCaineWosekret"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn134683"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn135456"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn135481"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn135624"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn135761"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn136944"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn137183"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn137456"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn137464"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn138834"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn139129"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn139249"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn139616"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn140079"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn141324"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn202426"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn202444"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn202552"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn202562"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn202642"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn202652"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn202730"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn202740"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn203001"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalorn203019"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalornExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalornHunter"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalornLehrer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalornLehrerBow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCavalornLehrerBow2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChani214876"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChani214896"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChani215768"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChani215885"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChani216003"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCharlotte431622"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChokta111037"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChokta111053"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChokta111324"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChokta111596"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChokta111921"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChokta111990"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChokta112034"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChokta186576"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceChokta221276"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCipher915923"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel144094"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel144110"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel149546"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel149562"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel149816"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel149832"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel150416"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel150497"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel150552"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel150967"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel151225"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCohsel197299"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorKalom82950"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar100858"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar102251"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar103452"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar106031"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar106031_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar106031_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar106031_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar106031_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar106031_4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar107077"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar141448"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar142358"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar144217"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar144217_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar144217_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar144246"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar220426"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar220629"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar220667"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar87302"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar88102"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar88621"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar88666"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorangar97444"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom100648"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom105823"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom137571"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom138524"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144135"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144135_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144135_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144135_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144135_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144650"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144650_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144650_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144650_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144650_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom144653"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom215071"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom85172"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalom85302"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalomBringbook"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorkalomBringfocus"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo114818"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo123064"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo129943"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo129969"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo130125"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo130447"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo133007"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo134808"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo291469"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo78292"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristo97581"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCorristoIntruder"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCronos114973"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCronos144504"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCronos144504_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCronos144504_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCronos93857"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCronosReward"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutscene105129"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutscene167363"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutscene167379"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutscenegreatprayer274825"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutscenegreatprayer274918"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutscenegreatprayer95072"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutscenegreatprayer95592"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutterBurg"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutterExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutterHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceCutterPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDamarok114795"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDamarok115841"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDamarok138034"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDamarok138068"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDamarok138284"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDamarok139211"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDamarok78286"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion112734"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion112989"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion113520"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion114011"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion115296"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion115330"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion115678"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion118090"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion121919"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion122609"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion122657"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion124471"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion130722"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion145449"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion145449_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion145449_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion145449_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion145449_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion145449_4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion145449_5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion145449_6"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion146985"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion156692"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion156713"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrion182803"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrionExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDarrionHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterJoinoc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterJoinocAdvance"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterJoinocForgetit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterJoinocHowmuch"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterJoinocOk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterJoinocOrenoworelse"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterJoinocThreat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterKalomsrecipesuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterKraut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDexterWherest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego100828"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego104160"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego105716"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego105732"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego105737"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego105780"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego105788"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego105817"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106066"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106066_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106066_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106066_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106066_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106113"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106113_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106113_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106113_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106353"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego106353_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego107920"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego108947"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego144472"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego144472_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego214558"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego93279"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego93382"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego97162"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego97295"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego97383"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiego97586"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoBrief"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoBringlistOffer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoBringlistSuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoBullit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoCelebs"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoExitGamestart"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoExitLater"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoGamestart"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoIanpassword"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoJoinanalyze"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoJoinoldcamp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoKolonie"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoMaptooldmine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoRules"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoTeach"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoTeachBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoTeachDex1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoTeachDex5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoTeachStr1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoTeachStr5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoTeachers"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoThorussays"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoWarumgeholfen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoWaytooldcamp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoWhattosaytogomez"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoWhosgomez"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDiegoWowaffe"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrago105761"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrago105761_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrago105761_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrago105761_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrago105761_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrake105762"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrake110339"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrake92777"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrake95481"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax105758"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax105758_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax221041"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax221739"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax221755"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax221771"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax431683"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax432055"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax432159"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax432191"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrax432556"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrpymonte225150"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDrpymonte225167"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDusty120225"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDusty120225_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDusty120225_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDusty120225_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDustyExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDustyHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDustyIwouldgo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDustyLetsgo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDustyMetmelvin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDustyOffer100ore"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceDustyWhynotleave"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceEbr100GomezWait4sc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceExtro186129"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceExtro186149"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFingersBecomeshadow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFingersBecomeshadowAnytips"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFingersBecomeshadowBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFingersBecomeshadowTeachme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFingersLearnt"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFingersLehrer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFiremages283886"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFiremages283902"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFisk108715"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFisk133943"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFisk142036"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcher106038"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcher106346"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcher106364"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcher106813"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcherExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcherFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcherHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcherHelloWhereelse"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcherHelloWhytalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcherProblem"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcherWegennek"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFletcherWonek"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFlex225236"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFlex225252"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFlex431622"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFortuno156804"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFortuno156825"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFortunoBuyjoints"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFortunoDailyration"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFortunoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFortunoGetgeschenk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFortunoGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFreemineorcEveryulumulu"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFreemineorcExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFreemineorcIntro"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFreemineorcLookingulumulu"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFreemineorcSucheulumulu"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFreemineorcWaspassiert"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceFreemineorcWastun"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampFmOrg150287"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampFmSfb150321"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampFmSld150532"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampNcBau150561"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampNcOrg150596"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampNcSld150635"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampOcGrd150664"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampOcVlk150742"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampOmGrd150771"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampOmVlk150800"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampScNov150829"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampScNov213199"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampScNov213244"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampScNov213287"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampScNov213348"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericAboutcampScTpl150872"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGenericPayfine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGhorim157913"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGhorimExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGhorimMissingharlok"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGhorimSuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGilbertExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGilbertFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGilbertHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomez145985"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomez147400"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomez227049"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomez229617"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomez230157"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezDabei"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezFault"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloKontakte"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloKontakteBaals"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloKontakteKalom"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloKontakteLares"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloKontakteNlhehler"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloKontakteThatsall"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloKontakteYberion"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloKopfab"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloSpinner"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezHelloThorussays"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGomezNurso"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorHanis157676"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorHanis157958"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorHanis78987"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorhanis616369"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorhanisArena"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorhanisCharge"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorhanisChargegood"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorhanisExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorhanisSleeper"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorhanisSummoning"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorhanisWaytost"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorhanisWhat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn100001"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn104381"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn147646"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn147646_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn669160485"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn669160578"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn699216397"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn77865"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn77916"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn77984"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn78022"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn86248"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn93168"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn97879"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGorn98516"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornAfterfm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornBecomesld"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornCronos"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornFmcentrance"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornFmgate"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornFmgate_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornFmwatch"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornFoundulumulu"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornFreemine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornGuardnc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornGuardncrunning"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornHut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornHutfree"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornLeaveforpost"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornLeben"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornMages"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornMyway"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornNcwait"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornPost"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRejoinforfm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRuinabyss"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRuingate"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRuinleave"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRuinleaveinside"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRuinvictory"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRuinwait"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRuinwall"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRuinwallwhat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornRuinwhat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornSecond"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornTakeback"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornWolf"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornWolfFm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornWolfWolf"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornabar89771"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornabar93112"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornadrakExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornadrakGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornadrakPermanent"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornadrakWassekret"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornadrakWhatfor"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornadun156783"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornakosh93129"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornaranExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornaranWache"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornatoth156846"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornatothAngartalked"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornatothAngartalkedNormal"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornatothAngartalkedShark"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornatothAngartalkedUnworthy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornavid109089"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornavid92552"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornavid93146"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornazar115156"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGornazar115172"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGraham141860"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGraham215216"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrahamBuymaps"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrahamExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrahamHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrahamSellmap"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrahamSellmapAufsmaul"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrahamSellmapBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrahamSellmapGivenotsell"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrahamSellmapPay"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGravoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGravoHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGravoHelpangrynow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGravoHelpangrynowBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGravoHelpangrynowDiego"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGravoHelpangrynowGomez"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGravoHelpangrynowThorus"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGravoHelphow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGravoInfluence"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrazkrak99790"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrazkrak99806"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusAufnahme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusGardist"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusNochwas"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusTeach"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusTeachBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusTeachDex1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusTeachDex11"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusTeachDex51"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusTeachStr11"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusWannabemage"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd200ThorusZweihand2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd201JackalWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd203BullitWait4sc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd205ScorpioBanished"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd205ScorpioCrossbow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd205ScorpioCrossbow2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd205ScorpioCrossbowBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd205ScorpioCrossbowOk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd205ScorpioHeypc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd205ScorpioTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd205ScorpioWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd208CutterWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd211SkipTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd211SkipWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd212Abblitzen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd212Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd212Firstin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd212Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd212Lastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd212Passgate"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd213Abblitzen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd213Attack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd213Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd213Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd213Lastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd213Passgate"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd213TorwacheWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd214TorwacheExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd214TorwacheJob"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd214TorwacheNodusty"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd214TorwacheSeethorus"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd215TorwacheExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd215TorwacheFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd215TorwacheFirstDiego"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd215TorwacheFirstJustlooking"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd215TorwacheFirstNopay"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd215TorwacheFirstPay"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd215TorwacheFirstTrouble"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd215TorwachePerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd216Dustyzoll"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd216DustyzollLittlewalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd216DustyzollPissoff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd216DustyzollTopsi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd216Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd216First"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd216TorwacheSeethorus"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd217Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd217First"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd218Attack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd218Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd218Firstin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd218Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd219StoneExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd219StoneGetstuff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd233BloodwynWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd237Attack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd237Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd237FirstwarnInfoNo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd237FirstwarnInfoRetreat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd237FirstwarnInfoYes"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd237Lastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd245Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd245Hello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd255FletcherWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd260DrakeCrawlerOkay"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd260DrakeExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd260DrakeGardeaufnahme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd260DrakeGefahr"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd260DrakeIan"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd260DrakeMine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd260DrakeMineMehr"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd261BrandickAleph"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd261BrandickExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronBluff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronBluffBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronBluffBad"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronBluffBandit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronBluffGood"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronBluffOre"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronBluffUgly"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronChest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronPissed"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronSell"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd262AaronSellnow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd263AsghanExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd263AsghanLairfound"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd263AsghanNest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd263AsghanOpen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd263AsghanSmalltalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd264Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd264GardistGardeaufnahme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd271UlbertAngry"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd271UlbertDrink"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd271UlbertDrunk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd271UlbertExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd271UlbertKey"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd271UlbertLock"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd271UlbertTrick"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd275Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd275Preexit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd275Tips"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd275Wasmachtihrhier"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd276Bla"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd276Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd276Tips"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd277GardistSittingork"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrd277GardistWorkingork"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimAtocdraussen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimAufnahme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimFalle"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimFalleAccepr"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimFalleDeny"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimFalleHalfhalf"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimFalleHowshare"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimHowfarareyou"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimLeben"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimNachfalle"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimNachfalleFrieden"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimNachfalleWeiterpruegeln"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimReadytogo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGrimYourpdv"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuard31145483"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuard31227021"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuard3199093"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuard3199109"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuard587693"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuard587713"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuard97909"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuard97986"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1200YberionEarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomBringweed"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomCrawlerzangen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomExperimente"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomJoinpsi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomJoinpsi2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomNest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomRecipe"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomSacheJa"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomSacheNein"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1201CorkalomWannajoin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1202CorangarExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1202CorangarSendsEarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1202CorangarSendsKnow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1202CorangarWhere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1204BaalnamibArmor"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1208BaalcadarFirsttest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1208BaalcadarKreis1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1208BaalcadarKreis2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1208BaalcadarKreis3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1208BaalcadarKreis4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1208BaalcadarSellstuff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1208BaalcadarTeach"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1208BaalcadarTeachBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1208BaalcadarTeachMan5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGur1212MadcorkalomTalk2sc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuy78347"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuyAdnc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuyAdoc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuyAdocBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuyAdocProtection"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuyAdocWarez"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuyAdst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuyExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuyHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceGuyMyownhut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHaenno1377926"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHaenno144003"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHaenno144019"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHaenno153420"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHaenno155239"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHaenno463456"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHaenno463770"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHarlokAngry"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHarlokExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHarlokFetchharlok"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHarlokFetchharlokBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHarlokFetchharlokOrelse"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHarlokFetchharlokPlease"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHarlokHarlokagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHarlokSendharlok"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHerekAnlegen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHerekBully"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHerekExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHerekMotz"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148621"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148638"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148672"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148689"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148705"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148721"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148740"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148756"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148772"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148788"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148804"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148804_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148827"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero148844"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero157978"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198515"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198551"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198588"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198605"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198623"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198641"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198665"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198682"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198699"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198733"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198775"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero198896"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero199166"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero226591"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero226637"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero226682"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero226730"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero226746"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero226762"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero226762_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero226924"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero227050"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHero227176"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHighpriest4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHighpriest5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHomer112734"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHomer82123"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHomerBuiltdam"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHomerExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHomerHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHomerPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHomerRunning"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHomerSuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHomerWannahelp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratio77631"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratio81404"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioHelloBecool"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioHelloPissoff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioHelpstr"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioPleaseteachstr"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioPleaseteachstrAttack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioPleaseteachstrDefend"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioPleaseteachstrRicelord"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioSorry"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioStory"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioThanks"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioThoughtstr"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioThoughtstrNoidea"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioThoughtstrRicelord"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioWasser"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHoratioWhyhere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHuno108256"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHuno108322"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHuno108625"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHuno109075"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHuno109146"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHuno119235"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHuno120923"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHuno122758"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHuno131171"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHunoBuysmith"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHunoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHunoHowlong"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHunoHowsyourbusiness"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceHunoYouknowyourjob"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceIan157854"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceIan157875"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceIan157875_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceIan300926"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceIe397AnnouncerAnnounce"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceIe397AnnouncerExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackalExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackalHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackalHelloLater"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackalHelloPay"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackalHelloWhatdoiget"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackalHelloWhatif"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackalPayday"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackalPermpaid"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackalSchutz"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJacko79919"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJacko80120"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJacko80827"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJacko80888"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJacko83041"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJacko83087"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJacko83220"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJackoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan144050"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan144066"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan147258"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan147901"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan148424"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan148610"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan149144"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan149182"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan149313"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan149334"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan149410"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan149709"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan149916"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan150298"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJan150796"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvis85298"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvis97990"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvisErzhaufen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvisExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvisFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvisMagier"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvisPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvisRest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvisSldinfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJarvisWohaufen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJeremiah81449"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJeremiah900812"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJeremiahExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJeremiahHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJeremiahHoratio"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJeremiahPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseMission"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseMissionForgetit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseMissionNo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseMissionWhat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseMissionYes"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseMissuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseMissuccessOk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseMissuccessWaaas"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJesseWarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoru137701"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoru220432"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoru220532"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruGetmagic"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruImpressgurus"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruJoinpsi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruJoinpsiJa"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruJoinpsiNein"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruJointsrunning"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruSleepercontact"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJoruTester"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJudge587741"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceJudge587761"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKalomDrugmonopol"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKalomKrautboteback"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKalomSuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf401DamarokExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf401DamarokHeal"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf401DamarokHealinfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf401DamarokWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoExplaincircles"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoExplainmage"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoHeavyarmor"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoKreis1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoKreis2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoKreis3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoKreis4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoMana"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoManaBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoManaMan1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf402CorristoManaMan5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf403DragoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf403DragoRune"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf404XardasSellmagicstuff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf405TorrezBook"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf405TorrezGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf405TorrezManaBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf405TorrezManaMan1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf405TorrezManaMan5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdf405TorrezSellbooks"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasGotolee"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasHeavyarmor"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasKreis1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasKreis2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasKreis3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasKreis4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasKreis5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasLesson"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasNomoreoc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasTimesup"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasTimesupJa2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw600SaturasTimesupJa3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosBarrier"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosBrief"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosBriefback"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosMana"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosManaMan1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosManaMan11"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosSellstuff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosWannajoin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosWannamage"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw604CronosWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw605RiordianGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw605RiordianHeal"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw605RiordianHealinfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw605RiordianTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKdw605RiordianWelcome"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharim109751"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharim109767"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimCharge"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimChargeBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimChargeInsult"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimChargeInsultFace"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimChargeInsultGoats"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimChargeInsultGomezass"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimChargeInsultStupid"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimInarena"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKharimWhat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKingadvisor587969"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKingadvisor587989"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKingrhobar587547"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKingrhobar587567"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgo109412"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgo109428"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgo133200"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgo133684"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgo133947"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgoCharge"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgoChargeBeer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgoChargeNow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgoChargereal"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgoGood"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgoInarena"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKirgoWhat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKrashok100503"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKrashok100519"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKrashok100616"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKrashok100800"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKrashok100852"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKrashok101798"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKyleExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKyleHutrage"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceKyleProblem"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares105815"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares105815_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares105815_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares105815_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares105815_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares109508"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares181606"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares215224"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares84904"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares84973"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares86268"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares90982"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares97151"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLares97168"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLee112218"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLee113706"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLee114045"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLee115142"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLee115602"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLee117013"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLee118575"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLee147673"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLee149223"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyFirstLater"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyFirstNever"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyFirstYes"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyFirstatnight"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyNeveragain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyPermAufsmaul"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyPermDurstig"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyPermNothing"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLeftyWorkday"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester105823"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester105823_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester106856"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester121198"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester144425"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester144425_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester161325"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester184934"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester226336"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester227046"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester452778"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester83361"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester87566"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester89073"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester92080"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester95516"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester95651"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester95651_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester95746"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester95746_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester95853"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester95853_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester95853_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester95853_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLester96120"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterCampinfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterCampinfoBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterCampinfoGil"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterCampinfoHerb"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterCampinfoSleeper"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterGuideoffer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterHowproofworthy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterSakrileg"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterShow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterShowhallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterWannajoin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterWannatalktomaster"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLesterWeitweg"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLutter225272"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLutter225289"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceLutter431622"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMadcorkalom"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMadcorkalom161636"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMadcorkalom161652"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMadcorkalom161668"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMadcorkalom221525"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMadcorkalom221631"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMage587785"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMage587805"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMalon630287"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMelvin105981"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMelvin108345"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMelvin226332"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMelvinExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMelvinHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMelvinMetdusty"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMercenary10105993"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMercenary10106009"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMercenary10106115"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMercenary11105101"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMercenary11105117"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMercenary93144"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMerdarion111217"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMerdarion114812"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMerdarion114907"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMerdarion132417"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMerdarion144587"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMerdarion181783"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMerdarionExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten103720"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten105180"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten105286"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten106630"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten131463"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten147249"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten147256"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten147721"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten147721_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten147899"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten147974"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten288981"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten76716"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten86682"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten96464"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten96508"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten96705"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten96861"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten96928"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten97011"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten97204"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten97321"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten97374"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMilten97574"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenComesback"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenGotocorristo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenLetter"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenLetterGive"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenLetterNoAgain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenLoadsword"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenLoadsword1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenLsaway"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenLsdone"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenLsnow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenLsoreheap"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenNocheinbrief"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenShwait"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenWannamage"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMiltenWotorrez"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220432"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220454"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220474"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220496"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220516"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220536"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220556"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220578"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220598"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordrag220618"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordragFightGetaway"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordragFightOrebarons"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMordragFightThorus"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud216366"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud221135"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud221363"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud221582"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud221656"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud221718"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud221747"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222247"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222247_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222263"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222263_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222279"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222279_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222295"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222295_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222311"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222311_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222327"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222327_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222359"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222375"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222391"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222407"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMud222423"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudDefeated"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudFirstexit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudFirstexitKomm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudFirstexitVerpiss"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudGetlost"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve10"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve11"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve12"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve13"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve14"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve15"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve16"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve17"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve18"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve19"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve6"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve7"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve8"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudNerve9"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMudShutup"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk100415"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk100426"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk100990"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk102226"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk103094"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk104218"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk105136"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk105739"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk106010"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk200192"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk99960"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMuk99976"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir111952"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir112183"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir113459"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir114929"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir116633"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir117019"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir117244"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir117611"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir125219"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir147803"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxir199713"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceMyxirExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNatalia214919"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNatalia214939"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNatalia216279"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNatalia216298"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNatalia216298_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNatalia216318"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefarius109431"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefarius109728"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefarius109883"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefarius111161"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefarius114950"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefariusExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefariusHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefariusNowready"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefariusOcnews"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefariusWannamage"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNefariusWosaturas"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1300TalasBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1300TalasBridge"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1300TalasExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1300TalasHelpBring"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1300TalasHelpOk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1300TalasReturned"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1300TalasUr"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1301CaineChest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1303NyrasGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1371BaalnetbekAgain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1371BaalnetbekCrazy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNov1371BaalnetbekExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice0485916"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice0485932"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice1083067"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice1083083"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice1083128"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice4482818"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice4482834"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice4483311"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice4582946"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice4582962"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice4583332"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice47142242"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNovice47142258"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyras110997"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyras144390"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyras144390_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyras144390_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyras144390_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyras85959"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyras86006"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyras86073"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyras86233"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyrasExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyrasHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyrasOrt"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyrasOrtCasual"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceNyrasOrtHoly"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanFriendlyhello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanIntemple"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanKrushak"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanOrccity"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanOtherway"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanThx"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanTongue"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanUlumulu"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanUlumuluAm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanUlumuluFm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanUlumuluVm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrcshamanWhy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrctemplewarriorm02102697"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrctemplewarriorm02102713"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrctemplewarriorm02102769"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrctemplewarriorm02105905"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrctemplewarriorm02105905_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrctemplewarriorm02105936"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrctemplewarriorm02105936_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801Lares400ore"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresBringlist"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresBringlistback"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresGetkraut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresGotokalom"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresMordragsentme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresReicht"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresTeachDex1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresTeachDex11"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresTeachDex51"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresTeachStr11"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresWannajoin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresWherelearn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg801LaresYouhere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg804Attack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg804Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg804Lastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg804OrganisatorExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg804OrganisatorGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg804OrganisatorPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordMorelocations"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordThanks"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordWhatgame"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordWhydangerous"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordWoequipment"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordWokarte"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordWokarteKaufen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordWokarteStehlen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg818RatfordWrongway"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxCreatures"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxCreaturesBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxCreaturesFell"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxCreaturesHaut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxCreaturesKralle"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxCreaturesPrettymuch"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxCreaturesZahn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxHunthere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxNoBeer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg819DraxScavenger"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg825OrganisatorExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg825OrganisatorPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragAtnewcamp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragCourier"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragFight"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragGotonewcamp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragHauab"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragJoinnewcamp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragNcinfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragProblem"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg826MordragTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg829Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg829Hello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg829Offerjoint"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg829Perm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg829Specialinfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg830Aufhalten"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg830Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg830Hello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg830Perm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg830What"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg833Buster"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg833BusterExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg843SharkyExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg843SharkyFisk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg843SharkyGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg843SharkyTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg855WolfExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg855WolfSellbow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg855WolfTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg855WolfTrain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg855WolfTrainagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg855WolfTrainoffer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg855WolfWherehunter"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg859AidanCreatures"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg859AidanCreaturesBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg859AidanCreaturesFell"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg859AidanCreaturesHaut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg859AidanCreaturesKralle"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg859AidanCreaturesZahn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg860RenyuGetlost"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg861KillianExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg861KillianGetlost"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg862JackoBanditencamp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg862JackoGoaway"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg862JackoGuard"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg862JackoGuardAngriff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg862JackoGuardInfowert"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg862JackoGuardTempler"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg873CipherExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg873CipherFisk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg873CipherFrombalor"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg873CipherHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg873CipherTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg875Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg875Perm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Amsfb"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Bribe"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Bribe100erz"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Bribe10erz"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Bribe50erz"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Gibkraut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Lastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Perm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Scsekte"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrg876Scsld"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry105679"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry106370"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry322291"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry323306"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry325545"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry325898"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry84444"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry85241"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry85244"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry85247"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrry85250"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrryGuardgate"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrryGuardgateNo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrryGuardgateYes"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrryNewcamp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrryOldcamp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrryPreexit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrryShore"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrryWaffe"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceOrryWoman"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePachoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePachoStop"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicBalkon"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicBalkon_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicChange"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicComeagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicComeback"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicComewithme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicFinish"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicFokusplace"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicFollowme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicGuidefirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicGuidefirstBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicGuidefirstHerb"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicGuidefirstMaingate"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicGuidefirstSmith"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicGuidefirstTempel"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicGuidefirstTrain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicHerb"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicIamhurt"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicSmith"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicSoon"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicTempel"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePcPsionicTrain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePeasant19146563"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePeasant19146563_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePeasant19146563_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePeasant1981330"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePeasant1981346"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePeasant2081484"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePeasant2081500"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePeasant2081817"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePeasant2088449"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePock79334"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePockExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePockForgotall"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePockHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePockKnowmuch"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePockWasser"
+  },
+  {
+    "category": "choice",
+    "id": "ChoicePockWhyjail"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuentin129340"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuentin130346"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuentin131045"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuentin131102"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuentin139225"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuentin143056"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuentin144038"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuentin144522"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuentin220345"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuest137058"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuestdealer422704"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceQuestdealer422724"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven105978"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven105978_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven105978_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven105978_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven214972"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven82504"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven84750"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven85519"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven89520"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven89985"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven91022"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRaven97436"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRavenAufnahme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRavenExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRavenFirstin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRavenKrautbote"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRavenPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRavenThere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRavenWho"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk105842"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk105999"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk78033"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk78049"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk78445"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk78827"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk78997"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk80131"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk80484"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk80850"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk80853"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk80872"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk81221"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk81374"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRayk81391"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRenyu79732"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRenyu80087"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRenyu88747"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRenyuExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiceLord78563"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiceLord79261"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiceLord81400"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiceLord81564"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiceLord81916"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRicelord109255"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRicelord109346"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRicelord84998"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRicelordExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRicelordHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordian114886"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordian137795"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordian138058"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordian138198"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordian138323"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordian146428"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordian235462"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordianExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordianMessage"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordianMessagewhy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRiordianReward"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRodriguez114839"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRodriguez132723"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRodriguez211573"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRodriguezExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRodriguezHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue01118244"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue01118260"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue01118583"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue01119011"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue01119044"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue01119276"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue01119281"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue01119397"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03122077"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03122093"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03122249"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03122249_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03122249_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03122270"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03122562"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03123027"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03123063"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue03123099"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue0497804"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue0497820"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRogue12225721"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoe109303"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoe76241"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoeAttack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoeBringlist"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoeComeagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoeExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoeFirstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoeLastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoeMordrag"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRoscoeWannajoin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRufus79090"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRufusExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRufusHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRufusRicelord"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRufusWasser"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceRufusWhy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino109495"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino110868"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino110919"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino110964"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino112364"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino112732"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino117589"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino220171"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino220298"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSantino220449"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas104762"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas105435"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas106469"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas106469_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas106469_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas106469_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas108301"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas116026"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas136787"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas136913"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas137049"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas137180"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas137218"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas137282"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas157881"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas92703"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturas97988"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasAllfoci"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasBringfocus2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasBringfocus3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasBringfocus4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasBringfocus5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasIntruder"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasMurder"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasNews"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasNowsld"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasXardas"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasXardasgo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasXardashelp"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasXardasproblem"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasXardaswhere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSaturasXardaswhy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScar157640"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScar157640_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScar157640_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScar157640_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScar157656"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScar157656_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScar157656_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScar157656_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScarExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScarFrau"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScarHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScarPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScarWhat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScatty156538"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyJoinoc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyKharimsuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyKirgosuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyOthercamps"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyTrain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyTrain1h"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyTrain2h"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyTrainBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyWannabet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScattyWhatdoyoudo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScorpioExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScorpioHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScorpioHelloJoin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScorpioHelloJustlooking"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScorpioHelloKraut"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScorpioHelloMages"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceScorpioRefusetrain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSenyanExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSenyanHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSenyanJusttalk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSeraphia134768"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSeraphia134784"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSeraphia137011"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSeraphia145801"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSfb1001Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSfb1001Hello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceShratComewithme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceShratExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceShratJoinpsi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceShratLeaveme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceShratWhyhere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceShrike88518"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceShrikeExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceShrikeGetlost"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceShrikeHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSilas78516"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSilas78543"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSilas78776"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSilas80551"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSilas80620"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSilas81291"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSilasExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSilasHehler"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSilasTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipFirstBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipFirstGomez"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipFirstThorus"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipFirstThorusAskhim"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipFirstThorusKickass"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipFirstThorusKickassagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipFirstThorusStranger"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSkipVerpatzt"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeBecomesldnowFreedom"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeBecomesldnowJustbecause"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeBecomesldnowNoother"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeChangeside"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeDamnpast"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeDefine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeFmtaken"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeMitmachen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld700LeeNowready"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld702Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld702First"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld702Perm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld709CordExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld709CordTrain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld709CordTrainagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld709CordTrainoffer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld723Attack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld723Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld723Lastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld728JarvisAufnahmesoldier"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld732Attack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld732Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld732Lastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld751SoeldnerExit1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld751SoeldnerExit2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld751SoeldnerInmine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld751SoeldnerIntro"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld751SoeldnerUmsehen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld752OkylExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld752OkylInmine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld752OkylIntro"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld752OkylPermit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld752OkylUmsehen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld752OkylWerbistdu"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753Baloro"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroAngebotdochannehmen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroExitInfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroExitInfo1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroHabsdabei"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroHabsnichtdabei"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroLetztesWort"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroScWillsWissen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroWasmeinstdu"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroWorumgehts"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroWorumgehtsJa"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld753BaloroWorumgehtsJaklar"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld760SoeldnerExit1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld760SoeldnerExit2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld760SoeldnerInmine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld760SoeldnerIntro"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld760SoeldnerUmsehen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld761SoeldnerBribe"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld761SoeldnerExit1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld761SoeldnerExit2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld761SoeldnerInmine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld761SoeldnerIntro"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSld761SoeldnerUmsehen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSleeper160307"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSleeper160307_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSleeper160307_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSleeper160307_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSleeper161534"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSleeper161534_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSleeper161559"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSleeper161559_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSly109616"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSly109644"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSly154803"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf107580"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf107977"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf108526"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf109305"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf109648"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf141307"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf141988"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf142111"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf142204"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnaf142425"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafAftersuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafWheremeatbugs"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafWheremushrooms"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafWherenek"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafZutaten"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafZutatenDoit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafZutatenKotz"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSnafZutatensuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSpecki222280"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSpecki225346"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSpecki225363"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone112089"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone112719"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone112921"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone113211"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone114964"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone115775"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone116373"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone117061"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone117385"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone117629"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone117769"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone121565"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone122991"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone124483"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone124856"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone129128"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone129952"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone182084"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone182159"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone363258"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStone448494"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStoneHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStoneNotselling"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt300AlbertoBuy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt300AlbertoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanGearRun"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanGearSuc"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanGetlist"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanGomez"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanHi"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanMagic"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanMine"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanMore"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanNest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanNotenough"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanOre"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt301IanWantlist"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt302ViperBuy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt302ViperExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt302ViperGreet"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt302ViperMelt"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskForgetsword"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskHehlersuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskMordragko"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskMordragkoFuckoff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskMordragkoPetze"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskMordragkoRelax"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskWhistlerssword"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskWhistlersswordBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskWhistlersswordFault"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt311FiskWhistlersswordTakeit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt315Lostnek"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt315LostnekDoit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt315LostnekWhy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt315Lostneksuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt315LostneksuccessNoproof"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt315LostneksuccessProof"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt315SlyAftersuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt315SlyExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt331FingersExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt335SantinoBuy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt335SantinoExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt336CavalornSellbow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceStt336CavalornTrade"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSwineyExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSwineyHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSwineyPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSwineySchuerfer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSwineySchuerferJa"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSwineySchuerferNein"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra134690"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra134706"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra135001"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra135325"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra136349"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra136700"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra143080"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra143489"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra144108"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra144623"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra145457"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra146114"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceSyra199568"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTalas106537"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTalas106558"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTalas111558"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTalas156731"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTalas156751"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTalas93601"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTalas93781"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTarrok100029"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTarrok102103"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTarrok229186"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTarrok99686"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar03106171"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar0382522"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar0382538"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar0382563"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar0382957"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar19138859"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar19138875"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar19152916"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar23125996"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar23218091"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar23218107"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar26139092"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar26139108"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar27139179"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar27139195"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar27152983"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTemplar87757"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTest183347"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTestcharacter77167"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron105690"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron105706"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron142259"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron142289"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron142600"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron143057"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron143136"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron145855"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron145873"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron146878"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTheron157335"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus109983"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus132524"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus132770"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus133908"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus134048"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus134409"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus134430"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus134730"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus89397"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus97958"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus97961"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus98585"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorus99670"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusBribeguard"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusDiegosentme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusEntercastle"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusGive1000ore"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusKdwsiegel"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusKrautbote"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusLetterformages"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragfailed"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoAnalyze"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoAnalyzeBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoKillhim"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoMageproblem"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoMagesprotect"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoMordragdead"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoMordraggone"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoOffer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoOfferBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoWhere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusMordragkoWhere1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusPerm2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusReadyforgomez"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusSttgeschafft"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusTryme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusTrymeagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusTrymeicandoit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceThorusWorkforgomez"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTochurnagg103012"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTochurnagg107280"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTochurnagg144060"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTochurnagg215959"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTochurnagg218049"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTochurnagg218682"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorik185897"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorik185917"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorik186016"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorik186125"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorlof115175"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorlof133834"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorlof134473"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorlof144472"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorlof144472_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorlof144472_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorlofExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorlofHallo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorlofMitmachen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrez107584"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrez107752"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrez109266"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrez110367"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrez114863"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrez133944"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrez220951"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrez221376"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrezBelohnung"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrezBelohnungDex"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrezBelohnungManamax"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrezBelohnungScrolls"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrezBelohnungStr"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrezBrieftausch"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrezExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTorrezPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1400GornabarExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1400GornabarInfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1400GornabarSuggest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1400GornabarVictory"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1401GornakoshCrawler"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1401GornakoshExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1401GornakoshInfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1401GornakoshSuggest"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1401GornakoshVictory"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothArmor"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothGetstuff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothTeach"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothTeachBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothTeachDex1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothTeachDex5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothTeachMan5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothTeachStr1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothTeachStr5"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothTrain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1402GornatothTrainagain"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1405Gornaran"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1405Gornaran2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1405Gornaran3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1405Gornaran4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1415TorwacheExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1415TorwacheFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1415TorwacheFirstJoin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1415TorwacheFirstJustlooking"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1415TorwacheSit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1415TorwacheTempleraufnahme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1416TorwacheExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1416TorwacheLife"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1433GornavidExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1433GornavidHealth"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1433GornavidIan"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1433GornavidVictory"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1436TemplerCrawler"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1436TemplerExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1437TemplerExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1437TemplerLeave"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1437TemplerLeavenow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1437TemplerNerv"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1438TemplerEggsearch"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1438TemplerExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1438TemplerInfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1438TemplerKalom"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1438TemplerWhy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1441Attack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1441Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1441FirstwarnConditionLester"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1441FirstwarnConditionYberion"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1441Lastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1442Attack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1442Firstwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1442FirstwarnConditionLester"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1442FirstwarnConditionYberion"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1442Lastwarn"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1455Gorboba"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceTpl1455Gorboba1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUlmar81075"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUlmar81091"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUlmar81201"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUlmar81815"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal100016"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal100460"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal102098"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal102545"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal102625"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal103900"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal104155"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal99842"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal99858"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmakhal99903"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmosh101727"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmosh101743"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmosh103091"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmosh111400"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmosh189634"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmosh189637"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmosh189640"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUmosh189643"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUndeadorctempleguard01152917"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnicorn225200"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnicorn225217"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnicorn431622"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00101DoesSettingVari58887"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00102DoesSimpleIfels58889"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00103DoesSimpleIfels58890"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00104DoesNegationWor58895"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00105DoesIfelseifelse58897"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00106DoesIfWithOrW58899"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00107DoesIfWithAnd58898"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00107DoesIfWithAnd58900"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00107DoesIfWithOrW58893"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest001Logic58888"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00201DoesForceEndCo58892"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00203DoesForceEndCo58896"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00203DoesForceEndCoSubd58896"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00204DoesForceEndCo58894"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest002ForceEndConversati58891"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00301DoesSubdialogWo58903"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00302DoSubdialogCond58904"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest00303DoesReturnToLa58905"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittest003Subdialogs58902"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUnittestPermanentDummy58901"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUriziel425867"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUriziel425883"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog100540"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog100556"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog101602"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog101666"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog102653"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog102911"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog103376"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog106273"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog108129"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog109069"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog143995"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog143995_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog143995_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog143995_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog143995_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog143995_4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog144095"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog144111"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog144111_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrnazkrog144111_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak100006"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak100352"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak100917"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak101497"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak102094"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak102212"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak102393"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak104486"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak104761"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak109625"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak109714"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak109741"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceUrshak188841"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVanlange222236"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVanlange225308"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVanlange225324"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVarraghashor213881"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVarragkasorg226967"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVarragkasorg427130"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVarragunhilqt427272"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya134729"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya134745"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya136965"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya137139"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya137139_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya137139_1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya137139_2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya137139_3"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya137139_4"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya137435"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya145496"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVelaya216062"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViran137143"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViran137484"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViran137921"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViran139081"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViran139217"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViranBloodflies"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViranExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViranFetchweed"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViranFetchweedGotohim"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViranFetchweedReally"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViranPerm"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViranRipoff"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViranRunning"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceViranWhat"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk520Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk520Leaveme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk534Exit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk534Leaveme"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk583GlenBuy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk583GlenExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk583GlenInfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk583GlenLockpick"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk584SnipesDeal"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk584SnipesDeal2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk584SnipesDealRun"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk584SnipesExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephAngry"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephClever"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephGlen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephGuards"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephInfo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephKey"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephSchuppen"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephSchuppen15"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephSchuppen30"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephSchuppen50"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk585AlephSchuppenBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk586GrimesExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk586GrimesFirst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk586GrimesKnow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk586GrimesStory"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk587GarpExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceVlk587GarpOrk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedge221511"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedge221529"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedge221548"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedge84938"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedge99089"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgeExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgeHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgeLehrer"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgeLehrerBack"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgeLehrerLockpick"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgeLehrerLockpick2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgeLehrerPickpocket"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgeLehrerPickpocket2"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgePsst"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWedgeWarnsofbutch"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerFavour"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerFavourOk"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerFavourOreaway"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerFavourWhynotsell"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerIamnew"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerMyswordSuccess"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerMyswordToolate"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerRunning110"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerRunningpayback"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWhistlerStandardkap1"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfArmorfinished"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfArmorinwork"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfGreetorg"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfHello"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfMcplatesenough"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfMcplatesfew"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfProfit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfSellarmor"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfSkin"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceWolfSpeak"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas104226"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas105605"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas108597"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas158962"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas159421"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas159448"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas160217"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas160241"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas160281"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas222255"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardas226937"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasAccept"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasAltrune"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasBetterarmor"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasDanger"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasDisturb"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasEventhow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasEventwhere"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasEventwhy"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasKdw"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasLoadsword"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasLoadsword01"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasLoadsword02"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasLoadsword09"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasMakeruneNo"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasMakeruneYes"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasMakerunedoit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasOthers"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasSaturas"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasSleeper"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasSwordloaded"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemon105037"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemon99664"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemonExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemonFireheart"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemonIceheart"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemonIntro"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemonMasterhow"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemonMasterwho"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemonNoheart"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceXardasdemonStoneheart"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberion105709"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberion105709_0"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberion109422"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberion109454"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberion113927"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberion85161"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberion86508"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberion86715"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberion86738"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberionBringfocus"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberionBringfocusRunning"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberionExit"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberionNyras"
+  },
+  {
+    "category": "choice",
+    "id": "ChoiceYberionWache"
+  },
+  {
+    "category": "info",
+    "id": "Info_Allgood"
+  },
+  {
+    "category": "info",
+    "id": "Info_Couldyoudowith"
+  },
+  {
+    "category": "info",
+    "id": "Info_Everyoneworks"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMORGAreyouok"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMORGHoware"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMORGSomething"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMORGTellme"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMORGWhatgoes"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMORGWhogives"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMORGWhoscharge"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMORGWhostheboss"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMORGYoudont"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBHowdo"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBHowsit"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBIwannaknow"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBWhatcamp"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBWhatdo"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBWhatif"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBWhatisthis"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBWhatslife"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBWhatslifehe"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBWhoaround"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBWhoscharge"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSFBWhosimport"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSLDAllgood"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSLDHowcan"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSLDHowits"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSLDHowjoin"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSLDIsthere"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSLDWhatsdeal"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSLDWhorules"
+  },
+  {
+    "category": "info",
+    "id": "Info_FMSLDWhosthebsss"
+  },
+  {
+    "category": "info",
+    "id": "Info_Hi"
+  },
+  {
+    "category": "info",
+    "id": "Info_HowCanIJoin"
+  },
+  {
+    "category": "info",
+    "id": "Info_HowIJoin"
+  },
+  {
+    "category": "info",
+    "id": "Info_HowareSTT"
+  },
+  {
+    "category": "info",
+    "id": "Info_Howarethings"
+  },
+  {
+    "category": "info",
+    "id": "Info_Howarethingshe"
+  },
+  {
+    "category": "info",
+    "id": "Info_HowcanIget"
+  },
+  {
+    "category": "info",
+    "id": "Info_HowdoIgetin"
+  },
+  {
+    "category": "info",
+    "id": "Info_Howsitgoing"
+  },
+  {
+    "category": "info",
+    "id": "Info_Howsitgoinghe"
+  },
+  {
+    "category": "info",
+    "id": "Info_Imnewhere"
+  },
+  {
+    "category": "info",
+    "id": "Info_Importantplaces"
+  },
+  {
+    "category": "info",
+    "id": "Info_Iseverything"
+  },
+  {
+    "category": "info",
+    "id": "Info_Issomething"
+  },
+  {
+    "category": "info",
+    "id": "Info_Isthereanyone"
+  },
+  {
+    "category": "info",
+    "id": "Info_Iwannajoin"
+  },
+  {
+    "category": "info",
+    "id": "Info_Iwannaknow"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUAreyou"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUHowsitgo"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUHowthings"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAULeader"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUSurethings"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUTellmecamp"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUWater"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUWaterLefty"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUWaterfromL"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUWhatcan"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUWhatshould"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCBAUYouwork"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGCanIherb"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGHowarething"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGHowits"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGIhavetojoin"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGIwannajoin"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGIwannaknow"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGSmokerolls"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGTellme"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGWhatIknow"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGWhatdoIhave"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGWhoscalling"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGWhosin"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGWhosleader"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGWorkaround"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCORGYoulook"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDBecomemerc"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDDoyouneed"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDEverything"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDHoware"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDInterested"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDSmokerolls"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDTroubleCamp"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDWhatcan"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDWhoischarge"
+  },
+  {
+    "category": "info",
+    "id": "Info_NCSLDWhoscalling"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDCanyou"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDDoyou"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDHowsit"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDIsevery"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDTellme"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDTellmine"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDWhatcan"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDWhatsthe"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDWhocalls"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMGRDWhosgot"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKAboutMC"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKAboutMine"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKHowareyou"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKHowdigger"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKHowsit"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKHowsitgoing"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKTell"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKTellmeabout"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKTellmecaves"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKWhatdo"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKWhatdoyou"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKWhatmine"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKWhocalls"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKWhocharge"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKWhohas"
+  },
+  {
+    "category": "info",
+    "id": "Info_OMVLKWhorules"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVCantell"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVEndGuide"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVGuide"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVHowareyou"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVHowcancamp"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVHowcani"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVHowsitgo"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVHowthings"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVIsthere"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVIwantto"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVWhatshould"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVWhocalls"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVWholeader"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCNOVWhostheboss"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCTPLEAboutcamp"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCTPLEBecometpl"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCTPLECouldyou"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCTPLEHowisgoing"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCTPLETakealook"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCTPLETellme"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCTPLEWhocharge"
+  },
+  {
+    "category": "info",
+    "id": "Info_SCTPLEverything"
+  },
+  {
+    "category": "info",
+    "id": "Info_WhatdoIhave"
+  },
+  {
+    "category": "info",
+    "id": "Info_Whatslife"
+  },
+  {
+    "category": "info",
+    "id": "Info_Whereareplaces"
+  },
+  {
+    "category": "info",
+    "id": "Info_Whogivesorders"
+  },
+  {
+    "category": "info",
+    "id": "Info_Whoischarge"
+  },
+  {
+    "category": "info",
+    "id": "Info_Whoruns"
+  },
+  {
+    "category": "info",
+    "id": "Info_Whorunsthis"
+  },
+  {
+    "category": "info",
+    "id": "Info_Whostheboss"
+  },
+  {
+    "category": "info",
+    "id": "Info_whohasthesay"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Aidan_106908"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Aidan_106928"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Aidan_106950"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Balor_443547"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Balor_443567"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Balor_443704"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Baloro_78345"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bandit_121356"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bandit_121376"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bandit_121491"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bandit_121511"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Blackmailer_116696"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Blackmailer_116716"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Blackmailer_117071"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Blackmailer_117091"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Blackmailer_118087"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Blackmailer_118107"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bloodwyn_107863"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bloodwyn_107883"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bloodwyn_107909"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bloodwyn_608601"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bouncer_111068"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bouncer_111088"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Brannok_120595"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Brannok_120615"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Brannok_120641"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Brannok_122194"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Brannok_122214"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Brannok_136200"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Brannok_136220"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Brannok_136242"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Brannok_138801"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bullit_146192"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Bullit_146212"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Caine_82145"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_134756"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_1347562"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_134776"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_1347762"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135157"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_1351572"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_13515722"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135157222"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135177"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_1351772"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_13517722"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135215"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135235"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135257"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135494"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135514"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135536"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135632"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135652"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_135674"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137031"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137051"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137090"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137114"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137223"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137243"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137273"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137302"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137322"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137477"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_137497"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_138896"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_138916"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_138938"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_138958"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139281"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139301"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139305"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139325"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139347"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139367"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139387"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139407"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139757"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_139777"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_141044"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_141064"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_141117"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_141137"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_141185"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_141212"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_141442"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_141462"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cavalorn_210443"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_111176"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_111196"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_111254"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_111657"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_111677"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_111938"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_112087"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_112107"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_116118"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_118756"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_118776"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_WarningChoktaArena"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_WarningChoktaArmor"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Chokta_WarningChoktaWeapon"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cohsel_197379"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cohsel_197399"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cohsel_197421"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_103156"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_103176"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_103355"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_129559"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_129579"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_129800"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_130042"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_130062"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_130101"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_130127"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_130724"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_130744"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_130897"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_130917"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_131332"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_131403"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_131423"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_131679"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_131735"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_131783"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_131815"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_135034"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_135054"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_144750"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_144770"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_145232"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_145585"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_145633"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Corristo_200685"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Cronos_210491"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Damarok_138407"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Damarok_138427"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Damarok_138499"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_112956"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113049"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113069"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113104"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113152"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113172"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113238"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113666"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113686"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113794"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_113956"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_114128"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_114148"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_11417822"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_11419822"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_114314"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_114334"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_114469"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_114623"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_114823"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_114843"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_114904"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_115075"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_115465"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_115485"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_115542"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_115562"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_115584"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_115604"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_115692"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_115712"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_116309"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_116337"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_118161"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_118181"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_122063"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_122083"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_12209422"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_12211422"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_122357"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_12286322"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_124593"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_124613"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_130731"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_130751"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_130799"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_134270"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_135196"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Darrion_135216"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Dexter_79661"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_100012"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_100997"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_101017"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_106673"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_106693"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_106715"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_106735"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_111283"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_111303"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_111349"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_209799"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_209819"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_209887"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_420206"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_98419"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_98439"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_98566"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_98646"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_98666"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_99037"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_99992"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_SleeperDiego01"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_SleeperDiego02"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_SleeperDiego03"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Diego_SleeperDiegoSides"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_DrPymonte_431622"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Drake_109710"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Drake_109730"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Drake_109756"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Drake_109794"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Drake_109909"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Drake_109929"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Drake_110049"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Drake_110182"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Drake_110202"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_207354"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_207374"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_207408"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_77553"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_77573"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_77642"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_77666"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_77757"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_80192"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_80212"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fingers_80613"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fisk_108937"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fisk_108957"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fisk_109019"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fisk_142228"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fisk_142248"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fletcher_106419"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fletcher_106439"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Fletcher_106715"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150400"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150420"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150485"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150509"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150547"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150567"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150589"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150630"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150655"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_GRD_150675"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_STT_150738"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_STT_150758"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_STT_150786"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_STT_150818"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_STT_150838"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_STT_150874"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_OC_STT_150894"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_SC_NOV_212582"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_SC_NOV_212602"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_SC_NOV_212655"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_SC_NOV_212685"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_SC_NOV_212727"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_AboutCamp_SC_NOV_212771"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121248"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121268"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121290"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121310"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121330"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121350"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121370"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121414"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121434"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_121623"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_FindNPC_FindNPC"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_PayFine_214600"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Generic_PayFine_214620"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_145991"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_146011"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_146058"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_146078"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_146128"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_146148"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_147329"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_147349"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_147422"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_147442"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gomez_147601"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_GorNaZar_115177"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_GorNaZar_115197"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_GorNaZar_115232"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_GorNaZar_115252"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_GorNaZar_115385"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_GorNaZar_115405"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_GorNaZar_115436"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gorn_101355"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gorn_1954666"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gorn_1954686"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gorn_89528"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gorn_89548"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gorn_89978"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gorn_90013"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gorn_91184"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Gorn_91204"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Guard31_99838"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Guard31_99858"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Guard31_99945"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_153524"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_153544"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_153732"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_153752"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_154042"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_154062"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_154471"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_154491"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_154754"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_154774"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_463522"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_463542"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_463843"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Haenno_463863"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero_BranCorpse"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero_STHeroInfoUrizielXardas"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__AITESTCHARACTER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__AM_UOW_UNDEADORCTEMPLEGUARD01_3032"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__BC_BAN_ARLIN_852"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__BC_BAN_BRANNOK_863"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__BC_BAN_QUENTIN_858"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__BC_BAN_TORIK_864"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CHARACTER_DUM_GUARD_0"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CUTSCENE_001_INTRO"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CUTSCENE_002_GREATPRAYER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CUTSCENE_003_FIREMAGES"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CUTSCENE_004_URIZIEL"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CUTSCENE_005_EXTRO"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CUTSCENE_DUM_JUDGE_0"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CUTSCENE_DUM_KINGADVISOR_0"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CUTSCENE_DUM_KINGRHOBAR_0"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__CUTSCENE_DUM_MAGE_0"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__FM_OSL_TARROK_2001"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__FM_SFB_SWINEY_1037"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__FM_SLD_BALORO_753"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__FM_SLD_MERCENARY02_751"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__FM_SLD_MERCENARY08_760"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__FM_SLD_MERCENARY09_761"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__FM_SLD_OKYL_752"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_FM_ORG"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_FM_SFB"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_FM_SLD"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_NC_BAU"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_NC_ORG"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_NC_SLD"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_OC_GRD"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_OC_STT"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_OC_VLK"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_OM_GRD"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_OM_VLK"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_OW_ORC"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_SC_NOV"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ABOUTCAMP_SC_TPL"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_FINDNPC"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_OC_QUEST_DREAMEDLAND"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_OC_QUEST_RANKUPGUARD"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_PAYFINE"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__GENERIC_ST_NOV_FINALBOSS"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__HERO"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_HOMER_935"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_HORATIO_901"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_JAN_942"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_JEREMIAH_912"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_MALON_930"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_PEASANT19_929"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_POCK_902"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_RAYK_941"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_RICELORD_900"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_BAU_RUFUS_903"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_KDW_CRONOS_604"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_KDW_MERDARION_602"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_KDW_MYXIR_601"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_KDW_NEFARIUS_603"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_KDW_RIORDIAN_605"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_KDW_SATURAS_600"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_NOV_BAALISIDRO_1333"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_NOV_BAALKAGAN_1332"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_BUSTER_833"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_BUTCH_851"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_CIPHER_873"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_DRAX_819"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_LARES_801"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_LEFTY_844"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_RATFORD_818"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE02_804"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE04_807"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE12_822"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE15_825"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE16_829"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE17_830"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE24_845"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE25_846"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE26_875"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROGUE27_876"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ROSCOE_840"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_SHARKY_843"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_SHRIKE_842"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_SILAS_841"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_ULMAR_881N"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_WEDGE_850"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_ORG_WOLF_855"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SFB_SCRAPER01_1001"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SFB_SENYAN_1000"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_CORD_709"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_GORN_669_SLEEPER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_GORN_699"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_GORN_699_SLEEPER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_HAENNO_741"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_JARVIS_728"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_LEE_700"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_MERCENARY01_702"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_MERCENARY09_723"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_MERCENARY10_725"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_MERCENARY11_726"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_MERCENARY15_732"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__NC_SLD_TORLOF_737"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_BLOODWYN_233"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_BULLIT_203"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_CUTTER_208"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_GATEGUARD01_212"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_GATEGUARD02_213"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_GATEGUARD03_214"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_GATEGUARD04_215"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_GATEGUARD05_216"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_GATEGUARD06_217"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_SCATTY_210"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_SKIP_211"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OCR_GRD_STONE_219"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_EBR_ARTO_102"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_EBR_BARTHOLO_106"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_EBR_GOMEZ_100"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_EBR_RAVEN_105"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_EBR_SCAR_101"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_BRIDGEGUARD01_275"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_BRIDGEGUARD02_276"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_FLETCHER_255"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_GUARD04_218"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_GUARD17_237"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_GUARD25_245"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_GUARD31_283N"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_JACKAL_201"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_KIRGO_251"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_ORRY_254"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_PACHO_224"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_SCORPIO_205"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_GRD_THORUS_200"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_IE_CHARLOTTE"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_IE_DRPYMONTE"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_IE_FLEX"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_IE_LUTTER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_IE_SPECKI_1401"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_IE_STEVE"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_IE_UNICORN"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_IE_VANLANGE_1400"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_KDF_CORRISTO_402"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_KDF_DAMAROK_401"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_KDF_DRAGO_403"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_KDF_MILTEN"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_KDF_MILTEN_SLEEPER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_KDF_RODRIGUEZ_400"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_KDF_TORREZ_405"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_NOV_BAALPARVEZ_1330"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_NOV_BAALTARAN_1331"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_ORG_MORDRAG_826"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_SLD_KHARIM_729"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_STT_DEXTER_329"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_STT_DIEGO"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_STT_DIEGO_SLEEPER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_STT_FINGERS_331"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_STT_FISK_311"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_STT_SLY_315"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_STT_WHISTLER_309"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_DIGGER18_520"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_DIGGER29_534"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_DUSTY_524"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_GRAHAM_573"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_GRAVO_572"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_GRIM_580"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_GUY_530"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_HEREK_511"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_HUNO_538"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_JESSE_564"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_KYLE_536"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_MUD_574"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_VLK_SNAF_581"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_WOC_SERAPHIA_110"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_WOC_SYRA_109"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OC_WOC_VELAYA_108"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OG_GUR_BAALLUKOR_1211"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OG_TPL_GORNAZAR_1446"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_GRD_AARON_262"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_GRD_ASGHAN_263"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_GRD_BRANDICK_261"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_GRD_DRAKE_260"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_GRD_GUARD05_264"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_GRD_GUARD12_277"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_GRD_ULBERT_271"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_SC_TPL_TEMPLAR03_1436"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_SC_TPL_TEMPLAR04_1437"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_SC_TPL_TEMPLAR05_1438"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_STT_ALBERTO_300"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_STT_IAN_301"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_STT_SANTINO_335"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_STT_VIPER_302"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_TPL_GORNABAR_1400"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_TPL_GORNAKOSH_1401"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_TPL_GORNAVID_1433"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_VLK_ALEPH_585"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_VLK_GARP_587"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_VLK_GLEN_583"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_VLK_GRIMES_586"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OM_VLK_SNIPES_584"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OW_OPS_MUK_2404"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OW_OPS_UMAKHAL_2402"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OW_OSM_URNAZKROG_2401"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OW_OWR_CHOKTA_2407"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OW_OWR_GRAZKRAK_2400"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OW_OWR_KRASHOK_2405"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OW_OWR_ORCTEMPLEWARRIORM02_2042"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OW_OWR_TOCHURNAGG_2403"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__OW_OWR_UMOSH_2406"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__QD_QUESTDEALER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_GUR_BAALCADAR_1208"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_GUR_BAALNAMIB_1204"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_GUR_BAALORUN_1209"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_GUR_BAALTONDRAL_1203"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_GUR_BAALTYON_1210"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_GUR_CORANGAR_1202"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_GUR_CORKALOM_1201"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_GUR_YBERION_1200"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_BAALNETBEK_1371"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_BALOR_1304"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_CAINE_1301"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_DARRION_1312"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_FORTUNO_1357"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_GHORIM_1310"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_HARLOK_1358"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_JORU_1305"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_LESTER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_LESTER_SLEEPER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_NOVICE04_1309"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_NOVICE10_1317"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_NOVICE44_1356N"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_NOVICE45_1357N"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_NOVICE47_1359N"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_NYRAS_1303"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_SHRAT_1356"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_TALAS_1300"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_THERON_1372N"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_NOV_VIRAN_1302"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_GORHANIS_1422"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_GORNADRAK_1439"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_GORNADUN_1411"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_GORNARAN_1405"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_GORNATOTH_1402"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_TEMPLAR03_1406"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_TEMPLAR11_1415"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_TEMPLAR12_1416"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_TEMPLAR19_1425"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_TEMPLAR23_1440"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_TEMPLAR24_1441"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_TEMPLAR25_1442"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_TEMPLAR26_1443N"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_TPL_TEMPLAR27_1444N"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_VLK_MELVIN_582"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_WSC_CHANI_1205"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__SC_WSC_NATALIA_1207"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_GOD_SLEEPER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_GUR_MADCORKALOM_1212"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_GUR_MADCORKALOM_1212_TRANCE"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_TPL_GORBOBA_1455"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_UOS_VARRAGARUSHAT"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_UOS_VARRAGHASHOR"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_UOS_VARRAGKASORG"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_UOS_VARRAGRUUUSHK"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_UOS_VARRAGUNHILQT"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__ST_VLK_MUD_SLEEPER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_NON_GILBERT_1500"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_ORG_AIDAN_859"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_ORG_BLACKMAILER_888"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_ORG_JACKO_862"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_ORG_KILLIAN_861"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_ORG_RENYU_860"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_ORG_ROGUE01_1501"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_ORG_ROGUE03_1503"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_OSL_URSHAK_2200"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_STT_CAVALORN_336"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UL_STT_COHSEL_337"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__UNITTEST_UNITTEST_UNITTEST_2203"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__XT_DMB_XARDAS_404"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__XT_DMB_XARDAS_404_SLEEPER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Hero__XT_XARDASDEMON"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108263"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108283"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108325"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108345"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108426"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108446"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108554"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108584"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108688"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_108729"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_109213"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_109233"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_120969"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_120989"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_121136"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_121160"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_122792"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_122812"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_122871"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_122898"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_131370"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_131390"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Huno_131476"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Jacko_82716"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Jacko_82736"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Jan_148274"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Jan_148294"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Jan_148468"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Jan_148488"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Jan_149448"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Jan_149468"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Joru_220456"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Joru_220476"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Krashok_100582"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Krashok_100602"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Krashok_100685"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Krashok_100719"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Krashok_100758"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_112842"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_120948"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_87210"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_87230"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_88238"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_88258"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_88280"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_89030"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_90584"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_90604"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_92460"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_92480"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_93417"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_93437"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lares_94381"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_112620"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_112640"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_112947"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_112967"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_113759"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_114934"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_116319"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_116339"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_116860"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_117620"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_117704"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_118165"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_118178"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_118185"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_118360"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_118459"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_118515"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_118623"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_122831"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_122851"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_123168"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_134211"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_134231"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_136762"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_139122"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_139142"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_139285"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_149865"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_149885"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_149907"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_150585"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_150605"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lee_150950"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lefty_216451"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lefty_216471"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lefty_216497"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lefty_216584"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lefty_216604"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lefty_216672"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_107748"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_107768"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_107790"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_107810"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_109323"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_109343"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_109393"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_110773"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_110793"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_111068"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_111088"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_111110"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_196014"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_196034"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_197063"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_197083"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_226467"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_226487"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_226588"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_226608"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_227076"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_227096"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_82020"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_82040"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_88119"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_88139"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_88327"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_88866"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_88886"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_96509"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_96529"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_98609"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_98629"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Lester_98658"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomST1"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomST1stHeart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomST2"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomST2ndHeart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomST3"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomST3rdHeart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomST4"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomST4Sleeper"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomSTLastHeart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_MadCorKalom_madcorkalomSTLastHeartSl"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1090832"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1091032"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1093672"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1103252"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1103452"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1103672"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1111452"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1114312"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1114512"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_1114732"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_79351"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Melvin_79371"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mercenary11_105274"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mercenary11_105294"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mercenary11_105411"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mercenary11_105540"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_102186"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_102206"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_102228"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_1192180"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_1192200"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_130950"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_131481"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_131501"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_150711"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_150731"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_151616"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_151636"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_289061"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_289081"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_289153"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_302533"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_303260"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_768172"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_866177"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_866197"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_866219"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_89474"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_89494"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_89516"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_89536"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_89556"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_96915"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_96935"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_97156"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_97381"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_97401"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_SleeperMilten01"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_SleeperMilten02"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_SleeperMilten03"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Milten_SleeperMilten04"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mud_221187"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mud_221207"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mud_MudGuide01"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mud_MudGuide02"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mud_MudGuide03"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mud_MudGuide04"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mud_MudGuide05"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Mud_MudGuide06"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Muk_200231"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Muk_200251"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Muk_200278"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Muk_200300"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Myxir_117391"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Myxir_117411"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Myxir_117523"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Myxir_118520"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Myxir_118540"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Myxir_124018"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NC_BAU_MALON_930__NC_BAU_PEASANT19_929"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NC_SLD_GORN_699__SC_NOV_LESTER"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NC_SLD_LEE_700__NC_KDW_SATURAS_600"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NC_SLD_MERCENARY03_705__NC_SLD_TORLOF_737"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NC_SLD_MERCENARY06_708__NC_KDW_CRONOS_604"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NC_SLD_TORLOF_737__NC_ORG_LARES_801"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NOV_SleeperAfterHarpies"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NOV_SleeperAfterOrcs"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NOV_SleeperAfterOrcs_0"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_NOV_SleeperFound"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nefarius_109454"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nefarius_109651"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nefarius_109671"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nefarius_109814"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nefarius_109834"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nefarius_110431"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nefarius_110939"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nefarius_114809"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nyras_90138"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nyras_90158"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nyras_950251"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nyras_950451"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nyras_96583"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Nyras_96603"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OCR_GRD_STONE_219__SC_NOV_DARRION_1312"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OC_EBR_BARTHOLO_106__OC_EBR_RAVEN_105"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OC_EBR_BARTHOLO_106__OC_KDF_DRAGO_403"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OC_KDF_MILTEN__OC_STT_DIEGO"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OC_ORG_MORDRAG_826__UL_ORG_BLACKMAILER_888"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OC_STT_DIEGO__NC_ORG_DRAX_819"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OC_STT_DIEGO__OC_GRD_ORRY_254"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OC_WOC_SERAPHIA_110__OC_WOC_VELAYA_108"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OW_OWORCAxe"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OW_OWORCDontspeak"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OW_OWORCDontyou"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OW_OWORCGrowl"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OW_OWORCMorra"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OW_OWORCTricked"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OW_OWORCWhat"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OW_OWR_TOCHURNAGG_2403__OW_OSM_URNAZKROG_2401"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OrcTempleWarriorM02_106522"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OrcTempleWarriorM02_106542"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OrcTempleWarriorM02_106820"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_OrcTempleWarriorM02_107633"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Orry_109306"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Orry_109326"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Orry_325783"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Orry_325803"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Orry_325938"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Orry_325958"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_129709"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_129773"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_130450"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_130526"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_130678"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_130698"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_130736"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_137885"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_137905"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_138362"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_138382"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_138615"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_147768"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quentin_147788"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_132621"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_132641"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_132765"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_132785"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_132811"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_133021"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_133041"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_133090"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_133131"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_144149"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_OCRankUp1"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_OCRankUp2"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_OCRankUp3"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_OCRankUp4"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_OCRankUp5"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Quest_QuestDreamLand"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_633767"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_633787"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_633831"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_633851"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_633871"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_633891"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_633937"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_633957"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_633997"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634024"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634060"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634090"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634125"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634145"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634167"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634187"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634285"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634324"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634372"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634392"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634414"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634434"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634521"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634541"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634608"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634628"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634688"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634721"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634741"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634775"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_634889"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_635083"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_635150"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_635178"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_635284"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Questdealer_635340"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Raven_89120"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Raven_89140"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Raven_89914"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Raven_93313"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Raven_93333"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Raven_98172"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Raven_98192"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Raven_98725"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Raven_98842"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_79097"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_79117"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_79767"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_81238"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_81258"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_81284"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_81306"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_81326"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_85620"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_85640"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_85901"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rayk_86514"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Renyu_79761"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Renyu_79781"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Renyu_79957"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Renyu_80010"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Riordian_137848"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Riordian_137868"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Riordian_137890"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rodriguez_132981"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rodriguez_133001"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue01_118288"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue01_118308"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue01_118347"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue01_118620"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue01_118640"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue01_118662"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue03_122284"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue03_122304"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue03_122326"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue03_122574"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue03_122594"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue03_122620"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue03_133895"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue03_133915"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue12_ShipmentAttack"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue12_ShipmentAttack_0"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue_113213"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue_113233"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Rogue_113257"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_SC_GUR_CORKALOM_1201__SC_GUR_CORANGAR_1202"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_SC_GUR_CORKALOM_1201__SC_GUR_YBERION_1200"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_SC_GUR_YBERION_1200__OG_GUR_BAALLUKOR_1211"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_SC_NOV_JORU_1305__SC_NOV_VIRAN_1302"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_SC_NOV_NYRAS_1303__SC_GUR_CORKALOM_1201"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_SC_TPL_TEMPLAR03_1406__SC_GUR_CORKALOM_1201"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Santino_110037"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Santino_110057"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Santino_110096"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Santino_110364"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Santino_110384"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Santino_116562"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Santino_116582"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Santino_116774"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Santino_116794"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_100211"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_100439"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_101094"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_101114"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_104009"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_104029"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_106411"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_106653"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_106673"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_111670"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_111690"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_112156"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_113560"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_113580"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_113693"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_113813"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_1192452"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_1192472"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_1192593"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_137190"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_137210"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_137240"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_93575"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_93595"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_99717"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Saturas_99737"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Scorpio_226837"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Scorpio_226857"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Scorpio_227399"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Scorpio_227429"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Seraphia_136773"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Seraphia_136793"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_83249"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_83253"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_83269"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_83273"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_83706"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_84013"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_84484"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_84504"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_85199"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_86719"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_86739"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Silas_86917"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperDiegoEnd"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperGornEnd"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperGornStart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperHarpyTower01"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperHarpyTower02"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperHarpyTower03"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperHarpyTower04"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperHarpyTowerTransit"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperLesterEnd"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperLesterStart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperMiltenEnd"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperMiltenStart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperMine02"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperMine03"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperMineEnd"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperMineStart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperOrcsConver01"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperOrcsConver02"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperOrcsConver03"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperOrcsConver04"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperOrcsConver05"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperOrcsEnd"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperOrcsStart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperXardasEnd"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Sleeper_SleeperXardasStart"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_107853"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_107873"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_108023"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_108073"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_108093"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_108203"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_1082032"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_108223"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_1082232"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_108830"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_108850"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_141404"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_141457"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_141483"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_141503"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_141906"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_142004"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_142024"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_142691"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Snaf_142711"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_112142"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_112162"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_112245"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_112384"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_112404"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_112726"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_112746"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_112813"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_112854"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_113045"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_113065"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_113605"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_113625"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_113919"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_113939"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_114315"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_114896"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115044"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115064"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115120"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115380"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115471"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115491"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115594"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115614"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115682"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115823"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115843"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115932"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_115952"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116044"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116090"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116137"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116157"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116267"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116670"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116690"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116768"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116894"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_116908"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_117141"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_117161"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_117572"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_117592"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_117865"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_117885"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_117981"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_121599"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_121619"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_122023"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_122043"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_122632"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_122998"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_123018"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_123040"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_123060"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_123397"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_123796"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_123966"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_124191"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_124245"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_124265"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_124599"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_124619"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_124757"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_124862"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_124882"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_129141"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_129161"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_129202"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_129485"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_129505"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_130009"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_130029"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_130209"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_181783"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_181803"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_181823"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Stone_227414"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Syra_134812"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Syra_134832"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Syra_135360"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Syra_135380"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Syra_141123"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Syra_142259"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Syra_142279"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Syra_143108"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Syra_143128"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_88151"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_881512"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_88171"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_881712"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_90956"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_93672"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_93692"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_94087"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_94107"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_942102"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_942302"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_95701"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_95756"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_95824"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_96908"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Talas_96928"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Tarrok_101836"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Tarrok_101854"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Tarrok_101856"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Tarrok_107518"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Tarrok_95190"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Tarrok_95387"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_110009"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_110783"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_110803"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_111292"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_85859"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_85879"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_85974"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_88131"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_89160"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar03_89180"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar19_138900"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar19_138920"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar19_138955"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Templar19_138975"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_142392"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_142412"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_142649"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_142669"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_147093"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_147113"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_147162"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_147243"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_149868"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_149888"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_149910"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Theron_150590"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_101373"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_1013732"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_101393"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_1013932"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_102058"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_1020582"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_132189"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_132209"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_132257"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_132285"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_134136"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_134156"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_134242"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_134286"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_134437"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_134457"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_134534"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_134554"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_138375"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_139084"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Thorus_143980"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_ToChurnagg_112143"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_ToChurnagg_112163"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_ToChurnagg_213867"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_ToChurnagg_213887"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_ToChurnagg_213909"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_107861"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_107881"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_108259"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_108279"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_110735"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_110755"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_110785"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_220767"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_220787"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_220875"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_221050"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_221070"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Torrez_221237"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Umakhal_101413"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Umakhal_101433"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Umakhal_104286"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Umakhal_104413"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Umakhal_104433"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Umakhal_105084"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Umakhal_109293"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_UrNazkrog_100814"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_UrNazkrog_100834"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_UrNazkrog_101006"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_UrNazkrog_101100"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_UrNazkrog_105147"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_UrNazkrog_106261"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_UrNazkrog_106486"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_UrNazkrog_108598"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_UrNazkrog_108618"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Velaya_137211"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Velaya_137231"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Velaya_137284"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Viran_137391"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Viran_137411"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Viran_146610"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Viran_146630"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Viran_146959"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Wedge_100053"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Wedge_103790"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Wedge_103810"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Wedge_104126"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Wedge_98969"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_101982"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_102002"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_102228"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_103308"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_107662"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_107682"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_109649"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_109669"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_110066"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_110086"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_110108"
+  },
+  {
+    "category": "topic",
+    "id": "Topic_Xardas_111753"
+  }
+]

--- a/apps/goresave/assets/npc_catalog.json
+++ b/apps/goresave/assets/npc_catalog.json
@@ -1,0 +1,5477 @@
+[
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_AITestDummy",
+    "id": "AITestDummy"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_AM_JuvenileTroll_01",
+    "id": "AM_JuvenileTroll_01"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_AM_Snapper_01",
+    "id": "AM_Snapper_01"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Arlin_852",
+    "id": "BC_BAN_Arlin_852"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_01",
+    "id": "BC_BAN_Bandit_01"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_02",
+    "id": "BC_BAN_Bandit_02"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_03",
+    "id": "BC_BAN_Bandit_03"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_04",
+    "id": "BC_BAN_Bandit_04"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_05",
+    "id": "BC_BAN_Bandit_05"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_06",
+    "id": "BC_BAN_Bandit_06"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_07",
+    "id": "BC_BAN_Bandit_07"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_08",
+    "id": "BC_BAN_Bandit_08"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_09",
+    "id": "BC_BAN_Bandit_09"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_10",
+    "id": "BC_BAN_Bandit_10"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_11",
+    "id": "BC_BAN_Bandit_11"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_12",
+    "id": "BC_BAN_Bandit_12"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_13",
+    "id": "BC_BAN_Bandit_13"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_14",
+    "id": "BC_BAN_Bandit_14"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_15",
+    "id": "BC_BAN_Bandit_15"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_16",
+    "id": "BC_BAN_Bandit_16"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_17",
+    "id": "BC_BAN_Bandit_17"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_18",
+    "id": "BC_BAN_Bandit_18"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_19",
+    "id": "BC_BAN_Bandit_19"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_20",
+    "id": "BC_BAN_Bandit_20"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_21",
+    "id": "BC_BAN_Bandit_21"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_22",
+    "id": "BC_BAN_Bandit_22"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Bandit_23",
+    "id": "BC_BAN_Bandit_23"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Brannok_863",
+    "id": "BC_BAN_Brannok_863"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Quentin_858",
+    "id": "BC_BAN_Quentin_858"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BC_BAN_Torik_864",
+    "id": "BC_BAN_Torik_864"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_BanditCamp_Bandit",
+    "id": "BanditCamp_Bandit"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_Escort01",
+    "id": "CS_Escort01"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_Escort02",
+    "id": "CS_Escort02"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_Escort03",
+    "id": "CS_Escort03"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_Escort04",
+    "id": "CS_Escort04"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_Escort05",
+    "id": "CS_Escort05"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_Escort06",
+    "id": "CS_Escort06"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_FireMage01",
+    "id": "CS_FireMage01"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_HeavyGuard01",
+    "id": "CS_HeavyGuard01"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_Judge",
+    "id": "CS_Judge"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_CS_Velaya",
+    "id": "CS_Velaya"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Character_Scout_Skeleton_Xardas_Sleeper",
+    "id": "Character_Scout_Skeleton_Xardas_Sleeper"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Character_Skeleton_Xardas_Sleeper",
+    "id": "Character_Skeleton_Xardas_Sleeper"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Character_Warrior_Skeleton_Xardas_Sleeper",
+    "id": "Character_Warrior_Skeleton_Xardas_Sleeper"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Creature",
+    "id": "Creature"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_BigMolerat",
+    "id": "Creature_BigMolerat"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Biter",
+    "id": "Creature_Biter"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Biter_Armored",
+    "id": "Creature_Biter_Armored"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Biter_OrcGraveyard",
+    "id": "Creature_Biter_OrcGraveyard"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Biter_Strapped",
+    "id": "Creature_Biter_Strapped"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Bloodfly",
+    "id": "Creature_Bloodfly"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Bloodhound",
+    "id": "Creature_Bloodhound"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_CorKalomDemon_Sleeper",
+    "id": "Creature_CorKalomDemon_Sleeper"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Demon_Fire",
+    "id": "Creature_Demon_Fire"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Demon_Fire_Sleeper",
+    "id": "Creature_Demon_Fire_Sleeper"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Demon_Fire_Sleeper_Ruushk_01",
+    "id": "Creature_Demon_Fire_Sleeper_Ruushk_01"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Demon_Fire_Sleeper_Ruushk_02",
+    "id": "Creature_Demon_Fire_Sleeper_Ruushk_02"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Demon_Fire_Sleeper_Ruushk_03",
+    "id": "Creature_Demon_Fire_Sleeper_Ruushk_03"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Demon_Lesser",
+    "id": "Creature_Demon_Lesser"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Demon_Lesser_VKasorg",
+    "id": "Creature_Demon_Lesser_VKasorg"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Demon_Lord",
+    "id": "Creature_Demon_Lord"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin",
+    "id": "Creature_Goblin"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin_Black",
+    "id": "Creature_Goblin_Black"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin_Black_Mace",
+    "id": "Creature_Goblin_Black_Mace"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin_Black_Torch",
+    "id": "Creature_Goblin_Black_Torch"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin_Green",
+    "id": "Creature_Goblin_Green"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin_Green_Club",
+    "id": "Creature_Goblin_Green_Club"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin_Green_Sword",
+    "id": "Creature_Goblin_Green_Sword"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin_Green_Torch",
+    "id": "Creature_Goblin_Green_Torch"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin_TrollTest",
+    "id": "Creature_Goblin_TrollTest"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Goblin_Warrior",
+    "id": "Creature_Goblin_Warrior"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Golem_Fire",
+    "id": "Creature_Golem_Fire"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Golem_Fire_Test",
+    "id": "Creature_Golem_Fire_Test"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Golem_Ice",
+    "id": "Creature_Golem_Ice"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Golem_IceMini",
+    "id": "Creature_Golem_IceMini"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Golem_Stone",
+    "id": "Creature_Golem_Stone"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Golem_Stone_AncientMonastery",
+    "id": "Creature_Golem_Stone_AncientMonastery"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Golem_Stone_Bridge",
+    "id": "Creature_Golem_Stone_Bridge"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Golem_Stone_Summoned",
+    "id": "Creature_Golem_Stone_Summoned"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Harpy",
+    "id": "Creature_Harpy"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Harpy_Sleeper",
+    "id": "Creature_Harpy_Sleeper"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_JuvenileTroll",
+    "id": "Creature_JuvenileTroll"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Lizard",
+    "id": "Creature_Lizard"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Lizard_Fire",
+    "id": "Creature_Lizard_Fire"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Lizard_Fire_Prime",
+    "id": "Creature_Lizard_Fire_Prime"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Lurker",
+    "id": "Creature_Lurker"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Lurker_Homer",
+    "id": "Creature_Lurker_Homer"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Meatbug",
+    "id": "Creature_Meatbug"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler",
+    "id": "Creature_Minecrawler"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Named",
+    "id": "Creature_Minecrawler_Named"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Nymph",
+    "id": "Creature_Minecrawler_Nymph"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Nymph_Queen",
+    "id": "Creature_Minecrawler_Nymph_Queen"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Queen",
+    "id": "Creature_Minecrawler_Queen"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Queen_Ph2",
+    "id": "Creature_Minecrawler_Queen_Ph2"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Queen_Ph2_Sleeper",
+    "id": "Creature_Minecrawler_Queen_Ph2_Sleeper"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Temple",
+    "id": "Creature_Minecrawler_Temple"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Temple_Sleeper",
+    "id": "Creature_Minecrawler_Temple_Sleeper"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Test",
+    "id": "Creature_Minecrawler_Test"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Wait_Test",
+    "id": "Creature_Minecrawler_Wait_Test"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Warrior",
+    "id": "Creature_Minecrawler_Warrior"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Minecrawler_Warrior_King",
+    "id": "Creature_Minecrawler_Warrior_King"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Molerat",
+    "id": "Creature_Molerat"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_OrcDog",
+    "id": "Creature_OrcDog"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Rat",
+    "id": "Creature_Rat"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Razor",
+    "id": "Creature_Razor"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_SH_ZombieSkeleton",
+    "id": "Creature_SH_ZombieSkeleton"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Scavenger_Adult",
+    "id": "Creature_Scavenger_Adult"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Scavenger_Adult_LayerHits",
+    "id": "Creature_Scavenger_Adult_LayerHits"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Scavenger_Adult_Riding",
+    "id": "Creature_Scavenger_Adult_Riding"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Scavenger_Adult_Riding_Cohsel",
+    "id": "Creature_Scavenger_Adult_Riding_Cohsel"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Scavenger_Medium",
+    "id": "Creature_Scavenger_Medium"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Scavenger_Young",
+    "id": "Creature_Scavenger_Young"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_ShadowBeast",
+    "id": "Creature_ShadowBeast"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_ShadowBeast_Cave",
+    "id": "Creature_ShadowBeast_Cave"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_ShadowBeast_Forest",
+    "id": "Creature_ShadowBeast_Forest"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_ShadowBeast_Frost",
+    "id": "Creature_ShadowBeast_Frost"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_ShadowBeast_Prime",
+    "id": "Creature_ShadowBeast_Prime"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_SkMageSummonedSkeleton",
+    "id": "Creature_SkMageSummonedSkeleton"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton",
+    "id": "Creature_Skeleton"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Base",
+    "id": "Creature_Skeleton_Base"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Mage",
+    "id": "Creature_Skeleton_Mage"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Mage1",
+    "id": "Creature_Skeleton_Mage1"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Mage2",
+    "id": "Creature_Skeleton_Mage2"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Mage3",
+    "id": "Creature_Skeleton_Mage3"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Mage4",
+    "id": "Creature_Skeleton_Mage4"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Scout",
+    "id": "Creature_Skeleton_Scout"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Summon",
+    "id": "Creature_Skeleton_Summon"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Warrior",
+    "id": "Creature_Skeleton_Warrior"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_Warrior_Summon",
+    "id": "Creature_Skeleton_Warrior_Summon"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Skeleton_XardasServant",
+    "id": "Creature_Skeleton_XardasServant"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Snapper",
+    "id": "Creature_Snapper"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Swampshark",
+    "id": "Creature_Swampshark"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Swampshark_Named",
+    "id": "Creature_Swampshark_Named"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Swampshark_Prime",
+    "id": "Creature_Swampshark_Prime"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_TheSleeper",
+    "id": "Creature_TheSleeper"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Troll",
+    "id": "Creature_Troll"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Troll_Adult_Shrinked",
+    "id": "Creature_Troll_Adult_Shrinked"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_VUnhilqtSkeleton",
+    "id": "Creature_VUnhilqtSkeleton"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Wolf",
+    "id": "Creature_Wolf"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Wolf_Alpha",
+    "id": "Creature_Wolf_Alpha"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Wolf_Scary",
+    "id": "Creature_Wolf_Scary"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_XT_XardasDemon",
+    "id": "Creature_XT_XardasDemon"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_XardasDemon",
+    "id": "Creature_XardasDemon"
+  },
+  {
+    "category": "creature",
+    "class": "CharacterDefinition_Creature_Zombie",
+    "id": "Creature_Zombie"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard01_246",
+    "id": "FM_GRD_Guard01_246"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard01_283",
+    "id": "FM_GRD_Guard01_283"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard02_284",
+    "id": "FM_GRD_Guard02_284"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard03_285",
+    "id": "FM_GRD_Guard03_285"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard04_286",
+    "id": "FM_GRD_Guard04_286"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard05_287",
+    "id": "FM_GRD_Guard05_287"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard06_288",
+    "id": "FM_GRD_Guard06_288"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard07_289",
+    "id": "FM_GRD_Guard07_289"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard08_290",
+    "id": "FM_GRD_Guard08_290"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard09_291",
+    "id": "FM_GRD_Guard09_291"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard10_292",
+    "id": "FM_GRD_Guard10_292"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard11_293",
+    "id": "FM_GRD_Guard11_293"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard12_294",
+    "id": "FM_GRD_Guard12_294"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard13_295",
+    "id": "FM_GRD_Guard13_295"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard14_296",
+    "id": "FM_GRD_Guard14_296"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard15_297",
+    "id": "FM_GRD_Guard15_297"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard16_298",
+    "id": "FM_GRD_Guard16_298"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_GRD_Guard17_299",
+    "id": "FM_GRD_Guard17_299"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_ORG_Rogue01_890",
+    "id": "FM_ORG_Rogue01_890"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_ORG_Rogue02_891",
+    "id": "FM_ORG_Rogue02_891"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_ORG_Rogue03_892",
+    "id": "FM_ORG_Rogue03_892"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper01_1030",
+    "id": "FM_SFB_Scraper01_1030"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper02_1031",
+    "id": "FM_SFB_Scraper02_1031"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper03_1032",
+    "id": "FM_SFB_Scraper03_1032"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper04_1033",
+    "id": "FM_SFB_Scraper04_1033"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper05_1034",
+    "id": "FM_SFB_Scraper05_1034"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper06_1035",
+    "id": "FM_SFB_Scraper06_1035"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper07_1036",
+    "id": "FM_SFB_Scraper07_1036"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper08_1038",
+    "id": "FM_SFB_Scraper08_1038"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper09_1039",
+    "id": "FM_SFB_Scraper09_1039"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper10_1040",
+    "id": "FM_SFB_Scraper10_1040"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper11_1041",
+    "id": "FM_SFB_Scraper11_1041"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper12_1042",
+    "id": "FM_SFB_Scraper12_1042"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper13_1043",
+    "id": "FM_SFB_Scraper13_1043"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Scraper14_1044",
+    "id": "FM_SFB_Scraper14_1044"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SFB_Swiney_1037",
+    "id": "FM_SFB_Swiney_1037"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Baloro_753",
+    "id": "FM_SLD_Baloro_753"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary01_750",
+    "id": "FM_SLD_Mercenary01_750"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary02_751",
+    "id": "FM_SLD_Mercenary02_751"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary03_755",
+    "id": "FM_SLD_Mercenary03_755"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary04_756",
+    "id": "FM_SLD_Mercenary04_756"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary05_757",
+    "id": "FM_SLD_Mercenary05_757"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary06_758",
+    "id": "FM_SLD_Mercenary06_758"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary07_759",
+    "id": "FM_SLD_Mercenary07_759"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary08_760",
+    "id": "FM_SLD_Mercenary08_760"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary09_761",
+    "id": "FM_SLD_Mercenary09_761"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary10_762",
+    "id": "FM_SLD_Mercenary10_762"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary11_763",
+    "id": "FM_SLD_Mercenary11_763"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary12_764",
+    "id": "FM_SLD_Mercenary12_764"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Mercenary13_765",
+    "id": "FM_SLD_Mercenary13_765"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_SLD_Okyl_752",
+    "id": "FM_SLD_Okyl_752"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_STT_Shadow01_336",
+    "id": "FM_STT_Shadow01_336"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_STT_Shadow02_337",
+    "id": "FM_STT_Shadow02_337"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_STT_Shadow03_338",
+    "id": "FM_STT_Shadow03_338"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_VLK_Digger01_5001",
+    "id": "FM_VLK_Digger01_5001"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_VLK_Digger02_5002",
+    "id": "FM_VLK_Digger02_5002"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_VLK_Digger03_5003",
+    "id": "FM_VLK_Digger03_5003"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_VLK_Digger04_5004",
+    "id": "FM_VLK_Digger04_5004"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_VLK_Digger05_5005",
+    "id": "FM_VLK_Digger05_5005"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_VLK_Digger06_5006",
+    "id": "FM_VLK_Digger06_5006"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_FM_VLK_Digger07_5007",
+    "id": "FM_VLK_Digger07_5007"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Human",
+    "id": "Human"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Homer_935",
+    "id": "NC_BAU_Homer_935"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Horatio_901",
+    "id": "NC_BAU_Horatio_901"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Jan_942",
+    "id": "NC_BAU_Jan_942"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Jeremiah_912",
+    "id": "NC_BAU_Jeremiah_912"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Malon_930",
+    "id": "NC_BAU_Malon_930"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant01_904",
+    "id": "NC_BAU_Peasant01_904"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant02_905",
+    "id": "NC_BAU_Peasant02_905"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant03_907",
+    "id": "NC_BAU_Peasant03_907"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant04_908",
+    "id": "NC_BAU_Peasant04_908"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant05_914",
+    "id": "NC_BAU_Peasant05_914"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant06_915",
+    "id": "NC_BAU_Peasant06_915"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant07_916",
+    "id": "NC_BAU_Peasant07_916"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant08_917",
+    "id": "NC_BAU_Peasant08_917"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant09_919",
+    "id": "NC_BAU_Peasant09_919"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant10_920",
+    "id": "NC_BAU_Peasant10_920"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant11_921",
+    "id": "NC_BAU_Peasant11_921"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant12_922",
+    "id": "NC_BAU_Peasant12_922"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant13_923",
+    "id": "NC_BAU_Peasant13_923"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant14_924",
+    "id": "NC_BAU_Peasant14_924"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant15_925",
+    "id": "NC_BAU_Peasant15_925"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant16_926",
+    "id": "NC_BAU_Peasant16_926"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant17_927",
+    "id": "NC_BAU_Peasant17_927"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant18_928",
+    "id": "NC_BAU_Peasant18_928"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Peasant19_929",
+    "id": "NC_BAU_Peasant19_929"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Pock_902",
+    "id": "NC_BAU_Pock_902"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Rayk_941",
+    "id": "NC_BAU_Rayk_941"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_RiceLord_900",
+    "id": "NC_BAU_RiceLord_900"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_BAU_Rufus_903",
+    "id": "NC_BAU_Rufus_903"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_KDW_Cronos_604",
+    "id": "NC_KDW_Cronos_604"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_KDW_Merdarion_602",
+    "id": "NC_KDW_Merdarion_602"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_KDW_Myxir_601",
+    "id": "NC_KDW_Myxir_601"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_KDW_Nefarius_603",
+    "id": "NC_KDW_Nefarius_603"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_KDW_Riordian_605",
+    "id": "NC_KDW_Riordian_605"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_KDW_Saturas_600",
+    "id": "NC_KDW_Saturas_600"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_NOV_BaalIsidro_1333",
+    "id": "NC_NOV_BaalIsidro_1333"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_NOV_BaalKagan_1332",
+    "id": "NC_NOV_BaalKagan_1332"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Bouncer01_875",
+    "id": "NC_ORG_Bouncer01_875"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Bouncer02_876",
+    "id": "NC_ORG_Bouncer02_876"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Bruce_828",
+    "id": "NC_ORG_Bruce_828"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Buster_833",
+    "id": "NC_ORG_Buster_833"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Butch_851",
+    "id": "NC_ORG_Butch_851"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Cipher_873",
+    "id": "NC_ORG_Cipher_873"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Drax_819",
+    "id": "NC_ORG_Drax_819"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Lares_801",
+    "id": "NC_ORG_Lares_801"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Lefty_844",
+    "id": "NC_ORG_Lefty_844"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Ratford_818",
+    "id": "NC_ORG_Ratford_818"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue01_800",
+    "id": "NC_ORG_Rogue01_800"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue02_804",
+    "id": "NC_ORG_Rogue02_804"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue03_806",
+    "id": "NC_ORG_Rogue03_806"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue04_807",
+    "id": "NC_ORG_Rogue04_807"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue05_810",
+    "id": "NC_ORG_Rogue05_810"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue06_811",
+    "id": "NC_ORG_Rogue06_811"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue07_815",
+    "id": "NC_ORG_Rogue07_815"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue08_816",
+    "id": "NC_ORG_Rogue08_816"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue09_817",
+    "id": "NC_ORG_Rogue09_817"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue10_820",
+    "id": "NC_ORG_Rogue10_820"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue11_821",
+    "id": "NC_ORG_Rogue11_821"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue12_822",
+    "id": "NC_ORG_Rogue12_822"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue13_823",
+    "id": "NC_ORG_Rogue13_823"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue14_824",
+    "id": "NC_ORG_Rogue14_824"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue15_825",
+    "id": "NC_ORG_Rogue15_825"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue16_829",
+    "id": "NC_ORG_Rogue16_829"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue17_830",
+    "id": "NC_ORG_Rogue17_830"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue18_831",
+    "id": "NC_ORG_Rogue18_831"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue19_832",
+    "id": "NC_ORG_Rogue19_832"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue20_834",
+    "id": "NC_ORG_Rogue20_834"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue21_836",
+    "id": "NC_ORG_Rogue21_836"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue22_837",
+    "id": "NC_ORG_Rogue22_837"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue23_838",
+    "id": "NC_ORG_Rogue23_838"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue24_845",
+    "id": "NC_ORG_Rogue24_845"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue24_846",
+    "id": "NC_ORG_Rogue24_846"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue25_846",
+    "id": "NC_ORG_Rogue25_846"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue26_875",
+    "id": "NC_ORG_Rogue26_875"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue27_876",
+    "id": "NC_ORG_Rogue27_876"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue28_877N",
+    "id": "NC_ORG_Rogue28_877N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue29_878N",
+    "id": "NC_ORG_Rogue29_878N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue30_879N",
+    "id": "NC_ORG_Rogue30_879N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue31_880N",
+    "id": "NC_ORG_Rogue31_880N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue33_882N",
+    "id": "NC_ORG_Rogue33_882N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue34_883N",
+    "id": "NC_ORG_Rogue34_883N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue35_884N",
+    "id": "NC_ORG_Rogue35_884N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue36_885N",
+    "id": "NC_ORG_Rogue36_885N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Rogue37_886N",
+    "id": "NC_ORG_Rogue37_886N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Roscoe_840",
+    "id": "NC_ORG_Roscoe_840"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Sharky_843",
+    "id": "NC_ORG_Sharky_843"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Shrike_842",
+    "id": "NC_ORG_Shrike_842"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Silas_841",
+    "id": "NC_ORG_Silas_841"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Ulmar_881N",
+    "id": "NC_ORG_Ulmar_881N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Wedge_850",
+    "id": "NC_ORG_Wedge_850"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_ORG_Wolf_855",
+    "id": "NC_ORG_Wolf_855"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SFB_Scraper01_1001",
+    "id": "NC_SFB_Scraper01_1001"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SFB_Senyan_1000",
+    "id": "NC_SFB_Senyan_1000"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Blade_704",
+    "id": "NC_SLD_Blade_704"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Cord_709",
+    "id": "NC_SLD_Cord_709"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Gorn_699",
+    "id": "NC_SLD_Gorn_699"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Gorn_699_Sleeper",
+    "id": "NC_SLD_Gorn_699_Sleeper"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Haenno_741",
+    "id": "NC_SLD_Haenno_741"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Jarvis_728",
+    "id": "NC_SLD_Jarvis_728"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Lee_700",
+    "id": "NC_SLD_Lee_700"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary01_702",
+    "id": "NC_SLD_Mercenary01_702"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary02_703",
+    "id": "NC_SLD_Mercenary02_703"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary03_705",
+    "id": "NC_SLD_Mercenary03_705"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary04_706",
+    "id": "NC_SLD_Mercenary04_706"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary05_707",
+    "id": "NC_SLD_Mercenary05_707"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary06_708",
+    "id": "NC_SLD_Mercenary06_708"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary07_710",
+    "id": "NC_SLD_Mercenary07_710"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary08_720",
+    "id": "NC_SLD_Mercenary08_720"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary09_723",
+    "id": "NC_SLD_Mercenary09_723"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary10_725",
+    "id": "NC_SLD_Mercenary10_725"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary11_726",
+    "id": "NC_SLD_Mercenary11_726"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary12_727",
+    "id": "NC_SLD_Mercenary12_727"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary13_730",
+    "id": "NC_SLD_Mercenary13_730"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary14_731",
+    "id": "NC_SLD_Mercenary14_731"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary15_732",
+    "id": "NC_SLD_Mercenary15_732"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary16_733",
+    "id": "NC_SLD_Mercenary16_733"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary17_735",
+    "id": "NC_SLD_Mercenary17_735"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary18_736",
+    "id": "NC_SLD_Mercenary18_736"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary19_738",
+    "id": "NC_SLD_Mercenary19_738"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary20_739N",
+    "id": "NC_SLD_Mercenary20_739N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Mercenary21_740N",
+    "id": "NC_SLD_Mercenary21_740N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Orik_701",
+    "id": "NC_SLD_Orik_701"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NC_SLD_Torlof_737",
+    "id": "NC_SLD_Torlof_737"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NewCamp_Mercenary",
+    "id": "NewCamp_Mercenary"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NewCamp_Peasant",
+    "id": "NewCamp_Peasant"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NewCamp_Rogue",
+    "id": "NewCamp_Rogue"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NewCamp_Scraper",
+    "id": "NewCamp_Scraper"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_NewCamp_WaterMage",
+    "id": "NewCamp_WaterMage"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_OA_Biter_Arena_01",
+    "id": "OA_Biter_Arena_01"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_OA_Lizard_Fire_01",
+    "id": "OA_Lizard_Fire_01"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_Bloodwyn_233",
+    "id": "OCR_GRD_Bloodwyn_233"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_Bullit_203",
+    "id": "OCR_GRD_Bullit_203"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_Cutter_208",
+    "id": "OCR_GRD_Cutter_208"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_GateGuard01_212",
+    "id": "OCR_GRD_GateGuard01_212"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_GateGuard02_213",
+    "id": "OCR_GRD_GateGuard02_213"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_GateGuard03_214",
+    "id": "OCR_GRD_GateGuard03_214"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_GateGuard04_215",
+    "id": "OCR_GRD_GateGuard04_215"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_GateGuard05_216",
+    "id": "OCR_GRD_GateGuard05_216"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_GateGuard06_217",
+    "id": "OCR_GRD_GateGuard06_217"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_Scatty_210",
+    "id": "OCR_GRD_Scatty_210"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_Skip_211",
+    "id": "OCR_GRD_Skip_211"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OCR_GRD_Stone_219",
+    "id": "OCR_GRD_Stone_219"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_EBR_Arto_102",
+    "id": "OC_EBR_Arto_102"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_EBR_Bartholo_106",
+    "id": "OC_EBR_Bartholo_106"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_EBR_Gomez_100",
+    "id": "OC_EBR_Gomez_100"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_EBR_Raven_105",
+    "id": "OC_EBR_Raven_105"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_EBR_Scar_101",
+    "id": "OC_EBR_Scar_101"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_BridgeGuard01_275",
+    "id": "OC_GRD_BridgeGuard01_275"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_BridgeGuard02_276",
+    "id": "OC_GRD_BridgeGuard02_276"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Fletcher_255",
+    "id": "OC_GRD_Fletcher_255"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard01_204",
+    "id": "OC_GRD_Guard01_204"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard02_206",
+    "id": "OC_GRD_Guard02_206"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard03_209",
+    "id": "OC_GRD_Guard03_209"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard04_218",
+    "id": "OC_GRD_Guard04_218"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard05_220",
+    "id": "OC_GRD_Guard05_220"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard06_221",
+    "id": "OC_GRD_Guard06_221"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard07_222",
+    "id": "OC_GRD_Guard07_222"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard08_223",
+    "id": "OC_GRD_Guard08_223"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard09_225",
+    "id": "OC_GRD_Guard09_225"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard10_226",
+    "id": "OC_GRD_Guard10_226"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard11_227",
+    "id": "OC_GRD_Guard11_227"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard12_228",
+    "id": "OC_GRD_Guard12_228"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard13_229",
+    "id": "OC_GRD_Guard13_229"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard14_230",
+    "id": "OC_GRD_Guard14_230"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard15_231",
+    "id": "OC_GRD_Guard15_231"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard16_232",
+    "id": "OC_GRD_Guard16_232"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard17_237",
+    "id": "OC_GRD_Guard17_237"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard18_238",
+    "id": "OC_GRD_Guard18_238"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard19_239",
+    "id": "OC_GRD_Guard19_239"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard20_240",
+    "id": "OC_GRD_Guard20_240"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard21_241",
+    "id": "OC_GRD_Guard21_241"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard22_242",
+    "id": "OC_GRD_Guard22_242"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard23_243",
+    "id": "OC_GRD_Guard23_243"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard24_244",
+    "id": "OC_GRD_Guard24_244"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard25_245",
+    "id": "OC_GRD_Guard25_245"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard26_252",
+    "id": "OC_GRD_Guard26_252"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard27_253",
+    "id": "OC_GRD_Guard27_253"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard28_265",
+    "id": "OC_GRD_Guard28_265"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard29_279",
+    "id": "OC_GRD_Guard29_279"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard30_280",
+    "id": "OC_GRD_Guard30_280"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard30_281N",
+    "id": "OC_GRD_Guard30_281N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard30_282N",
+    "id": "OC_GRD_Guard30_282N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard31_283N",
+    "id": "OC_GRD_Guard31_283N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard32_284N",
+    "id": "OC_GRD_Guard32_284N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard33_285N",
+    "id": "OC_GRD_Guard33_285N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard34_286N",
+    "id": "OC_GRD_Guard34_286N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard35_287N",
+    "id": "OC_GRD_Guard35_287N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard36_288N",
+    "id": "OC_GRD_Guard36_288N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard37_289N",
+    "id": "OC_GRD_Guard37_289N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard38_290N",
+    "id": "OC_GRD_Guard38_290N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard39_291N",
+    "id": "OC_GRD_Guard39_291N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard40_292N",
+    "id": "OC_GRD_Guard40_292N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard41_293N",
+    "id": "OC_GRD_Guard41_293N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard42_294N",
+    "id": "OC_GRD_Guard42_294N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Guard43_295N",
+    "id": "OC_GRD_Guard43_295N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Jackal_201",
+    "id": "OC_GRD_Jackal_201"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Kirgo_251",
+    "id": "OC_GRD_Kirgo_251"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Nek_282",
+    "id": "OC_GRD_Nek_282"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Orry_254",
+    "id": "OC_GRD_Orry_254"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Pacho_224",
+    "id": "OC_GRD_Pacho_224"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Scorpio_205",
+    "id": "OC_GRD_Scorpio_205"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_GRD_Thorus_200",
+    "id": "OC_GRD_Thorus_200"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_IE_Charlotte",
+    "id": "OC_IE_Charlotte"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_IE_DrPymonte",
+    "id": "OC_IE_DrPymonte"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_IE_Flex",
+    "id": "OC_IE_Flex"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_IE_Lutter",
+    "id": "OC_IE_Lutter"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_IE_Specki_1401",
+    "id": "OC_IE_Specki_1401"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_IE_Steve",
+    "id": "OC_IE_Steve"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_IE_Unicorn",
+    "id": "OC_IE_Unicorn"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_IE_VanLange_1400",
+    "id": "OC_IE_VanLange_1400"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_KDF_Corristo_402",
+    "id": "OC_KDF_Corristo_402"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_KDF_Damarok_401",
+    "id": "OC_KDF_Damarok_401"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_KDF_Drago_403",
+    "id": "OC_KDF_Drago_403"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_KDF_Milten",
+    "id": "OC_KDF_Milten"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_KDF_Milten_Sleeper",
+    "id": "OC_KDF_Milten_Sleeper"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_KDF_Rodriguez_400",
+    "id": "OC_KDF_Rodriguez_400"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_KDF_Torrez_405",
+    "id": "OC_KDF_Torrez_405"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_NOV_BaalParvez_1330",
+    "id": "OC_NOV_BaalParvez_1330"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_NOV_BaalTaran_1331",
+    "id": "OC_NOV_BaalTaran_1331"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_ORG_Mordrag_826",
+    "id": "OC_ORG_Mordrag_826"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_SLD_Kharim_729",
+    "id": "OC_SLD_Kharim_729"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Balam_324",
+    "id": "OC_STT_Balam_324"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Dexter_329",
+    "id": "OC_STT_Dexter_329"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Diego",
+    "id": "OC_STT_Diego"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Diego_Sleeper",
+    "id": "OC_STT_Diego_Sleeper"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Fingers_331",
+    "id": "OC_STT_Fingers_331"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Fisk_311",
+    "id": "OC_STT_Fisk_311"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Omid_325",
+    "id": "OC_STT_Omid_325"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow01_304",
+    "id": "OC_STT_Shadow01_304"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow02_306",
+    "id": "OC_STT_Shadow02_306"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow03_310",
+    "id": "OC_STT_Shadow03_310"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow04_313",
+    "id": "OC_STT_Shadow04_313"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow05_314",
+    "id": "OC_STT_Shadow05_314"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow06_316",
+    "id": "OC_STT_Shadow06_316"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow07_318",
+    "id": "OC_STT_Shadow07_318"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow08_319",
+    "id": "OC_STT_Shadow08_319"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow09_322",
+    "id": "OC_STT_Shadow09_322"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow10_328",
+    "id": "OC_STT_Shadow10_328"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Shadow11_330",
+    "id": "OC_STT_Shadow11_330"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Sly_315",
+    "id": "OC_STT_Sly_315"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_STT_Whistler_309",
+    "id": "OC_STT_Whistler_309"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger01_501",
+    "id": "OC_VLK_Digger01_501"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger02_502",
+    "id": "OC_VLK_Digger02_502"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger03_503",
+    "id": "OC_VLK_Digger03_503"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger04_504",
+    "id": "OC_VLK_Digger04_504"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger05_505",
+    "id": "OC_VLK_Digger05_505"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger06_506",
+    "id": "OC_VLK_Digger06_506"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger07_507",
+    "id": "OC_VLK_Digger07_507"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger08_508",
+    "id": "OC_VLK_Digger08_508"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger09_509",
+    "id": "OC_VLK_Digger09_509"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger10_510",
+    "id": "OC_VLK_Digger10_510"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger11_512",
+    "id": "OC_VLK_Digger11_512"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger12_513",
+    "id": "OC_VLK_Digger12_513"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger13_514",
+    "id": "OC_VLK_Digger13_514"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger14_515",
+    "id": "OC_VLK_Digger14_515"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger15_516",
+    "id": "OC_VLK_Digger15_516"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger16_517",
+    "id": "OC_VLK_Digger16_517"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger17_519",
+    "id": "OC_VLK_Digger17_519"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger18_520",
+    "id": "OC_VLK_Digger18_520"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger19_521",
+    "id": "OC_VLK_Digger19_521"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger20_522",
+    "id": "OC_VLK_Digger20_522"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger21_523",
+    "id": "OC_VLK_Digger21_523"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger22_526",
+    "id": "OC_VLK_Digger22_526"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger23_527",
+    "id": "OC_VLK_Digger23_527"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger24_528",
+    "id": "OC_VLK_Digger24_528"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger25_529",
+    "id": "OC_VLK_Digger25_529"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger26_531",
+    "id": "OC_VLK_Digger26_531"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger27_532",
+    "id": "OC_VLK_Digger27_532"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger28_533",
+    "id": "OC_VLK_Digger28_533"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger29_534",
+    "id": "OC_VLK_Digger29_534"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger30_535",
+    "id": "OC_VLK_Digger30_535"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger31_553",
+    "id": "OC_VLK_Digger31_553"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger32_554",
+    "id": "OC_VLK_Digger32_554"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger33_555",
+    "id": "OC_VLK_Digger33_555"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger34_556",
+    "id": "OC_VLK_Digger34_556"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger35_557",
+    "id": "OC_VLK_Digger35_557"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger36_560",
+    "id": "OC_VLK_Digger36_560"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger37_561",
+    "id": "OC_VLK_Digger37_561"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger38_565",
+    "id": "OC_VLK_Digger38_565"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger39_575",
+    "id": "OC_VLK_Digger39_575"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger40_576",
+    "id": "OC_VLK_Digger40_576"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger41_577",
+    "id": "OC_VLK_Digger41_577"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger42_578",
+    "id": "OC_VLK_Digger42_578"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger43_579N",
+    "id": "OC_VLK_Digger43_579N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Digger44_580N",
+    "id": "OC_VLK_Digger44_580N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Diggerfan01",
+    "id": "OC_VLK_Diggerfan01"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Diggerfan02",
+    "id": "OC_VLK_Diggerfan02"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Diggerfan03",
+    "id": "OC_VLK_Diggerfan03"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Diggerfan04",
+    "id": "OC_VLK_Diggerfan04"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Dusty_524",
+    "id": "OC_VLK_Dusty_524"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Graham_573",
+    "id": "OC_VLK_Graham_573"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Gravo_572",
+    "id": "OC_VLK_Gravo_572"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Grim_580",
+    "id": "OC_VLK_Grim_580"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Guy_530",
+    "id": "OC_VLK_Guy_530"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Herek_511",
+    "id": "OC_VLK_Herek_511"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Huno_538",
+    "id": "OC_VLK_Huno_538"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Jesse_564",
+    "id": "OC_VLK_Jesse_564"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Kyle_536",
+    "id": "OC_VLK_Kyle_536"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Mud_574",
+    "id": "OC_VLK_Mud_574"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_VLK_Snaf_581",
+    "id": "OC_VLK_Snaf_581"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_WOC_Prisoner01_111",
+    "id": "OC_WOC_Prisoner01_111"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_WOC_Prisoner02_112",
+    "id": "OC_WOC_Prisoner02_112"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_WOC_Seraphia_110",
+    "id": "OC_WOC_Seraphia_110"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_WOC_Syra_109",
+    "id": "OC_WOC_Syra_109"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OC_WOC_Velaya_108",
+    "id": "OC_WOC_Velaya_108"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OG_GUR_BaalLukor_1211",
+    "id": "OG_GUR_BaalLukor_1211"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OG_TPL_GorNaZar_1446",
+    "id": "OG_TPL_GorNaZar_1446"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OG_TPL_Templar01_1443",
+    "id": "OG_TPL_Templar01_1443"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OG_TPL_Templar02_1444",
+    "id": "OG_TPL_Templar02_1444"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OG_TPL_Templar03_1445",
+    "id": "OG_TPL_Templar03_1445"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OG_TPL_Templar05_1463",
+    "id": "OG_TPL_Templar05_1463"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Aaron_262",
+    "id": "OM_GRD_Aaron_262"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Asghan_263",
+    "id": "OM_GRD_Asghan_263"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Brandick_261",
+    "id": "OM_GRD_Brandick_261"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Drake_260",
+    "id": "OM_GRD_Drake_260"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard01_234",
+    "id": "OM_GRD_Guard01_234"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard02_235",
+    "id": "OM_GRD_Guard02_235"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard03_236",
+    "id": "OM_GRD_Guard03_236"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard05_264",
+    "id": "OM_GRD_Guard05_264"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard06_266",
+    "id": "OM_GRD_Guard06_266"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard07_267",
+    "id": "OM_GRD_Guard07_267"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard08_268",
+    "id": "OM_GRD_Guard08_268"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard09_269",
+    "id": "OM_GRD_Guard09_269"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard10_272",
+    "id": "OM_GRD_Guard10_272"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard11_273",
+    "id": "OM_GRD_Guard11_273"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard12_277",
+    "id": "OM_GRD_Guard12_277"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard13_278",
+    "id": "OM_GRD_Guard13_278"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard13_280",
+    "id": "OM_GRD_Guard13_280"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Guard14_281N",
+    "id": "OM_GRD_Guard14_281N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_GRD_Ulbert_271",
+    "id": "OM_GRD_Ulbert_271"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_SC_TPL_Templar03_1436",
+    "id": "OM_SC_TPL_Templar03_1436"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_SC_TPL_Templar04_1437",
+    "id": "OM_SC_TPL_Templar04_1437"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_SC_TPL_Templar05_1438",
+    "id": "OM_SC_TPL_Templar05_1438"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_STT_Alberto_300",
+    "id": "OM_STT_Alberto_300"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_STT_Ian_301",
+    "id": "OM_STT_Ian_301"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_STT_Santino_335",
+    "id": "OM_STT_Santino_335"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_STT_Viper_302",
+    "id": "OM_STT_Viper_302"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_TPL_GorNaBar_1400",
+    "id": "OM_TPL_GorNaBar_1400"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_TPL_GorNaKosh_1401",
+    "id": "OM_TPL_GorNaKosh_1401"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_TPL_GorNaVid_1433",
+    "id": "OM_TPL_GorNaVid_1433"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Aleph_585",
+    "id": "OM_VLK_Aleph_585"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger01_518",
+    "id": "OM_VLK_Digger01_518"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger02_525",
+    "id": "OM_VLK_Digger02_525"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger03_539",
+    "id": "OM_VLK_Digger03_539"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger04_540",
+    "id": "OM_VLK_Digger04_540"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger05_541",
+    "id": "OM_VLK_Digger05_541"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger06_542",
+    "id": "OM_VLK_Digger06_542"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger07_543",
+    "id": "OM_VLK_Digger07_543"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger08_544",
+    "id": "OM_VLK_Digger08_544"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger09_545",
+    "id": "OM_VLK_Digger09_545"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger10_546",
+    "id": "OM_VLK_Digger10_546"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger11_547",
+    "id": "OM_VLK_Digger11_547"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger12_548",
+    "id": "OM_VLK_Digger12_548"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger13_549",
+    "id": "OM_VLK_Digger13_549"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger14_550",
+    "id": "OM_VLK_Digger14_550"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger15_551",
+    "id": "OM_VLK_Digger15_551"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger16_558",
+    "id": "OM_VLK_Digger16_558"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger17_559",
+    "id": "OM_VLK_Digger17_559"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger18_562",
+    "id": "OM_VLK_Digger18_562"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger19_563",
+    "id": "OM_VLK_Digger19_563"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger20_566",
+    "id": "OM_VLK_Digger20_566"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger21_567",
+    "id": "OM_VLK_Digger21_567"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger22_571",
+    "id": "OM_VLK_Digger22_571"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger23_579",
+    "id": "OM_VLK_Digger23_579"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger24_588",
+    "id": "OM_VLK_Digger24_588"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger25_589",
+    "id": "OM_VLK_Digger25_589"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger26_590",
+    "id": "OM_VLK_Digger26_590"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger27_591",
+    "id": "OM_VLK_Digger27_591"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger28_592",
+    "id": "OM_VLK_Digger28_592"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger29_593",
+    "id": "OM_VLK_Digger29_593"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger30_1045N",
+    "id": "OM_VLK_Digger30_1045N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger31_1046N",
+    "id": "OM_VLK_Digger31_1046N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger32_1047N",
+    "id": "OM_VLK_Digger32_1047N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger33_1048N",
+    "id": "OM_VLK_Digger33_1048N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger34_1049N",
+    "id": "OM_VLK_Digger34_1049N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger35_1050N",
+    "id": "OM_VLK_Digger35_1050N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger36_1051N",
+    "id": "OM_VLK_Digger36_1051N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger37_1052N",
+    "id": "OM_VLK_Digger37_1052N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger38_1053N",
+    "id": "OM_VLK_Digger38_1053N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Digger39_1054N",
+    "id": "OM_VLK_Digger39_1054N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Garp_587",
+    "id": "OM_VLK_Garp_587"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Glen_583",
+    "id": "OM_VLK_Glen_583"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Grimes_586",
+    "id": "OM_VLK_Grimes_586"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OM_VLK_Snipes_584",
+    "id": "OM_VLK_Snipes_584"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OldCamp_Digger",
+    "id": "OldCamp_Digger"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OldCamp_FireMage",
+    "id": "OldCamp_FireMage"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OldCamp_Guard",
+    "id": "OldCamp_Guard"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OldCamp_OreBaron",
+    "id": "OldCamp_OreBaron"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OldCamp_Shadow",
+    "id": "OldCamp_Shadow"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_OldCamp_WomanSlave",
+    "id": "OldCamp_WomanSlave"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc",
+    "id": "Orc"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_OrcFemale",
+    "id": "OrcFemale"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_OrcShaman",
+    "id": "OrcShaman"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_OrcUndead",
+    "id": "OrcUndead"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_OrcUndead_Varrag",
+    "id": "OrcUndead_Varrag"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_OrcWorld",
+    "id": "OrcWorld"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_AM_UOW_UndeadOrcTempleGuard01_3032",
+    "id": "Orc_AM_UOW_UndeadOrcTempleGuard01_3032"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_Blacksmith",
+    "id": "Orc_Blacksmith"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_FM_OSL_OrcSlave01_6001",
+    "id": "Orc_FM_OSL_OrcSlave01_6001"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_FM_OSL_Tarrok_2001",
+    "id": "Orc_FM_OSL_Tarrok_2001"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OBL_OrcBlacksmith01_2063",
+    "id": "Orc_OW_OBL_OrcBlacksmith01_2063"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_Muk_2404",
+    "id": "Orc_OW_OPS_Muk_2404"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM01_2068",
+    "id": "Orc_OW_OPS_OrcPeasantM01_2068"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM02_2069",
+    "id": "Orc_OW_OPS_OrcPeasantM02_2069"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM03_2070",
+    "id": "Orc_OW_OPS_OrcPeasantM03_2070"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM04_2071",
+    "id": "Orc_OW_OPS_OrcPeasantM04_2071"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM05_2072",
+    "id": "Orc_OW_OPS_OrcPeasantM05_2072"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM06_2073",
+    "id": "Orc_OW_OPS_OrcPeasantM06_2073"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM07_2074",
+    "id": "Orc_OW_OPS_OrcPeasantM07_2074"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM08_2075",
+    "id": "Orc_OW_OPS_OrcPeasantM08_2075"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM09_2076",
+    "id": "Orc_OW_OPS_OrcPeasantM09_2076"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM10_2077",
+    "id": "Orc_OW_OPS_OrcPeasantM10_2077"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM11_2078",
+    "id": "Orc_OW_OPS_OrcPeasantM11_2078"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM12_2079",
+    "id": "Orc_OW_OPS_OrcPeasantM12_2079"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM13_2080",
+    "id": "Orc_OW_OPS_OrcPeasantM13_2080"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM14_2081",
+    "id": "Orc_OW_OPS_OrcPeasantM14_2081"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM15_2082",
+    "id": "Orc_OW_OPS_OrcPeasantM15_2082"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM16_2083",
+    "id": "Orc_OW_OPS_OrcPeasantM16_2083"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM17_2084",
+    "id": "Orc_OW_OPS_OrcPeasantM17_2084"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM18_2085",
+    "id": "Orc_OW_OPS_OrcPeasantM18_2085"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM19_2086",
+    "id": "Orc_OW_OPS_OrcPeasantM19_2086"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM20_2087",
+    "id": "Orc_OW_OPS_OrcPeasantM20_2087"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM21_2088",
+    "id": "Orc_OW_OPS_OrcPeasantM21_2088"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM22_2089",
+    "id": "Orc_OW_OPS_OrcPeasantM22_2089"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM23_2090",
+    "id": "Orc_OW_OPS_OrcPeasantM23_2090"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM24_2091",
+    "id": "Orc_OW_OPS_OrcPeasantM24_2091"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM25_2092",
+    "id": "Orc_OW_OPS_OrcPeasantM25_2092"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM26_2093",
+    "id": "Orc_OW_OPS_OrcPeasantM26_2093"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM27_2094",
+    "id": "Orc_OW_OPS_OrcPeasantM27_2094"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM28_2095",
+    "id": "Orc_OW_OPS_OrcPeasantM28_2095"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM29_2096",
+    "id": "Orc_OW_OPS_OrcPeasantM29_2096"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM30_2097",
+    "id": "Orc_OW_OPS_OrcPeasantM30_2097"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_OrcPeasantM31_2098",
+    "id": "Orc_OW_OPS_OrcPeasantM31_2098"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OPS_Umakhal_2402",
+    "id": "Orc_OW_OPS_Umakhal_2402"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcHunterM01_2059",
+    "id": "Orc_OW_OSC_OrcHunterM01_2059"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcHunterM02_2060",
+    "id": "Orc_OW_OSC_OrcHunterM02_2060"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcHunterM03_2061",
+    "id": "Orc_OW_OSC_OrcHunterM03_2061"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcHunterM04_2062",
+    "id": "Orc_OW_OSC_OrcHunterM04_2062"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM01_2021",
+    "id": "Orc_OW_OSC_OrcScoutM01_2021"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM02_2099",
+    "id": "Orc_OW_OSC_OrcScoutM02_2099"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM03_2100",
+    "id": "Orc_OW_OSC_OrcScoutM03_2100"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM04_2101",
+    "id": "Orc_OW_OSC_OrcScoutM04_2101"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM05_2102",
+    "id": "Orc_OW_OSC_OrcScoutM05_2102"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM06_2103",
+    "id": "Orc_OW_OSC_OrcScoutM06_2103"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM07_2104",
+    "id": "Orc_OW_OSC_OrcScoutM07_2104"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM08_2105",
+    "id": "Orc_OW_OSC_OrcScoutM08_2105"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM09_2106",
+    "id": "Orc_OW_OSC_OrcScoutM09_2106"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM10_2107",
+    "id": "Orc_OW_OSC_OrcScoutM10_2107"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM11_2108",
+    "id": "Orc_OW_OSC_OrcScoutM11_2108"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM12_2109",
+    "id": "Orc_OW_OSC_OrcScoutM12_2109"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM13_2111",
+    "id": "Orc_OW_OSC_OrcScoutM13_2111"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM14_2112",
+    "id": "Orc_OW_OSC_OrcScoutM14_2112"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM15_2113",
+    "id": "Orc_OW_OSC_OrcScoutM15_2113"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM16_2114",
+    "id": "Orc_OW_OSC_OrcScoutM16_2114"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM17_2115",
+    "id": "Orc_OW_OSC_OrcScoutM17_2115"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM18_2116",
+    "id": "Orc_OW_OSC_OrcScoutM18_2116"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM19_2117",
+    "id": "Orc_OW_OSC_OrcScoutM19_2117"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM20_2118",
+    "id": "Orc_OW_OSC_OrcScoutM20_2118"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM21_2204",
+    "id": "Orc_OW_OSC_OrcScoutM21_2204"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM22_2205",
+    "id": "Orc_OW_OSC_OrcScoutM22_2205"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM23_2206",
+    "id": "Orc_OW_OSC_OrcScoutM23_2206"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSC_OrcScoutM24_2207",
+    "id": "Orc_OW_OSC_OrcScoutM24_2207"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSM_OrcShamanM01_2064",
+    "id": "Orc_OW_OSM_OrcShamanM01_2064"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSM_OrcShamanM02_2065",
+    "id": "Orc_OW_OSM_OrcShamanM02_2065"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSM_OrcShamanM03_2066",
+    "id": "Orc_OW_OSM_OrcShamanM03_2066"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSM_OrcShamanM04_2067",
+    "id": "Orc_OW_OSM_OrcShamanM04_2067"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OSM_UrNazkrog_2401",
+    "id": "Orc_OW_OSM_UrNazkrog_2401"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_Chokta_2407",
+    "id": "Orc_OW_OWR_Chokta_2407"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_Grazkrak_2400",
+    "id": "Orc_OW_OWR_Grazkrak_2400"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_Krashok_2405",
+    "id": "Orc_OW_OWR_Krashok_2405"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcClanWarriorM01_2027",
+    "id": "Orc_OW_OWR_OrcClanWarriorM01_2027"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcClanWarriorM02_2034",
+    "id": "Orc_OW_OWR_OrcClanWarriorM02_2034"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcClanWarriorM03_2049",
+    "id": "Orc_OW_OWR_OrcClanWarriorM03_2049"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcClanWarriorM04_2050",
+    "id": "Orc_OW_OWR_OrcClanWarriorM04_2050"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM01_2003",
+    "id": "Orc_OW_OWR_OrcFighterM01_2003"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM02_2004",
+    "id": "Orc_OW_OWR_OrcFighterM02_2004"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM03_2005",
+    "id": "Orc_OW_OWR_OrcFighterM03_2005"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM04_2007",
+    "id": "Orc_OW_OWR_OrcFighterM04_2007"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM05_2008",
+    "id": "Orc_OW_OWR_OrcFighterM05_2008"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM06_2009",
+    "id": "Orc_OW_OWR_OrcFighterM06_2009"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM07_2011",
+    "id": "Orc_OW_OWR_OrcFighterM07_2011"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM08_2012",
+    "id": "Orc_OW_OWR_OrcFighterM08_2012"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM09_2013",
+    "id": "Orc_OW_OWR_OrcFighterM09_2013"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM10_2017",
+    "id": "Orc_OW_OWR_OrcFighterM10_2017"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM11_2018",
+    "id": "Orc_OW_OWR_OrcFighterM11_2018"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM12_2019",
+    "id": "Orc_OW_OWR_OrcFighterM12_2019"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM13_2053",
+    "id": "Orc_OW_OWR_OrcFighterM13_2053"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM14_2055",
+    "id": "Orc_OW_OWR_OrcFighterM14_2055"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM15_2056",
+    "id": "Orc_OW_OWR_OrcFighterM15_2056"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM16_2057",
+    "id": "Orc_OW_OWR_OrcFighterM16_2057"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcFighterM17_2058",
+    "id": "Orc_OW_OWR_OrcFighterM17_2058"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM01_2041",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM01_2041"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM02_2042",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM02_2042"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM03_2043",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM03_2043"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM04_2044",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM04_2044"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM05_2045",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM05_2045"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM06_2046",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM06_2046"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM07_2047",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM07_2047"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM08_2048",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM08_2048"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM09_2201",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM09_2201"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM10_2202",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM10_2202"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcTempleWarriorM11_2203",
+    "id": "Orc_OW_OWR_OrcTempleWarriorM11_2203"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM01_2001",
+    "id": "Orc_OW_OWR_OrcWarriorM01_2001"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM02_2002",
+    "id": "Orc_OW_OWR_OrcWarriorM02_2002"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM03_2006",
+    "id": "Orc_OW_OWR_OrcWarriorM03_2006"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM04_2010",
+    "id": "Orc_OW_OWR_OrcWarriorM04_2010"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM05_2014",
+    "id": "Orc_OW_OWR_OrcWarriorM05_2014"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM06_2015",
+    "id": "Orc_OW_OWR_OrcWarriorM06_2015"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM07_2016",
+    "id": "Orc_OW_OWR_OrcWarriorM07_2016"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM08_2020",
+    "id": "Orc_OW_OWR_OrcWarriorM08_2020"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM09_2022",
+    "id": "Orc_OW_OWR_OrcWarriorM09_2022"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM10_2023",
+    "id": "Orc_OW_OWR_OrcWarriorM10_2023"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM11_2024",
+    "id": "Orc_OW_OWR_OrcWarriorM11_2024"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM12_2025",
+    "id": "Orc_OW_OWR_OrcWarriorM12_2025"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM13_2026",
+    "id": "Orc_OW_OWR_OrcWarriorM13_2026"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM14_2028",
+    "id": "Orc_OW_OWR_OrcWarriorM14_2028"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM15_2029",
+    "id": "Orc_OW_OWR_OrcWarriorM15_2029"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM16_2030",
+    "id": "Orc_OW_OWR_OrcWarriorM16_2030"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM17_2031",
+    "id": "Orc_OW_OWR_OrcWarriorM17_2031"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM18_2032",
+    "id": "Orc_OW_OWR_OrcWarriorM18_2032"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM19_2033",
+    "id": "Orc_OW_OWR_OrcWarriorM19_2033"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM20_2035",
+    "id": "Orc_OW_OWR_OrcWarriorM20_2035"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM21_2036",
+    "id": "Orc_OW_OWR_OrcWarriorM21_2036"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM22_2037",
+    "id": "Orc_OW_OWR_OrcWarriorM22_2037"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM23_2038",
+    "id": "Orc_OW_OWR_OrcWarriorM23_2038"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM24_2039",
+    "id": "Orc_OW_OWR_OrcWarriorM24_2039"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM25_2040",
+    "id": "Orc_OW_OWR_OrcWarriorM25_2040"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM26_2051",
+    "id": "Orc_OW_OWR_OrcWarriorM26_2051"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM27_2052",
+    "id": "Orc_OW_OWR_OrcWarriorM27_2052"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM28_2054",
+    "id": "Orc_OW_OWR_OrcWarriorM28_2054"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_OrcWarriorM29_2110",
+    "id": "Orc_OW_OWR_OrcWarriorM29_2110"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_ToChurnagg_2403",
+    "id": "Orc_OW_OWR_ToChurnagg_2403"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_OW_OWR_Umosh_2406",
+    "id": "Orc_OW_OWR_Umosh_2406"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_PeasantM",
+    "id": "Orc_PeasantM"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOS_VarragArushat",
+    "id": "Orc_ST_UOS_VarragArushat"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOS_VarragHashor",
+    "id": "Orc_ST_UOS_VarragHashor"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOS_VarragKasorg",
+    "id": "Orc_ST_UOS_VarragKasorg"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOS_VarragRuuushk",
+    "id": "Orc_ST_UOS_VarragRuuushk"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOS_VarragUnhilqt",
+    "id": "Orc_ST_UOS_VarragUnhilqt"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard01_3016",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard01_3016"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard02_3017",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard02_3017"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard03_3018",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard03_3018"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard04_3019",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard04_3019"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard05_3020",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard05_3020"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard06_3021",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard06_3021"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard07_3022",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard07_3022"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard08_3023",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard08_3023"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard09_3024",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard09_3024"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard10_3025",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard10_3025"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard11_3026",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard11_3026"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard12_3027",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard12_3027"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard13_3028",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard13_3028"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard14_3029",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard14_3029"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard15_3030",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard15_3030"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcHighTempleGuard16_3031",
+    "id": "Orc_ST_UOW_UndeadOrcHighTempleGuard16_3031"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard01_3000",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard01_3000"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard02_3001",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard02_3001"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard03_3002",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard03_3002"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard04_3003",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard04_3003"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard05_3004",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard05_3004"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard06_3005",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard06_3005"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard07_3006",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard07_3006"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard08_3007",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard08_3007"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard09_3008",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard09_3008"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard10_3009",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard10_3009"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard11_3010",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard11_3010"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard12_3011",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard12_3011"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard13_3012",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard13_3012"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard14_3013",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard14_3013"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard15_3014",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard15_3014"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard16_3015",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard16_3015"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ST_UOW_UndeadOrcTempleGuard17_3033",
+    "id": "Orc_ST_UOW_UndeadOrcTempleGuard17_3033"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ScoutM",
+    "id": "Orc_ScoutM"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ShamanF",
+    "id": "Orc_ShamanF"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_ShamanM",
+    "id": "Orc_ShamanM"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_Sleeper",
+    "id": "Orc_Sleeper"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_Sleeper1",
+    "id": "Orc_Sleeper1"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_Sleeper2",
+    "id": "Orc_Sleeper2"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_Test",
+    "id": "Orc_Test"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_UL_OSL_UrShak_2200",
+    "id": "Orc_UL_OSL_UrShak_2200"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_UndeadWarriorM",
+    "id": "Orc_UndeadWarriorM"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Orc_WarriorM",
+    "id": "Orc_WarriorM"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_QD_Questdealer",
+    "id": "QD_Questdealer"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_GUR_BaalCadar_1208",
+    "id": "SC_GUR_BaalCadar_1208"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_GUR_BaalNamib_1204",
+    "id": "SC_GUR_BaalNamib_1204"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_GUR_BaalOrun_1209",
+    "id": "SC_GUR_BaalOrun_1209"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_GUR_BaalTondral_1203",
+    "id": "SC_GUR_BaalTondral_1203"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_GUR_BaalTyon_1210",
+    "id": "SC_GUR_BaalTyon_1210"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_GUR_CorAngar_1202",
+    "id": "SC_GUR_CorAngar_1202"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_GUR_CorKalom_1201",
+    "id": "SC_GUR_CorKalom_1201"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_GUR_YBerion_1200",
+    "id": "SC_GUR_YBerion_1200"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_BaalNetbek_1371",
+    "id": "SC_NOV_BaalNetbek_1371"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Balor_1304",
+    "id": "SC_NOV_Balor_1304"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Caine_1301",
+    "id": "SC_NOV_Caine_1301"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Darrion_1312",
+    "id": "SC_NOV_Darrion_1312"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Fortuno_1357",
+    "id": "SC_NOV_Fortuno_1357"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Ghorim_1310",
+    "id": "SC_NOV_Ghorim_1310"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Harlok_1358",
+    "id": "SC_NOV_Harlok_1358"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Joru_1305",
+    "id": "SC_NOV_Joru_1305"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Lester",
+    "id": "SC_NOV_Lester"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Lester_Sleeper",
+    "id": "SC_NOV_Lester_Sleeper"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice01_1306",
+    "id": "SC_NOV_Novice01_1306"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice02_1307",
+    "id": "SC_NOV_Novice02_1307"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice03_1308",
+    "id": "SC_NOV_Novice03_1308"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice04_1309",
+    "id": "SC_NOV_Novice04_1309"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice05_1311",
+    "id": "SC_NOV_Novice05_1311"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice06_1313",
+    "id": "SC_NOV_Novice06_1313"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice07_1314",
+    "id": "SC_NOV_Novice07_1314"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice08_1315",
+    "id": "SC_NOV_Novice08_1315"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice09_1316",
+    "id": "SC_NOV_Novice09_1316"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice10_1317",
+    "id": "SC_NOV_Novice10_1317"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice11_1318",
+    "id": "SC_NOV_Novice11_1318"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice12_1319",
+    "id": "SC_NOV_Novice12_1319"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice13_1320",
+    "id": "SC_NOV_Novice13_1320"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice14_1321",
+    "id": "SC_NOV_Novice14_1321"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice15_1322",
+    "id": "SC_NOV_Novice15_1322"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice16_1323",
+    "id": "SC_NOV_Novice16_1323"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice17_1324",
+    "id": "SC_NOV_Novice17_1324"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice18_1325",
+    "id": "SC_NOV_Novice18_1325"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice19_1326",
+    "id": "SC_NOV_Novice19_1326"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice20_1327",
+    "id": "SC_NOV_Novice20_1327"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice21_1328",
+    "id": "SC_NOV_Novice21_1328"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice22_1329",
+    "id": "SC_NOV_Novice22_1329"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice23_1334",
+    "id": "SC_NOV_Novice23_1334"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice24_1335",
+    "id": "SC_NOV_Novice24_1335"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice25_1336",
+    "id": "SC_NOV_Novice25_1336"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice26_1337",
+    "id": "SC_NOV_Novice26_1337"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice27_1338",
+    "id": "SC_NOV_Novice27_1338"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice28_1339",
+    "id": "SC_NOV_Novice28_1339"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice29_1340",
+    "id": "SC_NOV_Novice29_1340"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice30_1341",
+    "id": "SC_NOV_Novice30_1341"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice31_1342",
+    "id": "SC_NOV_Novice31_1342"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice32_1343",
+    "id": "SC_NOV_Novice32_1343"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice33_1344",
+    "id": "SC_NOV_Novice33_1344"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice34_1345",
+    "id": "SC_NOV_Novice34_1345"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice35_1346",
+    "id": "SC_NOV_Novice35_1346"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice36_1347",
+    "id": "SC_NOV_Novice36_1347"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice37_1348",
+    "id": "SC_NOV_Novice37_1348"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice38_1349",
+    "id": "SC_NOV_Novice38_1349"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice39_1350",
+    "id": "SC_NOV_Novice39_1350"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice40_1351",
+    "id": "SC_NOV_Novice40_1351"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice41_1353",
+    "id": "SC_NOV_Novice41_1353"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice42_1354",
+    "id": "SC_NOV_Novice42_1354"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice43_1355",
+    "id": "SC_NOV_Novice43_1355"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice44_1356N",
+    "id": "SC_NOV_Novice44_1356N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice45_1357N",
+    "id": "SC_NOV_Novice45_1357N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice46_1358N",
+    "id": "SC_NOV_Novice46_1358N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Novice47_1359N",
+    "id": "SC_NOV_Novice47_1359N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Nyras_1303",
+    "id": "SC_NOV_Nyras_1303"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Shrat_1356",
+    "id": "SC_NOV_Shrat_1356"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Talas_1300",
+    "id": "SC_NOV_Talas_1300"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Theron_1372N",
+    "id": "SC_NOV_Theron_1372N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_NOV_Viran_1302",
+    "id": "SC_NOV_Viran_1302"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_GorHanis_1422",
+    "id": "SC_TPL_GorHanis_1422"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_GorNaDrak_1439",
+    "id": "SC_TPL_GorNaDrak_1439"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_GorNaDun_1411",
+    "id": "SC_TPL_GorNaDun_1411"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_GorNaRan_1405",
+    "id": "SC_TPL_GorNaRan_1405"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_GorNaToth_1402",
+    "id": "SC_TPL_GorNaToth_1402"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_KalomBodyguard_1406",
+    "id": "SC_TPL_KalomBodyguard_1406"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar01_1403",
+    "id": "SC_TPL_Templar01_1403"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar02_1404",
+    "id": "SC_TPL_Templar02_1404"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar03_1406",
+    "id": "SC_TPL_Templar03_1406"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar03_1407",
+    "id": "SC_TPL_Templar03_1407"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar04_1408",
+    "id": "SC_TPL_Templar04_1408"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar05_1409",
+    "id": "SC_TPL_Templar05_1409"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar06_1410",
+    "id": "SC_TPL_Templar06_1410"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar08_1412",
+    "id": "SC_TPL_Templar08_1412"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar09_1413",
+    "id": "SC_TPL_Templar09_1413"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar10_1414",
+    "id": "SC_TPL_Templar10_1414"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar11_1415",
+    "id": "SC_TPL_Templar11_1415"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar12_1416",
+    "id": "SC_TPL_Templar12_1416"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar13_1417",
+    "id": "SC_TPL_Templar13_1417"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar14_1418",
+    "id": "SC_TPL_Templar14_1418"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar15_1419",
+    "id": "SC_TPL_Templar15_1419"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar16_1420",
+    "id": "SC_TPL_Templar16_1420"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar17_1423",
+    "id": "SC_TPL_Templar17_1423"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar18_1424",
+    "id": "SC_TPL_Templar18_1424"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar19_1425",
+    "id": "SC_TPL_Templar19_1425"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar20_1430",
+    "id": "SC_TPL_Templar20_1430"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar21_1431",
+    "id": "SC_TPL_Templar21_1431"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar22_1432",
+    "id": "SC_TPL_Templar22_1432"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar23_1440",
+    "id": "SC_TPL_Templar23_1440"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar24_1441",
+    "id": "SC_TPL_Templar24_1441"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar25_1442",
+    "id": "SC_TPL_Templar25_1442"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar26_1443N",
+    "id": "SC_TPL_Templar26_1443N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_TPL_Templar27_1444N",
+    "id": "SC_TPL_Templar27_1444N"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_VLK_Melvin_582",
+    "id": "SC_VLK_Melvin_582"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_WSC_Chani_1205",
+    "id": "SC_WSC_Chani_1205"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SC_WSC_Natalia_1207",
+    "id": "SC_WSC_Natalia_1207"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_SH_Skeleton",
+    "id": "SH_Skeleton"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_SH_Zombie_01",
+    "id": "SH_Zombie_01"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_GUR_MadCorKalom_1212",
+    "id": "ST_GUR_MadCorKalom_1212"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_GUR_MadCorKalom_1212_Into_Trance",
+    "id": "ST_GUR_MadCorKalom_1212_Into_Trance"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_GUR_MadCorKalom_1212_Trance",
+    "id": "ST_GUR_MadCorKalom_1212_Trance"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_GUR_MadCorKalom_1212_Trance_End",
+    "id": "ST_GUR_MadCorKalom_1212_Trance_End"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice01_1359",
+    "id": "ST_NOV_Novice01_1359"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice02_1360",
+    "id": "ST_NOV_Novice02_1360"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice03_1361",
+    "id": "ST_NOV_Novice03_1361"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice04_1362",
+    "id": "ST_NOV_Novice04_1362"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice05_1363",
+    "id": "ST_NOV_Novice05_1363"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice06_1364",
+    "id": "ST_NOV_Novice06_1364"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice07_1365",
+    "id": "ST_NOV_Novice07_1365"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice08_1366",
+    "id": "ST_NOV_Novice08_1366"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice09_1367",
+    "id": "ST_NOV_Novice09_1367"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice10_1368",
+    "id": "ST_NOV_Novice10_1368"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice11_1369",
+    "id": "ST_NOV_Novice11_1369"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_NOV_Novice12_1370",
+    "id": "ST_NOV_Novice12_1370"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_GorBoba_1455",
+    "id": "ST_TPL_GorBoba_1455"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar01_1447",
+    "id": "ST_TPL_Templar01_1447"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar02_1448",
+    "id": "ST_TPL_Templar02_1448"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar03_1449",
+    "id": "ST_TPL_Templar03_1449"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar04_1450",
+    "id": "ST_TPL_Templar04_1450"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar05_1451",
+    "id": "ST_TPL_Templar05_1451"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar06_1452",
+    "id": "ST_TPL_Templar06_1452"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar07_1453",
+    "id": "ST_TPL_Templar07_1453"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar08_1454",
+    "id": "ST_TPL_Templar08_1454"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar09_1456",
+    "id": "ST_TPL_Templar09_1456"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar10_1457",
+    "id": "ST_TPL_Templar10_1457"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar11_1458",
+    "id": "ST_TPL_Templar11_1458"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar12_1459",
+    "id": "ST_TPL_Templar12_1459"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_TPL_Templar13_1460",
+    "id": "ST_TPL_Templar13_1460"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_ST_VLK_Mud_Sleeper",
+    "id": "ST_VLK_Mud_Sleeper"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_SkMage_Test_Soul",
+    "id": "SkMage_Test_Soul"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SwampCamp_Guru",
+    "id": "SwampCamp_Guru"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SwampCamp_Novice",
+    "id": "SwampCamp_Novice"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SwampCamp_Templar",
+    "id": "SwampCamp_Templar"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_SwampCamp_WomanSlave",
+    "id": "SwampCamp_WomanSlave"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Swampshark_Sleeper",
+    "id": "Swampshark_Sleeper"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TC_TrollAdult_01",
+    "id": "TC_TrollAdult_01"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TC_TrollPrime",
+    "id": "TC_TrollPrime"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter",
+    "id": "TestCharacter"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_A1H",
+    "id": "TestCharacter_A1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_A1H_Master",
+    "id": "TestCharacter_A1H_Master"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_A1H_Trained",
+    "id": "TestCharacter_A1H_Trained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_A2H",
+    "id": "TestCharacter_A2H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_A2H_Master",
+    "id": "TestCharacter_A2H_Master"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_A2H_Trained",
+    "id": "TestCharacter_A2H_Trained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_AIWorldEvent_Follower",
+    "id": "TestCharacter_AIWorldEvent_Follower"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_AIWorldEvent_Leader",
+    "id": "TestCharacter_AIWorldEvent_Leader"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_BaalLukor",
+    "id": "TestCharacter_BaalLukor"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Bow",
+    "id": "TestCharacter_Bow"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Crossbow",
+    "id": "TestCharacter_Crossbow"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Crowd_Digger",
+    "id": "TestCharacter_Crowd_Digger"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Crowd_Guard",
+    "id": "TestCharacter_Crowd_Guard"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Digger",
+    "id": "TestCharacter_Digger"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Digger_Brave",
+    "id": "TestCharacter_Digger_Brave"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Dressed",
+    "id": "TestCharacter_Dressed"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Fists_Master",
+    "id": "TestCharacter_Fists_Master"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Fists_Trained",
+    "id": "TestCharacter_Fists_Trained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Fists_Untrained",
+    "id": "TestCharacter_Fists_Untrained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_FunctionalTests",
+    "id": "TestCharacter_FunctionalTests"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_FunctionalTests_Smalltalk",
+    "id": "TestCharacter_FunctionalTests_Smalltalk"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_FunctionalTests_WithoutMutables",
+    "id": "TestCharacter_FunctionalTests_WithoutMutables"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Gomez",
+    "id": "TestCharacter_Gomez"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Guard",
+    "id": "TestCharacter_Guard"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_GuardNH",
+    "id": "TestCharacter_GuardNH"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Guard_Coward",
+    "id": "TestCharacter_Guard_Coward"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_Base_Parent",
+    "id": "TestCharacter_Human_Base_Parent"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_LayerHits",
+    "id": "TestCharacter_Human_LayerHits"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_LayerHits_HitsAdditive",
+    "id": "TestCharacter_Human_LayerHits_HitsAdditive"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_LayerHits_HitsSupAr",
+    "id": "TestCharacter_Human_LayerHits_HitsSupAr"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_Simple",
+    "id": "TestCharacter_Human_Simple"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_Simple2",
+    "id": "TestCharacter_Human_Simple2"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_Simple_Blocking",
+    "id": "TestCharacter_Human_Simple_Blocking"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_Simple_CastSpell",
+    "id": "TestCharacter_Human_Simple_CastSpell"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_Simple_Executions",
+    "id": "TestCharacter_Human_Simple_Executions"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_Simple_VFX",
+    "id": "TestCharacter_Human_Simple_VFX"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_A1H",
+    "id": "TestCharacter_Human_TestTaunts_A1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_A2H",
+    "id": "TestCharacter_Human_TestTaunts_A2H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_Base",
+    "id": "TestCharacter_Human_TestTaunts_Base"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_Bow",
+    "id": "TestCharacter_Human_TestTaunts_Bow"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_Crossbow",
+    "id": "TestCharacter_Human_TestTaunts_Crossbow"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_Fists",
+    "id": "TestCharacter_Human_TestTaunts_Fists"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_M1H",
+    "id": "TestCharacter_Human_TestTaunts_M1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_M2H",
+    "id": "TestCharacter_Human_TestTaunts_M2H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_Mage_Rune",
+    "id": "TestCharacter_Human_TestTaunts_Mage_Rune"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_Mage_Scroll",
+    "id": "TestCharacter_Human_TestTaunts_Mage_Scroll"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_S1H",
+    "id": "TestCharacter_Human_TestTaunts_S1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_S2H",
+    "id": "TestCharacter_Human_TestTaunts_S2H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_S2H_Ma",
+    "id": "TestCharacter_Human_TestTaunts_S2H_Ma"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_S2H_Tr",
+    "id": "TestCharacter_Human_TestTaunts_S2H_Tr"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_Sff2H",
+    "id": "TestCharacter_Human_TestTaunts_Sff2H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Human_TestTaunts_T1H",
+    "id": "TestCharacter_Human_TestTaunts_T1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_M1H",
+    "id": "TestCharacter_M1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_M1H_Master",
+    "id": "TestCharacter_M1H_Master"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_M1H_Trained",
+    "id": "TestCharacter_M1H_Trained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_M2H",
+    "id": "TestCharacter_M2H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_M2H_Master",
+    "id": "TestCharacter_M2H_Master"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_M2H_Trained",
+    "id": "TestCharacter_M2H_Trained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage",
+    "id": "TestCharacter_Mage"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_AllSpells",
+    "id": "TestCharacter_Mage_AllSpells"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_BallLightning",
+    "id": "TestCharacter_Mage_BallLightning"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_ChainLightning",
+    "id": "TestCharacter_Mage_ChainLightning"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_FireBall",
+    "id": "TestCharacter_Mage_FireBall"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_FireBolt",
+    "id": "TestCharacter_Mage_FireBolt"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_FireRain",
+    "id": "TestCharacter_Mage_FireRain"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_FistOfWind",
+    "id": "TestCharacter_Mage_FistOfWind"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_Heal",
+    "id": "TestCharacter_Mage_Heal"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_Ice",
+    "id": "TestCharacter_Mage_Ice"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_IceBlock",
+    "id": "TestCharacter_Mage_IceBlock"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_IceBolt",
+    "id": "TestCharacter_Mage_IceBolt"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_IceWave",
+    "id": "TestCharacter_Mage_IceWave"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_Light",
+    "id": "TestCharacter_Mage_Light"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_Pyrokinesis",
+    "id": "TestCharacter_Mage_Pyrokinesis"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_StormFist",
+    "id": "TestCharacter_Mage_StormFist"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_StormOfFire",
+    "id": "TestCharacter_Mage_StormOfFire"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Mage_UrizielWaveOfDeath",
+    "id": "TestCharacter_Mage_UrizielWaveOfDeath"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Pickaxe",
+    "id": "TestCharacter_Pickaxe"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Pickaxe_Master",
+    "id": "TestCharacter_Pickaxe_Master"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Pickaxe_Trained",
+    "id": "TestCharacter_Pickaxe_Trained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_S1H",
+    "id": "TestCharacter_S1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_S1H_Master",
+    "id": "TestCharacter_S1H_Master"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_S1H_Trained",
+    "id": "TestCharacter_S1H_Trained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_S2H",
+    "id": "TestCharacter_S2H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_S2H_Master",
+    "id": "TestCharacter_S2H_Master"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_S2H_Trained",
+    "id": "TestCharacter_S2H_Trained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_ScavAdult_LayerHits_HitsAdditive",
+    "id": "TestCharacter_ScavAdult_LayerHits_HitsAdditive"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_ScavAdult_LayerHits_HitsSupAr",
+    "id": "TestCharacter_ScavAdult_LayerHits_HitsSupAr"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Sff2H",
+    "id": "TestCharacter_Sff2H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Sff2H_Master",
+    "id": "TestCharacter_Sff2H_Master"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Sff2H_Trained",
+    "id": "TestCharacter_Sff2H_Trained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_Sff2H_Untrained",
+    "id": "TestCharacter_Sff2H_Untrained"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_T1H",
+    "id": "TestCharacter_T1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_WallClimbing",
+    "id": "TestCharacter_WallClimbing"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestCharacter_WeaponSet",
+    "id": "TestCharacter_WeaponSet"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestDemon_Conversation",
+    "id": "TestDemon_Conversation"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_TestGuard",
+    "id": "TestGuard"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_TestGuardBow",
+    "id": "TestGuardBow"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_TestMage",
+    "id": "TestMage"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc",
+    "id": "TestOrc"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Axe",
+    "id": "TestOrcSimple_Axe"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Fists",
+    "id": "TestOrcSimple_Fists"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Fists_Warrior",
+    "id": "TestOrcSimple_Fists_Warrior"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Mace",
+    "id": "TestOrcSimple_Mace"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_NoWeapon",
+    "id": "TestOrcSimple_NoWeapon"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_SpecialParent",
+    "id": "TestOrcSimple_SpecialParent"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Staff",
+    "id": "TestOrcSimple_Staff"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Staff_BallLighting",
+    "id": "TestOrcSimple_Staff_BallLighting"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Staff_BreathOfDeath",
+    "id": "TestOrcSimple_Staff_BreathOfDeath"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Staff_ChainLighting",
+    "id": "TestOrcSimple_Staff_ChainLighting"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Staff_Fireball",
+    "id": "TestOrcSimple_Staff_Fireball"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Staff_Pyrokinesis",
+    "id": "TestOrcSimple_Staff_Pyrokinesis"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Staff_StormOfFire",
+    "id": "TestOrcSimple_Staff_StormOfFire"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Staff_Undead",
+    "id": "TestOrcSimple_Staff_Undead"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Sword",
+    "id": "TestOrcSimple_Sword"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_TauntParent",
+    "id": "TestOrcSimple_TauntParent"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Taunts_Axe",
+    "id": "TestOrcSimple_Taunts_Axe"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Taunts_Fists",
+    "id": "TestOrcSimple_Taunts_Fists"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Taunts_Mace",
+    "id": "TestOrcSimple_Taunts_Mace"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Taunts_Sword",
+    "id": "TestOrcSimple_Taunts_Sword"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrcSimple_Undead_SpecialParent",
+    "id": "TestOrcSimple_Undead_SpecialParent"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_A1H",
+    "id": "TestOrc_A1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_Conversation",
+    "id": "TestOrc_Conversation"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_Fists",
+    "id": "TestOrc_Fists"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_M1H",
+    "id": "TestOrc_M1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_S1H",
+    "id": "TestOrc_S1H"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_Sff1H_GVArushat",
+    "id": "TestOrc_Sff1H_GVArushat"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_Sff1H_Shaman",
+    "id": "TestOrc_Sff1H_Shaman"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_Sff1H_VHashor",
+    "id": "TestOrc_Sff1H_VHashor"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_Sff1H_VKasorg",
+    "id": "TestOrc_Sff1H_VKasorg"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_Sff1H_VRuuushk",
+    "id": "TestOrc_Sff1H_VRuuushk"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_Sff1H_VUnhilqt",
+    "id": "TestOrc_Sff1H_VUnhilqt"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_TestOrc_Sff1H_Varrags",
+    "id": "TestOrc_Sff1H_Varrags"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Test_MCrawler_B",
+    "id": "Test_MCrawler_B"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Test_MCrawler_L",
+    "id": "Test_MCrawler_L"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Test_MCrawler_R",
+    "id": "Test_MCrawler_R"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Test_MCrawler_Temple_Wait",
+    "id": "Test_MCrawler_Temple_Wait"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Test_MCrawler_Wait",
+    "id": "Test_MCrawler_Wait"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Test_MCrawler_Warrior_Wait",
+    "id": "Test_MCrawler_Warrior_Wait"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Test_Mini_Golem_Ice",
+    "id": "Test_Mini_Golem_Ice"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Test_Mini_Golem_Ice_Heal",
+    "id": "Test_Mini_Golem_Ice_Heal"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Tutorial_Combat_QuestDealer",
+    "id": "Tutorial_Combat_QuestDealer"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_NON_Gilbert_1500",
+    "id": "UL_NON_Gilbert_1500"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_Aidan_859",
+    "id": "UL_ORG_Aidan_859"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_Blackmailer_888",
+    "id": "UL_ORG_Blackmailer_888"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_CoBlackmailer_889",
+    "id": "UL_ORG_CoBlackmailer_889"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_Jacko_862",
+    "id": "UL_ORG_Jacko_862"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_Killian_861",
+    "id": "UL_ORG_Killian_861"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_Renyu_860",
+    "id": "UL_ORG_Renyu_860"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_Rogue01_1501",
+    "id": "UL_ORG_Rogue01_1501"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_Rogue02_1502",
+    "id": "UL_ORG_Rogue02_1502"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_Rogue03_1503",
+    "id": "UL_ORG_Rogue03_1503"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_ORG_Rogue04_1504",
+    "id": "UL_ORG_Rogue04_1504"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_STT_Cavalorn_336",
+    "id": "UL_STT_Cavalorn_336"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_UL_STT_Cohsel_337",
+    "id": "UL_STT_Cohsel_337"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_UL_Wolf_Cohsel",
+    "id": "UL_Wolf_Cohsel"
+  },
+  {
+    "category": "other",
+    "class": "CharacterDefinition_Viran_Bloodlfy",
+    "id": "Viran_Bloodlfy"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_XT_DMB_Xardas_404",
+    "id": "XT_DMB_Xardas_404"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_XT_DMB_Xardas_404_Sleeper",
+    "id": "XT_DMB_Xardas_404_Sleeper"
+  },
+  {
+    "category": "human",
+    "class": "CharacterDefinition_Human_XT_XardasDemon",
+    "id": "XT_XardasDemon"
+  }
+]

--- a/apps/goresave/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/goresave/lib/features/editor/domain/editor_notifier.dart
@@ -1281,6 +1281,52 @@ class EditorNotifier extends StateNotifier<EditorState> {
     );
   }
 
+  /// Insert a brand-new character into CharacterKnowledgeByUniqueName and write
+  /// the file immediately (with backup), then re-inspect so the new NPC's empty
+  /// Knowledge set is queryable for follow-on entry edits. Map insertions are
+  /// structural and applied one-at-a-time, so this is intentionally NOT a
+  /// pending edit. Returns true on success; on failure sets state.error and
+  /// returns false.
+  ///
+  /// Mirrors [applyMemoryEventEdit]: same no-save / isLoading / hasUnsavedEdits
+  /// guards (an immediate write + refresh re-seeds the editors and would discard
+  /// any unsaved pending edits), and the same _runWrite-then-refresh flow.
+  Future<bool> applyAddKnowledgeCharacter(String uniqueName) async {
+    final savePath = state.selectedPath;
+    if (savePath == null) {
+      state = state.copyWith(error: 'No save selected.');
+      return false;
+    }
+    if (state.isLoading) {
+      state = state.copyWith(
+        error: 'Another operation is in progress — try again when it finishes.',
+      );
+      return false;
+    }
+    if (state.hasUnsavedEdits) {
+      state = state.copyWith(
+        error:
+            'Save or reset your unsaved changes first — adding a character '
+            'writes the file immediately and would discard them.',
+      );
+      return false;
+    }
+    return _runWrite(
+      payload: {
+        'path': savePath,
+        'backup': true,
+        'edits': [
+          {
+            'path': 'private.knowledge.addCharacter',
+            'value': {'value': uniqueName.trim()},
+          },
+        ],
+        ..._codecPayload(),
+      },
+      message: (data) => _backupMessage('Character added', data),
+    );
+  }
+
   String _errorMessage(Map<String, Object?> response) {
     final error = (response['error'] as Map?)?.cast<String, Object?>();
     return error?['message'] as String? ?? 'Unknown core error';

--- a/apps/goresave/lib/features/editor/domain/knowledge_catalog.dart
+++ b/apps/goresave/lib/features/editor/domain/knowledge_catalog.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+class KnowledgeCatalogEntry {
+  const KnowledgeCatalogEntry({required this.id, required this.category});
+
+  final String id;
+  final String category;
+}
+
+class KnowledgeCatalog {
+  const KnowledgeCatalog(this.entries);
+
+  final List<KnowledgeCatalogEntry> entries;
+
+  static KnowledgeCatalog fromJsonString(String json) {
+    final list = (jsonDecode(json) as List)
+        .whereType<Map<String, Object?>>()
+        .map((e) => KnowledgeCatalogEntry(
+              id: e['id'] as String? ?? '',
+              category: e['category'] as String? ?? 'topic',
+            ))
+        .where((e) => e.id.isNotEmpty)
+        .toList()
+      ..sort((a, b) => a.id.compareTo(b.id));
+    return KnowledgeCatalog(list);
+  }
+
+  static Future<KnowledgeCatalog> loadBundled() async =>
+      fromJsonString(await rootBundle.loadString('assets/knowledge_catalog.json'));
+}

--- a/apps/goresave/lib/features/editor/domain/npc_catalog.dart
+++ b/apps/goresave/lib/features/editor/domain/npc_catalog.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+class NpcCatalogEntry {
+  const NpcCatalogEntry({
+    required this.id,
+    required this.className,
+    required this.category,
+  });
+
+  final String id;
+  final String className;
+  final String category;
+}
+
+class NpcCatalog {
+  const NpcCatalog(this.entries);
+
+  final List<NpcCatalogEntry> entries;
+
+  static NpcCatalog fromJsonString(String json) {
+    final list = (jsonDecode(json) as List)
+        .whereType<Map<String, Object?>>()
+        .map((e) => NpcCatalogEntry(
+              id: e['id'] as String? ?? '',
+              className: e['class'] as String? ?? '',
+              category: e['category'] as String? ?? 'other',
+            ))
+        .where((e) => e.id.isNotEmpty)
+        .toList()
+      ..sort((a, b) => a.id.compareTo(b.id));
+    return NpcCatalog(list);
+  }
+
+  static Future<NpcCatalog> loadBundled() async =>
+      fromJsonString(await rootBundle.loadString('assets/npc_catalog.json'));
+}

--- a/apps/goresave/lib/features/editor/ui/add_knowledge_entry_dialog.dart
+++ b/apps/goresave/lib/features/editor/ui/add_knowledge_entry_dialog.dart
@@ -151,7 +151,7 @@ class _AddKnowledgeEntryDialogState extends State<_AddKnowledgeEntryDialog> {
                                       icon:
                                           _iconForKnowledgeCategory(g.category),
                                       label:
-                                          '${g.category} (${g.entries.length})',
+                                          '${_cap(g.category)} (${g.entries.length})',
                                       selected: !searching &&
                                           g.category == selectedCategory,
                                       onTap: () => setState(() {
@@ -204,6 +204,8 @@ class _AddKnowledgeEntryDialogState extends State<_AddKnowledgeEntryDialog> {
     );
   }
 }
+
+String _cap(String s) => s.isEmpty ? s : '${s[0].toUpperCase()}${s.substring(1)}';
 
 IconData _iconForKnowledgeCategory(String category) {
   switch (category) {

--- a/apps/goresave/lib/features/editor/ui/add_knowledge_entry_dialog.dart
+++ b/apps/goresave/lib/features/editor/ui/add_knowledge_entry_dialog.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:goresave/features/editor/domain/knowledge_catalog.dart';
+import 'package:goresave/features/editor/ui/sidebar_tile.dart';
+
+/// Shows a picker dialog over [catalog] that lets the user choose a knowledge
+/// entry to add.
+///
+/// Returns the selected entry [id], or null if the dialog is dismissed.
+/// [exclude] is a set of **lowercase** ids to hide (entries already present).
+Future<String?> showAddKnowledgeEntryDialog(
+  BuildContext context, {
+  required KnowledgeCatalog catalog,
+  required Set<String> exclude,
+}) {
+  return showDialog<String>(
+    context: context,
+    builder: (_) =>
+        _AddKnowledgeEntryDialog(catalog: catalog, exclude: exclude),
+  );
+}
+
+class _AddKnowledgeEntryDialog extends StatefulWidget {
+  const _AddKnowledgeEntryDialog({
+    required this.catalog,
+    required this.exclude,
+  });
+
+  final KnowledgeCatalog catalog;
+  final Set<String> exclude;
+
+  @override
+  State<_AddKnowledgeEntryDialog> createState() =>
+      _AddKnowledgeEntryDialogState();
+}
+
+// Fixed display order for knowledge categories.
+const _kKnowledgeCategories = ['topic', 'choice', 'info'];
+
+// Sentinel value for the "All" sidebar entry.
+const _kAllCategory = '';
+
+typedef _EntryGroup = ({String category, List<KnowledgeCatalogEntry> entries});
+
+class _AddKnowledgeEntryDialogState extends State<_AddKnowledgeEntryDialog> {
+  String _query = '';
+  // Empty string means "All".
+  String _selectedCategory = _kAllCategory;
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<_EntryGroup> _buildGroups(List<KnowledgeCatalogEntry> available) {
+    final byCategory = <String, List<KnowledgeCatalogEntry>>{};
+    for (final entry in available) {
+      byCategory.putIfAbsent(entry.category, () => []).add(entry);
+    }
+    return [
+      for (final cat in _kKnowledgeCategories)
+        if (byCategory.containsKey(cat))
+          (category: cat, entries: byCategory[cat]!),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final available = widget.catalog.entries
+        .where((e) => !widget.exclude.contains(e.id.toLowerCase()))
+        .toList();
+    final groups = _buildGroups(available);
+
+    final selectedCategory = _selectedCategory;
+
+    // Right-pane entries: a non-empty query searches the whole catalog;
+    // "All" (_kAllCategory) shows everything; otherwise filter by category.
+    final query = _query.trim().toLowerCase();
+    final searching = query.isNotEmpty;
+    final List<KnowledgeCatalogEntry> shown;
+    if (searching) {
+      shown = available
+          .where((e) => e.id.toLowerCase().contains(query))
+          .toList();
+    } else if (selectedCategory == _kAllCategory) {
+      shown = available;
+    } else {
+      shown = groups
+              .where((g) => g.category == selectedCategory)
+              .firstOrNull
+              ?.entries ??
+          const [];
+    }
+
+    return AlertDialog(
+      title: const Text('Add knowledge entry'),
+      contentPadding: const EdgeInsets.fromLTRB(24, 16, 24, 0),
+      content: SizedBox(
+        width: 720,
+        height: 520,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _searchController,
+              decoration: const InputDecoration(
+                labelText: 'Search entries',
+                prefixIcon: Icon(Icons.search),
+                isDense: true,
+              ),
+              onChanged: (v) => setState(() {
+                _query = v;
+              }),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: groups.isEmpty
+                  ? const Center(
+                      child: Text('No knowledge entries available to add'))
+                  : Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        SizedBox(
+                          width: 200,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.surfaceContainerLow,
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: SingleChildScrollView(
+                              padding:
+                                  const EdgeInsets.symmetric(vertical: 6),
+                              child: Column(
+                                children: [
+                                  SidebarTile(
+                                    icon: Icons.list_outlined,
+                                    label: 'All (${available.length})',
+                                    selected: !searching &&
+                                        selectedCategory == _kAllCategory,
+                                    onTap: () => setState(() {
+                                      _selectedCategory = _kAllCategory;
+                                      _query = '';
+                                      _searchController.clear();
+                                    }),
+                                  ),
+                                  for (final g in groups)
+                                    SidebarTile(
+                                      icon:
+                                          _iconForKnowledgeCategory(g.category),
+                                      label:
+                                          '${g.category} (${g.entries.length})',
+                                      selected: !searching &&
+                                          g.category == selectedCategory,
+                                      onTap: () => setState(() {
+                                        _selectedCategory = g.category;
+                                        _query = '';
+                                        _searchController.clear();
+                                      }),
+                                    ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: shown.isEmpty
+                              ? const Center(
+                                  child: Text('No entries match'))
+                              : ListView.builder(
+                                  itemCount: shown.length,
+                                  itemBuilder: (context, index) =>
+                                      _entryTile(shown[index]),
+                                ),
+                        ),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(null),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+
+  Widget _entryTile(KnowledgeCatalogEntry entry) {
+    return ListTile(
+      dense: true,
+      leading: Icon(_iconForKnowledgeCategory(entry.category)),
+      title: Text(
+        entry.id,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      onTap: () => Navigator.of(context).pop(entry.id),
+    );
+  }
+}
+
+IconData _iconForKnowledgeCategory(String category) {
+  switch (category) {
+    case 'topic':
+      return Icons.topic_outlined;
+    case 'choice':
+      return Icons.call_split;
+    case 'info':
+      return Icons.info_outline;
+    default:
+      return Icons.help_outline;
+  }
+}

--- a/apps/goresave/lib/features/editor/ui/add_npc_dialog.dart
+++ b/apps/goresave/lib/features/editor/ui/add_npc_dialog.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'package:goresave/features/editor/domain/npc_catalog.dart';
+import 'package:goresave/features/editor/ui/sidebar_tile.dart';
+
+/// Shows a picker dialog over [catalog] that lets the user choose an NPC.
+///
+/// Returns the selected NPC [id], or null if the dialog is dismissed.
+/// [exclude] is a set of **lowercase** ids to hide (NPCs already present).
+Future<String?> showAddNpcDialog(
+  BuildContext context, {
+  required NpcCatalog catalog,
+  required Set<String> exclude,
+}) {
+  return showDialog<String>(
+    context: context,
+    builder: (_) => _AddNpcDialog(catalog: catalog, exclude: exclude),
+  );
+}
+
+class _AddNpcDialog extends StatefulWidget {
+  const _AddNpcDialog({required this.catalog, required this.exclude});
+
+  final NpcCatalog catalog;
+  final Set<String> exclude;
+
+  @override
+  State<_AddNpcDialog> createState() => _AddNpcDialogState();
+}
+
+typedef _NpcGroup = ({String category, List<NpcCatalogEntry> entries});
+
+// Sentinel value for the "All" sidebar entry.
+const _kAllCategory = '';
+
+class _AddNpcDialogState extends State<_AddNpcDialog> {
+  String _query = '';
+  // Empty string means "All".
+  String _selectedCategory = _kAllCategory;
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<_NpcGroup> _buildGroups(List<NpcCatalogEntry> available) {
+    final byCategory = <String, List<NpcCatalogEntry>>{};
+    for (final entry in available) {
+      byCategory.putIfAbsent(entry.category, () => []).add(entry);
+    }
+    // Collect distinct categories in the order they first appear (catalog is
+    // already sorted by id so this gives a stable, predictable order).
+    final seen = <String>{};
+    final orderedCategories = <String>[];
+    for (final entry in available) {
+      if (seen.add(entry.category)) {
+        orderedCategories.add(entry.category);
+      }
+    }
+    return [
+      for (final cat in orderedCategories)
+        (category: cat, entries: byCategory[cat]!),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final available = widget.catalog.entries
+        .where((e) => !widget.exclude.contains(e.id.toLowerCase()))
+        .toList();
+    final groups = _buildGroups(available);
+
+    final selectedCategory = _selectedCategory;
+
+    // Right-pane entries: a non-empty query searches the whole catalog;
+    // "All" (_kAllCategory) shows everything; otherwise filter by category.
+    final query = _query.trim().toLowerCase();
+    final searching = query.isNotEmpty;
+    final List<NpcCatalogEntry> shown;
+    if (searching) {
+      shown = available
+          .where((e) => e.id.toLowerCase().contains(query))
+          .toList();
+    } else if (selectedCategory == _kAllCategory) {
+      shown = available;
+    } else {
+      shown = groups
+              .where((g) => g.category == selectedCategory)
+              .firstOrNull
+              ?.entries ??
+          const [];
+    }
+
+    return AlertDialog(
+      title: const Text('Add NPC'),
+      contentPadding: const EdgeInsets.fromLTRB(24, 16, 24, 0),
+      content: SizedBox(
+        width: 720,
+        height: 520,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _searchController,
+              decoration: const InputDecoration(
+                labelText: 'Search NPCs',
+                prefixIcon: Icon(Icons.search),
+                isDense: true,
+              ),
+              onChanged: (v) => setState(() {
+                _query = v;
+              }),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: groups.isEmpty
+                  ? const Center(child: Text('No NPCs available to add'))
+                  : Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        SizedBox(
+                          width: 200,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.surfaceContainerLow,
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: SingleChildScrollView(
+                              padding:
+                                  const EdgeInsets.symmetric(vertical: 6),
+                              child: Column(
+                                children: [
+                                  SidebarTile(
+                                    icon: Icons.people_outline,
+                                    label: 'All (${available.length})',
+                                    selected: !searching &&
+                                        selectedCategory == _kAllCategory,
+                                    onTap: () => setState(() {
+                                      _selectedCategory = _kAllCategory;
+                                      _query = '';
+                                      _searchController.clear();
+                                    }),
+                                  ),
+                                  for (final g in groups)
+                                    SidebarTile(
+                                      icon: _iconForNpcCategory(g.category),
+                                      label:
+                                          '${g.category} (${g.entries.length})',
+                                      selected: !searching &&
+                                          g.category == selectedCategory,
+                                      onTap: () => setState(() {
+                                        _selectedCategory = g.category;
+                                        _query = '';
+                                        _searchController.clear();
+                                      }),
+                                    ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: shown.isEmpty
+                              ? const Center(child: Text('No NPCs match'))
+                              : ListView.builder(
+                                  itemCount: shown.length,
+                                  itemBuilder: (context, index) =>
+                                      _entryTile(shown[index]),
+                                ),
+                        ),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(null),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+
+  Widget _entryTile(NpcCatalogEntry entry) {
+    final theme = Theme.of(context);
+    return ListTile(
+      dense: true,
+      leading: Icon(_iconForNpcCategory(entry.category)),
+      title: Text(
+        entry.id,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        entry.category,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodySmall,
+      ),
+      onTap: () => Navigator.of(context).pop(entry.id),
+    );
+  }
+}
+
+IconData _iconForNpcCategory(String category) {
+  switch (category) {
+    case 'human':
+      return Icons.person_outline;
+    case 'creature':
+      return Icons.pets;
+    default:
+      return Icons.help_outline;
+  }
+}

--- a/apps/goresave/lib/features/editor/ui/add_npc_dialog.dart
+++ b/apps/goresave/lib/features/editor/ui/add_npc_dialog.dart
@@ -148,7 +148,7 @@ class _AddNpcDialogState extends State<_AddNpcDialog> {
                                     SidebarTile(
                                       icon: _iconForNpcCategory(g.category),
                                       label:
-                                          '${g.category} (${g.entries.length})',
+                                          '${_cap(g.category)} (${g.entries.length})',
                                       selected: !searching &&
                                           g.category == selectedCategory,
                                       onTap: () => setState(() {
@@ -198,7 +198,7 @@ class _AddNpcDialogState extends State<_AddNpcDialog> {
         overflow: TextOverflow.ellipsis,
       ),
       subtitle: Text(
-        entry.category,
+        _cap(entry.category),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
         style: theme.textTheme.bodySmall,
@@ -207,6 +207,8 @@ class _AddNpcDialogState extends State<_AddNpcDialog> {
     );
   }
 }
+
+String _cap(String s) => s.isEmpty ? s : '${s[0].toUpperCase()}${s.substring(1)}';
 
 IconData _iconForNpcCategory(String category) {
   switch (category) {

--- a/apps/goresave/lib/features/editor/ui/progression_panel.dart
+++ b/apps/goresave/lib/features/editor/ui/progression_panel.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 
 import '../domain/editor_models.dart';
 import '../domain/editor_notifier.dart';
+import '../domain/knowledge_catalog.dart';
+import '../domain/npc_catalog.dart';
 import '../domain/pending_edits.dart';
 import '../domain/progression_models.dart';
+import 'add_knowledge_entry_dialog.dart';
+import 'add_npc_dialog.dart';
 
 /// All five EQuestState values, in dropdown order.
 const questStates = <String>[
@@ -631,11 +635,61 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
   bool _checkingDuplicate = false;
   // Error text shown beneath the add field (duplicate-check failure, etc.).
   String? _addError;
+  // Bundled catalogs for the NPC + knowledge-entry picker dialogs. Null until
+  // loaded asynchronously in initState.
+  NpcCatalog? _npcCatalog;
+  KnowledgeCatalog? _knowledgeCatalog;
 
   @override
   void initState() {
     super.initState();
     _loadCharacters(offset: 0);
+    _loadCatalogs();
+  }
+
+  Future<void> _loadCatalogs() async {
+    final npc = await NpcCatalog.loadBundled();
+    final knowledge = await KnowledgeCatalog.loadBundled();
+    if (!mounted) return;
+    setState(() {
+      _npcCatalog = npc;
+      _knowledgeCatalog = knowledge;
+    });
+  }
+
+  Future<void> _addNpc() async {
+    final catalog = _npcCatalog;
+    if (catalog == null) return;
+    // Best-effort exclude: only NPCs on the currently loaded page are known
+    // here (the list is paginated/searchable). The core rejects true
+    // duplicates regardless.
+    final existing = _characters.characters
+        .map((c) => c.name.toLowerCase())
+        .toSet();
+    final picked = await showAddNpcDialog(
+      context,
+      catalog: catalog,
+      exclude: existing,
+    );
+    if (picked == null || !mounted) return;
+    final ok = await widget.notifier.applyAddKnowledgeCharacter(picked);
+    if (!mounted || !ok) return; // on failure the notifier set state.error.
+    await _loadCharacters(offset: 0);
+    if (!mounted) return;
+    await _selectCharacter(picked);
+  }
+
+  Future<void> _browseAddEntry() async {
+    final catalog = _knowledgeCatalog;
+    if (catalog == null) return;
+    final existing = _entries.entries.map((e) => e.toLowerCase()).toSet();
+    final picked = await showAddKnowledgeEntryDialog(
+      context,
+      catalog: catalog,
+      exclude: existing,
+    );
+    if (picked == null || !mounted) return;
+    await _addEntry(picked); // existing path: dup-check + pending edit.
   }
 
   @override
@@ -932,6 +986,17 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
+                        if (widget.editable) ...[
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: OutlinedButton.icon(
+                              icon: const Icon(Icons.person_add_alt_1, size: 18),
+                              label: const Text('Add NPC'),
+                              onPressed: _npcCatalog == null ? null : _addNpc,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                        ],
                         TextField(
                           controller: _characterSearch,
                           decoration: InputDecoration(
@@ -1072,6 +1137,17 @@ class _KnowledgeDetailState extends State<_KnowledgeDetail> {
                                                     _addController.text,
                                                   ),
                                           ),
+                                    // Browse the full knowledge-entry catalog.
+                                    // The free-text field above stays as a
+                                    // fallback for non-catalog tokens.
+                                    IconButton(
+                                      icon: const Icon(Icons.menu_book_outlined),
+                                      tooltip: 'Browse catalog',
+                                      onPressed:
+                                          addDisabled || _knowledgeCatalog == null
+                                          ? null
+                                          : _browseAddEntry,
+                                    ),
                                   ],
                                 );
                               },

--- a/apps/goresave/pubspec.yaml
+++ b/apps/goresave/pubspec.yaml
@@ -60,3 +60,5 @@ flutter:
   assets:
     - assets/goresave_icon.png
     - assets/item_catalog.json
+    - assets/npc_catalog.json
+    - assets/knowledge_catalog.json

--- a/apps/goresave/test/add_knowledge_entry_dialog_test.dart
+++ b/apps/goresave/test/add_knowledge_entry_dialog_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/knowledge_catalog.dart';
+import 'package:goresave/features/editor/ui/add_knowledge_entry_dialog.dart';
+
+void main() {
+  final catalog = KnowledgeCatalog.fromJsonString(
+    '[{"id":"Topic_Diego_209799","category":"topic"},'
+    '{"id":"ChoiceDiegoGamestart","category":"choice"},'
+    '{"id":"Info_FMORGAreyouok","category":"info"}]',
+  );
+
+  testWidgets('lists entries, excludes existing, returns selection',
+      (tester) async {
+    String? picked;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (context) {
+          return ElevatedButton(
+            onPressed: () async {
+              picked = await showAddKnowledgeEntryDialog(
+                context, catalog: catalog, exclude: {'choicediegogamestart'});
+            },
+            child: const Text('open'),
+          );
+        }),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Topic_Diego_209799'), findsOneWidget);
+    expect(find.text('ChoiceDiegoGamestart'), findsNothing);
+    await tester.tap(find.text('Topic_Diego_209799'));
+    await tester.pumpAndSettle();
+    expect(picked, 'Topic_Diego_209799');
+  });
+}

--- a/apps/goresave/test/add_npc_dialog_test.dart
+++ b/apps/goresave/test/add_npc_dialog_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/npc_catalog.dart';
+import 'package:goresave/features/editor/ui/add_npc_dialog.dart';
+
+void main() {
+  final catalog = NpcCatalog.fromJsonString(
+    '[{"id":"OC_STT_Diego","class":"c1","category":"human"},'
+    '{"id":"OC_GRD_Orry_254","class":"c2","category":"human"},'
+    '{"id":"Creature_Biter","class":"c3","category":"creature"}]',
+  );
+
+  testWidgets('lists catalog NPCs, excludes existing, returns selection',
+      (tester) async {
+    String? picked;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (context) {
+          return ElevatedButton(
+            onPressed: () async {
+              picked = await showAddNpcDialog(
+                context, catalog: catalog, exclude: {'oc_grd_orry_254'});
+            },
+            child: const Text('open'),
+          );
+        }),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('OC_STT_Diego'), findsOneWidget);
+    expect(find.text('OC_GRD_Orry_254'), findsNothing); // excluded
+    await tester.tap(find.text('OC_STT_Diego'));
+    await tester.pumpAndSettle();
+    expect(picked, 'OC_STT_Diego');
+  });
+}

--- a/apps/goresave/test/catalog_loaders_test.dart
+++ b/apps/goresave/test/catalog_loaders_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/npc_catalog.dart';
+import 'package:goresave/features/editor/domain/knowledge_catalog.dart';
+
+void main() {
+  test('NpcCatalog parses, filters empties, sorts by id', () {
+    final c = NpcCatalog.fromJsonString(
+      '[{"id":"OC_STT_Diego","class":"CharacterDefinition_Human_OC_STT_Diego","category":"human"},'
+      '{"id":"","class":"x","category":"human"},'
+      '{"id":"Creature_Biter","class":"CharacterDefinition_Creature_Biter","category":"creature"}]',
+    );
+    expect(c.entries.map((e) => e.id), ['Creature_Biter', 'OC_STT_Diego']);
+    expect(c.entries.first.category, 'creature');
+  });
+
+  test('KnowledgeCatalog parses, filters empties, sorts by id', () {
+    final c = KnowledgeCatalog.fromJsonString(
+      '[{"id":"Topic_Diego_209799","category":"topic"},'
+      '{"id":"","category":"choice"},'
+      '{"id":"ChoiceDiegoGamestart","category":"choice"}]',
+    );
+    expect(c.entries.map((e) => e.id), ['ChoiceDiegoGamestart', 'Topic_Diego_209799']);
+  });
+}

--- a/apps/goresave/test/editor_notifier_test.dart
+++ b/apps/goresave/test/editor_notifier_test.dart
@@ -1079,6 +1079,72 @@ void main() {
     },
   );
 
+  test(
+    'applyAddKnowledgeCharacter issues one write_save with the addCharacter edit',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(
+        core,
+        saveDir: r'C:\tmp\saves',
+        codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+        gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+      );
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      // Whitespace is trimmed before it reaches the core.
+      final result = await notifier.applyAddKnowledgeCharacter('  NewNpc  ');
+
+      expect(result, isTrue);
+
+      final write = core.requests.lastWhere((r) => r.command == 'write_save');
+      expect(write.payload['backup'], isTrue);
+      final edits = write.payload['edits'] as List;
+      expect(edits, hasLength(1));
+      final edit = edits.single as Map;
+      expect(edit['path'], 'private.knowledge.addCharacter');
+      expect(edit['value'], {'value': 'NewNpc'});
+    },
+  );
+
+  test(
+    'applyAddKnowledgeCharacter is blocked when pendingEdits is non-empty',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(
+        core,
+        saveDir: r'C:\tmp\saves',
+        codecHostPath: r'C:\tools\goresave_g1r_codec_host.exe',
+        gameExePath: r'C:\Games\G1R\G1R-Win64-Shipping.exe',
+      );
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      notifier.setPendingEdit(
+        'x',
+        const PendingSaveEdit(
+          edits: [
+            {'path': 'public.m_PlayerSaveName', 'value': 'Draft'},
+          ],
+        ),
+      );
+
+      final writesBefore = core.requests
+          .where((r) => r.command == 'write_save')
+          .length;
+
+      final result = await notifier.applyAddKnowledgeCharacter('NewNpc');
+
+      expect(result, isFalse);
+      expect(notifier.state.error, isNotNull);
+      // No write_save must have been issued.
+      final writesAfter = core.requests
+          .where((r) => r.command == 'write_save')
+          .length;
+      expect(writesAfter, writesBefore);
+      // Pending edit must still be intact.
+      expect(notifier.state.pendingEdits.containsKey('x'), isTrue);
+    },
+  );
+
   // ---------------------------------------------------------------------------
   // Profile switcher (selectProfile)
   // ---------------------------------------------------------------------------

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -2817,6 +2817,10 @@ fn inspect_private_payload(
                     "private.typed.setRemove",
                     "private.typed.arrayRemove",
                     "private.typed.arrayDuplicate",
+                    // Inserts a new entry into the CharacterKnowledgeByUniqueName
+                    // map; needs only a decodable typed parse (no inventory
+                    // main_container gating).
+                    "private.knowledge.addCharacter",
                 ]);
                 // addItem/removeItem are gated per save (clean template /
                 // removable item); mirror the inventory summary's gating so the
@@ -3792,6 +3796,10 @@ fn summarize_private_progression_overview(root: Option<&properties::RootObject>)
             "private.typed.setRemove",
             "private.typed.arrayRemove",
             "private.typed.arrayDuplicate",
+            // Knowledge add-character is a progression edit on the
+            // CharacterKnowledgeByUniqueName map summarized above; it requires
+            // only the typed parse (guaranteed here since `root` is Some).
+            "private.knowledge.addCharacter",
         ],
     })
 }
@@ -4977,27 +4985,32 @@ fn apply_private_edits(
              separate writes"
         )));
     }
-    // An inventory structural edit (addItem/removeItem) splices the MainContainer
-    // slot array and shifts every byte after the splice point. Any peer edit in
-    // the same batch is unsafe: a later edit resolves its target against the
-    // pre-splice layout — an in-place setItemCount patches stale byte offsets,
-    // and a typed setValue re-resolves a now-shifted array index — so it can
-    // corrupt the save or hit the wrong slot. Require such an edit to stand alone.
-    let inventory_structural_edits = edit_specs
+    // A splicing structural edit inserts or removes bytes mid-payload and shifts
+    // every byte after the splice point:
+    //   - inventory addItem/removeItem splice the MainContainer slot array, and
+    //   - knowledge.addCharacter inserts a new entry into the
+    //     CharacterKnowledgeByUniqueName MapProperty.
+    // Any peer edit in the same batch is unsafe: a later edit resolves its target
+    // against the pre-splice layout — an in-place setItemCount patches stale byte
+    // offsets, and a typed setValue re-resolves a now-shifted array index — so it
+    // can corrupt the save or hit the wrong slot. Require such an edit to stand alone.
+    let splicing_structural_edits = edit_specs
         .iter()
         .filter(|edit| {
             matches!(
                 edit,
-                PrivateEdit::InventoryAddItem(_) | PrivateEdit::InventoryRemoveItem(_)
+                PrivateEdit::InventoryAddItem(_)
+                    | PrivateEdit::InventoryRemoveItem(_)
+                    | PrivateEdit::KnowledgeAddCharacter(_)
             )
         })
         .count();
-    if inventory_structural_edits >= 1 && edit_specs.len() > 1 {
+    if splicing_structural_edits >= 1 && edit_specs.len() > 1 {
         return Err(CoreError::UnsupportedEdit(
-            "a write containing private.inventory.addItem or removeItem must \
-             contain no other edits — the structural splice shifts the byte \
-             offsets and array indices later edits resolve against; submit them \
-             as separate writes"
+            "a write containing private.inventory.addItem, private.inventory.removeItem, \
+             or private.knowledge.addCharacter must contain no other edits — the \
+             structural splice (slot-array or map insert) shifts the byte offsets and \
+             array indices later edits resolve against; submit them as separate writes"
                 .to_string(),
         ));
     }
@@ -10009,6 +10022,15 @@ mod tests {
                 .unwrap()
                 .contains(&json!("private.typed.setValue"))
         );
+        // knowledge.addCharacter is gated only on the typed parse (no map/
+        // main_container gating), so a typed-ok payload advertises it even when
+        // it carries no CharacterKnowledgeByUniqueName map.
+        assert!(
+            inspected["private"]["writable"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("private.knowledge.addCharacter"))
+        );
 
         let response = write_save_with_codec_backend(
             &path,
@@ -11592,6 +11614,89 @@ mod tests {
         );
     }
 
+    #[test]
+    fn write_save_rejects_knowledge_add_character_with_peer() {
+        // knowledge.addCharacter splices the CharacterKnowledgeByUniqueName map,
+        // shifting every byte after the insert. Like an inventory structural
+        // edit, it must stand alone: a peer edit in the same write resolves
+        // against the pre-splice layout and would corrupt the save.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-knowledge-peer.sav");
+        let private_payload = build_knowledge_map_payload(&["OC_STT_Diego"]);
+        let seed_compressed = b"seed-knowledge-peer".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot A"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let err = write_save_with_codec_backend(
+            &path,
+            &[
+                json!({
+                    "path": "private.knowledge.addCharacter",
+                    "value": { "value": "OC_TEST_BrandNew" }
+                }),
+                json!({
+                    "path": "private.typed.setValue",
+                    "value": { "path": ["m_MaxQuick"], "value": 9 }
+                }),
+            ],
+            false,
+            None,
+            Some(&backend),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("must contain no other edits"),
+            "unexpected error: {err}"
+        );
+        // The error must call out the map-insert case, not only inventory.
+        assert!(
+            err.to_string().contains("private.knowledge.addCharacter"),
+            "error should mention the knowledge op: {err}"
+        );
+    }
+
+    #[test]
+    fn write_save_accepts_knowledge_add_character_alone() {
+        // A solo knowledge.addCharacter is accepted and applied: the
+        // stand-alone rule only fires when peer edits are present.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-knowledge-solo.sav");
+        let output_path = dir.path().join("G1R-knowledge-solo.out.sav");
+        let private_payload = build_knowledge_map_payload(&["OC_STT_Diego"]);
+        let seed_compressed = b"seed-knowledge-solo".to_vec();
+        let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot A"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+        let backend = PrefixCodecBackend {
+            seed_compressed,
+            seed_uncompressed: private_payload,
+        };
+
+        let response = write_save_with_codec_backend(
+            &path,
+            &[json!({
+                "path": "private.knowledge.addCharacter",
+                "value": { "value": "OC_TEST_BrandNew" }
+            })],
+            false,
+            Some(&output_path),
+            Some(&backend),
+        )
+        .unwrap();
+        assert_eq!(response["editsApplied"], 1);
+    }
+
     // ── Task 5 helpers ──────────────────────────────────────────────────────
 
     fn private_enum_property(name: &str, enum_type: &str, label: &str) -> Vec<u8> {
@@ -12109,6 +12214,14 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .contains(&json!("private.typed.setValue"))
+        );
+        // The knowledge map is editable via add-character; the progression
+        // summary advertises it whenever the typed parse succeeds.
+        assert!(
+            progression["writable"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("private.knowledge.addCharacter"))
         );
         // The old heuristic fields are gone.
         assert!(progression.get("candidates").is_none());

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -3533,6 +3533,43 @@ fn progression_knowledge(
     }
 }
 
+/// Serialize one `CharacterKnowledgeByUniqueName` map entry: an inline Name key
+/// (the NPC's unique name) followed by an inline `KnowledgeSet` struct value that
+/// holds an empty `Knowledge` set. The struct value is a property list with one
+/// (empty) Name set named "Knowledge", terminated by the "None" sentinel that
+/// closes a non-native struct's property list.
+///
+/// The returned bytes are a schema-valid entry for the proven map layout and are
+/// meant to feed `ContainerEdit::MapInsert`. (Task 6 wires this into the IPC op;
+/// today only the round-trip test exercises it.)
+#[allow(dead_code)]
+fn encode_knowledge_map_entry(unique_name: &str) -> Vec<u8> {
+    let mut out = properties::encode_fstring_value(unique_name); // inline Name key
+    out.extend_from_slice(&encode_empty_name_set_property("Knowledge"));
+    out.extend_from_slice(&properties::encode_fstring_value("None"));
+    out
+}
+
+/// A tagged `SetProperty<NameProperty>` carrying zero elements. The byte layout
+/// matches the proven `name_set_property("Knowledge", &[])` fixture exactly:
+/// name fstring, "SetProperty" fstring, `1u32`, "NameProperty" fstring,
+/// `0u32` array_index, body-size `u32`, `0u8` tag_flags, then the body
+/// (`num_to_remove u32` + `count u32`).
+#[allow(dead_code)]
+fn encode_empty_name_set_property(name: &str) -> Vec<u8> {
+    let mut body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+    body.extend_from_slice(&0u32.to_le_bytes()); // count
+    let mut out = properties::encode_fstring_value(name);
+    out.extend_from_slice(&properties::encode_fstring_value("SetProperty"));
+    out.extend_from_slice(&1u32.to_le_bytes()); // array_index marker
+    out.extend_from_slice(&properties::encode_fstring_value("NameProperty"));
+    out.extend_from_slice(&0u32.to_le_bytes()); // array_index
+    out.extend_from_slice(&(body.len() as u32).to_le_bytes()); // body size
+    out.push(0); // tag_flags
+    out.extend_from_slice(&body);
+    out
+}
+
 fn progression_events(
     root: &properties::RootObject,
     query: &str,
@@ -11089,6 +11126,77 @@ mod tests {
         out.push(0); // tag_flags
         out.extend_from_slice(&body);
         out
+    }
+
+    /// Wrap a single `encode_knowledge_map_entry` blob in a one-entry
+    /// `CharacterKnowledgeByUniqueName` map, frame it as a private root, parse,
+    /// and return the entry's key string plus its `Knowledge` set elements.
+    ///
+    /// The map tag header mirrors `properties::knowledge_map_property` (the
+    /// corrected Task 3 layout); `parse_private_root` is the oracle — if the
+    /// produced entry bytes are wrong, this won't parse.
+    fn parse_single_knowledge_entry(entry_bytes: &[u8]) -> (String, Vec<String>) {
+        let mut body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        body.extend_from_slice(&1u32.to_le_bytes()); // count
+        body.extend_from_slice(entry_bytes);
+
+        // MapProperty<NameProperty, StructProperty(KnowledgeSet)> tag.
+        let mut prop = fstring("CharacterKnowledgeByUniqueName");
+        prop.extend_from_slice(&fstring("MapProperty"));
+        prop.extend_from_slice(&2u32.to_le_bytes()); // descriptor count
+        prop.extend_from_slice(&fstring("NameProperty")); // key type
+        prop.extend_from_slice(&0u32.to_le_bytes()); // key_flags
+        prop.extend_from_slice(&fstring("StructProperty")); // value type
+        prop.extend_from_slice(&1u32.to_le_bytes()); // struct descriptor count
+        prop.extend_from_slice(&fstring("KnowledgeSet")); // value struct type
+        prop.extend_from_slice(&1u32.to_le_bytes()); // package count
+        prop.extend_from_slice(&fstring("/Script/G1R")); // package
+        prop.extend_from_slice(&0u32.to_le_bytes()); // array_index
+        prop.extend_from_slice(&(body.len() as u32).to_le_bytes()); // size
+        prop.push(0); // tag_flags
+        prop.extend_from_slice(&body);
+
+        // Private-root framing: class fstring + object flag + props + "None" + footer.
+        let mut payload = fstring("/Script/Test.Save");
+        payload.push(0);
+        payload.extend_from_slice(&prop);
+        payload.extend_from_slice(&fstring("None"));
+        payload.extend_from_slice(&0u32.to_le_bytes());
+
+        let root = properties::parse_private_root(&payload).unwrap();
+        let (_, map_prop) =
+            properties::find_property_by_name(&root, "CharacterKnowledgeByUniqueName").unwrap();
+        let properties::PropertyValue::Map { entries, .. } = &map_prop.value else {
+            panic!("CharacterKnowledgeByUniqueName is not a map");
+        };
+        assert_eq!(entries.len(), 1, "expected exactly one entry");
+        let (key, value) = &entries[0];
+        let key = match key {
+            properties::PropertyValue::Name(s) | properties::PropertyValue::Str(s) => s.clone(),
+            other => panic!("unexpected key {other:?}"),
+        };
+        let knowledge = match struct_member(value, "Knowledge") {
+            Some(properties::PropertyValue::Set { elements, .. }) => elements
+                .iter()
+                .filter_map(|e| match e {
+                    properties::PropertyValue::Name(s) | properties::PropertyValue::Str(s) => {
+                        Some(s.clone())
+                    }
+                    _ => None,
+                })
+                .collect(),
+            other => panic!("Knowledge member is not a set: {other:?}"),
+        };
+        (key, knowledge)
+    }
+
+    #[test]
+    fn empty_knowledge_value_roundtrips_as_struct_with_empty_set() {
+        let key = "OC_TEST_Npc";
+        let entry = encode_knowledge_map_entry(key);
+        let (parsed_key, knowledge) = parse_single_knowledge_entry(&entry);
+        assert_eq!(parsed_key, key);
+        assert!(knowledge.is_empty());
     }
 
     #[test]

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -3540,9 +3540,8 @@ fn progression_knowledge(
 /// closes a non-native struct's property list.
 ///
 /// The returned bytes are a schema-valid entry for the proven map layout and are
-/// meant to feed `ContainerEdit::MapInsert`. (Task 6 wires this into the IPC op;
-/// today only the round-trip test exercises it.)
-#[allow(dead_code)]
+/// meant to feed `ContainerEdit::MapInsert`. Wired into the
+/// `private.knowledge.addCharacter` IPC op.
 fn encode_knowledge_map_entry(unique_name: &str) -> Vec<u8> {
     let mut out = properties::encode_fstring_value(unique_name); // inline Name key
     out.extend_from_slice(&encode_empty_name_set_property("Knowledge"));
@@ -3555,7 +3554,6 @@ fn encode_knowledge_map_entry(unique_name: &str) -> Vec<u8> {
 /// name fstring, "SetProperty" fstring, `1u32`, "NameProperty" fstring,
 /// `0u32` array_index, body-size `u32`, `0u8` tag_flags, then the body
 /// (`num_to_remove u32` + `count u32`).
-#[allow(dead_code)]
 fn encode_empty_name_set_property(name: &str) -> Vec<u8> {
     let mut body = 0u32.to_le_bytes().to_vec(); // num_to_remove
     body.extend_from_slice(&0u32.to_le_bytes()); // count
@@ -4934,6 +4932,20 @@ fn apply_private_edits(
                     parse_private_typed_container_edit(edit, edit.path.as_str())
                         .map(PrivateEdit::TypedContainer)
                 }
+                "private.knowledge.addCharacter" => {
+                    let name = edit
+                        .value
+                        .get("value")
+                        .and_then(|v| v.as_str())
+                        .ok_or_else(|| {
+                            CoreError::InvalidRequest(
+                                "private.knowledge.addCharacter requires a string `value`"
+                                    .to_string(),
+                            )
+                        })?
+                        .to_string();
+                    Ok(PrivateEdit::KnowledgeAddCharacter(name))
+                }
                 other => Err(CoreError::UnsupportedEdit(format!(
                     "{other} is not writable in this build"
                 ))),
@@ -5075,6 +5087,7 @@ enum PrivateEdit {
     InventoryRemoveItem(PrivateInventoryRemoveItemEdit),
     TypedSetValue(PrivateTypedSetValueEdit),
     TypedContainer(PrivateTypedContainerEdit),
+    KnowledgeAddCharacter(String),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -5734,6 +5747,9 @@ fn apply_private_edit_to_payload(
         PrivateEdit::TypedContainer(edit) => {
             apply_private_typed_container_edit_to_payload(payload, edit)
         }
+        PrivateEdit::KnowledgeAddCharacter(name) => {
+            apply_private_knowledge_add_character_to_payload(payload, name)
+        }
     }
 }
 
@@ -5759,6 +5775,75 @@ fn apply_private_typed_container_edit_to_payload(
             "container patch produced an inconsistent payload: {err}"
         ))
     })?;
+    *payload = patched;
+    Ok(())
+}
+
+/// Insert a brand-new NPC (empty `Knowledge` set) into the savegame's
+/// `CharacterKnowledgeByUniqueName` map. Resolves the nested map plus its
+/// enclosing size fields, rejects a duplicate name (case-insensitive Name
+/// semantics), then splices in a schema-valid empty-knowledge entry. All
+/// resolution and validation happen before `patch_container`, and the patch is
+/// applied on a scratch copy proven consistent by a strict re-parse, so a
+/// failed edit leaves the caller's payload untouched.
+fn apply_private_knowledge_add_character_to_payload(
+    payload: &mut Vec<u8>,
+    unique_name: &str,
+) -> Result<(), CoreError> {
+    let name = unique_name.trim();
+    if name.is_empty() {
+        return Err(CoreError::InvalidRequest(
+            "character name is empty".to_string(),
+        ));
+    }
+    // Resolve the map + enclosing size fields, and reject duplicates, in a scope
+    // that drops the borrow before the &mut payload patch.
+    let (target, enclosing) = {
+        let root = properties::parse_private_root(payload)?;
+        let (path, map_prop) =
+            properties::find_property_by_name(&root, "CharacterKnowledgeByUniqueName")
+                .ok_or_else(|| {
+                    CoreError::Parse("CharacterKnowledgeByUniqueName not found".to_string())
+                })?;
+        if let properties::PropertyValue::Map { entries, .. } = &map_prop.value {
+            if entries.iter().any(|(k, _)| {
+                map_key_string(k)
+                    .map(|s| s.eq_ignore_ascii_case(name))
+                    .unwrap_or(false)
+            }) {
+                return Err(CoreError::InvalidRequest(format!(
+                    "character {name:?} already has a knowledge entry"
+                )));
+            }
+        }
+        let segs = properties::parse_path(&path)?;
+        let chain = properties::resolve_chain(&root.properties, &segs)?;
+        (chain.target.clone(), chain.enclosing_size_fields.clone())
+    };
+    let entry = encode_knowledge_map_entry(name);
+    // Length-changing patch on a scratch copy, proven consistent by a strict
+    // re-parse before it touches the caller's payload.
+    let mut patched = payload.clone();
+    properties::patch_container(
+        &mut patched,
+        &target,
+        &enclosing,
+        &properties::ContainerEdit::MapInsert { entry_bytes: entry },
+    )?;
+    let root2 = properties::parse_private_root(&patched).map_err(|err| {
+        CoreError::Parse(format!(
+            "knowledge add-character produced an inconsistent payload: {err}"
+        ))
+    })?;
+    // Strict re-parse validation: the key must now resolve.
+    properties::find_property_by_name(&root2, "CharacterKnowledgeByUniqueName")
+        .and_then(|(_, p)| match &p.value {
+            properties::PropertyValue::Map { entries, .. } => entries
+                .iter()
+                .find(|(k, _)| map_key_string(k) == Some(name)),
+            _ => None,
+        })
+        .ok_or_else(|| CoreError::Parse("post-insert validation failed".to_string()))?;
     *payload = patched;
     Ok(())
 }
@@ -11197,6 +11282,88 @@ mod tests {
         let (parsed_key, knowledge) = parse_single_knowledge_entry(&entry);
         assert_eq!(parsed_key, key);
         assert!(knowledge.is_empty());
+    }
+
+    /// Build a full private-root payload whose only property is a
+    /// `CharacterKnowledgeByUniqueName` map carrying `chars` (each with an empty
+    /// `Knowledge` set). Uses the same corrected map-tag header proven in
+    /// Tasks 3/5 (`parse_single_knowledge_entry`), generalised to N entries.
+    fn build_knowledge_map_payload(chars: &[&str]) -> Vec<u8> {
+        let mut entries = Vec::new();
+        for name in chars {
+            entries.extend_from_slice(&encode_knowledge_map_entry(name));
+        }
+        let mut body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        body.extend_from_slice(&(chars.len() as u32).to_le_bytes()); // count
+        body.extend_from_slice(&entries);
+
+        // MapProperty<NameProperty, StructProperty(KnowledgeSet)> tag.
+        let mut prop = fstring("CharacterKnowledgeByUniqueName");
+        prop.extend_from_slice(&fstring("MapProperty"));
+        prop.extend_from_slice(&2u32.to_le_bytes()); // descriptor count
+        prop.extend_from_slice(&fstring("NameProperty")); // key type
+        prop.extend_from_slice(&0u32.to_le_bytes()); // key_flags
+        prop.extend_from_slice(&fstring("StructProperty")); // value type
+        prop.extend_from_slice(&1u32.to_le_bytes()); // struct descriptor count
+        prop.extend_from_slice(&fstring("KnowledgeSet")); // value struct type
+        prop.extend_from_slice(&1u32.to_le_bytes()); // package count
+        prop.extend_from_slice(&fstring("/Script/G1R")); // package
+        prop.extend_from_slice(&0u32.to_le_bytes()); // array_index
+        prop.extend_from_slice(&(body.len() as u32).to_le_bytes()); // size
+        prop.push(0); // tag_flags
+        prop.extend_from_slice(&body);
+
+        // Private-root framing: class fstring + object flag + props + "None" + footer.
+        let mut payload = fstring("/Script/Test.Save");
+        payload.push(0);
+        payload.extend_from_slice(&prop);
+        payload.extend_from_slice(&fstring("None"));
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        payload
+    }
+
+    #[test]
+    fn add_character_inserts_empty_entry_and_rejects_duplicate() {
+        let mut payload = build_knowledge_map_payload(&["OC_STT_Diego"]);
+        let new_npc = "OC_TEST_BrandNew";
+
+        // not present yet
+        let root0 = properties::parse_private_root(&payload).unwrap();
+        let before = progression_knowledge(&root0, "", None, 0, 10_000).unwrap();
+        assert!(!before["characters"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c["name"] == new_npc));
+
+        // apply
+        apply_private_knowledge_add_character_to_payload(&mut payload, new_npc).unwrap();
+
+        // present now with 0 entries; payload fully consistent
+        let root1 = properties::parse_private_root(&payload).unwrap();
+        assert_eq!(root1.consumed, payload.len());
+        let after = progression_knowledge(&root1, "", Some(new_npc), 0, 10).unwrap();
+        assert_eq!(after["total"], 0);
+
+        // duplicate rejected (case-insensitive Name semantics)
+        assert!(apply_private_knowledge_add_character_to_payload(&mut payload, new_npc).is_err());
+        assert!(
+            apply_private_knowledge_add_character_to_payload(&mut payload, "oc_test_brandnew")
+                .is_err()
+        );
+    }
+
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn add_character_roundtrips_on_real_payload() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let mut payload = std::fs::read(path).unwrap();
+        let new_npc = "OC_TEST_BrandNew";
+        apply_private_knowledge_add_character_to_payload(&mut payload, new_npc).unwrap();
+        let root = properties::parse_private_root(&payload).unwrap();
+        assert_eq!(root.consumed, payload.len());
+        let after = progression_knowledge(&root, "", Some(new_npc), 0, 10).unwrap();
+        assert_eq!(after["total"], 0);
     }
 
     #[test]

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -1037,6 +1037,10 @@ pub enum ContainerEdit {
     /// type; the caller is responsible for that (it is validated by the
     /// re-parse the caller performs afterwards).
     ArrayInsertBytes(Vec<u8>),
+    /// Append a pre-built (inline key ++ inline value) entry to a MapProperty.
+    /// The bytes must be schema-valid for this map's key/value descriptors; the
+    /// caller validates via the re-parse it performs afterwards.
+    MapInsert { entry_bytes: Vec<u8> },
 }
 
 fn set_string_elements(target: &Property) -> Option<&[PropertyValue]> {
@@ -1074,8 +1078,16 @@ pub fn patch_container(
     enclosing_size_fields: &[usize],
     edit: &ContainerEdit,
 ) -> Result<(), CoreError> {
-    let layout = container_layout(payload, target)?;
+    // Map inserts are handled inline (key/value pairs); `container_layout`
+    // rejects MapProperty, so resolve the Array/Set layout lazily and skip it
+    // for the map path. The shared size-chain fixup below runs for both.
+    let layout = match edit {
+        ContainerEdit::MapInsert { .. } => None,
+        _ => Some(container_layout(payload, target)?),
+    };
     let require_kind = |wanted: ContainerKind, op: &str| {
+        // Only reachable for Array/Set edits, where `layout` is always Some.
+        let layout = layout.as_ref().expect("non-map edit resolves a layout");
         if layout.kind == wanted {
             Ok(())
         } else {
@@ -1095,6 +1107,7 @@ pub fn patch_container(
     ) = match edit {
         ContainerEdit::SetAdd(value) => {
             require_kind(ContainerKind::Set, "setAdd")?;
+            let layout = layout.as_ref().expect("set edit resolves a layout");
             if !matches!(layout.inner_type.as_str(), "NameProperty" | "StrProperty") {
                 return Err(CoreError::UnsupportedEdit(format!(
                     "setAdd supports Name/Str sets; this set holds {}",
@@ -1114,6 +1127,7 @@ pub fn patch_container(
         }
         ContainerEdit::SetRemove(value) => {
             require_kind(ContainerKind::Set, "setRemove")?;
+            let layout = layout.as_ref().expect("set edit resolves a layout");
             let elements = set_string_elements(target)
                 .ok_or_else(|| CoreError::Parse("set value not parsed as a set".into()))?;
             let fold_case = layout.inner_type == "NameProperty";
@@ -1124,6 +1138,7 @@ pub fn patch_container(
         }
         ContainerEdit::ArrayRemove(index) => {
             require_kind(ContainerKind::Array, "arrayRemove")?;
+            let layout = layout.as_ref().expect("array edit resolves a layout");
             let range = layout.element_ranges.get(*index).cloned().ok_or_else(|| {
                 CoreError::InvalidRequest(format!(
                     "array index {index} out of bounds ({} elements)",
@@ -1134,6 +1149,7 @@ pub fn patch_container(
         }
         ContainerEdit::ArrayDuplicate(index) => {
             require_kind(ContainerKind::Array, "arrayDuplicate")?;
+            let layout = layout.as_ref().expect("array edit resolves a layout");
             let range = layout.element_ranges.get(*index).cloned().ok_or_else(|| {
                 CoreError::InvalidRequest(format!(
                     "array index {index} out of bounds ({} elements)",
@@ -1150,10 +1166,34 @@ pub fn patch_container(
             let end = target.value_offset + target.value_size;
             (None, end, bytes.clone(), 1)
         }
+        ContainerEdit::MapInsert { entry_bytes } => {
+            if target.type_name != "MapProperty" {
+                return Err(CoreError::InvalidRequest(format!(
+                    "mapInsert requires a MapProperty target, got {}",
+                    target.type_name
+                )));
+            }
+            let insert_at = target.value_offset + target.value_size; // end of map body
+            (None, insert_at, entry_bytes.clone(), 1)
+        }
+    };
+    // The entry/element count lives at `count_offset`; its current value comes
+    // from the layout for Array/Set, or from `map_layout` for the map path.
+    // Both are computed before any mutation (offsets stay valid until the
+    // splice), preserving the "failed patch leaves payload untouched" rule.
+    let (count, count_offset) = match edit {
+        ContainerEdit::MapInsert { .. } => {
+            let map = map_layout(payload, target)?;
+            (map.count, map.count_offset)
+        }
+        _ => {
+            let layout = layout.as_ref().expect("non-map edit resolves a layout");
+            (layout.count, layout.count_offset)
+        }
     };
     let removed = remove_range.as_ref().map_or(0, |r| r.len());
     let delta = insert_bytes.len() as i64 - removed as i64;
-    let new_count = u32::try_from(layout.count as i64 + count_delta)
+    let new_count = u32::try_from(count as i64 + count_delta)
         .map_err(|_| CoreError::Parse("container count underflow".to_string()))?;
     let new_size = u32::try_from(target.value_size as i64 + delta)
         .map_err(|_| CoreError::Parse("container size would leave the u32 range".to_string()))?;
@@ -1184,7 +1224,7 @@ pub fn patch_container(
     // The count field lives inside the value payload but always precedes the
     // splice position (elements follow the count), so writing it before the
     // splice is safe.
-    writes.push((layout.count_offset, new_count));
+    writes.push((count_offset, new_count));
     for (offset, value) in writes {
         payload[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
     }
@@ -2995,6 +3035,37 @@ mod tests {
         assert_eq!(layout.count, 2);
         assert_eq!(layout.entry_ranges.len(), 2);
         assert_eq!(layout.entry_ranges[0].end, layout.entry_ranges[1].start);
+    }
+
+    #[test]
+    fn map_insert_appends_entry_and_fixes_sizes() {
+        let mut payload = private_root_with_property(&knowledge_map_property(&["A"]));
+        let root = parse_private_root(&payload).unwrap();
+        let (_, prop) = find_property_by_name(&root, "CharacterKnowledgeByUniqueName").unwrap();
+        let enclosing: Vec<usize> = Vec::new(); // top-level property; no enclosing size fields
+
+        // New entry bytes: inline Name key "ZZ" + empty KnowledgeSet value.
+        let mut entry = fstring("ZZ");
+        let mut val = name_set_property("Knowledge", &[]);
+        val.extend_from_slice(&fstring("None"));
+        entry.extend_from_slice(&val);
+
+        let prop_owned = prop.clone();
+        drop(root);
+        patch_container(
+            &mut payload,
+            &prop_owned,
+            &enclosing,
+            &ContainerEdit::MapInsert { entry_bytes: entry },
+        )
+        .unwrap();
+
+        let root2 = parse_private_root(&payload).unwrap();
+        let (_, prop2) = find_property_by_name(&root2, "CharacterKnowledgeByUniqueName").unwrap();
+        let PropertyValue::Map { entries, .. } = &prop2.value else { panic!("not a map") };
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|(k, _)| matches!(k, PropertyValue::Name(s) if s == "ZZ")));
+        assert_eq!(root2.consumed, payload.len()); // proves size fields are consistent
     }
 
     fn int_array_property(name: &str, values: &[i32]) -> Vec<u8> {

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -969,6 +969,57 @@ pub fn container_layout(payload: &[u8], property: &Property) -> Result<Container
     })
 }
 
+/// Byte layout of a MapProperty value: the count-field offset and the absolute
+/// byte range of every (key+value) entry. Mirrors `container_layout` for maps,
+/// which `container_layout` rejects (maps have inline key/value pairs).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MapLayout {
+    pub count_offset: usize,
+    pub count: usize,
+    pub entry_ranges: Vec<core::ops::Range<usize>>,
+}
+
+pub fn map_layout(payload: &[u8], property: &Property) -> Result<MapLayout, CoreError> {
+    if property.type_name != "MapProperty" {
+        return Err(CoreError::InvalidRequest(format!(
+            "map_layout requires a MapProperty target, got {}",
+            property.type_name
+        )));
+    }
+    let (key, value) = property
+        .descriptor
+        .map
+        .as_deref()
+        .ok_or_else(|| CoreError::Parse("MapProperty missing descriptor".into()))?;
+    let end = property
+        .value_offset
+        .checked_add(property.value_size)
+        .filter(|end| *end <= payload.len())
+        .ok_or_else(|| CoreError::Parse("map value out of bounds".to_string()))?;
+    let mut r = Reader::new(&payload[property.value_offset..end], property.value_offset);
+    let _num_to_remove = r.u32()?;
+    let count_offset = r.abs_pos();
+    let count = r.u32()? as usize;
+    let mut entry_ranges = Vec::with_capacity(count.min(1 << 16));
+    for _ in 0..count {
+        let start = r.abs_pos();
+        read_inline_value(&mut r, key, 0)?;
+        read_inline_value(&mut r, value, 0)?;
+        entry_ranges.push(start..r.abs_pos());
+    }
+    if r.remaining() != 0 {
+        return Err(CoreError::Parse(format!(
+            "map body left {} bytes after {count} entries",
+            r.remaining()
+        )));
+    }
+    Ok(MapLayout {
+        count_offset,
+        count,
+        entry_ranges,
+    })
+}
+
 /// Structural container edit applied by `patch_container`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContainerEdit {
@@ -2898,6 +2949,52 @@ mod tests {
         out.extend_from_slice(&header(body.len() as u32, 0));
         out.extend_from_slice(&body);
         out
+    }
+
+    /// Wrap a single tagged property in a parseable private-root payload.
+    fn private_root_with_property(prop: &[u8]) -> Vec<u8> {
+        root("/Script/Test.Save", prop)
+    }
+
+    /// A MapProperty<NameProperty, StructProperty(KnowledgeSet)> with `chars`
+    /// entries, each an empty Knowledge set. Returns a full tagged property.
+    fn knowledge_map_property(chars: &[&str]) -> Vec<u8> {
+        let empty_value = || {
+            // Inline struct value: a property list holding one (empty) Name set
+            // named "Knowledge", terminated by "None".
+            let mut v = name_set_property("Knowledge", &[]);
+            v.extend_from_slice(&fstring("None"));
+            v
+        };
+        let mut body = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        body.extend_from_slice(&(chars.len() as u32).to_le_bytes()); // count
+        for c in chars {
+            body.extend_from_slice(&fstring(c)); // inline Name key
+            body.extend_from_slice(&empty_value()); // inline struct value
+        }
+        let mut out = tag("CharacterKnowledgeByUniqueName", "MapProperty");
+        out.extend_from_slice(&2u32.to_le_bytes()); // descriptor count
+        out.extend_from_slice(&fstring("NameProperty")); // key type
+        out.extend_from_slice(&0u32.to_le_bytes()); // key_flags
+        out.extend_from_slice(&fstring("StructProperty")); // value type
+        out.extend_from_slice(&1u32.to_le_bytes()); // struct descriptor count
+        out.extend_from_slice(&fstring("KnowledgeSet")); // value struct type
+        out.extend_from_slice(&1u32.to_le_bytes()); // package count
+        out.extend_from_slice(&fstring("/Script/G1R")); // package
+        out.extend_from_slice(&header(body.len() as u32, 0));
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn map_layout_reports_count_and_entry_ranges() {
+        let payload = private_root_with_property(&knowledge_map_property(&["A", "BB"]));
+        let root = parse_private_root(&payload).unwrap();
+        let (_, prop) = find_property_by_name(&root, "CharacterKnowledgeByUniqueName").unwrap();
+        let layout = map_layout(&payload, prop).unwrap();
+        assert_eq!(layout.count, 2);
+        assert_eq!(layout.entry_ranges.len(), 2);
+        assert_eq!(layout.entry_ranges[0].end, layout.entry_ranges[1].start);
     }
 
     fn int_array_property(name: &str, values: &[i32]) -> Vec<u8> {

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -800,7 +800,7 @@ pub fn patch_scalar(
 /// Serialized FString payload for a replacement value, mirroring the formats
 /// `Reader::fstring` accepts: empty => bare zero length, ASCII => 8-bit chars
 /// with a NUL terminator, otherwise UTF-16LE with a negative character count.
-fn encode_fstring_value(value: &str) -> Vec<u8> {
+pub(crate) fn encode_fstring_value(value: &str) -> Vec<u8> {
     if value.is_empty() {
         return 0i32.to_le_bytes().to_vec();
     }

--- a/docs/superpowers/plans/2026-06-15-knowledge-catalogs.md
+++ b/docs/superpowers/plans/2026-06-15-knowledge-catalogs.md
@@ -1,0 +1,1275 @@
+# Knowledge Catalogs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add catalog-backed pickers to the Knowledge tab — a full NPC list (incl. NPCs not yet in the save) and a full knowledge-entry list — plus a core op to add a brand-new NPC to the savegame's knowledge map.
+
+**Architecture:** Two Python scripts scrape the UE4SS object dump into bundled Flutter JSON assets (mirroring `tools/build_item_catalog.py`). A new Rust core `MapInsert` container edit + `private.knowledge.addCharacter` IPC op inserts an empty `KnowledgeSet` entry into `CharacterKnowledgeByUniqueName`. New Flutter picker dialogs (mirroring `add_inventory_item_dialog.dart`) drive both, reusing the existing entry add/remove path.
+
+**Tech Stack:** Rust (goresave_core), Python 3, Flutter/Dart.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-15-knowledge-catalogs-design.md`
+
+**Dump path (for local script runs/tests):**
+`D:\SteamLibrary\steamapps\common\Gothic 1 Remake\G1R\Binaries\Win64\ue4ss\UE4SS_ObjectDump.txt`
+
+---
+
+## File Structure
+
+**Create:**
+- `tools/build_npc_catalog.py` — dump → `npc_catalog.json`
+- `tools/build_knowledge_catalog.py` — dump → `knowledge_catalog.json`
+- `apps/goresave/assets/npc_catalog.json` — generated
+- `apps/goresave/assets/knowledge_catalog.json` — generated
+- `apps/goresave/lib/features/editor/domain/npc_catalog.dart` — loader
+- `apps/goresave/lib/features/editor/domain/knowledge_catalog.dart` — loader
+- `apps/goresave/lib/features/editor/ui/add_npc_dialog.dart` — NPC picker
+- `apps/goresave/lib/features/editor/ui/add_knowledge_entry_dialog.dart` — entry picker
+- `apps/goresave/test/add_npc_dialog_test.dart`
+- `apps/goresave/test/add_knowledge_entry_dialog_test.dart`
+
+**Modify:**
+- `crates/goresave_core/src/properties.rs` — add `ContainerEdit::MapInsert`, `map_layout()`, `patch_container` arm
+- `crates/goresave_core/src/lib.rs` — `private.knowledge.addCharacter` op + empty-`KnowledgeSet` encoder, promote `private_name_set_property` helper
+- `apps/goresave/pubspec.yaml:60-62` — register the two new assets
+- `apps/goresave/lib/features/editor/domain/editor_notifier.dart` — `addKnowledgeCharacter()` method
+- `apps/goresave/lib/features/editor/ui/progression_panel.dart` — wire both dialogs into `_KnowledgeDetail`
+
+---
+
+## Phase A — Catalog build scripts + assets
+
+### Task 1: NPC catalog build script
+
+**Files:**
+- Create: `tools/build_npc_catalog.py`
+- Create (generated): `apps/goresave/assets/npc_catalog.json`
+- Test: `tools/test_build_npc_catalog.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tools/test_build_npc_catalog.py
+import build_npc_catalog as m
+
+DUMP = [
+    "[0001] ASClass /Script/Angelscript.CharacterDefinition_Human_OC_STT_Diego [n: A]",
+    "[0002] ASClass /Script/Angelscript.CharacterDefinition_Human_NC_SLD_Gorn_699 [n: B]",
+    "[0003] ASClass /Script/Angelscript.CharacterDefinition_Creature_Biter [n: C]",
+    "[0004] ASClass /Script/Angelscript.CharacterDefinition_Human_OC_STT_Diego [n: D]",  # dup
+    "[0005] ASClass /Script/Angelscript.ItMw_Sword01 [n: E]",  # ignored
+]
+
+def test_human_unique_name_is_map_key_form():
+    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    by_id = {e["id"]: e for e in entries}
+    assert by_id["OC_STT_Diego"]["category"] == "human"
+    assert by_id["OC_STT_Diego"]["class"] == "CharacterDefinition_Human_OC_STT_Diego"
+
+def test_non_human_kept_and_flagged():
+    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    by_id = {e["id"]: e for e in entries}
+    assert by_id["Creature_Biter"]["category"] == "creature"
+
+def test_dedup_and_sorted():
+    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    ids = [e["id"] for e in entries]
+    assert ids == sorted(ids)
+    assert ids.count("OC_STT_Diego") == 1
+
+def test_ignores_non_character_classes():
+    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    assert all("Sword" not in e["id"] for e in entries)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools && python -m pytest test_build_npc_catalog.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'build_npc_catalog'`
+
+- [ ] **Step 3: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""Build apps/goresave/assets/npc_catalog.json from a UE4SS object dump.
+
+Usage: python tools/build_npc_catalog.py <UE4SS_ObjectDump.txt> [-o OUT.json]
+
+Extracts CharacterDefinition_* class identifiers only (id, class, category).
+The `id` of a Human definition is the exact CharacterKnowledgeByUniqueName map
+key (e.g. OC_STT_Diego). No localized names or stats are extracted.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+CLASS_RE = re.compile(r"ASClass /Script/Angelscript\.(CharacterDefinition_[A-Za-z0-9_]+)")
+
+# Sub-prefix after CharacterDefinition_ -> UI category.
+CATEGORY_BY_SUBPREFIX = [
+    ("Human_", "human"),
+    ("Creature_", "creature"),
+]
+
+
+def parse_dump_classes(lines) -> list[str]:
+    names: set[str] = set()
+    for line in lines:
+        match = CLASS_RE.search(line)
+        if match:
+            names.add(match.group(1))
+    return sorted(names)
+
+
+def build_catalog(class_names: list[str]) -> tuple[list[dict], list[str]]:
+    entries: list[dict] = []
+    skipped: list[str] = []
+    for cls in class_names:
+        rest = cls[len("CharacterDefinition_"):]
+        category = "other"
+        unique = rest
+        for sub, cat in CATEGORY_BY_SUBPREFIX:
+            if rest.startswith(sub):
+                category = cat
+                if cat == "human":
+                    unique = rest[len(sub):]  # map-key form
+                break
+        if not unique:
+            skipped.append(cls)
+            continue
+        entries.append({"id": unique, "class": cls, "category": category})
+    entries.sort(key=lambda e: e["id"])
+    # Dedup by id (different classes can collapse to the same unique name).
+    seen: set[str] = set()
+    deduped = []
+    for e in entries:
+        if e["id"] in seen:
+            continue
+        seen.add(e["id"])
+        deduped.append(e)
+    return deduped, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump", type=Path)
+    parser.add_argument(
+        "-o", "--out", type=Path,
+        default=Path(__file__).resolve().parent.parent
+        / "apps" / "goresave" / "assets" / "npc_catalog.json",
+    )
+    args = parser.parse_args()
+    names = parse_dump_classes(
+        args.dump.read_text(encoding="utf-8", errors="replace").splitlines()
+    )
+    entries, skipped = build_catalog(names)
+    args.out.write_text(
+        json.dumps(entries, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {len(entries)} npcs to {args.out}")
+    if skipped:
+        print(f"skipped {len(skipped)} classes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools && python -m pytest test_build_npc_catalog.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Generate the asset from the real dump**
+
+Run:
+```
+python tools/build_npc_catalog.py "D:\SteamLibrary\steamapps\common\Gothic 1 Remake\G1R\Binaries\Win64\ue4ss\UE4SS_ObjectDump.txt"
+```
+Expected: `wrote ~1000 npcs to ...npc_catalog.json`. Sanity-check it contains `OC_STT_Diego`:
+Run: `grep -c '"OC_STT_Diego"' apps/goresave/assets/npc_catalog.json` → `1`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/build_npc_catalog.py tools/test_build_npc_catalog.py apps/goresave/assets/npc_catalog.json
+git commit -m "feat(tools): build npc_catalog.json from UE4SS dump"
+```
+
+### Task 2: Knowledge entry catalog build script
+
+**Files:**
+- Create: `tools/build_knowledge_catalog.py`
+- Create (generated): `apps/goresave/assets/knowledge_catalog.json`
+- Test: `tools/test_build_knowledge_catalog.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tools/test_build_knowledge_catalog.py
+import build_knowledge_catalog as m
+
+DUMP = [
+    "[1] ASClass /Script/Angelscript.Topic_Diego_209799 [n: A]",
+    "[2] ASClass /Script/Angelscript.Info_FMORGAreyouok [n: B]",
+    "[3] ASClass /Script/Angelscript.ChoiceDiegoGamestart [n: C]",
+    "[4] ASClass /Script/Angelscript.Topic_Diego_209799 [n: D]",  # dup
+    "[5] ASClass /Script/Angelscript.ItMw_Sword01 [n: E]",  # ignored
+    "[6] ASClass /Script/Angelscript.CharacterDefinition_Human_OC_STT_Diego [n: F]",  # ignored
+]
+
+def test_categories():
+    entries = m.build_catalog(m.parse_dump_classes(DUMP))
+    by_id = {e["id"]: e for e in entries}
+    assert by_id["Topic_Diego_209799"]["category"] == "topic"
+    assert by_id["Info_FMORGAreyouok"]["category"] == "info"
+    assert by_id["ChoiceDiegoGamestart"]["category"] == "choice"
+
+def test_dedup_sorted_and_filtered():
+    entries = m.build_catalog(m.parse_dump_classes(DUMP))
+    ids = [e["id"] for e in entries]
+    assert ids == sorted(ids)
+    assert ids.count("Topic_Diego_209799") == 1
+    assert all("Sword" not in i and "CharacterDefinition" not in i for i in ids)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools && python -m pytest test_build_knowledge_catalog.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""Build apps/goresave/assets/knowledge_catalog.json from a UE4SS object dump.
+
+Usage: python tools/build_knowledge_catalog.py <UE4SS_ObjectDump.txt> [-o OUT.json]
+
+Extracts Topic_/Info_/Choice* class identifiers (id, category). These are the
+dialog-unlock knowledge tokens that appear in a character's Knowledge set.
+Voiceline tokens are intentionally excluded (localization keys, not classes).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Order matters: Topic_/Info_ before bare Choice.
+PATTERNS = [
+    (re.compile(r"ASClass /Script/Angelscript\.(Topic_[A-Za-z0-9_]+)"), "topic"),
+    (re.compile(r"ASClass /Script/Angelscript\.(Info_[A-Za-z0-9_]+)"), "info"),
+    (re.compile(r"ASClass /Script/Angelscript\.(Choice[A-Za-z0-9_]+)"), "choice"),
+]
+
+
+def parse_dump_classes(lines) -> list[tuple[str, str]]:
+    found: dict[str, str] = {}
+    for line in lines:
+        for rx, category in PATTERNS:
+            match = rx.search(line)
+            if match:
+                found.setdefault(match.group(1), category)
+                break
+    return sorted(found.items())
+
+
+def build_catalog(pairs: list[tuple[str, str]]) -> list[dict]:
+    entries = [{"id": name, "category": cat} for name, cat in pairs]
+    entries.sort(key=lambda e: e["id"])
+    return entries
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump", type=Path)
+    parser.add_argument(
+        "-o", "--out", type=Path,
+        default=Path(__file__).resolve().parent.parent
+        / "apps" / "goresave" / "assets" / "knowledge_catalog.json",
+    )
+    args = parser.parse_args()
+    pairs = parse_dump_classes(
+        args.dump.read_text(encoding="utf-8", errors="replace").splitlines()
+    )
+    entries = build_catalog(pairs)
+    args.out.write_text(
+        json.dumps(entries, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {len(entries)} knowledge tokens to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools && python -m pytest test_build_knowledge_catalog.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Generate the asset from the real dump**
+
+Run:
+```
+python tools/build_knowledge_catalog.py "D:\SteamLibrary\steamapps\common\Gothic 1 Remake\G1R\Binaries\Win64\ue4ss\UE4SS_ObjectDump.txt"
+```
+Expected: `wrote ~3900 knowledge tokens ...`. Sanity-check:
+Run: `grep -c '"Topic_Diego_209799"' apps/goresave/assets/knowledge_catalog.json` → `1`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/build_knowledge_catalog.py tools/test_build_knowledge_catalog.py apps/goresave/assets/knowledge_catalog.json
+git commit -m "feat(tools): build knowledge_catalog.json from UE4SS dump"
+```
+
+---
+
+## Phase B — Core map insertion + add-character op
+
+Background on the on-disk format (verified in `properties.rs`):
+- `CharacterKnowledgeByUniqueName` is a `MapProperty<NameProperty, StructProperty(KnowledgeSet)>`.
+- Map body layout: `num_to_remove:u32`, `count:u32`, then `count` × (inline key, inline value).
+- Inline `NameProperty` key = `fstring(name)`.
+- Inline `StructProperty` value (KnowledgeSet, non-native) = a tagged-property list terminated by `fstring("None")`. The one property is `Knowledge` (a `SetProperty<NameProperty>`).
+- The existing test helper `private_name_set_property(name, values)` (`lib.rs:11143`) emits exactly one such tagged `SetProperty`. An empty `KnowledgeSet` value = `private_name_set_property("Knowledge", &[]) ++ fstring("None")`.
+
+### Task 3: `map_layout()` helper
+
+**Files:**
+- Modify: `crates/goresave_core/src/properties.rs` (add after `container_layout`, ~line 970)
+- Test: same file, `#[cfg(test)]` module
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `properties.rs` test module (reuse existing `fstring` + `map_of_instanced_payload`-style helpers; if a Name→Set map helper does not exist, add this one near the other test helpers):
+
+```rust
+// test helper: a MapProperty<NameProperty, StructProperty(KnowledgeSet)> with
+// `chars` entries, each an empty Knowledge set. Returns a full tagged property.
+fn knowledge_map_property(chars: &[&str]) -> Vec<u8> {
+    // inline value bytes: tagged "Knowledge" SetProperty(empty) + "None"
+    let empty_value = || {
+        let mut v = name_set_property("Knowledge", &[]); // existing test helper
+        v.extend_from_slice(&fstring("None"));
+        v
+    };
+    let mut body = 0u32.to_le_bytes().to_vec();              // num_to_remove
+    body.extend_from_slice(&(chars.len() as u32).to_le_bytes()); // count
+    for c in chars {
+        body.extend_from_slice(&fstring(c));   // inline Name key
+        body.extend_from_slice(&empty_value()); // inline struct value
+    }
+    // tag header: name, "MapProperty", key/value inner type names, size, flags
+    let mut out = fstring("CharacterKnowledgeByUniqueName");
+    out.extend_from_slice(&fstring("MapProperty"));
+    out.extend_from_slice(&0u32.to_le_bytes()); // array_index
+    out.extend_from_slice(&fstring("NameProperty"));   // key type
+    out.extend_from_slice(&fstring("StructProperty"));  // value type
+    out.extend_from_slice(&fstring("KnowledgeSet"));    // value struct type
+    out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    out.push(0); // tag_flags
+    out.extend_from_slice(&body);
+    out
+}
+
+#[test]
+fn map_layout_reports_count_and_entry_ranges() {
+    // Build a private root whose only property is the knowledge map.
+    let payload = private_root_with_property(&knowledge_map_property(&["A", "BB"]));
+    let root = parse_private_root(&payload).unwrap();
+    let (_, prop) = find_property_by_name(&root, "CharacterKnowledgeByUniqueName").unwrap();
+    let layout = map_layout(&payload, prop).unwrap();
+    assert_eq!(layout.count, 2);
+    assert_eq!(layout.entry_ranges.len(), 2);
+    // entry_ranges must be contiguous and end at the map body end.
+    assert_eq!(layout.entry_ranges[0].end, layout.entry_ranges[1].start);
+}
+```
+
+> NOTE: `name_set_property`, `fstring`, and a private-root wrapper helper already
+> exist in the `properties.rs`/`lib.rs` test modules (see `properties.rs:2920`,
+> `2176`). If `private_root_with_property` does not exist in `properties.rs`,
+> add a minimal one that wraps a single tagged property in the class/flag/footer
+> framing `parse_private_root` expects (copy the structure from
+> `map_of_instanced_payload`'s caller).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core map_layout_reports_count -- --nocapture`
+Expected: FAIL — `cannot find function map_layout`
+
+- [ ] **Step 3: Implement `map_layout`**
+
+```rust
+/// Byte layout of a MapProperty value: the count-field offset and the absolute
+/// byte range of every (key+value) entry. Mirrors `container_layout` for maps,
+/// which `container_layout` rejects (maps have inline key/value pairs).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MapLayout {
+    pub count_offset: usize,
+    pub count: usize,
+    /// Absolute byte range of each entry (key bytes + value bytes).
+    pub entry_ranges: Vec<core::ops::Range<usize>>,
+}
+
+pub fn map_layout(payload: &[u8], property: &Property) -> Result<MapLayout, CoreError> {
+    if property.type_name != "MapProperty" {
+        return Err(CoreError::InvalidRequest(format!(
+            "map_layout requires a MapProperty target, got {}",
+            property.type_name
+        )));
+    }
+    let (key, value) = property
+        .descriptor
+        .map
+        .as_deref()
+        .ok_or_else(|| CoreError::Parse("MapProperty missing descriptor".into()))?;
+    let end = property
+        .value_offset
+        .checked_add(property.value_size)
+        .filter(|end| *end <= payload.len())
+        .ok_or_else(|| CoreError::Parse("map value out of bounds".to_string()))?;
+    let mut r = Reader::new(&payload[property.value_offset..end], property.value_offset);
+    let _num_to_remove = r.u32()?;
+    let count_offset = r.abs_pos();
+    let count = r.u32()? as usize;
+    let mut entry_ranges = Vec::with_capacity(count.min(1 << 16));
+    for _ in 0..count {
+        let start = r.abs_pos();
+        read_inline_value(&mut r, key, 0)?;
+        read_inline_value(&mut r, value, 0)?;
+        entry_ranges.push(start..r.abs_pos());
+    }
+    if r.remaining() != 0 {
+        return Err(CoreError::Parse(format!(
+            "map body left {} bytes after {count} entries",
+            r.remaining()
+        )));
+    }
+    Ok(MapLayout { count_offset, count, entry_ranges })
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core map_layout_reports_count`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/properties.rs
+git commit -m "feat(core): add map_layout helper for MapProperty editing"
+```
+
+### Task 4: `ContainerEdit::MapInsert` + `patch_container` arm
+
+**Files:**
+- Modify: `crates/goresave_core/src/properties.rs` (`ContainerEdit` enum ~973; `patch_container` ~1020)
+- Test: same file
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn map_insert_appends_entry_and_fixes_sizes() {
+    let mut payload = private_root_with_property(&knowledge_map_property(&["A"]));
+    let root = parse_private_root(&payload).unwrap();
+    let (_, prop) = find_property_by_name(&root, "CharacterKnowledgeByUniqueName").unwrap();
+    let enclosing = Vec::new(); // top-level property; no enclosing size fields
+
+    // Build new entry bytes: key "ZZ" + empty KnowledgeSet value.
+    let mut entry = fstring("ZZ");
+    let mut val = name_set_property("Knowledge", &[]);
+    val.extend_from_slice(&fstring("None"));
+    entry.extend_from_slice(&val);
+
+    patch_container(
+        &mut payload,
+        prop,
+        &enclosing,
+        &ContainerEdit::MapInsert { entry_bytes: entry },
+    )
+    .unwrap();
+
+    // Re-parse: the map now has 2 entries incl. "ZZ".
+    let root2 = parse_private_root(&payload).unwrap();
+    let (_, prop2) = find_property_by_name(&root2, "CharacterKnowledgeByUniqueName").unwrap();
+    let PropertyValue::Map { entries, .. } = &prop2.value else { panic!("not a map") };
+    assert_eq!(entries.len(), 2);
+    assert!(entries.iter().any(|(k, _)| matches!(k, PropertyValue::Name(s) if s == "ZZ")));
+    // consumed == payload length proves all size fields are consistent.
+    assert_eq!(root2.consumed, payload.len());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core map_insert_appends_entry`
+Expected: FAIL — `no variant ... MapInsert`
+
+- [ ] **Step 3: Add the enum variant**
+
+In `ContainerEdit` (after `ArrayInsertBytes`, ~line 988):
+
+```rust
+    /// Append a pre-built (inline key ++ inline value) entry to a MapProperty.
+    /// The bytes must be schema-valid for this map's key/value descriptors; the
+    /// caller validates via the re-parse it performs afterwards.
+    MapInsert { entry_bytes: Vec<u8> },
+```
+
+- [ ] **Step 4: Implement the `patch_container` arm**
+
+Inside `patch_container`'s `match edit { ... }` (alongside the other arms, before the closing of the match that produces `(remove_range, insert_at, insert_bytes, count_delta)`):
+
+```rust
+        ContainerEdit::MapInsert { entry_bytes } => {
+            if target.type_name != "MapProperty" {
+                return Err(CoreError::InvalidRequest(format!(
+                    "mapInsert requires a MapProperty target, got {}",
+                    target.type_name
+                )));
+            }
+            let map = map_layout(payload, target)?;
+            let insert_at = target.value_offset + target.value_size; // end of map body
+            (None, insert_at, entry_bytes.clone(), 1)
+        }
+```
+
+The count-field update is keyed off `layout.count_offset` for Set/Array. Maps
+have no `ContainerLayout`; their count-field offset comes from `map_layout`.
+Compute the count offset once, up front (before any splice, while offsets are
+still valid), and branch on the edit type:
+
+```rust
+    // Determine which count field to bump. Computed before the splice; offsets
+    // into `payload` are valid here because no mutation has happened yet.
+    let count_offset = match edit {
+        ContainerEdit::MapInsert { .. } => map_layout(payload, target)?.count_offset,
+        _ => layout.count_offset,
+    };
+```
+
+> IMPLEMENTATION NOTE: `container_layout(payload, target)` at the top of
+> `patch_container` returns `Err` for a `MapProperty` (it only accepts
+> Array/Set). Restructure the function head so the layout/count-offset lookup is
+> edit-aware: for `MapInsert`, call `map_layout` and skip `container_layout`; for
+> the existing edits, keep `container_layout`. The size-chain fixup (tag size at
+> `target.size_field_offset()` + every offset in `enclosing_size_fields`, then
+> the splice) is identical for both and must be reused, not duplicated. Keep the
+> "validate before mutate" guarantee: compute all offsets/deltas first, splice
+> last.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core map_insert_appends_entry`
+Expected: PASS
+
+- [ ] **Step 6: Run the full core suite (no regressions)**
+
+Run: `cargo test -p goresave_core`
+Expected: PASS (all existing tests still green)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/goresave_core/src/properties.rs
+git commit -m "feat(core): add ContainerEdit::MapInsert for map entry append"
+```
+
+### Task 5: Empty-`KnowledgeSet` encoder + promote set helper
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs` (promote `private_name_set_property` out of `#[cfg(test)]`; add `encode_empty_knowledge_value`)
+- Test: `crates/goresave_core/src/lib.rs` test module
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn empty_knowledge_value_roundtrips_as_struct_with_empty_set() {
+    let key = "OC_TEST_Npc";
+    let entry = encode_knowledge_map_entry(key);
+    // Parse the entry bytes as inline key+value using the same descriptors the
+    // map uses (NameProperty key, StructProperty/KnowledgeSet value).
+    let parsed = parse_knowledge_entry_for_test(&entry); // helper below
+    assert_eq!(parsed.0, key);                 // key
+    assert!(parsed.1.is_empty());              // Knowledge set has 0 elements
+}
+```
+
+> The test helper `parse_knowledge_entry_for_test` builds a one-entry map around
+> `entry`, runs `parse_private_root`, and returns `(key_string, knowledge_vec)`.
+> Reuse `knowledge_map_property` machinery from Task 3 by wrapping `entry` rather
+> than re-deriving it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core empty_knowledge_value_roundtrips`
+Expected: FAIL — `cannot find function encode_knowledge_map_entry`
+
+- [ ] **Step 3: Implement encoders**
+
+Promote the existing test helper to module scope (remove it from the test module, place near other byte writers; keep `fn fstring` usage consistent with the crate's existing FString writer — use the production `encode_fstring_value` if `fstring` is test-only):
+
+```rust
+/// Serialize one `CharacterKnowledgeByUniqueName` entry: inline Name key plus an
+/// inline `KnowledgeSet` struct value holding an empty `Knowledge` set.
+fn encode_knowledge_map_entry(unique_name: &str) -> Vec<u8> {
+    let mut out = properties::encode_fstring_value(unique_name); // inline Name key
+    // inline struct value: one tagged "Knowledge" SetProperty(empty) + "None"
+    out.extend_from_slice(&encode_empty_name_set_property("Knowledge"));
+    out.extend_from_slice(&properties::encode_fstring_value("None"));
+    out
+}
+
+/// A tagged `SetProperty<NameProperty>` with zero elements.
+fn encode_empty_name_set_property(name: &str) -> Vec<u8> {
+    let body = {
+        let mut b = 0u32.to_le_bytes().to_vec(); // num_to_remove
+        b.extend_from_slice(&0u32.to_le_bytes()); // count
+        b
+    };
+    let mut out = properties::encode_fstring_value(name);
+    out.extend_from_slice(&properties::encode_fstring_value("SetProperty"));
+    out.extend_from_slice(&1u32.to_le_bytes());                  // array_index
+    out.extend_from_slice(&properties::encode_fstring_value("NameProperty"));
+    out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    out.push(0); // tag_flags
+    out.extend_from_slice(&body);
+    out
+}
+```
+
+> If `properties::encode_fstring_value` is not `pub`, make it `pub(crate)`. The
+> byte layout above must match `private_name_set_property` from the test module
+> exactly — if a byte differs, the Task 4 round-trip test is the oracle.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core empty_knowledge_value_roundtrips`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): encode empty KnowledgeSet map entry bytes"
+```
+
+### Task 6: `private.knowledge.addCharacter` IPC op
+
+**Files:**
+- Modify: `crates/goresave_core/src/lib.rs` (op dispatch ~4893; new apply fn near `apply_private_typed_container_edit_to_payload` ~5703)
+- Test: `crates/goresave_core/src/lib.rs` integration test using a real payload
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn add_character_then_set_add_roundtrips_on_real_save() {
+    // Real decompressed private payload (see gothic-remake dump memory).
+    let payload = std::fs::read("../../work/decompressed/G1R-001.host.bin").unwrap();
+
+    // 1. New character must not already exist.
+    let new_npc = "OC_TEST_BrandNew";
+    let before = progression_knowledge(
+        &properties::parse_private_root(&payload).unwrap(), "", None, 0, 10_000,
+    ).unwrap();
+    assert!(!before["characters"].as_array().unwrap()
+        .iter().any(|c| c["name"] == new_npc));
+
+    // 2. Apply addCharacter to the payload.
+    let mut p = payload.clone();
+    apply_private_knowledge_add_character_to_payload(&mut p, new_npc).unwrap();
+
+    // 3. Re-query: the character exists with 0 entries.
+    let root = properties::parse_private_root(&p).unwrap();
+    let after = progression_knowledge(&root, "", Some(new_npc), 0, 10).unwrap();
+    assert_eq!(after["total"], 0);
+    assert_eq!(root.consumed, p.len());
+
+    // 4. Duplicate insert is rejected.
+    assert!(apply_private_knowledge_add_character_to_payload(&mut p, new_npc).is_err());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p goresave_core add_character_then_set_add`
+Expected: FAIL — `cannot find function apply_private_knowledge_add_character_to_payload`
+
+- [ ] **Step 3: Implement the apply function**
+
+Model it on `apply_private_typed_container_edit_to_payload` (`lib.rs:5703`): parse the
+root, resolve `CharacterKnowledgeByUniqueName` and its enclosing size-field
+offsets, reject if the key already exists, then `patch_container` with `MapInsert`.
+
+```rust
+fn apply_private_knowledge_add_character_to_payload(
+    payload: &mut Vec<u8>,
+    unique_name: &str,
+) -> Result<(), CoreError> {
+    let name = unique_name.trim();
+    if name.is_empty() {
+        return Err(CoreError::InvalidRequest("character name is empty".into()));
+    }
+    let root = properties::parse_private_root(payload)?;
+    let (path, map_prop) =
+        properties::find_property_by_name(&root, "CharacterKnowledgeByUniqueName")
+            .ok_or_else(|| CoreError::Parse(
+                "CharacterKnowledgeByUniqueName not found".into(),
+            ))?;
+    // Reject duplicates (UE Name keys compare case-insensitively).
+    if let PropertyValue::Map { entries, .. } = &map_prop.value {
+        if entries.iter().any(|(k, _)| {
+            properties::map_key_to_string(k)
+                .map(|s| s.eq_ignore_ascii_case(name))
+                .unwrap_or(false)
+        }) {
+            return Err(CoreError::InvalidRequest(format!(
+                "character {name:?} already has a knowledge entry"
+            )));
+        }
+    }
+    let enclosing = properties::enclosing_size_fields_for_path(&root, &path)?; // see note
+    let entry = encode_knowledge_map_entry(name);
+    properties::patch_container(
+        payload,
+        map_prop,
+        &enclosing,
+        &properties::ContainerEdit::MapInsert { entry_bytes: entry },
+    )?;
+    // Validate: strict re-parse must succeed and the key must now resolve.
+    let root2 = properties::parse_private_root(payload)?;
+    properties::find_property_by_name(&root2, "CharacterKnowledgeByUniqueName")
+        .and_then(|(_, p)| match &p.value {
+            PropertyValue::Map { entries, .. } => entries.iter().find(|(k, _)| {
+                properties::map_key_to_string(k).as_deref() == Some(name)
+            }),
+            _ => None,
+        })
+        .ok_or_else(|| CoreError::Parse("post-insert validation failed".into()))?;
+    Ok(())
+}
+```
+
+> NOTE on `enclosing_size_fields_for_path`: `apply_private_typed_container_edit_to_payload`
+> already computes the enclosing size-field offsets for a resolved path (it must,
+> to pass them to `patch_container`). Reuse that exact mechanism — extract it into
+> a shared helper if it is currently inline, rather than re-deriving. Borrow note:
+> `map_prop` borrows `root`; clone the small bits you need (the property is needed
+> by `patch_container` which takes `&Property` but mutates `payload`) — follow the
+> same borrow pattern the typed-container apply fn uses (it re-resolves against a
+> parse that is dropped before the mutable splice, or clones offsets). Match it.
+
+- [ ] **Step 4: Wire the op into dispatch**
+
+At the op dispatch (`lib.rs:4893`, alongside `"private.typed.setAdd"`), add:
+
+```rust
+        "private.knowledge.addCharacter" => {
+            let name = payload
+                .get("value")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| CoreError::InvalidRequest(
+                    "private.knowledge.addCharacter requires a string `value`".into(),
+                ))?
+                .to_string();
+            PrivateEdit::KnowledgeAddCharacter(name)
+        }
+```
+
+Add the `PrivateEdit::KnowledgeAddCharacter(String)` variant to the `PrivateEdit`
+enum, and in the place where `PrivateEdit` variants are applied to the payload
+(search for where `PrivateEdit::TypedContainer` is matched and
+`apply_private_typed_container_edit_to_payload` is called), add:
+
+```rust
+        PrivateEdit::KnowledgeAddCharacter(name) => {
+            apply_private_knowledge_add_character_to_payload(payload, name)?;
+        }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p goresave_core add_character_then_set_add`
+Expected: PASS
+
+- [ ] **Step 6: Full core suite**
+
+Run: `cargo test -p goresave_core`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/goresave_core/src/lib.rs
+git commit -m "feat(core): add private.knowledge.addCharacter op"
+```
+
+---
+
+## Phase C — Flutter catalog loaders
+
+### Task 7: NPC + knowledge catalog loaders and asset registration
+
+**Files:**
+- Create: `apps/goresave/lib/features/editor/domain/npc_catalog.dart`
+- Create: `apps/goresave/lib/features/editor/domain/knowledge_catalog.dart`
+- Modify: `apps/goresave/pubspec.yaml:60-62`
+- Test: `apps/goresave/test/catalog_loaders_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// apps/goresave/test/catalog_loaders_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/npc_catalog.dart';
+import 'package:goresave/features/editor/domain/knowledge_catalog.dart';
+
+void main() {
+  test('NpcCatalog parses, filters empties, sorts by id', () {
+    final c = NpcCatalog.fromJsonString(
+      '[{"id":"OC_STT_Diego","class":"CharacterDefinition_Human_OC_STT_Diego","category":"human"},'
+      '{"id":"","class":"x","category":"human"},'
+      '{"id":"Creature_Biter","class":"CharacterDefinition_Creature_Biter","category":"creature"}]',
+    );
+    expect(c.entries.map((e) => e.id), ['Creature_Biter', 'OC_STT_Diego']);
+    expect(c.entries.first.category, 'creature');
+  });
+
+  test('KnowledgeCatalog parses, filters empties, sorts by id', () {
+    final c = KnowledgeCatalog.fromJsonString(
+      '[{"id":"Topic_Diego_209799","category":"topic"},'
+      '{"id":"","category":"choice"},'
+      '{"id":"ChoiceDiegoGamestart","category":"choice"}]',
+    );
+    expect(c.entries.map((e) => e.id), ['ChoiceDiegoGamestart', 'Topic_Diego_209799']);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/goresave && flutter test test/catalog_loaders_test.dart`
+Expected: FAIL — cannot find `npc_catalog.dart`
+
+- [ ] **Step 3: Implement `npc_catalog.dart`** (mirror `item_catalog.dart`)
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+class NpcCatalogEntry {
+  const NpcCatalogEntry({
+    required this.id,
+    required this.className,
+    required this.category,
+  });
+
+  final String id;
+  final String className;
+  final String category;
+}
+
+class NpcCatalog {
+  const NpcCatalog(this.entries);
+
+  final List<NpcCatalogEntry> entries;
+
+  static NpcCatalog fromJsonString(String json) {
+    final list = (jsonDecode(json) as List)
+        .whereType<Map<String, Object?>>()
+        .map((e) => NpcCatalogEntry(
+              id: e['id'] as String? ?? '',
+              className: e['class'] as String? ?? '',
+              category: e['category'] as String? ?? 'other',
+            ))
+        .where((e) => e.id.isNotEmpty)
+        .toList()
+      ..sort((a, b) => a.id.compareTo(b.id));
+    return NpcCatalog(list);
+  }
+
+  static Future<NpcCatalog> loadBundled() async =>
+      fromJsonString(await rootBundle.loadString('assets/npc_catalog.json'));
+}
+```
+
+- [ ] **Step 4: Implement `knowledge_catalog.dart`**
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+class KnowledgeCatalogEntry {
+  const KnowledgeCatalogEntry({required this.id, required this.category});
+
+  final String id;
+  final String category;
+}
+
+class KnowledgeCatalog {
+  const KnowledgeCatalog(this.entries);
+
+  final List<KnowledgeCatalogEntry> entries;
+
+  static KnowledgeCatalog fromJsonString(String json) {
+    final list = (jsonDecode(json) as List)
+        .whereType<Map<String, Object?>>()
+        .map((e) => KnowledgeCatalogEntry(
+              id: e['id'] as String? ?? '',
+              category: e['category'] as String? ?? 'topic',
+            ))
+        .where((e) => e.id.isNotEmpty)
+        .toList()
+      ..sort((a, b) => a.id.compareTo(b.id));
+    return KnowledgeCatalog(list);
+  }
+
+  static Future<KnowledgeCatalog> loadBundled() async =>
+      fromJsonString(await rootBundle.loadString('assets/knowledge_catalog.json'));
+}
+```
+
+- [ ] **Step 5: Register assets in pubspec**
+
+Modify `apps/goresave/pubspec.yaml` (the `assets:` block at line 60):
+
+```yaml
+  assets:
+    - assets/goresave_icon.png
+    - assets/item_catalog.json
+    - assets/npc_catalog.json
+    - assets/knowledge_catalog.json
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd apps/goresave && flutter test test/catalog_loaders_test.dart`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/domain/npc_catalog.dart apps/goresave/lib/features/editor/domain/knowledge_catalog.dart apps/goresave/pubspec.yaml apps/goresave/test/catalog_loaders_test.dart
+git commit -m "feat(app): bundle npc + knowledge catalog loaders"
+```
+
+---
+
+## Phase D — Flutter dialogs + wiring
+
+### Task 8: Notifier method `addKnowledgeCharacter`
+
+**Files:**
+- Modify: `apps/goresave/lib/features/editor/domain/editor_notifier.dart` (near `loadKnowledgeCharacters`, ~1173)
+- Test: covered by Task 10's widget test + manual; add a focused notifier test if a notifier test harness exists.
+
+- [ ] **Step 1: Implement the method**
+
+Find how an inventory add edit is sent to the core (search `addItem` / the edit op send path in `editor_notifier.dart`) and follow it exactly. Add:
+
+```dart
+  /// Insert a brand-new character into CharacterKnowledgeByUniqueName.
+  /// Returns null on success, or an error string.
+  Future<String?> addKnowledgeCharacter(String uniqueName) async {
+    final result = await _sendPrivateEdit({
+      'op': 'private.knowledge.addCharacter',
+      'value': uniqueName,
+    });
+    return result.error; // shape matches existing _sendPrivateEdit callers
+  }
+```
+
+> The exact request envelope (`op`/`value` keys, the `_sendPrivateEdit` name) must
+> match what the existing typed-container edits send. Read the `setAdd` send path
+> in this file and mirror its envelope and error handling precisely — do not
+> invent new field names.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd apps/goresave && flutter analyze lib/features/editor/domain/editor_notifier.dart`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/domain/editor_notifier.dart
+git commit -m "feat(app): notifier addKnowledgeCharacter"
+```
+
+### Task 9: Add-NPC + add-entry picker dialogs
+
+**Files:**
+- Create: `apps/goresave/lib/features/editor/ui/add_npc_dialog.dart`
+- Create: `apps/goresave/lib/features/editor/ui/add_knowledge_entry_dialog.dart`
+- Test: `apps/goresave/test/add_npc_dialog_test.dart`, `apps/goresave/test/add_knowledge_entry_dialog_test.dart`
+
+Both dialogs mirror `apps/goresave/lib/features/editor/ui/add_inventory_item_dialog.dart`
+(category sidebar + search + list; returns the selected id via `Navigator.pop`).
+Differences: NPC dialog categories = the distinct `category` values in
+`NpcCatalog`; entry dialog categories = `topic`/`choice`/`info`. Each takes an
+`exclude` `Set<String>` (already-present ids, lowercased) to hide.
+
+- [ ] **Step 1: Write the failing test (NPC dialog)**
+
+```dart
+// apps/goresave/test/add_npc_dialog_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/npc_catalog.dart';
+import 'package:goresave/features/editor/ui/add_npc_dialog.dart';
+
+void main() {
+  final catalog = NpcCatalog.fromJsonString(
+    '[{"id":"OC_STT_Diego","class":"c1","category":"human"},'
+    '{"id":"OC_GRD_Orry_254","class":"c2","category":"human"},'
+    '{"id":"Creature_Biter","class":"c3","category":"creature"}]',
+  );
+
+  testWidgets('lists catalog NPCs, excludes existing, returns selection',
+      (tester) async {
+    String? picked;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (context) {
+          return ElevatedButton(
+            onPressed: () async {
+              picked = await showAddNpcDialog(
+                context,
+                catalog: catalog,
+                exclude: {'oc_grd_orry_254'},
+              );
+            },
+            child: const Text('open'),
+          );
+        }),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('OC_STT_Diego'), findsOneWidget);
+    expect(find.text('OC_GRD_Orry_254'), findsNothing); // excluded
+    await tester.tap(find.text('OC_STT_Diego'));
+    await tester.pumpAndSettle();
+    expect(picked, 'OC_STT_Diego');
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/goresave && flutter test test/add_npc_dialog_test.dart`
+Expected: FAIL — cannot find `add_npc_dialog.dart`
+
+- [ ] **Step 3: Implement `add_npc_dialog.dart`**
+
+Copy the structure of `add_inventory_item_dialog.dart` and adapt:
+- Public entrypoint `Future<String?> showAddNpcDialog(BuildContext context, {required NpcCatalog catalog, required Set<String> exclude})` that returns the selected `id`.
+- Filter out entries whose `id.toLowerCase()` is in `exclude`.
+- Left pane: distinct categories (e.g. `human`, `creature`, `other`) + an "All" option; right pane: searchable list of `NpcCatalogEntry` showing `id` (subtitle: `category`).
+- Tapping a row → `Navigator.pop(context, entry.id)`.
+
+> Keep the widget tree shapes (search `TextField`, `ListTile` per entry) so the
+> test's `find.text(id)` + tap works. Match the inventory dialog's theming/widgets.
+
+- [ ] **Step 4: Run NPC dialog test**
+
+Run: `cd apps/goresave && flutter test test/add_npc_dialog_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing test (entry dialog)**
+
+```dart
+// apps/goresave/test/add_knowledge_entry_dialog_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/editor/domain/knowledge_catalog.dart';
+import 'package:goresave/features/editor/ui/add_knowledge_entry_dialog.dart';
+
+void main() {
+  final catalog = KnowledgeCatalog.fromJsonString(
+    '[{"id":"Topic_Diego_209799","category":"topic"},'
+    '{"id":"ChoiceDiegoGamestart","category":"choice"},'
+    '{"id":"Info_FMORGAreyouok","category":"info"}]',
+  );
+
+  testWidgets('lists entries, excludes existing, returns selection',
+      (tester) async {
+    String? picked;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (context) {
+          return ElevatedButton(
+            onPressed: () async {
+              picked = await showAddKnowledgeEntryDialog(
+                context,
+                catalog: catalog,
+                exclude: {'choicediegogamestart'},
+              );
+            },
+            child: const Text('open'),
+          );
+        }),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Topic_Diego_209799'), findsOneWidget);
+    expect(find.text('ChoiceDiegoGamestart'), findsNothing);
+    await tester.tap(find.text('Topic_Diego_209799'));
+    await tester.pumpAndSettle();
+    expect(picked, 'Topic_Diego_209799');
+  });
+}
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `cd apps/goresave && flutter test test/add_knowledge_entry_dialog_test.dart`
+Expected: FAIL — cannot find `add_knowledge_entry_dialog.dart`
+
+- [ ] **Step 7: Implement `add_knowledge_entry_dialog.dart`**
+
+Same structure as the NPC dialog. Entrypoint
+`Future<String?> showAddKnowledgeEntryDialog(BuildContext context, {required KnowledgeCatalog catalog, required Set<String> exclude})`.
+Categories fixed: `topic`, `choice`, `info` (+ "All"). Rows show `id`.
+
+- [ ] **Step 8: Run entry dialog test**
+
+Run: `cd apps/goresave && flutter test test/add_knowledge_entry_dialog_test.dart`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/ui/add_npc_dialog.dart apps/goresave/lib/features/editor/ui/add_knowledge_entry_dialog.dart apps/goresave/test/add_npc_dialog_test.dart apps/goresave/test/add_knowledge_entry_dialog_test.dart
+git commit -m "feat(app): add-NPC and add-knowledge-entry picker dialogs"
+```
+
+### Task 10: Wire dialogs into the Knowledge tab
+
+**Files:**
+- Modify: `apps/goresave/lib/features/editor/ui/progression_panel.dart` (`_KnowledgeDetail`, ~594-1210)
+
+- [ ] **Step 1: Load catalogs in `_KnowledgeDetail` state**
+
+In `_KnowledgeDetailState`, add fields and load in `initState` (alongside the
+existing `_loadCharacters()` at ~674):
+
+```dart
+  NpcCatalog? _npcCatalog;
+  KnowledgeCatalog? _knowledgeCatalog;
+
+  Future<void> _loadCatalogs() async {
+    final npc = await NpcCatalog.loadBundled();
+    final know = await KnowledgeCatalog.loadBundled();
+    if (!mounted) return;
+    setState(() {
+      _npcCatalog = npc;
+      _knowledgeCatalog = know;
+    });
+  }
+```
+
+Add imports for `npc_catalog.dart`, `knowledge_catalog.dart`, `add_npc_dialog.dart`,
+`add_knowledge_entry_dialog.dart`, and call `_loadCatalogs()` in `initState`.
+
+- [ ] **Step 2: Add an "Add NPC" button**
+
+Near the character-list header (left pane of `_KnowledgeDetail`), add a button
+that opens the NPC dialog and inserts on selection:
+
+```dart
+  Future<void> _addNpc() async {
+    final catalog = _npcCatalog;
+    if (catalog == null) return;
+    final existing = _characters.map((c) => c.name.toLowerCase()).toSet();
+    final picked = await showAddNpcDialog(context, catalog: catalog, exclude: existing);
+    if (picked == null || !mounted) return;
+    final error = await widget.notifier.addKnowledgeCharacter(picked);
+    if (!mounted) return;
+    if (error != null) {
+      setState(() => _addError = 'Add NPC failed: $error');
+      return;
+    }
+    await _loadCharacters();       // refresh list (existing method)
+    await _selectCharacter(picked); // select the new NPC (existing method)
+  }
+```
+
+> Field/method names (`_characters`, `_loadCharacters`, `_selectCharacter`,
+> `_addError`) are the existing ones in `_KnowledgeDetailState` — confirm the
+> exact names while editing and match them. `_characters` is the loaded
+> `KnowledgeCharacter` list; if it is paginated, build `existing` from whatever
+> the state already holds (the dialog only needs a best-effort exclude; the core
+> rejects true duplicates anyway).
+
+- [ ] **Step 3: Add a "Browse catalog" affordance to entry add**
+
+Next to the existing free-text add field (the `_addController` TextField around
+the entry pane), add a button that opens the entry dialog and feeds the existing
+`_addEntry` path (`progression_panel.dart:777`):
+
+```dart
+  Future<void> _browseAddEntry() async {
+    final catalog = _knowledgeCatalog;
+    if (catalog == null) return;
+    final existing = _entries.entries.map((e) => e.toLowerCase()).toSet();
+    final picked = await showAddKnowledgeEntryDialog(
+      context, catalog: catalog, exclude: existing,
+    );
+    if (picked == null || !mounted) return;
+    await _addEntry(picked); // existing add path: dup-check + pending edit
+  }
+```
+
+The free-text field stays as-is for voiceline/non-catalog tokens.
+
+- [ ] **Step 4: Analyze + run the app's test suite**
+
+Run: `cd apps/goresave && flutter analyze`
+Expected: No errors.
+Run: `cd apps/goresave && flutter test`
+Expected: PASS (all tests, incl. the new dialog/loader tests).
+
+- [ ] **Step 5: Manual smoke (optional but recommended)**
+
+Use the `run` skill or `flutter run` to: open a save → Knowledge tab → "Add NPC"
+→ pick an NPC not in the save → confirm it appears with an empty entry list →
+"Browse catalog" → add a Topic → confirm it lands in pending edits → save.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/goresave/lib/features/editor/ui/progression_panel.dart
+git commit -m "feat(app): wire NPC + entry catalog pickers into Knowledge tab"
+```
+
+---
+
+## Final verification
+
+- [ ] `cargo test -p goresave_core` — all green
+- [ ] `cd apps/goresave && flutter analyze && flutter test` — all green
+- [ ] Manual: add a never-before-seen NPC + a Topic entry, save, reload the save, confirm both persist (round-trip through the real codec).
+- [ ] Update `gothic-remake-ue4ss-dump` memory: note the two new catalog regen commands alongside the existing item-catalog one.

--- a/docs/superpowers/specs/2026-06-15-knowledge-catalogs-design.md
+++ b/docs/superpowers/specs/2026-06-15-knowledge-catalogs-design.md
@@ -1,0 +1,146 @@
+# Knowledge tab: full NPC + entry catalogs
+
+Date: 2026-06-15
+Status: Approved (design)
+
+## Problem
+
+The editor's Knowledge tab only shows NPCs that already have a
+`CharacterKnowledgeByUniqueName` entry in the loaded savegame, and the
+entry-add field is free-text only. Two gaps:
+
+1. No way to add knowledge for an NPC that is **not yet** in the save.
+2. No discoverable list of **possible** knowledge entries to add.
+
+The Inventory tab already solves the analogous problem with a bundled item
+catalog (`assets/item_catalog.json`, built from a UE4SS object dump by
+`tools/build_item_catalog.py`). This feature brings the same pattern to
+knowledge.
+
+## Data feasibility (established)
+
+From the UE4SS object dump
+(`G1R/Binaries/Win64/ue4ss/UE4SS_ObjectDump.txt`):
+
+| Data | Source in dump | Count | Note |
+|------|----------------|-------|------|
+| NPC unique names | `ASClass …CharacterDefinition_Human_<key>` → `<key>` | 648 humans (1095 all CharacterDefinition_) | `<key>` is the exact `CharacterKnowledgeByUniqueName` map key, e.g. `OC_STT_Diego` |
+| Topic tokens | `ASClass …Topic_*` | 1291 | dialog/quest knowledge |
+| Choice tokens | `ASClass …Choice*` | 2479 | dialog choices |
+| Info tokens | `ASClass …Info_*` | 143 | dialog infos |
+
+**Voicelines are out of scope.** A real save's Knowledge set is ~80%
+`Voiceline_*` tokens, but those are localization keys (suffix
+`_AlkimiaLocalization`), not UObject classes — absent from the object dump and
+only present in raw `.locres` chunks inside the 27 GB IoStore container with no
+directory index. They are replay-tracking markers (suppress line repeats), not
+dialog-unlock knowledge, so low edit value. Confirmed via `retoc` extraction
+that no clean package-level source exists. The free-text entry field remains as
+a manual fallback for anyone who needs a specific voiceline.
+
+A real save's `KnowledgeSet` struct has exactly one field, `Knowledge`
+(a `SetProperty<NameProperty>`); there is no sibling field. Verified against
+`work/decompressed/G1R-001.host.bin` (47 characters, e.g. `OC_STT_Diego` =
+105 entries: 84 Voiceline / 17 Choice / 4 Topic).
+
+## Components
+
+### 1. Catalog build scripts → Flutter assets
+
+Two Python scripts modelled on `tools/build_item_catalog.py`:
+
+- `tools/build_npc_catalog.py` → `apps/goresave/assets/npc_catalog.json`
+  - Regex `ASClass /Script/Angelscript\.CharacterDefinition_(\S+)` → unique name.
+  - Humans: the `<key>` after `CharacterDefinition_Human_` is the map-key form
+    (`OC_STT_Diego`). Categorize by sub-prefix into `human` vs `creature`/other
+    so the picker can group/filter. Non-human keys are kept for visibility but
+    flagged (they are not known to be valid map keys; cosmetic).
+  - Entry shape: `{ "id": "OC_STT_Diego", "class": "CharacterDefinition_Human_OC_STT_Diego", "category": "human" }`.
+- `tools/build_knowledge_catalog.py` → `apps/goresave/assets/knowledge_catalog.json`
+  - Regex over `ASClass /Script/Angelscript\.(Topic_\S+|Info_\S+|Choice\S+)`.
+  - Entry shape: `{ "id": "Topic_Diego_209799", "category": "topic" }`
+    (`topic` | `choice` | `info`).
+
+Both are **frontend-only assets**. Unlike `item_catalog.json` they are **not**
+embedded in the Rust core and impose **no allow-list** — they exist purely for
+discovery/autocomplete. This keeps the core decoupled and preserves free-text.
+
+Regenerate command (matches the item-catalog convention, see
+`gothic-remake-ue4ss-dump` memory):
+
+```
+python tools/build_npc_catalog.py "<dump path>"
+python tools/build_knowledge_catalog.py "<dump path>"
+```
+
+### 2. Frontend (Flutter)
+
+In `apps/goresave/lib/features/editor/`:
+
+- New catalog models + loaders mirroring `domain/item_catalog.dart`:
+  `domain/npc_catalog.dart`, `domain/knowledge_catalog.dart`
+  (each: entry class, `loadBundled()` via `rootBundle`).
+- New picker dialogs mirroring `ui/add_inventory_item_dialog.dart`:
+  - **Add-NPC dialog**: full `npc_catalog`, category sidebar + search.
+    Excludes NPCs already present in the save. On pick → call the new core
+    add-character op, then refresh the character list and select the new NPC.
+  - **Add-entry dialog**: full `knowledge_catalog`, category (topic/choice/info)
+    + search, excludes entries already on the selected character. On pick →
+    feed into the existing `_addEntry` path. Keep the existing free-text field
+    as a fallback for non-catalog tokens (voicelines).
+- Wire both into `ui/progression_panel.dart` `_KnowledgeDetail` (existing
+  add/remove/dup-check logic at lines ~760–864 is reused unchanged for entries).
+
+### 3. Backend (Rust core)
+
+The current edit layer (`ContainerEdit` in `properties.rs:973`) only mutates
+existing Sets/Arrays. Adding a brand-new NPC requires inserting a new entry into
+the `CharacterKnowledgeByUniqueName` map, which has no precedent. New work:
+
+- New `ContainerEdit::MapInsert { key_bytes, value_bytes }` variant
+  (analogue of the existing `ArrayInsertBytes`).
+- New `map_layout()` helper that walks inline map entries to find the byte
+  boundary after the last entry and the count-field offset (maps lack the simple
+  count+elements layout of arrays/sets — keys/values are inline-encoded).
+- Extend `patch_container()` to handle `MapInsert`: splice `key_bytes ++
+  value_bytes` at the end of the map body, increment the entry count, and fix
+  the tag size + all enclosing size-chain fields (reuse the existing
+  `ArrayInsertBytes` size-fixup logic at `properties.rs:1103-1149`).
+- Build `value_bytes` = a minimal `KnowledgeSet { Knowledge: Set<Name>() }`
+  (empty set), synthesized via the existing test helper
+  `private_name_set_property` (`lib.rs:11143`) promoted to non-test code, or by
+  cloning a donor entry's struct bytes and clearing its set. `key_bytes` = the
+  NPC unique name encoded as an inline Name value.
+- New IPC op `private.knowledge.addCharacter` (payload: NPC unique name) that
+  resolves the map, rejects duplicates, applies the `MapInsert`, and
+  strict-re-parses to validate (existing validation pattern).
+- After insertion the new NPC has an empty `Knowledge` set; the user adds
+  entries through the unchanged `private.typed.setAdd` path.
+
+### 4. Policy
+
+- **No allow-list** on entries or on NPC keys: catalogs are discovery only;
+  free-text is always accepted. Voicelines stay reachable manually.
+- **Dedup**: the NPC picker hides NPCs already in the save; the entry picker
+  hides entries already on the selected character (server dup-check at
+  `progression_panel.dart:798` still guards races).
+
+## Testing
+
+- **Core**: `MapInsert` unit tests in `properties.rs` (empty map → 1 entry;
+  size-chain correctness; byte-exact re-parse round-trip). Integration test in
+  `lib.rs` against a real `work/decompressed/*.host.bin`: add a new character,
+  then `setAdd` an entry, verify both via `query_progression`.
+- **Catalog scripts**: smoke test that each script parses the dump and emits a
+  non-empty, schema-valid JSON with expected known IDs (e.g. `OC_STT_Diego`,
+  `Topic_Diego_209799`).
+- **Frontend**: widget tests for the two dialogs (loads catalog, filters by
+  category/search, excludes existing, returns selection).
+
+## Out of scope
+
+- Voiceline-token catalog (localization extraction).
+- Human-readable display names (would need DataTable/`.locres` parsing with the
+  USMAP; the picker shows raw IDs, consistent with the existing inventory and
+  knowledge UI).
+- Removing an entire NPC from the map (only add is requested).

--- a/tools/build_knowledge_catalog.py
+++ b/tools/build_knowledge_catalog.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Build apps/goresave/assets/knowledge_catalog.json from a UE4SS object dump.
+
+Usage: python tools/build_knowledge_catalog.py <UE4SS_ObjectDump.txt> [-o OUT.json]
+
+Extracts Topic_/Info_/Choice* class identifiers (id, category). These are the
+dialog-unlock knowledge tokens that appear in a character's Knowledge set.
+Voiceline tokens are intentionally excluded (localization keys, not classes).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Order matters: Topic_/Info_ before bare Choice.
+PATTERNS = [
+    (re.compile(r"ASClass /Script/Angelscript\.(Topic_[A-Za-z0-9_]+)"), "topic"),
+    (re.compile(r"ASClass /Script/Angelscript\.(Info_[A-Za-z0-9_]+)"), "info"),
+    (re.compile(r"ASClass /Script/Angelscript\.(Choice[A-Za-z0-9_]+)"), "choice"),
+]
+
+
+def parse_dump_classes(lines) -> list[tuple[str, str]]:
+    found: dict[str, str] = {}
+    for line in lines:
+        for rx, category in PATTERNS:
+            match = rx.search(line)
+            if match:
+                found.setdefault(match.group(1), category)
+                break
+    return sorted(found.items())
+
+
+def build_catalog(pairs: list[tuple[str, str]]) -> list[dict]:
+    entries = [{"id": name, "category": cat} for name, cat in pairs]
+    entries.sort(key=lambda e: e["id"])
+    return entries
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump", type=Path)
+    parser.add_argument(
+        "-o", "--out", type=Path,
+        default=Path(__file__).resolve().parent.parent
+        / "apps" / "goresave" / "assets" / "knowledge_catalog.json",
+    )
+    args = parser.parse_args()
+    pairs = parse_dump_classes(
+        args.dump.read_text(encoding="utf-8", errors="replace").splitlines()
+    )
+    entries = build_catalog(pairs)
+    args.out.write_text(
+        json.dumps(entries, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    counts: dict[str, int] = {}
+    for e in entries:
+        counts[e["category"]] = counts.get(e["category"], 0) + 1
+    summary = ", ".join(f"{k}: {counts[k]}" for k in sorted(counts))
+    print(f"wrote {len(entries)} knowledge tokens to {args.out}")
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/build_npc_catalog.py
+++ b/tools/build_npc_catalog.py
@@ -6,6 +6,11 @@ Usage: python tools/build_npc_catalog.py <UE4SS_ObjectDump.txt> [-o OUT.json]
 Extracts CharacterDefinition_* class identifiers only (id, class, category).
 The `id` of a Human definition is the exact CharacterKnowledgeByUniqueName map
 key (e.g. OC_STT_Diego). No localized names or stats are extracted.
+
+Id derivation: Human_ entries are stripped to the map-key form (e.g.
+OC_STT_Diego), while non-human entries keep their sub-prefix (e.g.
+Creature_Biter). Anything matching neither Human_ nor Creature_ is
+categorised as "other".
 """
 from __future__ import annotations
 
@@ -77,8 +82,18 @@ def main() -> int:
         json.dumps(entries, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
     print(f"wrote {len(entries)} npcs to {args.out}")
+    from collections import Counter
+    counts = Counter(e["category"] for e in entries)
+    print(", ".join(f"{cat}: {counts[cat]}" for cat in sorted(counts)))
+    others = [e["class"] for e in entries if e["category"] == "other"]
+    if others:
+        print(f"other category ({len(others)} classes):")
+        for cls in others:
+            print(f"  - {cls}")
     if skipped:
-        print(f"skipped {len(skipped)} classes")
+        print(f"skipped {len(skipped)} classes:")
+        for name in skipped:
+            print(f"  - {name}")
     return 0
 
 

--- a/tools/build_npc_catalog.py
+++ b/tools/build_npc_catalog.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Build apps/goresave/assets/npc_catalog.json from a UE4SS object dump.
+
+Usage: python tools/build_npc_catalog.py <UE4SS_ObjectDump.txt> [-o OUT.json]
+
+Extracts CharacterDefinition_* class identifiers only (id, class, category).
+The `id` of a Human definition is the exact CharacterKnowledgeByUniqueName map
+key (e.g. OC_STT_Diego). No localized names or stats are extracted.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+CLASS_RE = re.compile(r"ASClass /Script/Angelscript\.(CharacterDefinition_[A-Za-z0-9_]+)")
+
+CATEGORY_BY_SUBPREFIX = [
+    ("Human_", "human"),
+    ("Creature_", "creature"),
+]
+
+
+def parse_dump_classes(lines) -> list[str]:
+    names: set[str] = set()
+    for line in lines:
+        match = CLASS_RE.search(line)
+        if match:
+            names.add(match.group(1))
+    return sorted(names)
+
+
+def build_catalog(class_names: list[str]) -> tuple[list[dict], list[str]]:
+    entries: list[dict] = []
+    skipped: list[str] = []
+    for cls in class_names:
+        rest = cls[len("CharacterDefinition_"):]
+        category = "other"
+        unique = rest
+        for sub, cat in CATEGORY_BY_SUBPREFIX:
+            if rest.startswith(sub):
+                category = cat
+                if cat == "human":
+                    unique = rest[len(sub):]  # map-key form
+                break
+        if not unique:
+            skipped.append(cls)
+            continue
+        entries.append({"id": unique, "class": cls, "category": category})
+    entries.sort(key=lambda e: e["id"])
+    seen: set[str] = set()
+    deduped = []
+    for e in entries:
+        if e["id"] in seen:
+            continue
+        seen.add(e["id"])
+        deduped.append(e)
+    return deduped, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump", type=Path)
+    parser.add_argument(
+        "-o", "--out", type=Path,
+        default=Path(__file__).resolve().parent.parent
+        / "apps" / "goresave" / "assets" / "npc_catalog.json",
+    )
+    args = parser.parse_args()
+    names = parse_dump_classes(
+        args.dump.read_text(encoding="utf-8", errors="replace").splitlines()
+    )
+    entries, skipped = build_catalog(names)
+    args.out.write_text(
+        json.dumps(entries, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {len(entries)} npcs to {args.out}")
+    if skipped:
+        print(f"skipped {len(skipped)} classes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_build_knowledge_catalog.py
+++ b/tools/test_build_knowledge_catalog.py
@@ -1,0 +1,24 @@
+from build_knowledge_catalog import build_catalog, parse_dump_classes
+
+DUMP = [
+    "[1] ASClass /Script/Angelscript.Topic_Diego_209799 [n: A]",
+    "[2] ASClass /Script/Angelscript.Info_FMORGAreyouok [n: B]",
+    "[3] ASClass /Script/Angelscript.ChoiceDiegoGamestart [n: C]",
+    "[4] ASClass /Script/Angelscript.Topic_Diego_209799 [n: D]",  # dup
+    "[5] ASClass /Script/Angelscript.ItMw_Sword01 [n: E]",  # ignored
+    "[6] ASClass /Script/Angelscript.CharacterDefinition_Human_OC_STT_Diego [n: F]",  # ignored
+]
+
+def test_categories():
+    entries = build_catalog(parse_dump_classes(DUMP))
+    by_id = {e["id"]: e for e in entries}
+    assert by_id["Topic_Diego_209799"]["category"] == "topic"
+    assert by_id["Info_FMORGAreyouok"]["category"] == "info"
+    assert by_id["ChoiceDiegoGamestart"]["category"] == "choice"
+
+def test_dedup_sorted_and_filtered():
+    entries = build_catalog(parse_dump_classes(DUMP))
+    ids = [e["id"] for e in entries]
+    assert ids == sorted(ids)
+    assert ids.count("Topic_Diego_209799") == 1
+    assert all("Sword" not in i and "CharacterDefinition" not in i for i in ids)

--- a/tools/test_build_npc_catalog.py
+++ b/tools/test_build_npc_catalog.py
@@ -1,4 +1,4 @@
-import build_npc_catalog as m
+from build_npc_catalog import build_catalog, parse_dump_classes
 
 DUMP = [
     "[0001] ASClass /Script/Angelscript.CharacterDefinition_Human_OC_STT_Diego [n: A]",
@@ -9,22 +9,22 @@ DUMP = [
 ]
 
 def test_human_unique_name_is_map_key_form():
-    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    entries, _ = build_catalog(parse_dump_classes(DUMP))
     by_id = {e["id"]: e for e in entries}
     assert by_id["OC_STT_Diego"]["category"] == "human"
     assert by_id["OC_STT_Diego"]["class"] == "CharacterDefinition_Human_OC_STT_Diego"
 
-def test_non_human_kept_and_flagged():
-    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+def test_creature_category():
+    entries, _ = build_catalog(parse_dump_classes(DUMP))
     by_id = {e["id"]: e for e in entries}
     assert by_id["Creature_Biter"]["category"] == "creature"
 
 def test_dedup_and_sorted():
-    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    entries, _ = build_catalog(parse_dump_classes(DUMP))
     ids = [e["id"] for e in entries]
     assert ids == sorted(ids)
     assert ids.count("OC_STT_Diego") == 1
 
 def test_ignores_non_character_classes():
-    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    entries, _ = build_catalog(parse_dump_classes(DUMP))
     assert all("Sword" not in e["id"] for e in entries)

--- a/tools/test_build_npc_catalog.py
+++ b/tools/test_build_npc_catalog.py
@@ -1,0 +1,30 @@
+import build_npc_catalog as m
+
+DUMP = [
+    "[0001] ASClass /Script/Angelscript.CharacterDefinition_Human_OC_STT_Diego [n: A]",
+    "[0002] ASClass /Script/Angelscript.CharacterDefinition_Human_NC_SLD_Gorn_699 [n: B]",
+    "[0003] ASClass /Script/Angelscript.CharacterDefinition_Creature_Biter [n: C]",
+    "[0004] ASClass /Script/Angelscript.CharacterDefinition_Human_OC_STT_Diego [n: D]",  # dup
+    "[0005] ASClass /Script/Angelscript.ItMw_Sword01 [n: E]",  # ignored
+]
+
+def test_human_unique_name_is_map_key_form():
+    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    by_id = {e["id"]: e for e in entries}
+    assert by_id["OC_STT_Diego"]["category"] == "human"
+    assert by_id["OC_STT_Diego"]["class"] == "CharacterDefinition_Human_OC_STT_Diego"
+
+def test_non_human_kept_and_flagged():
+    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    by_id = {e["id"]: e for e in entries}
+    assert by_id["Creature_Biter"]["category"] == "creature"
+
+def test_dedup_and_sorted():
+    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    ids = [e["id"] for e in entries]
+    assert ids == sorted(ids)
+    assert ids.count("OC_STT_Diego") == 1
+
+def test_ignores_non_character_classes():
+    entries, _ = m.build_catalog(m.parse_dump_classes(DUMP))
+    assert all("Sword" not in e["id"] for e in entries)


### PR DESCRIPTION
## Summary

Adds catalog-backed pickers to the editor's Knowledge tab so you can:
- **Add any NPC** — incl. NPCs not yet present in the savegame — from a full catalog (`npc_catalog.json`, 1095 entries scraped from the UE4SS object dump: 648 human / 99 creature / 348 other).
- **Browse the full knowledge-entry catalog** when adding an entry (`knowledge_catalog.json`, 3913 entries: 1291 topic / 2479 choice / 143 info). The free-text field stays as a fallback for non-catalog tokens.

Mirrors the existing inventory item-catalog pattern.

### Backend (goresave_core)
- New `properties::map_layout()` + `ContainerEdit::MapInsert` to append an entry to a `MapProperty`.
- New `private.knowledge.addCharacter` op: inserts a brand-new NPC with an empty `KnowledgeSet` into `CharacterKnowledgeByUniqueName` (rejects case-insensitive duplicates, strict re-parse validation).
- Gated as a solo structural edit (shifts byte offsets like inventory addItem) + advertised in the writable capability lists.

### Frontend (Flutter)
- `NpcCatalog` / `KnowledgeCatalog` loaders + bundled assets.
- `add_npc_dialog` / `add_knowledge_entry_dialog` pickers (category sidebar + search + dedup).
- `applyAddKnowledgeCharacter` notifier — immediate apply (write + re-inspect) so a new NPC's empty set is queryable for follow-on entry edits.
- Wired into the Knowledge tab; existing entry add/remove/dup-check unchanged.

### Tooling
- `tools/build_npc_catalog.py` + `tools/build_knowledge_catalog.py` (with tests), modelled on `build_item_catalog.py`.

### Out of scope
Voiceline tokens (localization keys, absent from the object dump; replay-tracking, low edit value). Catalogs are frontend-only — no core allow-list, so free-text entry still works.

## Test Plan
- [x] `cargo test -p goresave_core` — 254 passed, 0 failed, 3 ignored
- [x] real-save round-trip (`add_character_roundtrips_on_real_payload`, ignored, run with `GORESAVE_PAYLOAD_BIN`)
- [x] `flutter test` — 131 passed
- [x] `flutter analyze` — no new issues
- [ ] manual: add a never-before-seen NPC + a Topic entry, save, reload, confirm both persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New length-changing map splice on save payload and immediate write path for new NPCs; mistakes could corrupt saves, though duplicate checks and solo-edit gating mirror proven inventory structural edits.
> 
> **Overview**
> The Knowledge tab can now **add NPCs from a bundled catalog** (~1095 scraped names) even when they are not already in the save, and **browse a full knowledge-entry catalog** (~3913 tokens) when adding entries, with free-text still supported for off-catalog IDs.
> 
> **Core (`goresave_core`):** Introduces `map_layout()` and `ContainerEdit::MapInsert` so `MapProperty` values can grow by splicing a pre-encoded key/value pair. New IPC op **`private.knowledge.addCharacter`** inserts an NPC with an empty `KnowledgeSet` into `CharacterKnowledgeByUniqueName`, rejects case-insensitive duplicates, validates via strict re-parse, and is treated like inventory structural edits (solo write only, writable when typed parse succeeds).
> 
> **Flutter:** Loads `npc_catalog.json` / `knowledge_catalog.json`, shows category+search pickers (`add_npc_dialog`, `add_knowledge_entry_dialog`), and **`applyAddKnowledgeCharacter`** writes immediately and re-inspects so follow-on entry edits work. Wired in `progression_panel` (Knowledge UI).
> 
> **Tooling:** `build_npc_catalog.py` and `build_knowledge_catalog.py` (with tests), following the existing item-catalog builder pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c9af1f2c8316444f9df13d8523d60b4b0c5a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->