### PR TITLE
fix(core): restore inventory Add button via clean-template detection

### DIFF
--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -6074,25 +6074,52 @@ fn main_container_summary(root: &properties::RootObject) -> Option<MainContainer
 }
 
 /// True when a template's m_Payload carries item-specific state that must not be
-/// cloned onto a new item. The only "clean" shape is one made up entirely of
-/// EMPTY containers (the known empty-map payload). Any non-empty container, or
-/// any scalar/name/object/enum leaf, counts as state — a directly-stored field
-/// such as a durability integer would otherwise be mistaken for a clean slot and
-/// copied into an unrelated new item.
+/// cloned onto a new item. A "clean" payload is one whose every leaf is at its
+/// default value and whose every container is empty. A real default-initialised
+/// ItemPayload is NOT a bare empty map — it carries scalar leaves at their
+/// defaults (m_StageLevel=0, m_OptionalObject="", m_Ownership...TagName="None").
+/// Treating any scalar leaf as state (the old rule) therefore flagged EVERY real
+/// G1R item as stateful, left has_clean_template false on real saves, and hid the
+/// inventory Add button. Only a non-default leaf (a non-zero number, true bool,
+/// non-empty/non-"None" string, populated opaque/native struct) or a non-empty
+/// container is genuine item state — e.g. a durability value stored in
+/// m_GenericData, which must not be copied into an unrelated new item.
 fn payload_carries_state(value: &properties::PropertyValue) -> bool {
     use properties::{PropertyValue as PV, StructValue as SV};
     match value {
+        // Containers carry state only when non-empty.
         PV::Array { elements } | PV::Set { elements, .. } => !elements.is_empty(),
         PV::Map { entries, .. } => !entries.is_empty(),
         PV::ObjectInstances(instances) => !instances.is_empty(),
-        PV::Struct(SV::Properties(props)) => props.iter().any(|p| payload_carries_state(&p.value)),
-        PV::Struct(SV::Instanced(Some(instanced))) => instanced
-            .properties
-            .iter()
-            .any(|p| payload_carries_state(&p.value)),
-        // An empty/absent instanced struct carries nothing; any other leaf
-        // (scalar/name/object/enum) is item-specific state.
-        PV::Struct(SV::Instanced(None)) => false,
+        PV::Struct(s) => match s {
+            SV::Properties(props) => props.iter().any(|p| payload_carries_state(&p.value)),
+            SV::Instanced(Some(instanced)) => instanced
+                .properties
+                .iter()
+                .any(|p| payload_carries_state(&p.value)),
+            SV::Instanced(None) => false,
+            // Native-serialized struct variants carry state only when non-default.
+            // A real default ItemPayload nests an EMPTY GameplayTagContainer
+            // (m_Ownership.OwnedByGuild); without this it would read as state and
+            // mark every real slot dirty, hiding inventory add.
+            SV::GameplayTagContainer(tags) => !tags.is_empty(),
+            SV::Vector3 { x, y, z } => *x != 0.0 || *y != 0.0 || *z != 0.0,
+            SV::Vector3f { x, y, z } => *x != 0.0 || *y != 0.0 || *z != 0.0,
+            SV::Vector4 { x, y, z, w } => *x != 0.0 || *y != 0.0 || *z != 0.0 || *w != 0.0,
+            SV::Vector2 { x, y } => *x != 0.0 || *y != 0.0,
+            SV::Guid(bytes) => bytes.iter().any(|&b| b != 0),
+            SV::DateTime(v) => *v != 0,
+        },
+        // Scalar leaves carry state only when set away from their default.
+        PV::Int(0) | PV::UInt32(0) | PV::Int64(0) | PV::Byte(0) => false,
+        PV::Float(f) => *f != 0.0,
+        PV::Double(f) => *f != 0.0,
+        PV::Bool(b) => *b,
+        // Empty string and the FName null ("None") are the default for
+        // string/name/object/class/enum leaves.
+        PV::Str(s) | PV::Name(s) | PV::Object(s) | PV::Enum(s) => !(s.is_empty() || s == "None"),
+        PV::Opaque(bytes) => !bytes.is_empty(),
+        // Any remaining leaf (non-zero number, SoftObject) is item state.
         _ => true,
     }
 }
@@ -12944,6 +12971,115 @@ mod tests {
         )];
         let main = vec![stateful(0, "/Script/Angelscript.ItMw_Sword")];
         let mut payload = typed_inventory_private_payload(&other, &main);
+        let before = payload.clone();
+        let edit = PrivateInventoryAddItemEdit {
+            path: "/Script/Angelscript.ItMi_Sulfur".to_string(),
+            count: 1,
+        };
+        let err = apply_private_inventory_add_item_to_payload(&mut payload, &edit).unwrap_err();
+        assert!(err.to_string().contains("clean"), "unexpected error: {err}");
+        assert_eq!(payload, before);
+    }
+
+    fn inv_name_property(name: &str, value: &str) -> Vec<u8> {
+        inv_tagged(name, "NameProperty", &[], 0, &fstring(value))
+    }
+
+    /// Native-serialized empty GameplayTagContainer (tag count 0), mirroring
+    /// m_Ownership.OwnedByGuild in a real default ItemPayload.
+    fn inv_empty_gameplay_tag_container(name: &str) -> Vec<u8> {
+        let mut descriptor = 1u32.to_le_bytes().to_vec();
+        descriptor.extend_from_slice(&fstring("GameplayTagContainer"));
+        descriptor.extend_from_slice(&1u32.to_le_bytes());
+        descriptor.extend_from_slice(&fstring("/Script/GameplayTags"));
+        inv_tagged(
+            name,
+            "StructProperty",
+            &descriptor,
+            properties::TAG_FLAG_NATIVE_SERIALIZE,
+            &0u32.to_le_bytes(),
+        )
+    }
+
+    /// A default-initialised ItemPayload as it actually appears in real G1R
+    /// saves: all scalar leaves at default (m_StageLevel=0, m_OptionalObject="",
+    /// TagName="None") AND a nested EMPTY native GameplayTagContainer
+    /// (m_Ownership.OwnedByGuild). This is the genuine "clean" template shape; the
+    /// empty tag container is the leaf the first fix overlooked.
+    fn inv_default_scalar_payload() -> Vec<u8> {
+        let mut ownership_inner = inv_struct_property(
+            "UseOwnershipOfArea",
+            "GameplayTag",
+            &inv_name_property("TagName", "None"),
+        );
+        ownership_inner.extend_from_slice(&inv_empty_gameplay_tag_container("OwnedByGuild"));
+        let ownership = inv_struct_property("m_Ownership", "OwnershipSettings", &ownership_inner);
+        let mut out = int_property("m_StageLevel", 0);
+        out.extend_from_slice(&inv_object_property("m_OptionalObject", ""));
+        out.extend_from_slice(&ownership);
+        out
+    }
+
+    /// Same shape but with a non-default scalar leaf (m_StageLevel set): genuine
+    /// item-specific state the add must refuse to clone.
+    fn inv_nondefault_scalar_payload() -> Vec<u8> {
+        let mut out = int_property("m_StageLevel", 7);
+        out.extend_from_slice(&inv_object_property("m_OptionalObject", ""));
+        out
+    }
+
+    #[test]
+    fn add_item_clones_default_scalar_payload_slot() {
+        // Real G1R item slots carry a default-initialised ItemPayload whose scalar
+        // leaves are all zero/empty/None. These are semantically clean and must be
+        // usable as an addItem template. The old rule flagged ANY scalar leaf as
+        // state, so every real slot looked stateful, has_clean_template was always
+        // false on real saves, and the inventory Add button vanished.
+        let main_slots = vec![
+            inv_item_slot(
+                0,
+                INV_MAIN_LABEL,
+                "/Script/Angelscript.ItMi_Orenugget",
+                3,
+                &inv_default_scalar_payload(),
+            ),
+            inv_item_slot(
+                1,
+                INV_MAIN_LABEL,
+                "/Script/Angelscript.ItFo_Apple",
+                1,
+                &inv_default_scalar_payload(),
+            ),
+        ];
+        let mut payload = typed_inventory_private_payload(&[], &main_slots);
+        let edit = PrivateInventoryAddItemEdit {
+            path: "/Script/Angelscript.ItMi_Sulfur".to_string(),
+            count: 4,
+        };
+        apply_private_inventory_add_item_to_payload(&mut payload, &edit).unwrap();
+        assert_eq!(inv_slot_count(&payload, 1), 3);
+        let refs = scan_fstrings(&payload, 0);
+        let (items, _t, _s) = summarize_private_inventory_items(&payload, &refs, usize::MAX);
+        assert!(
+            items
+                .iter()
+                .any(|it| it["path"] == "/Script/Angelscript.ItMi_Sulfur" && it["count"] == 4)
+        );
+    }
+
+    #[test]
+    fn add_item_rejects_nondefault_scalar_payload_as_state() {
+        // A non-default scalar leaf (m_StageLevel != 0) is genuine item state. If
+        // that is the only payload shape available, there is no clean template —
+        // relaxing the default-value rule must NOT swallow real state.
+        let main = vec![inv_item_slot(
+            0,
+            INV_MAIN_LABEL,
+            "/Script/Angelscript.ItMw_Sword",
+            1,
+            &inv_nondefault_scalar_payload(),
+        )];
+        let mut payload = typed_inventory_private_payload(&[], &main);
         let before = payload.clone();
         let edit = PrivateInventoryAddItemEdit {
             path: "/Script/Angelscript.ItMi_Sulfur".to_string(),

--- a/crates/goresave_core/src/lib.rs
+++ b/crates/goresave_core/src/lib.rs
@@ -6035,7 +6035,7 @@ fn main_container_summary(root: &properties::RootObject) -> Option<MainContainer
             {
                 for slot in &slots {
                     if !struct_element_property(slot, "m_Payload")
-                        .is_some_and(|p| payload_carries_state(&p.value))
+                        .is_some_and(property_carries_state)
                     {
                         has_clean_template = true;
                     }
@@ -6073,35 +6073,61 @@ fn main_container_summary(root: &properties::RootObject) -> Option<MainContainer
     })
 }
 
-/// True when a template's m_Payload carries item-specific state that must not be
-/// cloned onto a new item. A "clean" payload is one whose every leaf is at its
-/// default value and whose every container is empty. A real default-initialised
-/// ItemPayload is NOT a bare empty map — it carries scalar leaves at their
-/// defaults (m_StageLevel=0, m_OptionalObject="", m_Ownership...TagName="None").
-/// Treating any scalar leaf as state (the old rule) therefore flagged EVERY real
-/// G1R item as stateful, left has_clean_template false on real saves, and hid the
-/// inventory Add button. Only a non-default leaf (a non-zero number, true bool,
-/// non-empty/non-"None" string, populated opaque/native struct) or a non-empty
-/// container is genuine item state — e.g. a durability value stored in
-/// m_GenericData, which must not be copied into an unrelated new item.
-fn payload_carries_state(value: &properties::PropertyValue) -> bool {
-    use properties::{PropertyValue as PV, StructValue as SV};
+/// Scalar `m_Payload` fields that are part of the known default ItemPayload
+/// shape and may legitimately appear at their default value in a clean template.
+/// A direct scalar leaf NOT in this set is treated as item-specific state even
+/// when it currently holds the type default (0/""/false/"None"), because its
+/// real default is unknown and cloning it could seed an unrelated new item with
+/// stale state (e.g. a directly-stored durability that happens to be 0).
+const CLEAN_PAYLOAD_SCALAR_FIELDS: &[&str] = &["m_StageLevel", "m_OptionalObject", "TagName"];
+
+/// True when a scalar payload leaf holds a non-default value. Default is the
+/// type's zero value: 0 / 0.0 / false, and "" or the FName null "None" for
+/// string/name/object/class/enum leaves.
+fn scalar_leaf_is_nondefault(value: &properties::PropertyValue) -> bool {
+    use properties::PropertyValue as PV;
     match value {
+        PV::Int(0) | PV::UInt32(0) | PV::Int64(0) | PV::Byte(0) => false,
+        PV::Float(f) => *f != 0.0,
+        PV::Double(f) => *f != 0.0,
+        PV::Bool(b) => *b,
+        PV::Str(s) | PV::Name(s) | PV::Object(s) | PV::Enum(s) => !(s.is_empty() || s == "None"),
+        PV::Opaque(bytes) => !bytes.is_empty(),
+        // Any remaining leaf (non-zero number, SoftObject) is item state.
+        _ => true,
+    }
+}
+
+/// True when a property within a template's `m_Payload` carries item-specific
+/// state that must not be cloned onto a new item. A "clean" payload has every
+/// container empty and every scalar leaf either an empty/default container field
+/// or a known default ItemPayload scalar at its default value.
+///
+/// A real default-initialised ItemPayload is NOT a bare empty map: it carries
+/// `m_StageLevel=0`, `m_OptionalObject=""`, empty `m_GenericData`/`m_InnerItems`
+/// maps, `m_Ownership.UseOwnershipOfArea.TagName="None"`, and an EMPTY native
+/// GameplayTagContainer (`m_Ownership.OwnedByGuild`). The old rule flagged any
+/// scalar leaf as state, so every real slot looked dirty, `has_clean_template`
+/// was always false, and the inventory Add button vanished.
+///
+/// Containers are state iff non-empty (name-independent). Scalars are gated by
+/// name: only the known default ItemPayload fields may be default-clean; an
+/// unrecognised direct scalar is always state, so a directly-stored value such
+/// as a durability is never cloned even when it currently equals the default.
+fn property_carries_state(prop: &properties::Property) -> bool {
+    use properties::{PropertyValue as PV, StructValue as SV};
+    match &prop.value {
         // Containers carry state only when non-empty.
         PV::Array { elements } | PV::Set { elements, .. } => !elements.is_empty(),
         PV::Map { entries, .. } => !entries.is_empty(),
         PV::ObjectInstances(instances) => !instances.is_empty(),
         PV::Struct(s) => match s {
-            SV::Properties(props) => props.iter().any(|p| payload_carries_state(&p.value)),
-            SV::Instanced(Some(instanced)) => instanced
-                .properties
-                .iter()
-                .any(|p| payload_carries_state(&p.value)),
+            SV::Properties(props) => props.iter().any(property_carries_state),
+            SV::Instanced(Some(instanced)) => {
+                instanced.properties.iter().any(property_carries_state)
+            }
             SV::Instanced(None) => false,
             // Native-serialized struct variants carry state only when non-default.
-            // A real default ItemPayload nests an EMPTY GameplayTagContainer
-            // (m_Ownership.OwnedByGuild); without this it would read as state and
-            // mark every real slot dirty, hiding inventory add.
             SV::GameplayTagContainer(tags) => !tags.is_empty(),
             SV::Vector3 { x, y, z } => *x != 0.0 || *y != 0.0 || *z != 0.0,
             SV::Vector3f { x, y, z } => *x != 0.0 || *y != 0.0 || *z != 0.0,
@@ -6110,17 +6136,12 @@ fn payload_carries_state(value: &properties::PropertyValue) -> bool {
             SV::Guid(bytes) => bytes.iter().any(|&b| b != 0),
             SV::DateTime(v) => *v != 0,
         },
-        // Scalar leaves carry state only when set away from their default.
-        PV::Int(0) | PV::UInt32(0) | PV::Int64(0) | PV::Byte(0) => false,
-        PV::Float(f) => *f != 0.0,
-        PV::Double(f) => *f != 0.0,
-        PV::Bool(b) => *b,
-        // Empty string and the FName null ("None") are the default for
-        // string/name/object/class/enum leaves.
-        PV::Str(s) | PV::Name(s) | PV::Object(s) | PV::Enum(s) => !(s.is_empty() || s == "None"),
-        PV::Opaque(bytes) => !bytes.is_empty(),
-        // Any remaining leaf (non-zero number, SoftObject) is item state.
-        _ => true,
+        // Scalar leaf: state unless it is a known default ItemPayload field
+        // currently at its default value.
+        _ => {
+            !CLEAN_PAYLOAD_SCALAR_FIELDS.contains(&prop.name.as_str())
+                || scalar_leaf_is_nondefault(&prop.value)
+        }
     }
 }
 
@@ -6202,7 +6223,7 @@ fn apply_private_inventory_add_item_to_payload(
     // MainContainer), borrow a clean slot's bytes from another container and fix
     // m_InventoryType to MainContainer below.
     let is_clean = |slot: &properties::PropertyValue| {
-        !struct_element_property(slot, "m_Payload").is_some_and(|p| payload_carries_state(&p.value))
+        !struct_element_property(slot, "m_Payload").is_some_and(property_carries_state)
     };
     let max_id = slots.iter().filter_map(slot_id).max().unwrap_or(-1);
     let new_id = max_id.checked_add(1).ok_or_else(|| {
@@ -6418,8 +6439,7 @@ fn donor_slot_template_bytes(
         // Find any slot with an empty m_Payload (don't clone item-specific
         // state) — not just the last one, which may be stateful.
         let Some(donor_index) = donor_slots.iter().position(|slot| {
-            !struct_element_property(slot, "m_Payload")
-                .is_some_and(|p| payload_carries_state(&p.value))
+            !struct_element_property(slot, "m_Payload").is_some_and(property_carries_state)
         }) else {
             continue;
         };
@@ -12701,14 +12721,45 @@ mod tests {
         let properties::PropertyValue::Array { elements } = &slots.value else {
             panic!("m_Slots is not an array");
         };
-        let payload_value = |slot| &struct_element_property(slot, "m_Payload").unwrap().value;
+        let payload_prop = |slot| struct_element_property(slot, "m_Payload").unwrap();
         assert!(
-            !payload_carries_state(payload_value(&elements[0])),
+            !property_carries_state(payload_prop(&elements[0])),
             "an empty-map payload must be treated as a clean template"
         );
         assert!(
-            payload_carries_state(payload_value(&elements[1])),
+            property_carries_state(payload_prop(&elements[1])),
             "a payload with a direct scalar field must be treated as state"
+        );
+    }
+
+    #[test]
+    fn payload_carries_state_flags_zero_valued_unknown_scalar() {
+        // An unrecognised direct scalar at the type default (Durability=0) must
+        // still read as state: its real default is unknown, so cloning the slot
+        // would seed an unrelated new item with a stale field. Only the known
+        // default ItemPayload scalars may be default-clean.
+        let mut zero_scalar = inv_empty_payload_map();
+        zero_scalar.extend_from_slice(&int_property("Durability", 0));
+        let slot = inv_item_slot(
+            0,
+            INV_MAIN_LABEL,
+            "/Script/Angelscript.ItMi_Orenugget",
+            1,
+            &zero_scalar,
+        );
+        let payload = typed_inventory_private_payload(&[], &[slot]);
+        let root = properties::parse_private_root(&payload).unwrap();
+        let slots = properties::resolve(
+            &root.properties,
+            &properties::parse_path(&inv_slots_prefix(1)).unwrap(),
+        )
+        .unwrap();
+        let properties::PropertyValue::Array { elements } = &slots.value else {
+            panic!("m_Slots is not an array");
+        };
+        assert!(
+            property_carries_state(struct_element_property(&elements[0], "m_Payload").unwrap()),
+            "a zero-valued unknown scalar must be treated as state"
         );
     }
 

--- a/crates/goresave_core/src/properties.rs
+++ b/crates/goresave_core/src/properties.rs
@@ -1575,10 +1575,16 @@ fn read_sized_value(
                 entries,
             })
         }
-        other => Err(CoreError::Parse(format!(
-            "unsupported property type {other:?} at 0x{:x}",
-            r.abs_pos()
-        ))),
+        // Any leaf type we don't model: keep its sized payload opaque (read-only,
+        // round-tripped unchanged) rather than aborting. read_property bounds the
+        // sub-reader to exactly `size` bytes, so this consumes the whole payload
+        // byte-exact. Aborting here would fail the entire typed parse and gate off
+        // every typed-parse tab (All data, Progression, Inventory add/remove,
+        // Player editing) — the breakage the Text/FieldPath opaque arms each fixed
+        // one type at a time. Container types (Struct/Array/Set/Map/Enum) are
+        // matched above and still error if their descriptor is missing, so a real
+        // stream desync on a known type surfaces rather than being swallowed.
+        _ => Ok(PropertyValue::Opaque(r.read(r.remaining())?.to_vec())),
     }
 }
 
@@ -1879,6 +1885,28 @@ mod tests {
             PropertyValue::Opaque(vec![1, 2, 3, 4, 5, 6, 7, 8])
         );
         assert_eq!(parsed.properties[0].type_name, "FieldPathProperty");
+    }
+
+    #[test]
+    fn unknown_leaf_property_kept_opaque() {
+        // Any leaf property type the parser does not model must keep its sized
+        // payload as opaque bytes instead of aborting the whole typed parse.
+        // A single unmodelled type would otherwise leave privateTypedVerified
+        // false and gate off every typed-parse tab (All data, Progression,
+        // Inventory add/remove, Player editing) — the recurring breakage the
+        // FieldPathProperty/TextProperty opaque arms were each added to fix.
+        let body = vec![9u8, 8, 7, 6, 5];
+        let mut props = tag("SomeFuture", "WeakObjectProperty");
+        props.extend_from_slice(&header(body.len() as u32, 0));
+        props.extend_from_slice(&body);
+        let payload = root("/Script/Test.Save", &props);
+
+        let parsed = parse_private_root(&payload).unwrap();
+        assert_eq!(
+            parsed.properties[0].value,
+            PropertyValue::Opaque(vec![9, 8, 7, 6, 5])
+        );
+        assert_eq!(parsed.properties[0].type_name, "WeakObjectProperty");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The inventory **Add item** button disappeared. It is gated on `canAddItem`, which requires the core to advertise `private.inventory.addItem` in the inventory `writable` list — and that requires `has_clean_template`: a state-free `m_Payload` slot to clone as the new item's template.

The clean-slot test (`payload_carries_state`) treated **any** scalar leaf, and any non-`Properties`/`Instanced` struct, as item state. But a real default `ItemPayload` is not an empty map — it carries default leaves (`m_StageLevel=0`, `m_OptionalObject=""`, `m_Ownership.UseOwnershipOfArea.TagName="None"`) **and a nested empty native `GameplayTagContainer`** (`m_Ownership.OwnedByGuild`). So every real item slot read as stateful → `has_clean_template` always false on real saves → button gone.

## Fix

- **`payload_carries_state`** redefined as "every leaf at its default, every container empty": default scalars (`0` / `""` / `"None"` / `false`) and empty native struct variants (`GameplayTagContainer` / `Vector` / `Guid` / `DateTime`) are not state. Genuine state (e.g. a value in `m_GenericData`) still blocks cloning, so it is never copied onto an unrelated new item.
- **Typed parser** (`read_sized_value`): unknown *leaf* property types are now kept opaque (read-only, byte-exact round-trip) instead of aborting the whole typed parse — the same robustness the `TextProperty`/`FieldPathProperty` arms added, generalized. Containers still error on a missing descriptor, so real desyncs still surface.

## Verification

- `cargo test -p goresave_core` — 257 passed.
- New regression tests: realistic default-`ItemPayload` fixture (including the empty `GameplayTagContainer` the first pass overlooked) clones successfully; non-default scalar payload still rejected; unknown leaf type kept opaque.
- **End-to-end on a real save (G1R-004, copy)**: `addItem` now succeeds (`editsApplied=1`, stacks 114→115) where it previously failed with "no clean slot".

## Notes

Core-only change; the Flutter UI gate already reads `writable`. The app must be rebuilt against the new core to surface the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inventory template cloning rules and broadens typed-parse tolerance for unknown leaf types; behavior is constrained by tests and still rejects cloning slots with non-default or unknown scalar payload fields.
> 
> **Overview**
> Restores the inventory **Add item** flow by fixing how the core decides whether an `m_Payload` slot is a safe clone template (`has_clean_template` → `private.inventory.addItem` in `writable`).
> 
> **Clean-template detection** replaces value-only `payload_carries_state` with **`property_carries_state`**, which walks the payload tree by property name and value. Non-empty containers still count as state. **Known default ItemPayload scalars** (`m_StageLevel`, `m_OptionalObject`, `TagName`) at type defaults are no longer treated as dirty; **empty native structs** (including an empty **`GameplayTagContainer`**) are clean. **Unrecognized scalar fields** stay state even at `0`/`""`/`"None"`, so fields like `Durability` are never cloned onto new items.
> 
> **Typed parser** (`read_sized_value`): unmodeled **leaf** property types (e.g. `WeakObjectProperty`) are stored as **`PropertyValue::Opaque`** and round-tripped instead of aborting the full private typed parse (same pattern as existing `TextProperty` / `FieldPathProperty` handling).
> 
> Regression tests cover realistic default-`ItemPayload` add, rejection of non-default and unknown zero scalars, and opaque unknown leaf types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c09ab5c03a6de4e58835a0199ac97f13c173719. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->