### PR TITLE
fix(codec-host): load system DLLs from System32 before game dir (UE4SS proxy)

### DIFF
--- a/crates/goresave_g1r_codec_host/src/lib.rs
+++ b/crates/goresave_g1r_codec_host/src/lib.rs
@@ -1505,6 +1505,25 @@ fn protect_mapped_sections(
     Ok(protected)
 }
 
+/// Resolve `dll_name` to a real file in the Windows system directory, if present.
+///
+/// Uses `SystemRoot`/`windir` (falling back to `C:\Windows`) so it honours
+/// non-default Windows installs. Returns `None` when no such system DLL exists,
+/// which lets the caller fall through to the game-directory search.
+#[cfg(windows)]
+fn system32_dll_path(dll_name: &str) -> Option<PathBuf> {
+    // Reject anything with path components: a PE import is a bare filename.
+    if Path::new(dll_name).components().count() != 1 {
+        return None;
+    }
+    let system_root = env::var_os("SystemRoot")
+        .or_else(|| env::var_os("windir"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\Windows"));
+    let system_dll = system_root.join("System32").join(dll_name);
+    system_dll.is_file().then_some(system_dll)
+}
+
 impl WindowsImportResolver {
     pub fn with_search_dirs(search_dirs: Vec<PathBuf>) -> Self {
         Self { search_dirs }
@@ -1515,6 +1534,21 @@ impl WindowsImportResolver {
         if dll_path.is_absolute() && dll_path.is_file() {
             return Some(dll_path.to_path_buf());
         }
+
+        // On Windows, prefer the real system DLL from System32 over any
+        // identically-named DLL in the game directory. Mod loaders such as
+        // UE4SS install proxy DLLs under well-known system names (dwmapi.dll,
+        // winmm.dll, dxgi.dll, xinput1_3.dll, ...). Loading such a proxy into
+        // the codec host process runs its DllMain, which tries to load
+        // UE4SS.dll relative to the host and fails with a MessageBox popup.
+        // Only system DLLs that actually exist in System32 are short-circuited
+        // here; game-specific DLLs (e.g. bink2w64.dll) are absent there and
+        // fall through to the game-directory search below.
+        #[cfg(windows)]
+        if let Some(system_dll) = system32_dll_path(dll_name) {
+            return Some(system_dll);
+        }
+
         self.search_dirs
             .iter()
             .map(|dir| dir.join(dll_name))
@@ -3848,6 +3882,50 @@ mod runtime_work_timeout_tests {
             runtime_work_worker_timeout(usize::MAX),
             Duration::from_secs(600)
         );
+    }
+}
+
+#[cfg(all(test, windows))]
+mod candidate_dll_path_tests {
+    use super::*;
+
+    #[test]
+    fn prefers_system32_over_game_dir_proxy() {
+        // Plant a fake proxy DLL in a "game" dir under a real system DLL name.
+        let game_dir = std::env::temp_dir().join("goresave_dll_test_proxy");
+        let _ = fs::create_dir_all(&game_dir);
+        let proxy = game_dir.join("dwmapi.dll");
+        fs::write(&proxy, b"not a real dll").unwrap();
+
+        let resolver = WindowsImportResolver::with_search_dirs(vec![game_dir.clone()]);
+        let resolved = resolver.candidate_dll_path("dwmapi.dll").unwrap();
+
+        // Must resolve to the real System32 copy, never the planted proxy.
+        assert_ne!(resolved, proxy);
+        assert_eq!(
+            resolved.parent().unwrap().file_name().unwrap(),
+            std::ffi::OsStr::new("System32")
+        );
+
+        let _ = fs::remove_dir_all(&game_dir);
+    }
+
+    #[test]
+    fn falls_back_to_game_dir_for_non_system_dll() {
+        // A game-specific DLL that does not exist in System32 must resolve
+        // from the game directory.
+        let game_dir = std::env::temp_dir().join("goresave_dll_test_game");
+        let _ = fs::create_dir_all(&game_dir);
+        let game_dll = game_dir.join("goresave_fake_game.dll");
+        fs::write(&game_dll, b"game dll").unwrap();
+
+        let resolver = WindowsImportResolver::with_search_dirs(vec![game_dir.clone()]);
+        let resolved = resolver
+            .candidate_dll_path("goresave_fake_game.dll")
+            .unwrap();
+        assert_eq!(resolved, game_dll);
+
+        let _ = fs::remove_dir_all(&game_dir);
     }
 }
 

--- a/crates/goresave_g1r_codec_host/src/lib.rs
+++ b/crates/goresave_g1r_codec_host/src/lib.rs
@@ -1521,6 +1521,11 @@ fn protect_mapped_sections(
 /// Names are compared case-insensitively. UE4SS defaults to `dwmapi.dll` but is
 /// configurable to other names in this list, so the whole proxy family is
 /// covered.
+/// This list intentionally contains only core OS API DLLs that mod loaders
+/// wrap — it must NOT include redistributable DLLs that games legitimately ship
+/// application-local (e.g. `d3dcompiler_47.dll`, `xaudio2_9.dll`, the VC
+/// runtime). Overriding those to System32 could bind imports to a different
+/// build than the executable ships, which is exactly what scoping avoids.
 #[cfg(windows)]
 const KNOWN_PROXY_DLLS: &[&str] = &[
     "d3d8.dll",
@@ -1528,8 +1533,6 @@ const KNOWN_PROXY_DLLS: &[&str] = &[
     "d3d10.dll",
     "d3d11.dll",
     "d3d12.dll",
-    "d3dcompiler_43.dll",
-    "d3dcompiler_47.dll",
     "ddraw.dll",
     "dinput.dll",
     "dinput8.dll",
@@ -1542,8 +1545,6 @@ const KNOWN_PROXY_DLLS: &[&str] = &[
     "version.dll",
     "wininet.dll",
     "winmm.dll",
-    "xapofx1_5.dll",
-    "xaudio2_9.dll",
     "xinput1_1.dll",
     "xinput1_2.dll",
     "xinput1_3.dll",
@@ -3989,8 +3990,19 @@ mod candidate_dll_path_tests {
         let app_local = game_dir.join("vcruntime140.dll");
         fs::write(&app_local, b"app-local vc runtime").unwrap();
 
-        // Precondition: this name is not in the proxy override set.
-        assert!(!KNOWN_PROXY_DLLS.contains(&"vcruntime140.dll"));
+        // Precondition: redistributable DLLs games ship app-local must not be
+        // in the proxy override set, even when an identically-named copy exists
+        // in System32.
+        for name in [
+            "vcruntime140.dll",
+            "msvcp140.dll",
+            "d3dcompiler_43.dll",
+            "d3dcompiler_47.dll",
+            "xaudio2_9.dll",
+            "xapofx1_5.dll",
+        ] {
+            assert!(!KNOWN_PROXY_DLLS.contains(&name), "{name} must not be proxied");
+        }
 
         let resolver = WindowsImportResolver::with_search_dirs(vec![game_dir.clone()]);
         let resolved = resolver.candidate_dll_path("vcruntime140.dll").unwrap();

--- a/crates/goresave_g1r_codec_host/src/lib.rs
+++ b/crates/goresave_g1r_codec_host/src/lib.rs
@@ -1505,15 +1505,68 @@ fn protect_mapped_sections(
     Ok(protected)
 }
 
-/// Resolve `dll_name` to a real file in the Windows system directory, if present.
+/// Well-known Windows system DLL names that mod loaders (UE4SS, ReShade, ENB,
+/// ...) commonly hijack by dropping an identically-named proxy/wrapper DLL next
+/// to the game executable. Loading such a proxy into the codec host process
+/// runs its `DllMain`, which (for UE4SS) tries to load `UE4SS.dll` relative to
+/// the host and fails with a `Failed to load UE4SS.dll` MessageBox (issue #18).
 ///
-/// Uses `SystemRoot`/`windir` (falling back to `C:\Windows`) so it honours
-/// non-default Windows installs. Returns `None` when no such system DLL exists,
-/// which lets the caller fall through to the game-directory search.
+/// We deliberately scope the System32 override to this set rather than "any DLL
+/// that also exists in System32": that keeps the normal loader order
+/// (application directory before the system directory) for genuine app-local
+/// dependencies a game may ship under a system name (e.g. `msvcp140.dll`,
+/// `vcruntime140.dll`, `d3dcompiler_47.dll`), so we never resolve imports from
+/// an older/different system copy than the executable was built against.
+///
+/// Names are compared case-insensitively. UE4SS defaults to `dwmapi.dll` but is
+/// configurable to other names in this list, so the whole proxy family is
+/// covered.
+#[cfg(windows)]
+const KNOWN_PROXY_DLLS: &[&str] = &[
+    "d3d8.dll",
+    "d3d9.dll",
+    "d3d10.dll",
+    "d3d11.dll",
+    "d3d12.dll",
+    "d3dcompiler_43.dll",
+    "d3dcompiler_47.dll",
+    "ddraw.dll",
+    "dinput.dll",
+    "dinput8.dll",
+    "dsound.dll",
+    "dwmapi.dll",
+    "dxgi.dll",
+    "msacm32.dll",
+    "msvfw32.dll",
+    "opengl32.dll",
+    "version.dll",
+    "wininet.dll",
+    "winmm.dll",
+    "xapofx1_5.dll",
+    "xaudio2_9.dll",
+    "xinput1_1.dll",
+    "xinput1_2.dll",
+    "xinput1_3.dll",
+    "xinput1_4.dll",
+    "xinput9_1_0.dll",
+];
+
+/// Resolve a known mod-loader-proxy DLL name to the real file in the Windows
+/// system directory, if present.
+///
+/// Returns `None` for any name not in [`KNOWN_PROXY_DLLS`], for names with path
+/// components (a PE import is a bare filename), or when no such system DLL
+/// exists — all of which let the caller fall through to the game-directory
+/// search. Uses `SystemRoot`/`windir` (falling back to `C:\Windows`) so it
+/// honours non-default Windows installs.
 #[cfg(windows)]
 fn system32_dll_path(dll_name: &str) -> Option<PathBuf> {
     // Reject anything with path components: a PE import is a bare filename.
     if Path::new(dll_name).components().count() != 1 {
+        return None;
+    }
+    let lowered = dll_name.to_ascii_lowercase();
+    if !KNOWN_PROXY_DLLS.contains(&lowered.as_str()) {
         return None;
     }
     let system_root = env::var_os("SystemRoot")
@@ -1535,15 +1588,12 @@ impl WindowsImportResolver {
             return Some(dll_path.to_path_buf());
         }
 
-        // On Windows, prefer the real system DLL from System32 over any
-        // identically-named DLL in the game directory. Mod loaders such as
-        // UE4SS install proxy DLLs under well-known system names (dwmapi.dll,
-        // winmm.dll, dxgi.dll, xinput1_3.dll, ...). Loading such a proxy into
-        // the codec host process runs its DllMain, which tries to load
-        // UE4SS.dll relative to the host and fails with a MessageBox popup.
-        // Only system DLLs that actually exist in System32 are short-circuited
-        // here; game-specific DLLs (e.g. bink2w64.dll) are absent there and
-        // fall through to the game-directory search below.
+        // On Windows, for the narrow set of system DLL names that mod loaders
+        // hijack (see KNOWN_PROXY_DLLS), prefer the real System32 copy over an
+        // identically-named proxy DLL in the game directory. This avoids running
+        // UE4SS's proxy DllMain inside the codec host (issue #18). Every other
+        // name — including genuine app-local dependencies and game-specific
+        // DLLs — keeps the normal application-directory-first search below.
         #[cfg(windows)]
         if let Some(system_dll) = system32_dll_path(dll_name) {
             return Some(system_dll);
@@ -3924,6 +3974,45 @@ mod candidate_dll_path_tests {
             .candidate_dll_path("goresave_fake_game.dll")
             .unwrap();
         assert_eq!(resolved, game_dll);
+
+        let _ = fs::remove_dir_all(&game_dir);
+    }
+
+    #[test]
+    fn keeps_app_local_copy_for_non_proxy_system_name() {
+        // A genuine app-local dependency that shares a system DLL name but is
+        // NOT a known mod-loader proxy (e.g. the VC runtime) must keep the
+        // normal application-directory-first loader order, even though the same
+        // name exists in System32.
+        let game_dir = std::env::temp_dir().join("goresave_dll_test_applocal");
+        let _ = fs::create_dir_all(&game_dir);
+        let app_local = game_dir.join("vcruntime140.dll");
+        fs::write(&app_local, b"app-local vc runtime").unwrap();
+
+        // Precondition: this name is not in the proxy override set.
+        assert!(!KNOWN_PROXY_DLLS.contains(&"vcruntime140.dll"));
+
+        let resolver = WindowsImportResolver::with_search_dirs(vec![game_dir.clone()]);
+        let resolved = resolver.candidate_dll_path("vcruntime140.dll").unwrap();
+        assert_eq!(resolved, app_local);
+
+        let _ = fs::remove_dir_all(&game_dir);
+    }
+
+    #[test]
+    fn proxy_name_match_is_case_insensitive() {
+        let game_dir = std::env::temp_dir().join("goresave_dll_test_case");
+        let _ = fs::create_dir_all(&game_dir);
+        let proxy = game_dir.join("DWMAPI.DLL");
+        fs::write(&proxy, b"not a real dll").unwrap();
+
+        let resolver = WindowsImportResolver::with_search_dirs(vec![game_dir.clone()]);
+        let resolved = resolver.candidate_dll_path("DWMAPI.DLL").unwrap();
+        assert_ne!(resolved, proxy);
+        assert_eq!(
+            resolved.parent().unwrap().file_name().unwrap(),
+            std::ffi::OsStr::new("System32")
+        );
 
         let _ = fs::remove_dir_all(&game_dir);
     }


### PR DESCRIPTION
## Problem

Fixes #18. On game installs with **UE4SS** (or similar mod loaders), checking paths or running edits fails with a Windows `Failed to load UE4SS.dll` MessageBox, and the editor reports that private player edits need a verified G1R codec host.

**Root cause:** `WindowsImportResolver::candidate_dll_path` searched the game directory (`self.search_dirs`) *before* system paths. UE4SS installs proxy DLLs under well-known system names (`dwmapi.dll`, `winmm.dll`, `dxgi.dll`, `xinput1_3.dll`, ...) in `Binaries/Win64/`. The codec host loaded the proxy instead of the real system DLL; the proxy `DllMain` then tried to load `UE4SS.dll` relative to the host process, failed, popped the error box, and blocked verification.

## Fix

`candidate_dll_path` now prefers the real `System32` copy for any import that actually exists there (gated `#[cfg(windows)]`), via a new `system32_dll_path` helper:

- Resolves against `%SystemRoot%\System32` (falls back `windir` -> `C:\Windows`), so non-default Windows installs work.
- Returns `Some` only when the system DLL exists — game-specific DLLs (e.g. `bink2w64.dll`) are absent from System32 and still resolve from the game directory, preserving existing behavior.
- Rejects names with path components, since PE imports are bare filenames.

## Tests

Two new `#[cfg(all(test, windows))]` tests:
- `prefers_system32_over_game_dir_proxy` — a planted `dwmapi.dll` in the game dir resolves to the System32 copy, never the proxy.
- `falls_back_to_game_dir_for_non_system_dll` — a non-system DLL resolves from the game dir.

Both pass; `cargo build`/`clippy` clean (no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters which DLL path is loaded during manual PE import resolution for the codec host; incorrect allowlist entries could break modded or redistributable-heavy installs, though scoping and tests limit exposure.
> 
> **Overview**
> Fixes **#18** by changing **`WindowsImportResolver::candidate_dll_path`** so PE imports no longer pick up UE4SS/ReShade-style **proxy DLLs** from the game folder when the import name matches a known hijacked system DLL.
> 
> Before resolving from **`search_dirs`** (typically the exe directory), the resolver now checks a new **`KNOWN_PROXY_DLLS`** allowlist (e.g. **`dwmapi.dll`**, **`dxgi.dll`**, **`winmm.dll`**, **`xinput*`**). For those names only, **`system32_dll_path`** returns **`%SystemRoot%\System32\...`** when the file exists, with case-insensitive matching and rejection of path components. **VC runtimes**, **`d3dcompiler_*`**, and other app-local redistributables are **not** on the list, so **`vcruntime140.dll`** in the game dir still wins over System32.
> 
> Four new **`#[cfg(all(test, windows))]`** tests cover proxy → System32, game-only DLLs, app-local VC runtime, and case-insensitive proxy names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec2eb0ce2454c14ef0566f01b30a66d5bd6ede9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->