### PR TITLE
feat(gore-as): AngelScript cache decompiler + splice modding

### DIFF
--- a/crates/gore-as/src/cache/decompile.rs
+++ b/crates/gore-as/src/cache/decompile.rs
@@ -14,12 +14,52 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 
-use super::disasm::disassemble;
+use super::disasm::{disassemble, Instr};
+use super::model::{param_slot_map, returns_struct_by_value};
 use super::refs::RefResolver;
 use super::walk_modules::FuncCode;
 
 /// AngelScript value-pointer size in dwords on x64 (AS_PTR_SIZE).
 const AS_PTR_SIZE: i32 = 2;
+
+/// Build the AS_PTR_SIZE-aware frame-offset -> parameter-index map for a function, choosing
+/// between the no-RVO and RVO-slot variants by which one best fits the offsets the bytecode
+/// actually references (self-correcting RVO heuristic — spec §3.1 option a). Shared shape with
+/// `structure.rs::Ctx::build_param_off_map`.
+pub(crate) fn build_param_off_map(f: &FuncCode, instrs: &[Instr]) -> HashMap<i32, usize> {
+    let base = param_slot_map(&f.param_types, f.is_method, false);
+    if !returns_struct_by_value(&f.ret) {
+        return base;
+    }
+    let rvo = param_slot_map(&f.param_types, f.is_method, true);
+    // Count how many DISTINCT observed negative frame offsets each candidate map explains.
+    // A by-value struct return ALWAYS carries the RVO out-pointer per the ABI, so prefer the
+    // RVO map on ties; only fall back to the no-RVO map if it strictly explains MORE observed
+    // offsets (i.e. the return type was mis-classified as by-value).
+    let observed = observed_neg_offsets(instrs);
+    let score = |m: &HashMap<i32, usize>| observed.iter().filter(|o| m.contains_key(o)).count();
+    if score(&base) > score(&rvo) {
+        base
+    } else {
+        rvo
+    }
+}
+
+/// The set of distinct negative frame offsets (`< 0`, excluding `this`@0) that appear as the
+/// first word operand of an instruction — i.e. slots the body actually reads/writes. Used to
+/// score the RVO-vs-no-RVO param maps against reality.
+fn observed_neg_offsets(instrs: &[Instr]) -> std::collections::HashSet<i32> {
+    let mut set = std::collections::HashSet::new();
+    for ins in instrs {
+        for &w in &ins.words {
+            let off = w as i16 as i32;
+            if off < 0 {
+                set.insert(off);
+            }
+        }
+    }
+    set
+}
 
 #[derive(Clone)]
 enum Expr {
@@ -62,20 +102,26 @@ pub fn decompile_function(f: &FuncCode, refs: &RefResolver) -> String {
     let mut arg_stack: Vec<Expr> = Vec::new();
     let mut body = String::new();
 
+    // AS_PTR_SIZE-aware frame-offset -> param-index map (handles 2-dword handles/refs and the
+    // hidden by-value-return RVO slot). Self-corrects the RVO guess against observed offsets.
+    let param_off_map = build_param_off_map(f, &instrs);
     let slot_name = |off: i32| -> Expr {
         if off > 0 {
             return Expr::Var(format!("local_{off}"));
         }
-        // Methods carry an implicit `this` at slot 0 with params at -AS_PTR_SIZE, -AS_PTR_SIZE-1, …
-        // Free functions have no `this`: params start at slot 0 (0, -1, -2, …). See structure.rs.
-        let idx = if f.is_method {
-            if off == 0 {
-                return Expr::This;
-            }
-            (-off - AS_PTR_SIZE) as usize
-        } else {
-            (-off) as usize
-        };
+        if f.is_method && off == 0 {
+            return Expr::This;
+        }
+        if let Some(&idx) = param_off_map.get(&off) {
+            return match f.param_names.get(idx) {
+                Some(n) if !n.is_empty() => Expr::Var(n.clone()),
+                _ => Expr::Var(format!("arg{idx}")),
+            };
+        }
+        // Genuinely unmapped negative slot (variadic/defaulted tail the signature undercounts):
+        // fall back to a stable `arg{N}` derived from the linear position so the same offset
+        // always renders the same identifier.
+        let idx = if f.is_method { (-off - AS_PTR_SIZE) as usize } else { (-off) as usize };
         match f.param_names.get(idx) {
             Some(n) if !n.is_empty() => Expr::Var(n.clone()),
             _ => Expr::Var(format!("arg{idx}")),

--- a/crates/gore-as/src/cache/decompile.rs
+++ b/crates/gore-as/src/cache/decompile.rs
@@ -26,12 +26,31 @@ const AS_PTR_SIZE: i32 = 2;
 /// between the no-RVO and RVO-slot variants by which one best fits the offsets the bytecode
 /// actually references (self-correcting RVO heuristic — spec §3.1 option a). Shared shape with
 /// `structure.rs::Ctx::build_param_off_map`.
-pub(crate) fn build_param_off_map(f: &FuncCode, instrs: &[Instr]) -> HashMap<i32, usize> {
-    let base = param_slot_map(&f.param_types, f.is_method, false);
+pub(crate) fn build_param_off_map(
+    f: &FuncCode,
+    instrs: &[Instr],
+    refs: &RefResolver,
+) -> HashMap<i32, usize> {
+    build_param_off_map_rvo(f, instrs, refs).0
+}
+
+/// Like [`build_param_off_map`] but also returns the frame offset of the hidden RVO out-pointer
+/// slot when the RVO map is the chosen one (i.e. this function returns a struct by value and the
+/// observed offsets don't contradict it). The RVO slot sits between `this` (or the frame base for
+/// a free fn) and the first real parameter — at the cursor position the rvo `off -= AS_PTR_SIZE`
+/// reserves, which equals the no-RVO param-0 start: `-AS_PTR_SIZE` for a method, `0` for a free
+/// fn. Lets the body recognise the return slot so a `CopyScript <retSlot> = <local>` is rendered
+/// as `return <local>` and the slot is never mis-named as parameter 0.
+pub(crate) fn build_param_off_map_rvo(
+    f: &FuncCode,
+    instrs: &[Instr],
+    refs: &RefResolver,
+) -> (HashMap<i32, usize>, Option<i32>) {
+    let base = param_slot_map(&f.param_types, f.is_method, false, Some(refs));
     if !returns_struct_by_value(&f.ret) {
-        return base;
+        return (base, None);
     }
-    let rvo = param_slot_map(&f.param_types, f.is_method, true);
+    let rvo = param_slot_map(&f.param_types, f.is_method, true, Some(refs));
     // Count how many DISTINCT observed negative frame offsets each candidate map explains.
     // A by-value struct return ALWAYS carries the RVO out-pointer per the ABI, so prefer the
     // RVO map on ties; only fall back to the no-RVO map if it strictly explains MORE observed
@@ -39,9 +58,10 @@ pub(crate) fn build_param_off_map(f: &FuncCode, instrs: &[Instr]) -> HashMap<i32
     let observed = observed_neg_offsets(instrs);
     let score = |m: &HashMap<i32, usize>| observed.iter().filter(|o| m.contains_key(o)).count();
     if score(&base) > score(&rvo) {
-        base
+        (base, None)
     } else {
-        rvo
+        let rvo_off = if f.is_method { -AS_PTR_SIZE } else { 0 };
+        (rvo, Some(rvo_off))
     }
 }
 
@@ -104,7 +124,7 @@ pub fn decompile_function(f: &FuncCode, refs: &RefResolver) -> String {
 
     // AS_PTR_SIZE-aware frame-offset -> param-index map (handles 2-dword handles/refs and the
     // hidden by-value-return RVO slot). Self-corrects the RVO guess against observed offsets.
-    let param_off_map = build_param_off_map(f, &instrs);
+    let param_off_map = build_param_off_map(f, &instrs, refs);
     let slot_name = |off: i32| -> Expr {
         if off > 0 {
             return Expr::Var(format!("local_{off}"));

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -247,6 +247,12 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     for (slot, ty) in &slot_overrides {
         local_types.insert(*slot, ty.clone());
     }
+    // member-access-derived types: the field's declaring class is the strongest signal for a
+    // slot used as a member-access base; apply AFTER (overriding) the call-arg guess.
+    let member_overrides = infer_slot_types_from_members(f, refs);
+    for (slot, ty) in &member_overrides {
+        local_types.insert(*slot, ty.clone());
+    }
     let body = body_statements_ctor(&fc, refs, depth + 1, super_ctor, Some(&f.ret), fields, Some(&param_types), class_name, Some(&local_types));
     // hoist every referenced local; infer_locals types what it can, the rest default to `int`
     // (a wrong type just becomes a compile error the in-game loop force-stubs, rather than the
@@ -266,6 +272,12 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
             if ty == "?" && locals.get(slot).map(|t| t != "?").unwrap_or(false) {
                 continue;
             }
+            locals.insert(*slot, ty.clone());
+        }
+    }
+    // member-derived declaring-class types override the cache's wrong/general slot type
+    for (slot, ty) in &member_overrides {
+        if used.contains(slot) {
             locals.insert(*slot, ty.clone());
         }
     }
@@ -549,6 +561,44 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
             _ => None,
         })
         .collect()
+}
+
+/// Member-access-driven slot typing: a `LoadRObjR`/`LoadVObjR base, off, tid` reads field
+/// `member(tid,off)` off the object in `base`; `member_type(tid,off)` is the field's DECLARING
+/// class — exactly the type `base` must have for `base.field` to compile. The cache often types
+/// the slot too generally (`UObject`) or wrong (`FGameplayTag` for a `FGameplayTagContainer`),
+/// or not at all (`int`), producing "<field> is not a member of <T>". Override the slot with the
+/// declaring class. Conservative: LOCAL slots only (base > 0), single consistent declaring type
+/// (conflict -> drop), non-empty non-primitive.
+fn infer_slot_types_from_members(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
+    let instrs = match disassemble(&f.bytecode) {
+        Ok(i) => i,
+        Err(_) => return HashMap::new(),
+    };
+    let mut cand: HashMap<i32, Option<String>> = HashMap::new();
+    for ins in &instrs {
+        if matches!(ins.op.name, "LoadRObjR" | "LoadVObjR") {
+            let base = match ins.words.first() {
+                Some(w) => *w as i16 as i32,
+                None => continue,
+            };
+            if base <= 0 {
+                continue; // this / param-as-receiver: skip (only local slots here)
+            }
+            let off = ins.words.get(1).copied().unwrap_or(0) as i32;
+            let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
+            let Some(ty) = refs.member_type(tid, off) else { continue };
+            if ty.is_empty() || is_primitive(ty) {
+                continue;
+            }
+            match cand.get(&base) {
+                None => { cand.insert(base, Some(ty.to_string())); }
+                Some(Some(prev)) if prev != ty => { cand.insert(base, None); }
+                _ => {}
+            }
+        }
+    }
+    cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect()
 }
 
 /// §3.3 consumer-driven typing of out-of-range `argN` slots. Scans the body for the RHS of an

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -113,12 +113,23 @@ pub fn emit_module(m: &Module, refs: &RefResolver) -> String {
 
     // free functions = module.functions that aren't generator-synthesized accessors
     for f in &m.functions {
-        if is_generated(f, &class_names, &class_members) {
+        if is_generated(f, &class_names, &class_members) || is_generated_spawn(f, refs) {
             continue;
         }
         emit_function(&mut s, f, refs, false, false, 0);
     }
     s
+}
+
+/// The AngelScript-UE binding auto-generates `<Actor> Spawn(const FVector&, const FRotator&,
+/// const FName&, bool, ULevel)` as a free function for every actor class. The cache also carries
+/// it as a module function, so emitting it duplicates the native binding ("a function with the
+/// same name and parameters already exists" — un-stubbable, the declaration itself collides). Skip.
+fn is_generated_spawn(f: &Func, refs: &RefResolver) -> bool {
+    f.name == "Spawn"
+        && f.params.len() == 5
+        && f.ret.is_object_handle
+        && f.params.first().map(|p| p.ty.base_name(refs)).as_deref() == Some("FVector")
 }
 
 fn emit_class(s: &mut String, c: &Class, refs: &RefResolver) {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -488,6 +488,13 @@ fn used_locals(body: &str) -> HashSet<i32> {
 /// override `slot -> type` ONLY for never-written slots with a single consistent consumer object
 /// type, so it can never clobber a real producer type. Pairs args from the stack TOP (robust to the
 /// cache counting the implicit `this` in a method's param list).
+/// True if a return type name denotes a struct/template returned BY VALUE via a hidden RVO
+/// out-slot (`F*` engine struct, `T*` template value like TSubclassOf). Enums/primitives/objects
+/// return in a register, not an out-slot, so they are excluded.
+fn ret_is_struct(ty: &str) -> bool {
+    matches!(ty.split('<').next().unwrap_or(ty).bytes().next(), Some(b'F') | Some(b'T'))
+}
+
 fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
     let instrs = match disassemble(&f.bytecode) {
         Ok(i) => i,
@@ -514,13 +521,21 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
     }
     let mut ostack: Vec<Option<i32>> = Vec::new();
     let mut cand: HashMap<i32, Option<String>> = HashMap::new(); // slot -> Some(type) | None(conflict)
-    let mut pair = |ostack: &mut Vec<Option<i32>>, params: Option<&[super::types::DataType]>, is_method: bool, cand: &mut HashMap<i32, Option<String>>| {
+    let mut pair = |ostack: &mut Vec<Option<i32>>, params: Option<&[super::types::DataType]>, is_method: bool, ret_struct: bool, cand: &mut HashMap<i32, Option<String>>| {
         let Some(params) = params else { ostack.clear(); return; };
-        let total = if is_method { params.len() + 1 } else { params.len() };
+        // A method returning a struct BY VALUE (F/T/E) carries a hidden RVO out-slot pushed as the
+        // last user arg (just before the receiver); count it so it is consumed, but exclude it from
+        // pairing (it is NOT params[last] — pairing it would shift every real arg one param over and
+        // mis-type the slot, e.g. the TSubclassOf out param landing on an EQuestState param).
+        let rvo = (ret_struct && is_method) as usize;
+        let total = if is_method { params.len() + 1 + rvo } else { params.len() };
         let take = total.min(ostack.len());
         let popped = ostack.split_off(ostack.len() - take);
-        // method: top popped entry is the receiver -> drop it; the rest are the user args
-        let args = if is_method && !popped.is_empty() { &popped[..popped.len() - 1] } else { &popped[..] };
+        // method: top popped entry is the receiver -> drop it (plus the RVO out-slot just below it);
+        // the rest are the user args.
+        let args = if is_method && !popped.is_empty() {
+            &popped[..popped.len().saturating_sub(1 + rvo)]
+        } else { &popped[..] };
         // pair from the TOP: last arg <-> last param (so a leading `this` param, if the cache
         // counts it, never shifts the user-arg pairing).
         for (i, slot) in args.iter().rev().enumerate() {
@@ -546,11 +561,38 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
             | "TYPEID" | "OBJTYPE" | "PshListElmnt" => ostack.push(None),
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
-                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), &mut cand);
+                let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand);
             }
             "CALLSYS" | "Thiscall1" => {
                 let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
-                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), &mut cand);
+                // `$beh0` is the in-place CONSTRUCT behaviour: `<arg> ; PSF <slot> ; CALLSYS $beh0`
+                // constructs the value AT the PSF'd receiver slot (top of stack). That slot's type
+                // is the construct OWNER (e.g. TSubclassOf<UQuest>), not any callee param — pairing
+                // it as an ordinary arg mis-types it (EQuestState). Type the receiver from the owner
+                // and consume the behaviour's operands without arg-pairing.
+                if refs.func_by_ptr(ptr) == Some("$beh0") {
+                    let owner = refs.func_owner_by_ptr(ptr).map(|s| s.to_string());
+                    // receiver = top operand; ctor args = the params below it.
+                    if let Some(Some(rslot)) = ostack.last().copied() {
+                        if let Some(ty) = owner {
+                            if !ty.is_empty() {
+                                match cand.get(&rslot) {
+                                    None => { cand.insert(rslot, Some(ty)); }
+                                    Some(Some(prev)) if *prev != ty => { cand.insert(rslot, None); }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                    // pop receiver + ctor args off the operand stack so they don't leak.
+                    let nargs = refs.func_params_by_ptr(ptr).map(|p| p.len()).unwrap_or(0);
+                    let drop_n = (1 + nargs).min(ostack.len());
+                    ostack.truncate(ostack.len() - drop_n);
+                    continue;
+                }
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand);
             }
             _ => {}
         }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -196,7 +196,10 @@ fn emit_function(s: &mut String, f: &Func, refs: &RefResolver, is_method: bool, 
 #[allow(clippy::too_many_arguments)]
 fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: bool, is_ctor: bool, depth: usize, super_ctor: Option<&str>, fields: Option<&HashMap<String, String>>, class_name: Option<&str>) {
     let ind = "    ".repeat(depth);
-    let ret = f.ret.render(refs);
+    // Strip a leading `const` from the return type: a return-by-value `const` is meaningless in
+    // AngelScript, and the cache sets the const flag inconsistently between a base method and its
+    // override -> "must have the same return type as in the base class". Stripping makes them match.
+    let ret = f.ret.render(refs).trim_start_matches("const ").to_string();
     let params = render_params(f, refs);
     if f.is_ufunction {
         let _ = writeln!(s, "{ind}UFUNCTION()");

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -143,6 +143,10 @@ fn is_generated_spawn(f: &Func, refs: &RefResolver) -> bool {
     {
         return true;
     }
+    // subsystem/singleton accessor: `<Subsystem> Get()` / `GetG1R()` (0 params, handle return).
+    if matches!(f.name.as_str(), "Get" | "GetG1R") && f.params.is_empty() {
+        return true;
+    }
     false
 }
 

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -117,7 +117,7 @@ pub fn emit_module(m: &Module, refs: &RefResolver) -> String {
         if is_generated(f, &class_names, &class_members) || is_generated_spawn(f, refs) {
             continue;
         }
-        if !seen_free.insert(format!("{}({})", f.name, render_params(f, refs))) {
+        if !seen_free.insert(format!("{}({})", f.name, param_sig(f, refs))) {
             continue; // duplicate signature -> "function ... already exists"
         }
         emit_function(&mut s, f, refs, false, false, 0);
@@ -197,7 +197,7 @@ fn emit_class(s: &mut String, c: &Class, refs: &RefResolver) {
         if m.name.starts_with("__") {
             continue;
         }
-        if !seen_sigs.insert(format!("{}({})", m.name, render_params(m, refs))) {
+        if !seen_sigs.insert(format!("{}({})", m.name, param_sig(m, refs))) {
             continue; // duplicate signature
         }
         emit_function_ctor(s, m, refs, true, false, 1, None, Some(&field_types), Some(&c.name));
@@ -388,6 +388,31 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         }
     }
     let _ = writeln!(s, "{ind}}}");
+}
+
+/// AngelScript overload identity ignores parameter NAMES — two functions are the same overload
+/// when their parameter TYPES + reference modifiers match. Use this (not `render_params`, which
+/// appends names) as the dedup key, so two cache entries with the same name+types but different
+/// stored arg-names don't both get emitted (which fails with "a function with the same name and
+/// parameters already exists").
+fn param_sig(f: &Func, refs: &RefResolver) -> String {
+    f.params
+        .iter()
+        .map(|p| {
+            let ty = p.ty.render(refs);
+            let amp = if p.ty.is_reference {
+                match p.flags & 3 {
+                    2 => "&out",
+                    3 => "&inout",
+                    _ => "&in",
+                }
+            } else {
+                ""
+            };
+            format!("{ty}{amp}")
+        })
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 fn render_params(f: &Func, refs: &RefResolver) -> String {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -243,10 +243,15 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // hoist every referenced local; infer_locals types what it can, the rest default to `int`
     // (a wrong type just becomes a compile error the in-game loop force-stubs, rather than the
     // whole function stubbing on an undeclared identifier).
+    let used = used_locals(&body);
     let mut locals = infer_locals(f, refs);
-    for n in used_locals(&body) {
+    for &n in &used {
         locals.entry(n).or_insert_with(|| "int".to_string());
     }
+    // Drop locals never referenced in the body: `obj_locals` includes profiling temporaries like
+    // FScopeCycleCounter / FStatID that the body never uses, and they have no default constructor,
+    // so declaring an unused one fails ("No default constructor"). An unused declaration is dead.
+    locals.retain(|slot, _| used.contains(slot));
     // arg slots the bytecode reads beyond the declared parameter list (the signature parse
     // undercounts some value-type / defaulted params). Declare them as `int` locals so the
     // body compiles instead of stubbing wholesale; a wrong type the in-game loop force-stubs.

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -231,6 +231,8 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         func: f.name.clone(),
         is_method,
         param_names: f.params.iter().map(|p| p.name.clone()).collect(),
+        param_types: f.params.iter().map(|p| p.ty.clone()).collect(),
+        ret: f.ret.clone(),
         bytecode: f.bytecode.clone(),
     };
     let param_types: Vec<String> = f.params.iter().map(|p| p.ty.base_name(refs)).collect();
@@ -277,6 +279,11 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     let mut oor_args: Vec<i32> =
         used_idents(&body, "arg").into_iter().filter(|&n| n as usize >= f.params.len()).collect();
     oor_args.sort_unstable();
+    // §3.3 safety net: an unmapped `argN` (signature undercount / RVO-return slot) declared as
+    // `int` breaks any member/operator use on it ("Illegal operation on 'int'"). Type it from
+    // its CONSUMER instead — the RHS of `argN = <expr>` (a field/local/param whose type we know)
+    // — so the declaration is member-compatible. Falls back to `int` when nothing is recoverable.
+    let oor_arg_types = infer_oor_arg_types(&body, &oor_args, fields, &locals, &param_types);
 
     // force-stub functions the in-game compile flagged as unrecoverable (by Class::method).
     let qid = match class_name {
@@ -300,7 +307,18 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
             }
         }
         for n in &oor_args {
-            let _ = writeln!(s, "{ind}    int arg{n} = 0;");
+            match oor_arg_types.get(n) {
+                Some(ty) if is_primitive(ty) => {
+                    let _ = writeln!(s, "{ind}    {ty} arg{n} = {};", default_for(ty));
+                }
+                Some(ty) => {
+                    // object/struct/handle local: default-constructs itself (no initializer).
+                    let _ = writeln!(s, "{ind}    {ty} arg{n};");
+                }
+                None => {
+                    let _ = writeln!(s, "{ind}    int arg{n} = 0;");
+                }
+            }
         }
         // RVODEF marks a return whose value couldn't be recovered: substitute a type-correct
         // default. A handle return defaults to `nullptr` (no local needed — and it sidesteps
@@ -531,6 +549,67 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
             _ => None,
         })
         .collect()
+}
+
+/// §3.3 consumer-driven typing of out-of-range `argN` slots. Scans the body for the RHS of an
+/// `argN = <expr>` assignment (including `return argN = <expr>;`) and resolves `<expr>`'s type
+/// from the maps we already have: `this.<field>` -> field type, `local_M` -> local type,
+/// `<param>` -> param type. A type that supports member access makes `argN.Member` legal where a
+/// bare `int` would not. Anything unresolved is left out (declared `int`, as before — no regression).
+fn infer_oor_arg_types(
+    body: &str,
+    oor_args: &[i32],
+    fields: Option<&HashMap<String, String>>,
+    locals: &BTreeMap<i32, String>,
+    param_types: &[String],
+) -> HashMap<i32, String> {
+    let mut out: HashMap<i32, String> = HashMap::new();
+    if oor_args.is_empty() {
+        return out;
+    }
+    // a primitive/enum int-ish RHS isn't worth retyping (int default already works); only adopt a
+    // type that is NOT a bare primitive (i.e. a struct/handle/array the member access needs).
+    let adopt = |out: &mut HashMap<i32, String>, n: i32, ty: String| {
+        if !ty.is_empty() && !is_primitive(&ty) {
+            out.entry(n).or_insert(ty);
+        }
+    };
+    for line in body.lines() {
+        let t = line.trim();
+        let t = t.strip_prefix("return ").unwrap_or(t);
+        // parse `argN = RHS;`
+        let Some(rest) = t.strip_prefix("arg") else { continue };
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        let Ok(n) = digits.parse::<i32>() else { continue };
+        if !oor_args.contains(&n) {
+            continue;
+        }
+        let after = rest[digits.len()..].trim_start();
+        let Some(rhs) = after.strip_prefix("= ") else { continue };
+        let rhs = rhs.trim().trim_end_matches(';').trim();
+        // `this.<field>` (single member hop) -> the field's type.
+        if let Some(field) = rhs.strip_prefix("this.") {
+            if !field.contains('.') && !field.contains('(') {
+                if let Some(ty) = fields.and_then(|m| m.get(field)) {
+                    adopt(&mut out, n, ty.clone());
+                    continue;
+                }
+            }
+        }
+        // `local_M` -> that local's inferred type.
+        if let Some(m) = rhs.strip_prefix("local_") {
+            if let Ok(slot) = m.parse::<i32>() {
+                if let Some(ty) = locals.get(&slot) {
+                    adopt(&mut out, n, ty.clone());
+                    continue;
+                }
+            }
+        }
+        // a bare parameter name -> its declared type (param_types is index-aligned to params,
+        // but we only have names in the body; skip — names aren't carried here). Left for future.
+        let _ = param_types;
+    }
+    out
 }
 
 /// Infer (slot, type) for primitive + object locals to hoist as declarations.

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -257,6 +257,13 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // declare never-written consumer-typed slots with their inferred type (not the cache's wrong one)
     for (slot, ty) in &slot_overrides {
         if used.contains(slot) {
+            // Never let a consumer-derived `?` (the AngelScript template type, e.g. an opCast
+            // out-param slot) clobber a concrete type already inferred for the slot — declaring
+            // `? local_N;` is a syntax error that stubs the whole function. Keep the concrete
+            // type (e.g. the opCast retype) when the override is the unusable `?`.
+            if ty == "?" && locals.get(slot).map(|t| t != "?").unwrap_or(false) {
+                continue;
+            }
             locals.insert(*slot, ty.clone());
         }
     }
@@ -579,6 +586,48 @@ fn infer_locals(f: &Func, refs: &RefResolver) -> BTreeMap<i32, String> {
                 locals.insert(dst, ty);
             }
             _ => {}
+        }
+    }
+    // opCast retype: a script-handle downcast `T@ dst = Cast<T>(src)` lowers to
+    // `TYPEID <tid> ; PSF <dst> ; PshVPtr <src> ; CALLSYS opCast`, and the cache types the
+    // out-slot `dst` as the AngelScript `?` template type. Declaring `? local_N;` is a syntax
+    // error ("Expected expression value, instead found '?'") that stubs the whole function.
+    // Retype `dst` to the cast's resolved target T (from the preceding TYPEID) so it declares
+    // as e.g. `UGothicFinalDataGame local_N;` and the recovered `local_N = Cast<T>(src);`
+    // type-checks. This is the declaration-side counterpart of the structure.rs opCast recovery.
+    {
+        let mut last_tid: Option<i32> = None;
+        let mut last_psf: Option<i32> = None;
+        for ins in &instrs {
+            match ins.op.name {
+                "TYPEID" => {
+                    last_tid = ins.dwords.first().map(|d| *d as i32);
+                    last_psf = None;
+                }
+                "PSF" => {
+                    // first PSF after a TYPEID is the opCast out-slot destination
+                    if last_tid.is_some() {
+                        last_psf = ins.words.first().map(|w| *w as i16 as i32);
+                    }
+                }
+                "CALLSYS" | "Thiscall1" => {
+                    let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+                    if refs.func_by_ptr(ptr) == Some("opCast") {
+                        if let (Some(tid), Some(dst)) = (last_tid, last_psf) {
+                            if dst > 0 {
+                                if let Some(t) = super::structure::resolve_cast_typeid(refs, tid) {
+                                    if t.starts_with('U') || t.starts_with('A') {
+                                        locals.insert(dst, t);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    last_tid = None;
+                    last_psf = None;
+                }
+                _ => {}
+            }
         }
     }
     let _ = token_keyword; // keep import used if obj path elided

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -347,12 +347,21 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
                 }
             }
         }
-        // RVODEF marks a return whose value couldn't be recovered: substitute a type-correct
-        // default. A handle return defaults to `nullptr` (no local needed — and it sidesteps
-        // "no default constructor" for engine object types); everything else uses a default
-        // local `{ret} __r;` (works for primitives, enums and default-constructible structs).
-        if body.contains(RVODEF) {
-            // Object/AActor handles have no default constructor, so `{ret} __r;` fails to
+        // The hidden RVO return slot is named `__return` by the decompiler. When a store arm
+        // (RefCpyV / numeric-cast / etc.) writes that slot inside a branch — `__return = local_4;`
+        // — the slot must be a DECLARED local or the module fails to parse ("'__return' is not
+        // declared"). Declare it once (typed as the return type) whenever the body references it,
+        // and fold the RVODEF default-return into it so there is a single coherent return local.
+        // A handle return defaults to null on declaration, so `UFoo __return;` is valid (no
+        // "no default constructor" issue that bare struct RVODEF hits).
+        let uses_return_slot = body.contains("__return");
+        if uses_return_slot {
+            let _ = writeln!(s, "{ind}    {ret} __return;");
+            // Any unrecovered-default RET in this body returns the same slot.
+            s.push_str(&body.replace(RVODEF, "__return"));
+        } else if body.contains(RVODEF) {
+            // RVODEF marks a return whose value couldn't be recovered: substitute a type-correct
+            // default. Object/AActor handles have no default constructor, so `{ret} __r;` fails to
             // compile — return `nullptr` directly (this build's null-handle literal, matching
             // PshNull/CmpPtrNull). `render` strips `@`, so detect handles via the DataType flag.
             if f.ret.is_object_handle {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -235,10 +235,16 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     };
     let param_types: Vec<String> = f.params.iter().map(|p| p.ty.base_name(refs)).collect();
     // object-local slot -> type name, so the decompiler can insert downcasts on stores.
-    let local_types: HashMap<i32, String> = f.obj_locals.iter().map(|(slot, tinfo)| {
+    let mut local_types: HashMap<i32, String> = f.obj_locals.iter().map(|(slot, tinfo)| {
         let ty = super::types::DataType { token: 5, type_info: *tinfo, is_object_handle: true, ..Default::default() }.base_name(refs);
         (*slot, ty)
     }).collect();
+    // consumer-side override: never-written arg slots get the type their callee expects (fixes
+    // mis-typed default/optional-arg slots — FName->UAIState_DailyRoutine, TSubclassOf<X>->X).
+    let slot_overrides = infer_slot_types(f, refs);
+    for (slot, ty) in &slot_overrides {
+        local_types.insert(*slot, ty.clone());
+    }
     let body = body_statements_ctor(&fc, refs, depth + 1, super_ctor, Some(&f.ret), fields, Some(&param_types), class_name, Some(&local_types));
     // hoist every referenced local; infer_locals types what it can, the rest default to `int`
     // (a wrong type just becomes a compile error the in-game loop force-stubs, rather than the
@@ -247,6 +253,12 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     let mut locals = infer_locals(f, refs);
     for &n in &used {
         locals.entry(n).or_insert_with(|| "int".to_string());
+    }
+    // declare never-written consumer-typed slots with their inferred type (not the cache's wrong one)
+    for (slot, ty) in &slot_overrides {
+        if used.contains(slot) {
+            locals.insert(*slot, ty.clone());
+        }
     }
     // Drop locals never referenced in the body: `obj_locals` includes profiling temporaries like
     // FScopeCycleCounter / FStatID that the body never uses, and they have no default constructor,
@@ -431,6 +443,87 @@ fn used_locals(body: &str) -> HashSet<i32> {
         }
     }
     out
+}
+
+/// Consumer-side slot typing: a slot that is NEVER written but is passed as a call argument takes
+/// the type that call's parameter expects (e.g. an optional/default-arg slot the cache mis-typed —
+/// FName where UAIState_DailyRoutine is wanted, or TSubclassOf<X> where X is wanted). Returns an
+/// override `slot -> type` ONLY for never-written slots with a single consistent consumer object
+/// type, so it can never clobber a real producer type. Pairs args from the stack TOP (robust to the
+/// cache counting the implicit `this` in a method's param list).
+fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
+    let instrs = match disassemble(&f.bytecode) {
+        Ok(i) => i,
+        Err(_) => return HashMap::new(),
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32);
+    let writes = |op: &str| {
+        op.starts_with("SetV") || op.starts_with("CpyVtoV") || op.starts_with("CpyRtoV")
+            || op.starts_with("RDR") || op.contains("TO") || op == "STOREOBJ" || op == "PopRPtr"
+            || op.starts_with("ADD") || op.starts_with("SUB") || op.starts_with("MUL")
+            || op.starts_with("DIV") || op.starts_with("MOD") || op.starts_with("NEG")
+            || op.starts_with("Inc") || op.starts_with("Dec") || op == "NOT"
+            || op.starts_with("B") || op == "ALLOC"
+    };
+    let mut written: HashSet<i32> = HashSet::new();
+    for ins in &instrs {
+        if writes(ins.op.name) {
+            if let Some(d) = w0(ins) {
+                if d > 0 {
+                    written.insert(d);
+                }
+            }
+        }
+    }
+    let mut ostack: Vec<Option<i32>> = Vec::new();
+    let mut cand: HashMap<i32, Option<String>> = HashMap::new(); // slot -> Some(type) | None(conflict)
+    let mut pair = |ostack: &mut Vec<Option<i32>>, params: Option<&[super::types::DataType]>, is_method: bool, cand: &mut HashMap<i32, Option<String>>| {
+        let Some(params) = params else { ostack.clear(); return; };
+        let total = if is_method { params.len() + 1 } else { params.len() };
+        let take = total.min(ostack.len());
+        let popped = ostack.split_off(ostack.len() - take);
+        // method: top popped entry is the receiver -> drop it; the rest are the user args
+        let args = if is_method && !popped.is_empty() { &popped[..popped.len() - 1] } else { &popped[..] };
+        // pair from the TOP: last arg <-> last param (so a leading `this` param, if the cache
+        // counts it, never shifts the user-arg pairing).
+        for (i, slot) in args.iter().rev().enumerate() {
+            if let Some(s) = slot {
+                if let Some(pt) = params.len().checked_sub(1 + i).and_then(|j| params.get(j)) {
+                    let ty = pt.base_name(refs);
+                    match cand.get(s) {
+                        None => { cand.insert(*s, Some(ty)); }
+                        Some(Some(prev)) if *prev != ty => { cand.insert(*s, None); }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    };
+    for ins in &instrs {
+        match ins.op.name {
+            "PshVPtr" | "PshV4" | "PshV8" | "PSF" => {
+                let s = w0(ins).unwrap_or(0);
+                ostack.push(if s > 0 { Some(s) } else { None });
+            }
+            "PshC4" | "PshC8" | "PshNull" | "PGA" | "PshGPtr" | "PshG4" | "PshRPtr" | "STR"
+            | "TYPEID" | "OBJTYPE" | "PshListElmnt" => ostack.push(None),
+            "CALL" | "CALLINTF" | "CALLBND" => {
+                let id = ins.dwords.first().copied().unwrap_or(0) as i32;
+                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), &mut cand);
+            }
+            "CALLSYS" | "Thiscall1" => {
+                let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), &mut cand);
+            }
+            _ => {}
+        }
+    }
+    cand.into_iter()
+        .filter_map(|(slot, ty)| match ty {
+            Some(t) if !written.contains(&slot) && !is_primitive(t.trim_end_matches('@')) && t != "void" && !t.is_empty() => Some((slot, t)),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Infer (slot, type) for primitive + object locals to hoist as declarations.

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -112,9 +112,13 @@ pub fn emit_module(m: &Module, refs: &RefResolver) -> String {
     }
 
     // free functions = module.functions that aren't generator-synthesized accessors
+    let mut seen_free: HashSet<String> = HashSet::new();
     for f in &m.functions {
         if is_generated(f, &class_names, &class_members) || is_generated_spawn(f, refs) {
             continue;
+        }
+        if !seen_free.insert(format!("{}({})", f.name, render_params(f, refs))) {
+            continue; // duplicate signature -> "function ... already exists"
         }
         emit_function(&mut s, f, refs, false, false, 0);
     }
@@ -180,6 +184,11 @@ fn emit_class(s: &mut String, c: &Class, refs: &RefResolver) {
     for ctor in &c.ctors {
         emit_function_ctor(s, ctor, refs, true, true, 1, super_name, Some(&field_types), Some(&c.name));
     }
+    // Dedup methods by name+parameters: the cache can carry two entries that render to the same
+    // signature (e.g. a const- and non-const-return overload that collapse once the meaningless
+    // return `const` is stripped), which AngelScript rejects as "a function with the same name
+    // and parameters already exists".
+    let mut seen_sigs: HashSet<String> = HashSet::new();
     for m in &c.methods {
         // `__InitDefaults` (and other `__`-prefixed generator methods) set the CDO defaults
         // via raw `__StaticType_*` symbols and untyped literals we can't reconstruct offline;
@@ -187,6 +196,9 @@ fn emit_class(s: &mut String, c: &Class, refs: &RefResolver) {
         // class compiles. (Runtime UPROPERTY defaults are lost; real script logic is intact.)
         if m.name.starts_with("__") {
             continue;
+        }
+        if !seen_sigs.insert(format!("{}({})", m.name, render_params(m, refs))) {
+            continue; // duplicate signature
         }
         emit_function_ctor(s, m, refs, true, false, 1, None, Some(&field_types), Some(&c.name));
     }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -272,6 +272,21 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
             if ty == "?" && locals.get(slot).map(|t| t != "?").unwrap_or(false) {
                 continue;
             }
+            // Never let an ARGLESS template head (e.g. a `TArray` opAssign/copy-ctor param whose
+            // own DataType carries no SubTypes) downgrade an already-specific instantiation from
+            // the authoritative obj_locals type (`TArray<EQuestState>`). Declaring a bare `TArray`
+            // is invalid (template needs args) and would stub the function; the cache's recorded
+            // object-local type is the better signal, so keep it when the override is just its
+            // template head with the `<...>` stripped.
+            if !ty.contains('<') {
+                if let Some(prev) = locals.get(slot) {
+                    if let Some(head) = prev.split('<').next() {
+                        if prev.contains('<') && head == ty {
+                            continue;
+                        }
+                    }
+                }
+            }
             locals.insert(*slot, ty.clone());
         }
     }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -121,15 +121,29 @@ pub fn emit_module(m: &Module, refs: &RefResolver) -> String {
     s
 }
 
-/// The AngelScript-UE binding auto-generates `<Actor> Spawn(const FVector&, const FRotator&,
-/// const FName&, bool, ULevel)` as a free function for every actor class. The cache also carries
-/// it as a module function, so emitting it duplicates the native binding ("a function with the
-/// same name and parameters already exists" — un-stubbable, the declaration itself collides). Skip.
+/// The AngelScript-UE binding auto-generates factory free functions for every actor/component
+/// class. The cache also carries them as module functions, so emitting them duplicates the native
+/// binding ("a function with the same name and parameters already exists" — un-stubbable, the
+/// declaration itself collides). Skip the exact generated shapes:
+///   - actor:     `<Actor> Spawn(const FVector&, const FRotator&, const FName&, bool, ULevel)`
+///   - component: `<Comp> Get|GetOrCreate|Create(const AActor, const FName&)`
 fn is_generated_spawn(f: &Func, refs: &RefResolver) -> bool {
-    f.name == "Spawn"
-        && f.params.len() == 5
-        && f.ret.is_object_handle
-        && f.params.first().map(|p| p.ty.base_name(refs)).as_deref() == Some("FVector")
+    if !f.ret.is_object_handle {
+        return false;
+    }
+    let p0 = f.params.first().map(|p| p.ty.base_name(refs));
+    let p0 = p0.as_deref();
+    if f.name == "Spawn" && f.params.len() == 5 && p0 == Some("FVector") {
+        return true;
+    }
+    if matches!(f.name.as_str(), "Get" | "GetOrCreate" | "Create")
+        && f.params.len() == 2
+        && p0 == Some("AActor")
+        && f.params.get(1).map(|p| p.ty.base_name(refs)).as_deref() == Some("FName")
+    {
+        return true;
+    }
+    false
 }
 
 fn emit_class(s: &mut String, c: &Class, refs: &RefResolver) {

--- a/crates/gore-as/src/cache/mod.rs
+++ b/crates/gore-as/src/cache/mod.rs
@@ -9,6 +9,7 @@ pub mod header;
 pub mod isa;
 pub mod model;
 pub mod refs;
+pub mod remap;
 pub mod scan;
 pub mod splice;
 pub mod structure;

--- a/crates/gore-as/src/cache/model.rs
+++ b/crates/gore-as/src/cache/model.rs
@@ -6,9 +6,62 @@
 //! Unlike `walk_modules` (which skips types for the fast splice path), this captures
 //! everything the emitter needs.
 
+use std::collections::HashMap;
+
 use super::header::CacheHeader;
 use super::types::{DataType, DATA_TYPE_SIZE};
 use super::wire::{Cursor, WireError};
+
+/// AngelScript value-pointer size in dwords on x64 (`AS_PTR_SIZE`). Every handle/reference
+/// and every 64-bit scalar occupies this many frame slots; mirrors `isa.rs`/`decompile.rs`.
+pub const AS_PTR_SIZE: i32 = 2;
+
+/// Number of frame dword slots a parameter of this type occupies (`GetSizeOnStackDWords`):
+/// pointer-sized for every UObject/AActor handle, every `&`-reference and 64-bit scalar;
+/// 1 for ordinary 32-bit-or-smaller value primitives/enums. Struct-by-value (rare — the
+/// engine usually passes structs by reference) has no registered dword-size table here, so it
+/// defaults to `AS_PTR_SIZE`, the safe conservative width.
+pub fn slot_width_dwords(p: &DataType) -> i32 {
+    if p.is_object_handle || p.is_reference {
+        return AS_PTR_SIZE;
+    }
+    match p.token {
+        // 64-bit scalars occupy 2 dwords: int64 / uint64 / double, AND `float` (0x51) because
+        // this build is `floatIsFloat64` (see types.rs / render_const) — its `float` is 64-bit.
+        // `float32` (0x50) is the genuine 32-bit type (width 1).
+        0x47 | 0x4E | 0x5E | 0x51 => AS_PTR_SIZE,
+        5 => AS_PTR_SIZE, // struct-by-value (no size table -> conservative)
+        _ => 1,           // int/uint/float32/bool/int8..16/enum by value
+    }
+}
+
+/// True when the return type is an F-struct returned BY VALUE — which inserts a hidden RVO
+/// out-pointer slot (one `AS_PTR_SIZE`) between `this` and the first real parameter.
+/// UObject/AActor handles (`is_object_handle`) return in the value register, NOT via an RVO
+/// slot, so they are excluded.
+pub fn returns_struct_by_value(ret: &DataType) -> bool {
+    ret.token == 5 && !ret.is_object_handle && !ret.is_reference
+}
+
+/// Build the AS_PTR_SIZE-aware map from a frame offset (signed dword slot, negative below the
+/// frame pointer) to the 0-based parameter index. Each parameter consumes its real slot width,
+/// so param *i* lives at a cumulative offset, NOT at `-i`.
+///
+/// `rvo` controls whether the hidden by-value-return RVO out-pointer slot is reserved before
+/// the first param (callers self-correct on the observed offsets — see structure.rs/decompile.rs).
+pub fn param_slot_map(params: &[DataType], is_method: bool, rvo: bool) -> HashMap<i32, usize> {
+    let mut map = HashMap::new();
+    // Cursor start: free fn -> param 0 at off 0; method -> first param after `this` (-AS_PTR_SIZE).
+    let mut off: i32 = if is_method { -AS_PTR_SIZE } else { 0 };
+    if rvo {
+        off -= AS_PTR_SIZE; // skip the hidden RVO out-pointer slot
+    }
+    for (i, p) in params.iter().enumerate() {
+        map.insert(off, i);
+        off -= slot_width_dwords(p);
+    }
+    map
+}
 
 #[derive(Debug, Clone)]
 pub struct Param {

--- a/crates/gore-as/src/cache/model.rs
+++ b/crates/gore-as/src/cache/model.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 
 use super::header::CacheHeader;
+use super::refs::RefResolver;
 use super::types::{DataType, DATA_TYPE_SIZE};
 use super::wire::{Cursor, WireError};
 
@@ -18,10 +19,17 @@ pub const AS_PTR_SIZE: i32 = 2;
 
 /// Number of frame dword slots a parameter of this type occupies (`GetSizeOnStackDWords`):
 /// pointer-sized for every UObject/AActor handle, every `&`-reference and 64-bit scalar;
-/// 1 for ordinary 32-bit-or-smaller value primitives/enums. Struct-by-value (rare — the
-/// engine usually passes structs by reference) has no registered dword-size table here, so it
-/// defaults to `AS_PTR_SIZE`, the safe conservative width.
-pub fn slot_width_dwords(p: &DataType) -> i32 {
+/// 1 for ordinary 32-bit-or-smaller value primitives/enums. A genuine struct passed BY VALUE
+/// (rare — the engine usually passes structs by reference) has no registered dword-size table
+/// here, so it defaults to `AS_PTR_SIZE`, the safe conservative width.
+///
+/// `refs` lets a `token == 5` value type be resolved to its name so an ENUM (`E`-prefixed,
+/// UE/codebase convention; 32-bit underlying storage) is correctly sized at 1 dword rather than
+/// the conservative struct width 2. Without this, a function with an enum-by-value parameter
+/// FOLLOWING a wider param (handle/ref/struct) mis-maps every later param's frame offset (the
+/// cumulative cursor over-counts), which is what stubbed `MakeRequirement` (4 EQuestState params
+/// after a `TSubclassOf&` ref). Passing `None` keeps the conservative width-2 fallback.
+pub fn slot_width_dwords(p: &DataType, refs: Option<&RefResolver>) -> i32 {
     if p.is_object_handle || p.is_reference {
         return AS_PTR_SIZE;
     }
@@ -30,9 +38,31 @@ pub fn slot_width_dwords(p: &DataType) -> i32 {
         // this build is `floatIsFloat64` (see types.rs / render_const) — its `float` is 64-bit.
         // `float32` (0x50) is the genuine 32-bit type (width 1).
         0x47 | 0x4E | 0x5E | 0x51 => AS_PTR_SIZE,
-        5 => AS_PTR_SIZE, // struct-by-value (no size table -> conservative)
-        _ => 1,           // int/uint/float32/bool/int8..16/enum by value
+        5 => {
+            // token 5 is the catch-all "identifier" token shared by enums, value structs,
+            // templates and objects. An enum's underlying storage is a 32-bit int -> 1 dword;
+            // only a genuine value STRUCT (F*/T* by value) needs the conservative width 2. Use
+            // the resolved type name (E-prefix = enum, the established convention used by the
+            // value-type checks in structure.rs/cast_arg) to tell them apart.
+            if refs
+                .and_then(|r| r.type_by_ptr(p.type_info))
+                .map(is_enum_name)
+                .unwrap_or(false)
+            {
+                1
+            } else {
+                AS_PTR_SIZE // struct-by-value (no size table -> conservative)
+            }
+        }
+        _ => 1, // int/uint/float32/bool/int8..16/enum by value
     }
+}
+
+/// True for an enum type NAME by the codebase/UE `E`-prefix convention (e.g. `EQuestState`).
+/// Enums are 32-bit value types (1 frame dword), unlike `F`/`T` value structs (conservative 2).
+fn is_enum_name(name: &str) -> bool {
+    let mut b = name.bytes();
+    matches!(b.next(), Some(b'E')) && matches!(b.next(), Some(c) if c.is_ascii_uppercase())
 }
 
 /// True when the return type is an F-struct returned BY VALUE — which inserts a hidden RVO
@@ -49,7 +79,12 @@ pub fn returns_struct_by_value(ret: &DataType) -> bool {
 ///
 /// `rvo` controls whether the hidden by-value-return RVO out-pointer slot is reserved before
 /// the first param (callers self-correct on the observed offsets — see structure.rs/decompile.rs).
-pub fn param_slot_map(params: &[DataType], is_method: bool, rvo: bool) -> HashMap<i32, usize> {
+pub fn param_slot_map(
+    params: &[DataType],
+    is_method: bool,
+    rvo: bool,
+    refs: Option<&RefResolver>,
+) -> HashMap<i32, usize> {
     let mut map = HashMap::new();
     // Cursor start: free fn -> param 0 at off 0; method -> first param after `this` (-AS_PTR_SIZE).
     let mut off: i32 = if is_method { -AS_PTR_SIZE } else { 0 };
@@ -58,7 +93,7 @@ pub fn param_slot_map(params: &[DataType], is_method: bool, rvo: bool) -> HashMa
     }
     for (i, p) in params.iter().enumerate() {
         map.insert(off, i);
-        off -= slot_width_dwords(p);
+        off -= slot_width_dwords(p, refs);
     }
     map
 }

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -49,6 +49,10 @@ pub struct RefResolver {
     /// FunctionReferences owning class name (from the ObjectType ptr) — disambiguates native
     /// method overloads when looking up arity in the Binds.Cache native API.
     func_owner: HashMap<i64, String>,
+    /// FunctionReferences namespace (e.g. `Gameplay`, `Math`, `System`) for free/static native
+    /// functions — a call must be qualified `Namespace::func(...)` or the global-scope lookup
+    /// fails with "No matching signatures". Empty for un-namespaced globals and for methods.
+    func_ns: HashMap<i64, String>,
     /// Native AngelScript API arities parsed from Binds.Cache (fallback arity for native calls
     /// whose param count isn't carried in the script FunctionReferences).
     native: Option<super::binds::NativeApi>,
@@ -89,7 +93,7 @@ impl RefResolver {
             let key = c.read_i64()?;
             let name = c.read_sia()?;
             c.read_sia()?; // Module
-            c.read_sia()?; // Namespace
+            let ns = c.read_sia()?; // Namespace
             c.skip(4)?; // bIsConst
             c.skip(4)?; // bIsImportedDecl
             let is_method = c.read_bool4()?;
@@ -109,6 +113,11 @@ impl RefResolver {
             r.func_ret.insert(key, ret);
             if let Some(cls) = r.type_by_ptr.get(&objtype) {
                 r.func_owner.insert(key, cls.clone());
+            }
+            // Only a non-method (free/static) function needs namespace qualification; a method is
+            // rendered via its receiver. Record the namespace so the call site can prefix it.
+            if !is_method && !ns.is_empty() {
+                r.func_ns.insert(key, ns);
             }
             r.func_by_ptr.insert(key, name);
         }
@@ -199,6 +208,10 @@ impl RefResolver {
     }
     pub fn func_by_ptr(&self, ptr: i64) -> Option<&str> {
         self.func_by_ptr.get(&ptr).map(|s| s.as_str())
+    }
+    /// Namespace (`Gameplay`, `Math`, ...) for a free/static native function by ptr, if any.
+    pub fn func_ns_by_ptr(&self, ptr: i64) -> Option<&str> {
+        self.func_ns.get(&ptr).map(|s| s.as_str())
     }
     /// Parameter DataTypes for a function by ptr (excludes the receiver).
     pub fn func_params_by_ptr(&self, ptr: i64) -> Option<&[DataType]> {

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -170,6 +170,15 @@ impl RefResolver {
             .and_then(|p| self.func_by_ptr.get(p))
             .map(|s| s.as_str())
     }
+    /// Owning class name of a function by ptr (the ObjectType the method belongs to). Used to
+    /// qualify `Class::StaticClass()` with the TARGET class, not the calling class.
+    pub fn func_owner_by_ptr(&self, ptr: i64) -> Option<&str> {
+        self.func_owner.get(&ptr).map(|s| s.as_str())
+    }
+    /// Owning class name of a function by id.
+    pub fn func_owner_by_id(&self, id: i32) -> Option<&str> {
+        self.funcid_to_ptr.get(&id).and_then(|p| self.func_owner.get(p)).map(|s| s.as_str())
+    }
     pub fn type_by_ptr(&self, ptr: i64) -> Option<&str> {
         self.type_by_ptr.get(&ptr).map(|s| s.as_str())
     }
@@ -212,6 +221,19 @@ impl RefResolver {
     /// Namespace (`Gameplay`, `Math`, ...) for a free/static native function by ptr, if any.
     pub fn func_ns_by_ptr(&self, ptr: i64) -> Option<&str> {
         self.func_ns.get(&ptr).map(|s| s.as_str())
+    }
+    /// Namespace for a free/static native function by id, if any.
+    pub fn func_ns_by_id(&self, id: i32) -> Option<&str> {
+        self.funcid_to_ptr.get(&id).and_then(|p| self.func_ns.get(p)).map(|s| s.as_str())
+    }
+    /// Target class of a `StaticClass` call: StaticClass is a namespaced free fn whose
+    /// Namespace IS the (fully-qualified) target class — the LAST `::` segment is the class
+    /// name (objtype is NULL for StaticClass, so func_owner can't carry it).
+    pub fn staticclass_class_by_id(&self, id: i32) -> Option<&str> {
+        self.func_ns_by_id(id).map(|ns| ns.rsplit("::").next().unwrap_or(ns))
+    }
+    pub fn staticclass_class_by_ptr(&self, ptr: i64) -> Option<&str> {
+        self.func_ns_by_ptr(ptr).map(|ns| ns.rsplit("::").next().unwrap_or(ns))
     }
     /// Parameter DataTypes for a function by ptr (excludes the receiver).
     pub fn func_params_by_ptr(&self, ptr: i64) -> Option<&[DataType]> {

--- a/crates/gore-as/src/cache/remap.rs
+++ b/crates/gore-as/src/cache/remap.rs
@@ -1,0 +1,905 @@
+//! REF-REMAPPING: rewrite a regen-extracted module's bytecode ref operands from REGEN
+//! keys/ids to the equivalent VANILLA (base) keys/ids, by SYMBOL IDENTITY (name + module +
+//! namespace + signature), so the module can be spliced into the vanilla base WITHOUT
+//! appending any tail-table rows (the module now references vanilla's existing rows).
+//!
+//! Why this is needed (`work/reversing/gore-as/specs/ref-remap.md`): the 7 global tail
+//! tables are keyed by RUNTIME POINTERS / engine ids captured at serialization. A full-tree
+//! regen assigns DIFFERENT keys than vanilla for the SAME symbols. `replace_module` merges
+//! the mini's tables into the base on key-collision; with non-colliding regen keys EVERY row
+//! would be appended (cache grows ~22 MB, duplicate type registration, boot crash). The fix:
+//! rewrite the module's bytecode operands to vanilla keys, then ship EMPTY tail tables so the
+//! merge adds nothing.
+//!
+//! Operand classification is the authoritative table from `findings/decompile-refs.md §3`
+//! (verbatim from the engine `FAngelscriptBytecodeReferencer` Store/Load switch). See
+//! `OP_REFS` below. Remap is SIZE-PRESERVING (i64 key->i64 key, i32 id->i32 id) so operand
+//! dwords are patched in place; no resize.
+
+use std::collections::{HashMap, HashSet};
+
+use super::disasm::disassemble;
+use super::header::CacheHeader;
+use super::types::DATA_TYPE_SIZE;
+use super::walk_modules::module_region_end;
+use super::wire::{Cursor, WireError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RemapError {
+    #[error("wire error: {0}")]
+    Wire(#[from] WireError),
+    #[error("disasm error: {0}")]
+    Disasm(String),
+    #[error("mini-cache must contain exactly 1 module, found {0}")]
+    NotSingle(u32),
+    #[error(
+        "unresolved {kind} ref in op {op} (regen key {key:#x}, name {name:?}): \
+         no matching symbol in the base cache. This module introduces a NEW symbol the base \
+         lacks — minimal-row fallback not yet implemented."
+    )]
+    Unresolved {
+        kind: &'static str,
+        op: &'static str,
+        key: i64,
+        name: String,
+    },
+    #[error(
+        "ambiguous {kind} ref in op {op} (name {name:?}): matches {n} distinct base keys — \
+         identity is not unique enough to remap safely."
+    )]
+    Ambiguous {
+        kind: &'static str,
+        op: &'static str,
+        name: String,
+        n: usize,
+    },
+    #[error(
+        "POST-CONDITION FAILED: {n} regen tail-table key(s) SURVIVED in the remapped module's \
+         bytes (a regen ptr-key that resolves to null in vanilla → boot crash). These live in a \
+         module-record field the remap does not yet cover. First {shown}: {detail}"
+    )]
+    SurvivingRegenKeys {
+        n: usize,
+        shown: usize,
+        detail: String,
+    },
+}
+
+/// Field separator for composing a stable symbol identity string (unlikely in any name).
+const SEP: char = '\u{1f}';
+
+/// Symbol identity → key inverse maps for one cache's tail tables, plus the forward key→name
+/// maps needed to compose function/global identities and to report unresolved refs.
+struct SymTables {
+    /// T1: type ptr key -> identity ; identity -> ptr key.
+    type_id_of_ptr: HashMap<i64, String>,
+    type_ptr_of_id: HashMap<String, Vec<i64>>,
+    /// T2: type-id (i32, raw operand) -> type ptr.
+    typeid_to_ptr: HashMap<i32, i64>,
+    /// inverse of T2: type ptr -> type-id (raw i32 operand).
+    ptr_to_typeid: HashMap<i64, i32>,
+    /// T3: func ptr key -> identity ; identity -> ptr key.
+    func_id_of_ptr: HashMap<i64, String>,
+    func_ptr_of_id: HashMap<String, Vec<i64>>,
+    /// forward Name (for error messages) per func ptr.
+    func_name_of_ptr: HashMap<i64, String>,
+    type_name_of_ptr: HashMap<i64, String>,
+    global_name_of_ptr: HashMap<i64, String>,
+    /// T4: func-id (i32, raw operand) -> func ptr.
+    funcid_to_ptr: HashMap<i32, i64>,
+    ptr_to_funcid: HashMap<i64, i32>,
+    /// T5: global ptr key -> identity ; identity -> ptr key.
+    global_id_of_ptr: HashMap<i64, String>,
+    global_ptr_of_id: HashMap<String, Vec<i64>>,
+    /// EVERY int64 ptr-key that appears as a key in this cache's tail tables: T1 type ptrs,
+    /// T3 func ptrs, T5 global ptrs, and the ptr values in T2/T4 (id->ptr). Used by the
+    /// post-condition scan to assert no regen ptr-key survives in a remapped module's bytes.
+    /// (T7 PropertyReferences keys are DERIVED `(tid<<1)|(off<<33)|1` — not raw ptrs — and are
+    /// never an operand/embedded field, so they are excluded here; the type-id remap handles them.)
+    all_ptr_keys: HashSet<i64>,
+}
+
+/// Read a DataType's stable identity contribution: token + (for object/value types) the
+/// resolved TYPE IDENTITY of its `type_info` ptr (the build-specific ptr resolved to a portable
+/// identity that includes the type's name + template subtypes — so `TSubclassOf<AFoo>` and
+/// `TSubclassOf<ABar>` are distinguished, which matters for conversion-operator overloads).
+fn datatype_identity(c: &mut Cursor, type_id_of_ptr: &HashMap<i64, String>) -> Result<String, WireError> {
+    // 6 bools, i64 type_info, i32 token (mirror DataType::read order).
+    let b0 = c.read_bool4()?;
+    let b1 = c.read_bool4()?;
+    let b2 = c.read_bool4()?;
+    let b3 = c.read_bool4()?;
+    let b4 = c.read_bool4()?;
+    let b5 = c.read_bool4()?;
+    let type_info = c.read_i64()?;
+    let token = c.read_i32()?;
+    let tident = if token == 5 {
+        type_id_of_ptr.get(&type_info).cloned().unwrap_or_default()
+    } else {
+        String::new()
+    };
+    Ok(format!(
+        "{}{}{}{}{}{}:{token}:{tident}",
+        b0 as u8, b1 as u8, b2 as u8, b3 as u8, b4 as u8, b5 as u8
+    ))
+}
+
+impl SymTables {
+    /// Parse the 7 tail tables of `bytes` into identity maps. Two passes over T3 are avoided
+    /// by parsing T1 first (so func owner/param type ptrs resolve to names).
+    fn build(bytes: &[u8]) -> Result<Self, WireError> {
+        let tail = module_region_end(bytes)?;
+        let mut c = Cursor::at(bytes, tail);
+
+        let mut all_ptr_keys: HashSet<i64> = HashSet::new();
+        let mut type_id_of_ptr = HashMap::new();
+        let mut type_ptr_of_id: HashMap<String, Vec<i64>> = HashMap::new();
+        let mut type_name_of_ptr = HashMap::new();
+
+        // T1 TypeReferences: i64 key + (Name, Module, Namespace, TArray<DataType> SubTypes).
+        // PASS 1: collect key -> (Name, Module, Namespace, raw subtype DataType bytes). The
+        // identity must include each subtype's RESOLVED NAME (so `TSubclassOf<AFoo>` differs
+        // from `TSubclassOf<ABar>` — they share Name `TSubclassOf` but distinct subtype ptrs),
+        // and subtype ptrs may forward-reference other T1 rows, so build names first.
+        struct RawType {
+            key: i64,
+            name: String,
+            module: String,
+            namespace: String,
+            /// (token, subtype_type_info_ptr) per subtype.
+            subs: Vec<(i32, i64)>,
+        }
+        let ntypes = c.read_count("TypeReferences")?;
+        let mut raw_types = Vec::with_capacity(ntypes);
+        for _ in 0..ntypes {
+            let key = c.read_i64()?;
+            all_ptr_keys.insert(key);
+            let name = c.read_sia()?;
+            let module = c.read_sia()?;
+            let namespace = c.read_sia()?;
+            let nsub = c.read_count("TypeRef.SubTypes")?;
+            let mut subs = Vec::with_capacity(nsub);
+            for _ in 0..nsub {
+                // DataType (36 B): 24 bools + i64 type_info + i32 token.
+                let base = c.pos();
+                let type_info = i64::from_le_bytes(bytes[base + 24..base + 32].try_into().unwrap());
+                let token = i32::from_le_bytes(bytes[base + 32..base + 36].try_into().unwrap());
+                subs.push((token, type_info));
+                c.skip(DATA_TYPE_SIZE)?;
+            }
+            type_name_of_ptr.insert(key, name.clone());
+            raw_types.push(RawType { key, name, module, namespace, subs });
+        }
+        // PASS 2: compose identities using resolved subtype names.
+        for rt in &raw_types {
+            let mut sub_ident = String::new();
+            for (token, sub_ptr) in &rt.subs {
+                let sub_name = if *token == 5 {
+                    type_name_of_ptr.get(sub_ptr).cloned().unwrap_or_default()
+                } else {
+                    String::new()
+                };
+                sub_ident.push_str(&format!("{token}:{sub_name},"));
+            }
+            let identity = format!(
+                "{}{SEP}{}{SEP}{}{SEP}{}:{sub_ident}",
+                rt.module, rt.namespace, rt.name, rt.subs.len()
+            );
+            type_id_of_ptr.insert(rt.key, identity.clone());
+            type_ptr_of_id.entry(identity).or_default().push(rt.key);
+        }
+
+        // T2 TypeIdReferenceToPointer: i32 id -> i64 ptr.
+        let mut typeid_to_ptr = HashMap::new();
+        let mut ptr_to_typeid = HashMap::new();
+        for _ in 0..c.read_count("TypeIdRef")? {
+            let id = c.read_i32()?;
+            let ptr = c.read_i64()?;
+            all_ptr_keys.insert(ptr);
+            typeid_to_ptr.insert(id, ptr);
+            ptr_to_typeid.insert(ptr, id);
+        }
+
+        // T3 FunctionReferences: i64 key + (Name, Module, Namespace, 3 bool, i64 ObjectType,
+        // TArray<DataType> params, DataType ret).
+        let mut func_id_of_ptr = HashMap::new();
+        let mut func_ptr_of_id: HashMap<String, Vec<i64>> = HashMap::new();
+        let mut func_name_of_ptr = HashMap::new();
+        for _ in 0..c.read_count("FunctionReferences")? {
+            let key = c.read_i64()?;
+            all_ptr_keys.insert(key);
+            let name = c.read_sia()?;
+            let module = c.read_sia()?;
+            let namespace = c.read_sia()?;
+            let _is_const = c.read_bool4()?;
+            let _is_imported = c.read_bool4()?;
+            let is_method = c.read_bool4()?;
+            let objtype = c.read_i64()?;
+            // Use the owner's FULL type identity (name + template subtypes), not just its name,
+            // so e.g. `TSubclassOf<AFoo>::opImplConv` and `TSubclassOf<ABar>::opImplConv` (which
+            // share the bare owner name `TSubclassOf`) are distinguished.
+            let owner = type_id_of_ptr.get(&objtype).cloned().unwrap_or_default();
+            let nparams = c.read_count("FuncRef.Params")?;
+            let mut params = String::new();
+            for _ in 0..nparams {
+                params.push_str(&datatype_identity(&mut c, &type_id_of_ptr)?);
+                params.push(',');
+            }
+            let ret = datatype_identity(&mut c, &type_id_of_ptr)?;
+            let identity = format!(
+                "{module}{SEP}{namespace}{SEP}{owner}{SEP}{name}{SEP}{}{SEP}{params}{SEP}{ret}",
+                is_method as u8
+            );
+            func_id_of_ptr.insert(key, identity.clone());
+            func_ptr_of_id.entry(identity).or_default().push(key);
+            func_name_of_ptr.insert(key, name);
+        }
+
+        // T4 FunctionIdReferenceToPointer: i32 id -> i64 ptr.
+        let mut funcid_to_ptr = HashMap::new();
+        let mut ptr_to_funcid = HashMap::new();
+        for _ in 0..c.read_count("FuncIdRef")? {
+            let id = c.read_i32()?;
+            let ptr = c.read_i64()?;
+            all_ptr_keys.insert(ptr);
+            funcid_to_ptr.insert(id, ptr);
+            ptr_to_funcid.insert(ptr, id);
+        }
+
+        // T5 GlobalReferences: i64 key + (Name, Module, Namespace, i32 bIsString).
+        let mut global_id_of_ptr = HashMap::new();
+        let mut global_ptr_of_id: HashMap<String, Vec<i64>> = HashMap::new();
+        let mut global_name_of_ptr = HashMap::new();
+        for _ in 0..c.read_count("GlobalReferences")? {
+            let key = c.read_i64()?;
+            all_ptr_keys.insert(key);
+            let name = c.read_sia()?;
+            let module = c.read_sia()?;
+            let namespace = c.read_sia()?;
+            let is_string = c.read_bool4()?;
+            let identity = format!("{module}{SEP}{namespace}{SEP}{name}{SEP}{}", is_string as u8);
+            global_id_of_ptr.insert(key, identity.clone());
+            global_ptr_of_id.entry(identity).or_default().push(key);
+            global_name_of_ptr.insert(key, name);
+        }
+        // T6 StaticNames + T7 PropertyReferences are not operand-referenced (member ops carry a
+        // TYPE-ID, not a prop key — the prop key is derived from typeid+offset), so skip them.
+
+        Ok(SymTables {
+            type_id_of_ptr,
+            type_ptr_of_id,
+            typeid_to_ptr,
+            ptr_to_typeid,
+            func_id_of_ptr,
+            func_ptr_of_id,
+            func_name_of_ptr,
+            type_name_of_ptr,
+            global_name_of_ptr,
+            funcid_to_ptr,
+            ptr_to_funcid,
+            global_id_of_ptr,
+            global_ptr_of_id,
+            all_ptr_keys,
+        })
+    }
+
+    /// Resolve a regen ptr-key to a human name (type/func/global) for diagnostic reporting.
+    fn name_of_key(&self, key: i64) -> String {
+        if let Some(n) = self.type_name_of_ptr.get(&key) {
+            return format!("type {n:?}");
+        }
+        if let Some(n) = self.func_name_of_ptr.get(&key) {
+            return format!("func {n:?}");
+        }
+        if let Some(n) = self.global_name_of_ptr.get(&key) {
+            return format!("global {n:?}");
+        }
+        "<id-table ptr (T2/T4) with no direct T1/T3/T5 row>".to_string()
+    }
+}
+
+/// One surviving regen-key found in the remapped module's bytes.
+#[derive(Debug, Clone)]
+pub struct SurvivingKey {
+    /// Byte offset of the 8-byte LE value WITHIN the module entry (mod_start-relative).
+    pub byte_off: usize,
+    pub value: i64,
+    /// Human description (symbol the regen-key maps to).
+    pub name: String,
+}
+
+/// HARD POST-CONDITION: scan the whole module-entry byte range for any 8-byte little-endian
+/// int64 that is a REGEN tail-table key but NOT a VANILLA key — i.e. a surviving regen-key
+/// that the remap failed to rewrite. Such a value resolves to a null object in vanilla's
+/// context and is dereferenced by the engine → boot crash. The invariant is ZERO hits.
+///
+/// Disambiguation against false positives: regen ptr-keys are large heap pointers
+/// (`~0x0000_2xxx_xxxx_xxxx`). A coincidental int64 in non-ref data (e.g. a `double`/`int64`
+/// constant baked into bytecode) could in principle equal a regen-key. We suppress that class
+/// of false positive two ways: (1) a value that is ALSO a vanilla key is, by construction,
+/// already correct (it points at the right vanilla symbol) and is skipped; (2) we require the
+/// value to be a real regen TABLE KEY (present in `all_ptr_keys`) — random immediates almost
+/// never collide with an actual 48-bit heap pointer that was a live type/func/global at regen
+/// time. Any residual hit is reported (offset+value+name) so it can be field-classified rather
+/// than silently ignored — correctness over convenience.
+fn scan_surviving_regen_keys(
+    module_bytes: &[u8],
+    regen: &SymTables,
+    base: &SymTables,
+) -> Vec<SurvivingKey> {
+    let mut hits = Vec::new();
+    if module_bytes.len() < 8 {
+        return hits;
+    }
+    // Slide an 8-byte window over every byte offset (unaligned: a qword operand sits at a
+    // dword boundary, embedded int64s at varying offsets — scan every byte to miss nothing).
+    for off in 0..=module_bytes.len() - 8 {
+        let v = i64::from_le_bytes(module_bytes[off..off + 8].try_into().unwrap());
+        if v == 0 {
+            continue;
+        }
+        if regen.all_ptr_keys.contains(&v) && !base.all_ptr_keys.contains(&v) {
+            hits.push(SurvivingKey {
+                byte_off: off,
+                value: v,
+                name: regen.name_of_key(v),
+            });
+        }
+    }
+    hits
+}
+
+/// Where a ref operand lives within an instruction + which table it keys.
+#[derive(Clone, Copy)]
+enum RefKind {
+    GlobalPtr,
+    FuncPtr,
+    TypePtr,
+    FuncId,
+    TypeId,
+}
+
+/// One ref operand site: the dword index within the instruction + its kind.
+struct RefSite {
+    /// First operand dword index within the instruction (the low dword for a qword).
+    dw_index: usize,
+    is_qword: bool,
+    kind: RefKind,
+}
+
+/// Operand sites per opcode. Empty for non-ref ops. The authoritative classification from
+/// `findings/decompile-refs.md §3`. ALLOC carries TWO ref operands (type ptr + ctor func id).
+fn ref_sites(op: &str) -> Vec<RefSite> {
+    use RefKind::*;
+    match op {
+        // global ptr (QW @ dword 1)
+        "PshGPtr" | "PshG4" | "PGA" | "LDG" => vec![RefSite { dw_index: 1, is_qword: true, kind: GlobalPtr }],
+        // LdGRdR4 / CpyGtoV4: wW_QW (QW @ dword 1). CpyVtoG4: rW_QW (QW @ dword 1).
+        "LdGRdR4" | "CpyGtoV4" | "CpyVtoG4" => vec![RefSite { dw_index: 1, is_qword: true, kind: GlobalPtr }],
+        // SetG4: QW_DW (QW @ dword 1 = global ptr; DW @ dword 3 = literal value, NOT a ref).
+        "SetG4" => vec![RefSite { dw_index: 1, is_qword: true, kind: GlobalPtr }],
+        // func ptr (QW @ dword 1)
+        "CALLSYS" | "FuncPtr" | "Thiscall1" => vec![RefSite { dw_index: 1, is_qword: true, kind: FuncPtr }],
+        // type ptr (QW @ dword 1)
+        "OBJTYPE" | "FREE" | "FinConstruct" | "CopyScript" => {
+            vec![RefSite { dw_index: 1, is_qword: true, kind: TypePtr }]
+        }
+        // DestructScript: rW_QW (QW @ dword 1 = type ptr).
+        "DestructScript" => vec![RefSite { dw_index: 1, is_qword: true, kind: TypePtr }],
+        // func id (DW @ dword 1)
+        "CALL" | "CALLBND" | "CALLINTF" => vec![RefSite { dw_index: 1, is_qword: false, kind: FuncId }],
+        // type id (DW @ dword 1)
+        "TYPEID" | "Cast" => vec![RefSite { dw_index: 1, is_qword: false, kind: TypeId }],
+        // COPY: W_DW (DW @ dword 1 = type id).
+        "COPY" => vec![RefSite { dw_index: 1, is_qword: false, kind: TypeId }],
+        // SetListType: rW_DW_DW (type id = INTARG(bc+1) = DW @ dword 2).
+        "SetListType" => vec![RefSite { dw_index: 2, is_qword: false, kind: TypeId }],
+        // member type-id: ADDSi/LoadThisR (W_DW, DW @ dword 1); LoadRObjR/LoadVObjR (rW_W_DW, DW @ dword 2).
+        "ADDSi" | "LoadThisR" => vec![RefSite { dw_index: 1, is_qword: false, kind: TypeId }],
+        "LoadRObjR" | "LoadVObjR" => vec![RefSite { dw_index: 2, is_qword: false, kind: TypeId }],
+        // ALLOC: QW_DW (type ptr @ dword 1; ctor func id @ dword 3).
+        "ALLOC" => vec![
+            RefSite { dw_index: 1, is_qword: true, kind: TypePtr },
+            RefSite { dw_index: 3, is_qword: false, kind: FuncId },
+        ],
+        _ => Vec::new(),
+    }
+}
+
+/// Result of remapping one function's bytecode: per-table count of operands rewritten.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct RemapCounts {
+    pub global_ptr: usize,
+    pub func_ptr: usize,
+    pub type_ptr: usize,
+    pub func_id: usize,
+    pub type_id: usize,
+    /// Embedded module-record int64 refs (ObjVariableTypes/DerivedFrom/ShadowType/Factory/Behavior).
+    pub embed_type_ptr: usize,
+    pub embed_func_id: usize,
+}
+
+impl RemapCounts {
+    fn add(&mut self, other: &RemapCounts) {
+        self.global_ptr += other.global_ptr;
+        self.func_ptr += other.func_ptr;
+        self.type_ptr += other.type_ptr;
+        self.func_id += other.func_id;
+        self.type_id += other.type_id;
+        self.embed_type_ptr += other.embed_type_ptr;
+        self.embed_func_id += other.embed_func_id;
+    }
+    pub fn total(&self) -> usize {
+        self.global_ptr + self.func_ptr + self.type_ptr + self.func_id + self.type_id
+            + self.embed_type_ptr + self.embed_func_id
+    }
+}
+
+/// Resolve a regen ptr-key to the equivalent base ptr-key by identity. `None` if the regen
+/// ptr isn't in the regen table (e.g. an id that didn't index a ptr — caller handles).
+fn remap_ptr(
+    kind: &'static str,
+    op: &'static str,
+    regen_key: i64,
+    regen_id_of_ptr: &HashMap<i64, String>,
+    regen_name_of_ptr: &HashMap<i64, String>,
+    base_ptr_of_id: &HashMap<String, Vec<i64>>,
+) -> Result<i64, RemapError> {
+    let identity = regen_id_of_ptr.get(&regen_key).ok_or_else(|| RemapError::Unresolved {
+        kind,
+        op,
+        key: regen_key,
+        name: regen_name_of_ptr.get(&regen_key).cloned().unwrap_or_default(),
+    })?;
+    match base_ptr_of_id.get(identity).map(|v| v.as_slice()) {
+        Some([k]) => Ok(*k),
+        Some([]) | None => Err(RemapError::Unresolved {
+            kind,
+            op,
+            key: regen_key,
+            name: regen_name_of_ptr.get(&regen_key).cloned().unwrap_or_default(),
+        }),
+        Some(many) => Err(RemapError::Ambiguous {
+            kind,
+            op,
+            name: regen_name_of_ptr.get(&regen_key).cloned().unwrap_or_default(),
+            n: many.len(),
+        }),
+    }
+}
+
+/// Remap one function's bytecode dwords IN PLACE. `code` is the function's `Vec<i32>`.
+fn remap_bytecode(
+    code: &mut [i32],
+    regen: &SymTables,
+    base: &SymTables,
+) -> Result<RemapCounts, RemapError> {
+    let instrs = disassemble(code).map_err(|e| RemapError::Disasm(e.to_string()))?;
+    let mut counts = RemapCounts::default();
+    for ins in &instrs {
+        for site in ref_sites(ins.op.name) {
+            let base_off = ins.offset_dw + site.dw_index;
+            match site.kind {
+                RefKind::GlobalPtr => {
+                    let regen_key = read_qw(code, base_off);
+                    let nk = remap_ptr(
+                        "global", ins.op.name, regen_key,
+                        &regen.global_id_of_ptr, &regen.global_name_of_ptr, &base.global_ptr_of_id,
+                    )?;
+                    write_qw(code, base_off, nk);
+                    counts.global_ptr += 1;
+                }
+                RefKind::FuncPtr => {
+                    let regen_key = read_qw(code, base_off);
+                    let nk = remap_ptr(
+                        "function", ins.op.name, regen_key,
+                        &regen.func_id_of_ptr, &regen.func_name_of_ptr, &base.func_ptr_of_id,
+                    )?;
+                    write_qw(code, base_off, nk);
+                    counts.func_ptr += 1;
+                }
+                RefKind::TypePtr => {
+                    let regen_key = read_qw(code, base_off);
+                    let nk = remap_ptr(
+                        "type", ins.op.name, regen_key,
+                        &regen.type_id_of_ptr, &regen.type_name_of_ptr, &base.type_ptr_of_id,
+                    )?;
+                    write_qw(code, base_off, nk);
+                    counts.type_ptr += 1;
+                }
+                RefKind::FuncId => {
+                    let regen_id = code[base_off];
+                    // id -> regen ptr. If absent, the id isn't a real func ref (defensive) — skip.
+                    let Some(&regen_ptr) = regen.funcid_to_ptr.get(&regen_id) else { continue };
+                    let nptr = remap_ptr(
+                        "function-id", ins.op.name, regen_ptr,
+                        &regen.func_id_of_ptr, &regen.func_name_of_ptr, &base.func_ptr_of_id,
+                    )?;
+                    // base ptr -> base id (the operand is the id, not the ptr).
+                    let new_id = *base.ptr_to_funcid.get(&nptr).ok_or_else(|| RemapError::Unresolved {
+                        kind: "function-id(no base id)", op: ins.op.name, key: nptr,
+                        name: base.func_name_of_ptr.get(&nptr).cloned().unwrap_or_default(),
+                    })?;
+                    code[base_off] = new_id;
+                    counts.func_id += 1;
+                }
+                RefKind::TypeId => {
+                    let regen_id = code[base_off];
+                    // Primitive type-ids (<= LAST_PRIMITIVE) are not in T2 — they resolve to
+                    // themselves and need no remap. Skip silently (decompile-refs.md §2.5).
+                    let Some(&regen_ptr) = regen.typeid_to_ptr.get(&regen_id) else { continue };
+                    let nptr = remap_ptr(
+                        "type-id", ins.op.name, regen_ptr,
+                        &regen.type_id_of_ptr, &regen.type_name_of_ptr, &base.type_ptr_of_id,
+                    )?;
+                    let new_id = *base.ptr_to_typeid.get(&nptr).ok_or_else(|| RemapError::Unresolved {
+                        kind: "type-id(no base id)", op: ins.op.name, key: nptr,
+                        name: base.type_name_of_ptr.get(&nptr).cloned().unwrap_or_default(),
+                    })?;
+                    code[base_off] = new_id;
+                    counts.type_id += 1;
+                }
+            }
+        }
+    }
+    Ok(counts)
+}
+
+fn read_qw(code: &[i32], dw: usize) -> i64 {
+    let lo = code[dw] as u32 as u64;
+    let hi = code[dw + 1] as u32 as u64;
+    (lo | (hi << 32)) as i64
+}
+
+fn write_qw(code: &mut [i32], dw: usize, val: i64) {
+    let v = val as u64;
+    code[dw] = (v & 0xFFFF_FFFF) as u32 as i32;
+    code[dw + 1] = ((v >> 32) & 0xFFFF_FFFF) as u32 as i32;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Module-entry byte walker that records each function's ByteCode TArray byte span, so the
+// remapped dwords can be written back in place (the rest of the module entry is copied verbatim).
+// ---------------------------------------------------------------------------------------------
+
+/// Byte location of one function's `ByteCode TArray<int32>` DATA (after the count prefix).
+struct CodeSpan {
+    /// Byte offset of the first bytecode dword (just after the int32 count).
+    data_off: usize,
+    /// Number of int32 dwords.
+    count: usize,
+}
+
+/// An embedded module-record int64 reference field (NOT in the bytecode stream): its absolute
+/// byte offset + which table it keys. These carry regen ptr/id keys too and must be remapped.
+#[derive(Clone, Copy)]
+enum EmbedKind {
+    TypePtr,
+    FuncId,
+}
+struct EmbedRef {
+    byte_off: usize,
+    kind: EmbedKind,
+}
+
+/// Everything the byte-walker collects from the single module entry.
+#[derive(Default)]
+struct ModuleSpans {
+    code: Vec<CodeSpan>,
+    embeds: Vec<EmbedRef>,
+}
+
+/// Walk the single module entry in `mini` (TMap key + module value) and collect every
+/// function's ByteCode span + every embedded int64 ref. Mirrors `walk_modules::read_module_c`
+/// but records byte offsets.
+fn collect_module_spans(mini: &[u8]) -> Result<ModuleSpans, WireError> {
+    let mut c = Cursor::at(mini, CacheHeader::SIZE);
+    c.read_fstring()?; // TMap key
+    let mut spans = ModuleSpans::default();
+    read_module_spans(&mut c, mini, &mut spans)?;
+    Ok(spans)
+}
+
+/// A `FAngelscriptPrecompiledDataType` (36 B): 6×bool(24) + int64 TypeInfo.OldReference(+24) +
+/// int32 Token(+32). The TypeInfo.OldReference is a T1 TYPE ptr (0 for primitives). Record it as
+/// an embedded type-ptr ref (skipped at remap time when 0), then advance past the 36 bytes.
+/// CONFIRMED: container-splice.md §0/§3 (void ReturnType has TypeInfo.Old=0). This is the field
+/// that carried the surviving regen-keys — every DataType in function signatures / property /
+/// global / import records embeds one, and the prior remap skipped them wholesale.
+fn embed_datatype(c: &mut Cursor, out: &mut ModuleSpans) -> Result<(), WireError> {
+    let dt_start = c.pos();
+    out.embeds.push(EmbedRef { byte_off: dt_start + 24, kind: EmbedKind::TypePtr });
+    c.skip(DATA_TYPE_SIZE)?;
+    Ok(())
+}
+
+fn read_function_spans(c: &mut Cursor, bytes: &[u8], out: &mut ModuleSpans) -> Result<(), WireError> {
+    c.read_sia()?; // Name
+    c.read_sia()?; // Namespace
+    embed_datatype(c, out)?; // ReturnType
+    let nptypes = c.read_count("ParameterTypes")?;
+    for _ in 0..nptypes {
+        embed_datatype(c, out)?;
+    }
+    c.skip_tarray_sia("ParameterNames")?;
+    c.skip_tarray_fixed(4, "ParameterFlags")?;
+    c.skip_tarray_sia("ParameterDefaultArgs")?;
+    c.skip(4)?; // FunctionTraits
+    // ByteCode TArray<int32>: record the span.
+    let count = c.read_count("ByteCode")?;
+    let data_off = c.pos();
+    out.code.push(CodeSpan { data_off, count });
+    c.skip(count * 4)?;
+    let _ = bytes; // (bytes used only for span math; offsets are absolute)
+    c.skip_tarray_fixed(4, "ByteCodeReferences")?;
+    c.skip(4)?; // VariableSpace
+    // ObjVariableTypes: TArray<int64> of TYPE ptrs (T1) per object local slot — remap each.
+    let nobj = c.read_count("ObjVariableTypes")?;
+    for _ in 0..nobj {
+        out.embeds.push(EmbedRef { byte_off: c.pos(), kind: EmbedKind::TypePtr });
+        c.skip(8)?;
+    }
+    c.skip_tarray_fixed(4, "ObjVariablePos")?;
+    c.skip(4)?; // ObjVariablesOnHeap
+    c.skip_tarray_fixed(4, "VariableInfoProgramPos")?;
+    c.skip_tarray_fixed(4, "VariableInfoOffset")?;
+    c.skip_tarray_fixed(4, "VariableInfoOption")?;
+    c.skip(4)?; // StackNeeded
+    c.skip(4)?; // Id
+    c.skip(4)?; // DeclaredAt
+    c.skip_tarray_fixed(4, "LineNumbers")?;
+    if c.read_bool4()? {
+        c.read_sia()?; // UnrealFunctionName
+        c.skip_tarray_sia("UF.MetaSpec")?;
+        c.skip_tarray_sia("UF.MetaValues")?;
+        c.skip(18 * 4)?;
+    }
+    Ok(())
+}
+
+fn read_property_spans(c: &mut Cursor, out: &mut ModuleSpans) -> Result<(), WireError> {
+    c.read_sia()?; // Name
+    embed_datatype(c, out)?; // Type
+    c.skip(4)?; // bIsPrivate
+    c.skip(4)?; // bIsProtected
+    if c.read_bool4()? {
+        c.skip_tarray_sia("UP.MetaSpec")?;
+        c.skip_tarray_sia("UP.MetaValues")?;
+        c.skip(9 * 4)?;
+        let replicated = c.read_bool4()?;
+        c.skip(4)?; // bSkipReplication
+        c.skip(4)?; // bSkipSerialization
+        c.skip(4)?; // bSaveGame
+        if replicated {
+            c.skip(4)?; // ReplicationCondition
+            c.skip(4)?; // bRepNotify
+        }
+        c.skip(4)?; // bConfig
+        c.skip(4)?; // bInterp
+        c.skip(4)?; // bAssetRegistrySearchable
+    }
+    Ok(())
+}
+
+fn read_class_spans(c: &mut Cursor, bytes: &[u8], out: &mut ModuleSpans) -> Result<(), WireError> {
+    c.read_sia()?; // ClassName
+    c.read_sia()?; // Namespace
+    c.skip(4)?; // Flags
+    let nprops = c.read_count("Class.Properties")?;
+    for _ in 0..nprops {
+        read_property_spans(c, out)?;
+    }
+    let nmethods = c.read_count("Class.Methods")?;
+    for _ in 0..nmethods {
+        read_function_spans(c, bytes, out)?;
+    }
+    c.skip_tarray_fixed(4, "Class.MethodTable")?;
+    // DerivedFrom + ShadowType: int64 TYPE ptrs (T1). Value 0 = none (skipped at remap time).
+    out.embeds.push(EmbedRef { byte_off: c.pos(), kind: EmbedKind::TypePtr });
+    c.skip(8)?; // DerivedFrom
+    out.embeds.push(EmbedRef { byte_off: c.pos(), kind: EmbedKind::TypePtr });
+    c.skip(8)?; // ShadowType
+    let nctors = c.read_count("Class.Constructors")?;
+    for _ in 0..nctors {
+        read_function_spans(c, bytes, out)?;
+    }
+    // FactoryRefs + BehaviorRefs: TArray<int64> of FUNC ids (T4); 0/non-id values are
+    // sentinels/behavior-type tags (remap skips anything not in the regen funcid table).
+    let nfact = c.read_count("Class.FactoryRefs")?;
+    for _ in 0..nfact {
+        out.embeds.push(EmbedRef { byte_off: c.pos(), kind: EmbedKind::FuncId });
+        c.skip(8)?;
+    }
+    let nbeh = c.read_count("Class.BehaviorRefs")?;
+    for _ in 0..nbeh {
+        out.embeds.push(EmbedRef { byte_off: c.pos(), kind: EmbedKind::FuncId });
+        c.skip(8)?;
+    }
+    let nbehav = c.read_count("Class.BehaviorFunctions")?;
+    for _ in 0..nbehav {
+        read_function_spans(c, bytes, out)?;
+    }
+    c.skip_tarray_fixed(4, "Class.BehaviorFunctionTypes")?;
+    if c.read_bool4()? {
+        c.read_sia()?; // SuperClass
+        c.read_sia()?; // CodeSuperClass
+        c.skip(8 * 4)?;
+        c.read_sia()?; // StaticClassGVName
+        c.skip(4)?; // bPlaceable
+        c.skip_tarray_sia("Class.MetaSpec")?;
+        c.skip_tarray_sia("Class.MetaValues")?;
+        c.read_sia()?; // ComposeOntoClassName
+    }
+    Ok(())
+}
+
+fn read_enum_spans(c: &mut Cursor) -> Result<(), WireError> {
+    c.read_sia()?; // Name
+    c.read_sia()?; // Namespace
+    c.skip_tarray_sia("Enum.Names")?;
+    c.skip_tarray_fixed(4, "Enum.Values")?;
+    Ok(())
+}
+
+fn read_global_spans(c: &mut Cursor, bytes: &[u8], out: &mut ModuleSpans) -> Result<(), WireError> {
+    c.read_sia()?; // Name
+    c.read_sia()?; // Namespace
+    embed_datatype(c, out)?; // Type
+    if !c.read_bool4()? {
+        // !bIsDefaultInit
+        if c.read_bool4()? {
+            c.skip(8)?; // PureConstantValue
+        } else if c.read_bool4()? {
+            read_function_spans(c, bytes, out)?; // InitFunc carries bytecode too
+        }
+    }
+    Ok(())
+}
+
+fn read_function_import_spans(c: &mut Cursor, out: &mut ModuleSpans) -> Result<(), WireError> {
+    c.read_sia()?; // ImportedFromModule
+    c.read_sia()?; // Name
+    c.read_sia()?; // Namespace
+    let nptypes = c.read_count("Import.ParameterTypes")?;
+    for _ in 0..nptypes {
+        embed_datatype(c, out)?;
+    }
+    c.skip_tarray_fixed(4, "Import.ParameterFlags")?;
+    c.skip_tarray_sia("Import.ParameterDefaultArgs")?;
+    embed_datatype(c, out)?; // ReturnType
+    Ok(())
+}
+
+fn read_module_spans(c: &mut Cursor, bytes: &[u8], out: &mut ModuleSpans) -> Result<(), WireError> {
+    c.read_sia()?; // ModuleName
+    let nfns = c.read_count("Module.Functions")?;
+    for _ in 0..nfns {
+        read_function_spans(c, bytes, out)?;
+    }
+    let nclasses = c.read_count("Module.Classes")?;
+    for _ in 0..nclasses {
+        read_class_spans(c, bytes, out)?;
+    }
+    let nenums = c.read_count("Module.Enums")?;
+    for _ in 0..nenums {
+        read_enum_spans(c)?;
+    }
+    let nglobals = c.read_count("Module.GlobalVariables")?;
+    for _ in 0..nglobals {
+        read_global_spans(c, bytes, out)?;
+    }
+    let nimports = c.read_count("Module.FunctionImports")?;
+    for _ in 0..nimports {
+        read_function_import_spans(c, out)?;
+    }
+    c.skip(8)?; // CodeHash
+    c.skip_tarray_sia("Module.ImportedModules")?;
+    c.read_sia()?; // StaticsClassName
+    c.skip_tarray_sia("Module.DeclaredEvents")?;
+    c.skip_tarray_sia("Module.DeclaredDelegates")?;
+    c.read_sia()?; // ScriptRelativeFilename
+    c.skip_tarray_sia("Module.PostInitFunctions")?;
+    Ok(())
+}
+
+/// Public entry: rewrite `extracted_mini`'s module bytecode refs to `base`'s keys, returning a
+/// new 1-module mini whose tail tables are EMPTY (28 zero bytes). See module docs.
+pub fn remap_module_to_base(extracted_mini: &[u8], base: &[u8]) -> Result<(Vec<u8>, RemapCounts), RemapError> {
+    let mini_n = super::walk_modules::module_count(extracted_mini);
+    if mini_n != 1 {
+        return Err(RemapError::NotSingle(mini_n));
+    }
+
+    let regen = SymTables::build(extracted_mini)?;
+    let base_syms = SymTables::build(base)?;
+
+    // The module entry occupies [CacheHeader::SIZE .. module_region_end]. Copy it out so we can
+    // patch bytecode dwords in place, then emit header(count=1) + module + 28 zero bytes.
+    let mod_start = CacheHeader::SIZE;
+    let mod_end = module_region_end(extracted_mini)?;
+    let mut module_bytes = extracted_mini[mod_start..mod_end].to_vec();
+
+    // Spans are absolute offsets into `extracted_mini`; translate to module_bytes-relative.
+    let spans = collect_module_spans(extracted_mini)?;
+    let mut total = RemapCounts::default();
+    for span in &spans.code {
+        let rel = span.data_off - mod_start;
+        // Read the bytecode dwords into a Vec<i32>.
+        let mut code: Vec<i32> = (0..span.count)
+            .map(|k| {
+                let o = rel + k * 4;
+                i32::from_le_bytes(module_bytes[o..o + 4].try_into().unwrap())
+            })
+            .collect();
+        let counts = remap_bytecode(&mut code, &regen, &base_syms)?;
+        total.add(&counts);
+        // Write patched dwords back.
+        for (k, &dw) in code.iter().enumerate() {
+            let o = rel + k * 4;
+            module_bytes[o..o + 4].copy_from_slice(&dw.to_le_bytes());
+        }
+    }
+
+    // Embedded module-record int64 refs (outside the bytecode stream).
+    for em in &spans.embeds {
+        let o = em.byte_off - mod_start;
+        let regen_key = i64::from_le_bytes(module_bytes[o..o + 8].try_into().unwrap());
+        if regen_key == 0 {
+            continue; // null / none sentinel — leave as-is.
+        }
+        match em.kind {
+            EmbedKind::TypePtr => {
+                let nk = remap_ptr(
+                    "type(embed)", "ObjVar/DerivedFrom/ShadowType", regen_key,
+                    &regen.type_id_of_ptr, &regen.type_name_of_ptr, &base_syms.type_ptr_of_id,
+                )?;
+                module_bytes[o..o + 8].copy_from_slice(&nk.to_le_bytes());
+                total.embed_type_ptr += 1;
+            }
+            EmbedKind::FuncId => {
+                // FactoryRefs/BehaviorRefs hold func-IDS in int64 slots, interleaved with
+                // sentinels/behavior-type tags. A value present in the regen func-id table IS a
+                // real func ref to remap; anything else (a behavior-type enum, a small tag) is
+                // NOT and is left untouched.
+                let regen_id = regen_key as i32;
+                let Some(&regen_ptr) = regen.funcid_to_ptr.get(&regen_id) else { continue };
+                let nptr = remap_ptr(
+                    "function-id(embed)", "Factory/BehaviorRefs", regen_ptr,
+                    &regen.func_id_of_ptr, &regen.func_name_of_ptr, &base_syms.func_ptr_of_id,
+                )?;
+                let new_id = *base_syms.ptr_to_funcid.get(&nptr).ok_or_else(|| RemapError::Unresolved {
+                    kind: "function-id(embed,no base id)", op: "Factory/BehaviorRefs", key: nptr,
+                    name: base_syms.func_name_of_ptr.get(&nptr).cloned().unwrap_or_default(),
+                })?;
+                // Preserve the high 32 bits (the regen slot stored the id in the low dword; the
+                // high dword was 0 for a real id — keep whatever was there for safety on tags).
+                let new_val = (regen_key & !0xFFFF_FFFFi64) | (new_id as u32 as i64);
+                module_bytes[o..o + 8].copy_from_slice(&new_val.to_le_bytes());
+                total.embed_func_id += 1;
+            }
+        }
+    }
+
+    // HARD POST-CONDITION: no regen tail-table key may survive anywhere in the remapped module
+    // bytes. If one does, it lives in a module-record field the remap doesn't cover yet — fail
+    // loudly (with offsets+names) instead of shipping a cache that null-derefs on boot.
+    let surviving = scan_surviving_regen_keys(&module_bytes, &regen, &base_syms);
+    if !surviving.is_empty() {
+        let shown = surviving.len().min(12);
+        let detail = surviving[..shown]
+            .iter()
+            .map(|s| format!("@+{:#x}={:#x} ({})", s.byte_off, s.value, s.name))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(RemapError::SurvivingRegenKeys { n: surviving.len(), shown, detail });
+    }
+
+    // Emit: FGuid+magic (from mini) + Modules count=1 + module bytes + 7 empty tables.
+    let mut out = Vec::with_capacity(CacheHeader::SIZE + module_bytes.len() + 28);
+    out.extend_from_slice(&extracted_mini[..0x14]); // FGuid + magic
+    out.extend_from_slice(&1u32.to_le_bytes()); // Modules count = 1
+    out.extend_from_slice(&module_bytes);
+    out.extend_from_slice(&[0u8; 28]); // 7 tables × int32 count 0
+    Ok((out, total))
+}

--- a/crates/gore-as/src/cache/splice.rs
+++ b/crates/gore-as/src/cache/splice.rs
@@ -186,6 +186,45 @@ fn append_merged_tables(
     }
 }
 
+/// Extract one module from `cache` into a standalone 1-module mini-cache: its `Modules`
+/// TMap entry followed by the cache's FULL global tail tables. Used to pull a dependency-
+/// heavy module (which can't be compiled standalone) out of a full-tree regen so it can be
+/// [`replace_module`]'d into the vanilla base. The loader has no integrity check, so the
+/// carried-over FGuid is harmless; the full tail tables guarantee every ref the module's
+/// bytecode uses is present, and `replace_module`'s merge folds them into the base.
+pub fn extract_module(cache: &[u8], target_name: &str) -> Result<Vec<u8>, SpliceError> {
+    let ranges = module_ranges(cache)?;
+    let (_, start, end) = ranges
+        .iter()
+        .find(|(n, _, _)| n == target_name)
+        .cloned()
+        .ok_or_else(|| SpliceError::NameNotFound(target_name.to_string()))?;
+    let tail_off = module_region_end(cache)?;
+    let mut out = Vec::with_capacity(0x18 + (end - start) + (cache.len() - tail_off));
+    out.extend_from_slice(&cache[..0x14]); // FGuid + magic
+    out.extend_from_slice(&1u32.to_le_bytes()); // Modules count = 1
+    out.extend_from_slice(&cache[start..end]); // the one module's TMap entry
+    out.extend_from_slice(&cache[tail_off..]); // full global tail tables
+    Ok(out)
+}
+
+/// Rewrite an extracted (regen-tables) 1-module mini's bytecode refs to the VANILLA `base`'s
+/// keys/ids and return a NEW 1-module mini with EMPTY tail tables (28 zero bytes), so it can be
+/// [`replace_module`]'d into `base` without appending any tail-table rows.
+///
+/// This is the REF-REMAPPING step (`work/reversing/gore-as/specs/ref-remap.md`): the 7 global
+/// tail tables are keyed by runtime pointers/ids captured at serialization, so a full-tree regen
+/// assigns DIFFERENT keys than vanilla for the SAME symbols. Splicing the regen mini verbatim
+/// would append every regen row (cache grows ~22 MB → boot crash). Here we resolve each ref
+/// operand by SYMBOL IDENTITY (name + module + namespace + signature) to the base's key, then
+/// ship empty tables so the merge adds nothing and the cache stays vanilla-sized.
+///
+/// Returns the remapped mini bytes. Any ref whose symbol is not present in `base` is a HARD
+/// ERROR (the module introduces a NEW symbol — minimal-row fallback is a later phase).
+pub fn remap_module_to_base(extracted_mini: &[u8], base: &[u8]) -> Result<Vec<u8>, super::remap::RemapError> {
+    super::remap::remap_module_to_base(extracted_mini, base).map(|(bytes, _counts)| bytes)
+}
+
 /// Replace an existing module in `base` with `new_mini`'s single module, keeping the
 /// `Modules` count UNCHANGED. The new module's tail-table entries are merged into `base`'s
 /// the same way [`splice_case_a`] does (per `case-a-tables-and-exec.md` §3): see

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -885,9 +885,12 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 pending = if f == "StaticClass" {
                     stack.clear();
                     pending_ty = None;
-                    // The class is the function's OWNER (the X in X::StaticClass()), not the
+                    // The class is the StaticClass func's NAMESPACE last-segment (objtype is
+                    // NULL for StaticClass; the target class lives in the namespace), not the
                     // calling class — `local = UFoo::StaticClass()` from inside UBar must say UFoo.
-                    let cls = ctx.refs.func_owner_by_id(id).or(ctx.class_name).unwrap_or("UObject");
+                    let cls = ctx.refs.staticclass_class_by_id(id)
+                        .or_else(|| ctx.refs.func_owner_by_id(id))
+                        .or(ctx.class_name).unwrap_or("UObject");
                     Some(format!("{cls}::StaticClass()"))
                 } else {
                     pending_ty = ctx.refs.func_ret_by_id(id).map(|d| d.base_name(ctx.refs));
@@ -971,7 +974,9 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 pending = if f == "StaticClass" {
                     stack.clear();
                     pending_ty = None;
-                    let cls = ctx.refs.func_owner_by_ptr(ptr).or(ctx.class_name).unwrap_or("UObject");
+                    let cls = ctx.refs.staticclass_class_by_ptr(ptr)
+                        .or_else(|| ctx.refs.func_owner_by_ptr(ptr))
+                        .or(ctx.class_name).unwrap_or("UObject");
                     Some(format!("{cls}::StaticClass()"))
                 } else {
                     pending_ty = ctx.refs.func_ret_by_ptr(ptr).map(|d| d.base_name(ctx.refs));

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1033,7 +1033,13 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             }
             "CMPIi" | "CMPIu" => {
                 let c = ins.dwords.first().copied().unwrap_or(0) as i32;
-                cmp = Some(Cmp { a: name(w(ins, 0)), b: c.to_string(), ..Default::default() });
+                let s = w(ins, 0);
+                // an enum compared to an int literal needs explicit int(enum) — AngelScript has
+                // no implicit enum<->int (e.g. `if (_AlternativeState != 0)`).
+                let a = if ctx.slot_type(s).as_deref().map(is_enum_name).unwrap_or(false) {
+                    format!("int({})", name(s))
+                } else { name(s) };
+                cmp = Some(Cmp { a, b: c.to_string(), ..Default::default() });
             }
             // CMPIf's dword immediate is an IEEE-754 float payload, not an int — render it as
             // a float literal so e.g. `x < 1.0f` doesn't become `x < 1065353216`.

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -299,15 +299,11 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         .into_iter()
         .filter(|x| !x.s.is_empty() && x.s != UNRESOLVED)
         .collect();
-    // Effective arity for receiver detection + phantom trimming: the in-game compile validates
-    // against the shipped Binds.Cache, so its native arity is authoritative — prefer it over the
-    // script FunctionReferences param count (which can disagree). Falls back to the script count.
+    // Effective arity: the in-game compile validates against the shipped Binds.Cache, so its native
+    // arity is authoritative — prefer it over the script FunctionReferences param count. Falls back.
     let arity = native_arity.or_else(|| params.map(|p| p.len()));
-    // Receiver detection: a METHOD call always pushes its receiver on the stack, so for any
-    // `is_method` call with a non-empty stack the top entry IS the receiver — pop it. (The cache's
-    // param count is unreliable for this: for many native methods it COUNTS the implicit `this`,
-    // so `params_len==a.len` even though the receiver is present, which a pure count test would
-    // misread as a free call — e.g. `GetNPCState(local)` instead of `local.GetNPCState()`.)
+    // Receiver: a METHOD call always pushes its receiver as the top entry (the cache param count is
+    // unreliable here — it often COUNTS the implicit `this`), so detect by the bIsMethod flag.
     let has_recv = is_method && !a.is_empty();
     if has_recv {
         let recv = a.pop().unwrap();
@@ -607,11 +603,18 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 // else: this PSF is the destination local for the following ALLOC; don't push.
             }
             "PshRPtr" => {
-                let (s, ty) = match value_reg.take() {
-                    Some(v) => (v, None),
-                    None => (ref_reg.clone().unwrap_or_else(|| UNRESOLVED.into()), ref_reg_ty.clone()),
-                };
-                stack.push(Arg::typed(s, ty));
+                // The value register holds a just-completed call's return value; PshRPtr pushes it
+                // back onto the operand stack as the NEXT call's argument (e.g. the receiver/arg of
+                // a chained call). Prefer that live call result over the stale member-ref register.
+                if let Some(p) = pending.take() {
+                    stack.push(Arg::typed(p, pending_ty.take()));
+                } else {
+                    let (s, ty) = match value_reg.take() {
+                        Some(v) => (v, None),
+                        None => (ref_reg.clone().unwrap_or_else(|| UNRESOLVED.into()), ref_reg_ty.clone()),
+                    };
+                    stack.push(Arg::typed(s, ty));
+                }
             }
             "PGA" | "PshGPtr" | "PshG4" => {
                 let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -565,6 +565,23 @@ fn field_assign_rhs(rhs: &str, tyname: &str) -> String {
     }
 }
 
+/// True if `tyname` is a UE enum type (`E<Upper>...`) — same shape `cast_to_typename` keys on.
+fn is_enum_name(tyname: &str) -> bool {
+    let b = tyname.as_bytes();
+    b.len() >= 2 && b[0] == b'E' && b[1].is_ascii_uppercase()
+}
+
+/// Wrap an enum-typed RHS being stored into an INT slot as `int(expr)`. AngelScript has no
+/// implicit enum->int conversion, so an enum field-read / enum-returning call stored into an
+/// `int` local fails to compile. Only fires when the value is a known enum AND the dest is an
+/// int slot (so enum->enum and enum->enum-param copies stay bare).
+fn enum_to_int(rhs: String, src_ty: Option<&str>, dst_is_int: bool) -> String {
+    match src_ty {
+        Some(t) if dst_is_int && is_enum_name(t) => format!("int({rhs})"),
+        _ => rhs,
+    }
+}
+
 /// Cast an int RHS to a named target type: `bool` -> `(x != 0)`, UE enum
 /// (`E<Upper>...`) -> `EEnum(x)`. Returns None when no cast applies.
 fn cast_to_typename(rhs: &str, tyname: &str) -> Option<String> {
@@ -770,7 +787,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             _ if n.starts_with("RDR") => {
                 flush!();
                 if let Some(r) = &ref_reg {
-                    out.push(format!("{} = {};", name(w(ins, 0)), r));
+                    let dst_slot = w(ins, 0);
+                    let dst_is_int = dst_slot > 0 && ctx.slot_type(dst_slot).is_none();
+                    let rhs = enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int);
+                    out.push(format!("{} = {rhs};", name(dst_slot)));
                 }
             }
             _ if n.starts_with("WRTV") => {
@@ -1016,7 +1036,11 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             }
             "CpyRtoV4" | "CpyRtoV8" => {
                 if let Some(p) = pending.take() {
-                    out.push(format!("{} = {};", name(w(ins, 0)), p));
+                    // an enum-returning call stored into an int slot needs an explicit int(...)
+                    let dst_slot = w(ins, 0);
+                    let dst_is_int = dst_slot > 0 && ctx.slot_type(dst_slot).is_none();
+                    let rhs = enum_to_int(p, pending_ty.as_deref(), dst_is_int);
+                    out.push(format!("{} = {rhs};", name(dst_slot)));
                 }
                 pending_ty = None;
             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -967,7 +967,15 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 } else {
                     pending_ty = ctx.refs.func_ret_by_ptr(ptr).map(|d| d.base_name(ctx.refs));
                     let na = ctx.refs.native_arity_by_ptr(ptr, &f);
-                    build_call(&mut stack, &f, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, ctx.refs)
+                    // A free/static native function in a namespace (Gameplay, Math, System, ...)
+                    // must be called qualified `Namespace::func(...)` or the global lookup fails
+                    // with "No matching signatures". (Methods carry no namespace -> rendered via
+                    // their receiver, unchanged. Arity lookup still uses the bare name + owner.)
+                    let qualified = match ctx.refs.func_ns_by_ptr(ptr) {
+                        Some(ns) => format!("{ns}::{f}"),
+                        None => f.clone(),
+                    };
+                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, ctx.refs)
                 };
             }
             "CallPtr" => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -303,24 +303,18 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     // against the shipped Binds.Cache, so its native arity is authoritative — prefer it over the
     // script FunctionReferences param count (which can disagree). Falls back to the script count.
     let arity = native_arity.or_else(|| params.map(|p| p.len()));
-    // Receiver detection by COUNT, not the unreliable bIsMethod flag: AngelScript pushes
-    // receiver + N args (N+1 entries) for a method, N for a free call, and the cache's param
-    // count N is reliable. The recovered stack often carries phantom extras (values the
-    // decompiler couldn't attribute to an earlier consumer) at the BOTTOM, so when the count
-    // overshoots a known arity we pop the receiver (top) and keep only the last N args,
-    // dropping the leading noise — this is what `recv.Get0Param()` getters need.
-    let has_recv = match arity {
-        Some(w) if a.len() == w => false,                   // exact free arity
-        // receiver + w only when this is actually a method; for a free call w+1 is a phantom
-        // extra (trimmed below), not a receiver — else a real arg gets mislabeled as `recv`.
-        Some(w) if a.len() == w + 1 => is_method,
-        // overshoot/undershoot/no signature: trust the bIsMethod hint.
-        Some(_) | None => is_method && !a.is_empty(),
-    };
+    // Receiver detection: a METHOD call always pushes its receiver on the stack, so for any
+    // `is_method` call with a non-empty stack the top entry IS the receiver — pop it. (The cache's
+    // param count is unreliable for this: for many native methods it COUNTS the implicit `this`,
+    // so `params_len==a.len` even though the receiver is present, which a pure count test would
+    // misread as a free call — e.g. `GetNPCState(local)` instead of `local.GetNPCState()`.)
+    let has_recv = is_method && !a.is_empty();
     if has_recv {
         let recv = a.pop().unwrap();
-        // trim phantom extras: keep only the last `w` pushed values as the call args.
+        // trim phantom extras: keep only the last `w` user args (the cache arity may include the
+        // now-popped `this`, so cap below the popped count, never above).
         if let Some(w) = arity {
+            let w = w.min(a.len());
             if a.len() > w {
                 a.drain(..a.len() - w);
             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -435,9 +435,14 @@ fn arg_mismatch_count(a: &[Arg], params: &[DataType], refs: &RefResolver) -> usi
 /// mismatches against the declared params, the call was reverse-pushed -> reverse it. This is
 /// self-validating (a correctly-ordered call already has 0 mismatches, so it is never touched),
 /// so it cannot regress calls that already type-check.
+///
+/// Handles trailing-default omission: a call may pass FEWER args than the callee has params
+/// (the trailing ones default), e.g. `NewObject(Outer, Class)` for `NewObject(Outer, Class,
+/// Name=, bTransient=, Template=)`. The provided args still align to the FIRST params, so the
+/// reversal is scored against `params[0..a.len()]` (more args than params is never valid -> skip).
 fn maybe_reverse_args(a: &mut Vec<Arg>, params: Option<&[DataType]>, refs: &RefResolver) {
     let Some(params) = params else { return };
-    if a.len() < 2 || a.len() != params.len() {
+    if a.len() < 2 || a.len() > params.len() {
         return;
     }
     let fwd = arg_mismatch_count(a, params, refs);
@@ -880,7 +885,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 pending = if f == "StaticClass" {
                     stack.clear();
                     pending_ty = None;
-                    Some(format!("{}::StaticClass()", ctx.class_name.unwrap_or("UObject")))
+                    // The class is the function's OWNER (the X in X::StaticClass()), not the
+                    // calling class — `local = UFoo::StaticClass()` from inside UBar must say UFoo.
+                    let cls = ctx.refs.func_owner_by_id(id).or(ctx.class_name).unwrap_or("UObject");
+                    Some(format!("{cls}::StaticClass()"))
                 } else {
                     pending_ty = ctx.refs.func_ret_by_id(id).map(|d| d.base_name(ctx.refs));
                     let na = ctx.refs.native_arity_by_id(id, &f);
@@ -963,7 +971,8 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 pending = if f == "StaticClass" {
                     stack.clear();
                     pending_ty = None;
-                    Some(format!("{}::StaticClass()", ctx.class_name.unwrap_or("UObject")))
+                    let cls = ctx.refs.func_owner_by_ptr(ptr).or(ctx.class_name).unwrap_or("UObject");
+                    Some(format!("{cls}::StaticClass()"))
                 } else {
                     pending_ty = ctx.refs.func_ret_by_ptr(ptr).map(|d| d.base_name(ctx.refs));
                     let na = ctx.refs.native_arity_by_ptr(ptr, &f);

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -859,6 +859,17 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 flush!();
                 out.push(format!("{0} = {0} - 1;", name(w(ins, 0))));
             }
+            // asBC_INCi/DECi (NO_ARG): ++/-- the int at the value/ref register — an lvalue that
+            // is a member or deref (LoadThisR/LoadRObjR set ref_reg), unlike IncVi/DecVi which
+            // carry a slot operand. Render as a compound assignment on the recovered member expr.
+            "INCi" | "INCi64" | "INCi16" | "INCi8" => {
+                flush!();
+                if let Some(r) = &ref_reg { out.push(format!("{0} = {0} + 1;", r)); }
+            }
+            "DECi" | "DECi64" | "DECi16" | "DECi8" => {
+                flush!();
+                if let Some(r) = &ref_reg { out.push(format!("{0} = {0} - 1;", r)); }
+            }
             "NEGi" | "NEGf" | "NEGd" => {
                 flush!();
                 out.push(format!("{0} = -{0};", name(w(ins, 0))));
@@ -1160,6 +1171,23 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             "STR" => stack.push(Arg::obj("\"\"".into())),         // +3: string-constant push
             "PshListElmnt" => stack.push(Arg::int(name(w(ins, 0)))), // +2: list element
             "COPY" => { stack.pop(); }                           // -2: pop the source ptr
+            // asBC_CopyScript (QW_ARG = object-type ptr; stack -2): a script value-type / struct
+            // copy = the source-level assignment `dest = src;`. Stack top = SRC, next = DEST
+            // (target pushed first). Both operands arrive as fully-rendered member/local exprs.
+            // Dropping it left the destination (member or RVO temp) unwritten -> garbage/null.
+            "CopyScript" => {
+                let src = stack.pop();
+                let dst = stack.pop();
+                if let (Some(dst), Some(src)) = (dst, src) {
+                    if !dst.s.is_empty() && dst.s != UNRESOLVED
+                        && !src.s.is_empty() && src.s != UNRESOLVED
+                        && dst.s != src.s
+                    {
+                        flush!();
+                        out.push(format!("{} = {};", dst.s, src.s));
+                    }
+                }
+            }
             // asBC_Cast (DW_ARG=target typeid): a script-handle DOWNCAST. Pop the source handle
             // and push the cast RESULT `Cast<T>(src)` (typed) so the following store writes the
             // real object instead of dropping it. T is the instruction's own typeid operand.

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -752,10 +752,13 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 flush!();
                 out.push(format!("{0} = -{0};", name(w(ins, 0))));
             }
-            // asBC NOT (opcode 6) is the boolean logical invert, not numeric negation.
+            // asBC NOT (opcode 6) is the boolean logical invert. The slot is held as `int` (and
+            // is often also written with integer values like `= 1`), and AngelScript rejects `!`
+            // on int ("Illegal operation on this datatype"); render an int-safe toggle instead.
             "NOT" => {
                 flush!();
-                out.push(format!("{0} = !{0};", name(w(ins, 0))));
+                let s = name(w(ins, 0));
+                out.push(format!("{s} = int({s} == 0);"));
             }
             // ---- comparisons ----
             "CMPi" | "CMPu" | "CMPf" | "CMPd" | "CMPi64" | "CMPu64" => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -346,6 +346,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
                 return Some(format!("({} {op} {})", recv.s, r));
             }
         }
+        maybe_reverse_args(&mut a, params, refs);
         Some(format!("{}.{f}({})", recv.s, render_args(&a, params, refs)))
     } else {
         if refs.is_type_name(f) {
@@ -363,7 +364,63 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
                 a.drain(..a.len() - w);
             }
         }
+        maybe_reverse_args(&mut a, params, refs);
         Some(format!("{f}({})", render_args(&a, params, refs)))
+    }
+}
+
+/// Count DEFINITE type mismatches when pairing args[i] with params[i] (mirrors `cast_arg`'s
+/// "this arg can't possibly match" rule). A value-type (F/E/T) head-mismatch or an object
+/// arg that is a known non-subclass of a known-script param both count; everything else
+/// (unknown types, int->primitive casts, engine upcasts) is treated as a possible match so
+/// the score never penalizes a legitimately-ordered call.
+fn arg_mismatch_count(a: &[Arg], params: &[DataType], refs: &RefResolver) -> usize {
+    let head = |s: &str| s.split('<').next().unwrap_or(s).to_string();
+    let is_value = |s: &str| matches!(s.bytes().next(), Some(b'F') | Some(b'E') | Some(b'T'));
+    let is_obj = |s: &str| matches!(s.bytes().next(), Some(b'U') | Some(b'A'));
+    let mut n = 0;
+    for (i, arg) in a.iter().enumerate() {
+        let Some(pt) = params.get(i) else { continue };
+        if pt.token != 5 {
+            continue; // primitive/enum param: int casts handle it, not a definite mismatch
+        }
+        let Some(at) = &arg.ty else { continue };
+        let (ph, ah) = (head(&pt.base_name(refs)), head(at));
+        if is_value(&ph) && is_value(&ah) && ph != ah {
+            n += 1;
+        } else if is_obj(&ph) && is_obj(&ah) && ah != ph
+            && refs.is_script_class(&ah) && refs.is_script_class(&ph)
+            && !refs.is_subclass(&ah, &ph)
+        {
+            n += 1;
+        } else if is_value(&ph) && is_obj(&ah) {
+            n += 1; // an object can never satisfy a value-struct (F/E/T) parameter
+        } else if is_obj(&ph) && is_value(&ah) {
+            n += 1; // a value-struct can never satisfy an object parameter
+        }
+    }
+    n
+}
+
+/// AngelScript pushes call arguments such that, for some calls (notably mixin/member-style
+/// calls), the collected stack order is the REVERSE of the source parameter order. Detect this
+/// purely by type evidence: if reversing the args produces STRICTLY fewer definite type
+/// mismatches against the declared params, the call was reverse-pushed -> reverse it. This is
+/// self-validating (a correctly-ordered call already has 0 mismatches, so it is never touched),
+/// so it cannot regress calls that already type-check.
+fn maybe_reverse_args(a: &mut Vec<Arg>, params: Option<&[DataType]>, refs: &RefResolver) {
+    let Some(params) = params else { return };
+    if a.len() < 2 || a.len() != params.len() {
+        return;
+    }
+    let fwd = arg_mismatch_count(a, params, refs);
+    if fwd == 0 {
+        return; // already matches -> leave untouched
+    }
+    let mut rev = a.clone();
+    rev.reverse();
+    if arg_mismatch_count(&rev, params, refs) < fwd {
+        a.reverse();
     }
 }
 

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -323,15 +323,66 @@ struct Cmp {
 /// last-pushed entry (top of stack); the rest are args in push order. Operator-overload
 /// methods (opAssign/opAdd/opEquals/...) render as the source operator. Returns None for
 /// compiler-generated behaviors ($behN construct/destruct) that have no source form.
-fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option<&str>, params: Option<&[DataType]>, native_arity: Option<usize>, refs: &RefResolver) -> Option<String> {
+fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option<&str>, params: Option<&[DataType]>, native_arity: Option<usize>, trusted_arity: Option<usize>, refs: &RefResolver) -> Option<String> {
     if f.starts_with('$') || f.starts_with('~') || f == "__STATIC_NAME" {
+        // EDIT C (the dominant FName form): `__STATIC_NAME` is the synthesized name-table accessor
+        // that produces an FName from a pushed name-table INDEX into the return register; a
+        // following `PshRPtr` re-pushes it as the ENCLOSING call's arg. Dropping it (return None)
+        // loses that arg → `this.GetCharacter()` (0-arg). Recover it as a renderable `FName(<idx>)`
+        // value so it FLOWS into `pending` and PshRPtr restores ARITY (`this.GetCharacter(FName(...))`).
+        // The literal is the name-table index, not the string (acceptable per spec: correct arity
+        // beats a dropped arg). Gate: exactly one int operand on top (the index).
+        if f == "__STATIC_NAME" {
+            if let Some(top) = stack.last() {
+                if top.is_int && !top.s.is_empty() {
+                    let idx = stack.pop().unwrap();
+                    return Some(format!("FName({})", idx.s));
+                }
+            }
+        }
         // generated construct/destruct behavior ($beh, ~Dtor — implicit in AS source) and the
         // synthesized static-name accessor (__STATIC_NAME) have no valid source form; emitting
         // them produces stray `~`/identifier tokens that abort the whole module's parse.
-        stack.clear();
+        //
+        // EDIT A: clearing the WHOLE stack also annihilates an ENCLOSING call's already-pushed
+        // args when this behaviour runs in the MIDDLE of that call's arg-push sequence (the RVO /
+        // by-value out-param idiom). Truncate ONLY this behaviour's own receiver + params (the
+        // PSF'd slot it constructs + its declared args) so enclosing operands survive.
+        match params {
+            Some(p) => {
+                let consume = (p.len() + 1).min(stack.len()); // ctor args + 1 receiver(PSF out-slot)
+                stack.truncate(stack.len() - consume);
+            }
+            // No param info: drop only a top PSF out-slot (the thing it just constructed); never a
+            // genuine sibling arg. If the top isn't a PSF slot, leave the stack untouched.
+            None => {
+                if stack.last().map(|a| a.is_psf).unwrap_or(false) {
+                    stack.pop();
+                }
+            }
+        }
         return None;
     }
-    let mut a: Vec<Arg> = std::mem::take(stack)
+    // EDIT B-PRIME: `mem::take` empties the ENTIRE operand stack — so a NESTED call eats the
+    // enclosing call's deeper args (proven: GetHero/GetDistanceTo). When a TRUSTED arity is known
+    // (script param count, which is authoritative; or Binds native arity), take ONLY the top
+    // `need` entries (this call's receiver + args) and LEAVE deeper entries for the enclosing call.
+    // Untrusted -> keep the original take-all (cache native param counts are unreliable).
+    let need = trusted_arity.map(|n| n + is_method as usize);
+    let mut a: Vec<Arg> = match need {
+        Some(k) if stack.len() > k => {
+            // Split off this call's own operands (top `k`); the deeper entries belong to an
+            // ENCLOSING call. BUT only PRESERVE deeper entries that are plausibly real enclosing
+            // args (typed locals/globals/PSF slots) — a stranded plain int/const literal left over
+            // from an unmodeled push is dead and, if preserved, pollutes the enclosing call's arg
+            // list and force-stubs it (regression). Drop such dead leading constants here, which is
+            // exactly what the old whole-stack `mem::take` did for them.
+            let own = stack.split_off(stack.len() - k);
+            stack.retain(|x| !x.is_int);
+            own
+        }
+        _ => std::mem::take(stack),
+    }
         .into_iter()
         .filter(|x| !x.s.is_empty() && x.s != UNRESOLVED)
         .collect();
@@ -386,6 +437,18 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         Some(format!("{}.{f}({})", recv.s, render_args(&a, params, refs)))
     } else {
         if refs.is_type_name(f) {
+            // EDIT C: a value-type factory call (FName/E*/T* — NOT U*/A*, which use ALLOC) whose
+            // result is built into the return register and re-pushed by a following `PshRPtr` as
+            // an ENCLOSING call's arg. Dropping it (return None) loses that arg → the consuming
+            // call renders 0-arg (`this.GetCharacter()`). Instead render it as `T(args)` so it
+            // FLOWS into `pending` and PshRPtr recovers it (`this.GetCharacter(FName(...))`).
+            // Restores ARITY; the literal may be a name-table index (acceptable per spec). Gate
+            // strictly: value type AND non-empty args (a 0-arg in-place default ctor stays None).
+            let is_value = matches!(f.bytes().next(), Some(b'F') | Some(b'E') | Some(b'T'));
+            if is_value && !a.is_empty() {
+                maybe_reverse_args(&mut a, params, refs);
+                return Some(format!("{f}({})", render_args(&a, params, refs)));
+            }
             return None; // free-standing in-place constructor — implicit in AS source
         }
         // an operator-overload method with no stack receiver (its target was in the reference
@@ -935,7 +998,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 } else {
                     pending_ty = ctx.refs.func_ret_by_id(id).map(|d| d.base_name(ctx.refs));
                     let na = ctx.refs.native_arity_by_id(id, &f);
-                    build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, ctx.refs)
+                    // SCRIPT call by id: the cache FunctionReference param count is authoritative
+                    // (only NATIVE param lists undercount), so trust it for the EDIT B-PRIME split.
+                    let trusted = ctx.refs.func_params_by_id(id).map(|p| p.len());
+                    build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, ctx.refs)
                 };
             }
             "CALLSYS" | "Thiscall1" => {
@@ -1029,13 +1095,16 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         Some(ns) => format!("{ns}::{f}"),
                         None => f.clone(),
                     };
-                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, ctx.refs)
+                    // NATIVE call by ptr: the cache param list undercounts, so trust ONLY the
+                    // Binds native arity (`na`) for the EDIT B-PRIME split; None falls back to
+                    // take-all (byte-identical to today when Binds is absent).
+                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, na, ctx.refs)
                 };
             }
             "CallPtr" => {
                 let f = name(w(ins, 0));
                 pending_ty = None;
-                pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, ctx.refs);
+                pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, ctx.refs);
             }
             // ---- object construction ----
             "ALLOC" => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -91,6 +91,24 @@ pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, supe
     body
 }
 
+/// If `v` is a top-level assignment expression `lhs = rhs` (the RVO return-slot write pattern),
+/// return the RHS — `return lhs = rhs;` is a parse error, the RHS is the real returned value.
+fn strip_return_assign(v: &str) -> &str {
+    let b = v.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0;
+    while i + 2 < b.len() {
+        match b[i] {
+            b'(' | b'[' => depth += 1,
+            b')' | b']' => depth -= 1,
+            b' ' if depth == 0 && b[i + 1] == b'=' && b[i + 2] == b' ' => return v[i + 3..].trim(),
+            _ => {}
+        }
+        i += 1;
+    }
+    v
+}
+
 /// Decompile a function to a self-contained `function(...) { ... }` (readable, not recompilable).
 pub fn decompile(f: &FuncCode, refs: &RefResolver) -> String {
     let params: Vec<String> = f
@@ -851,6 +869,11 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 }
                 match v {
                     Some(v) => {
+                        // RVO: a non-trivial return is built by writing the hidden return slot
+                        // then returning it -> the decompiler renders `return slot = <value>;`,
+                        // which is a syntax error (aborts the whole module's parse). The
+                        // assignment RHS is the actual returned value.
+                        let v = strip_return_assign(&v).to_string();
                         let v = match ctx.ret_ty {
                             Some(rt) if looks_int(&v) => {
                                 let tn = if rt.token == 0x41 { "bool".to_string() } else { rt.base_name(ctx.refs) };

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -93,8 +93,8 @@ pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, supe
     let float_slots = float_operand_slots(&instrs);
     // AS_PTR_SIZE-aware frame-offset -> param-index map (2-dword handles/refs + hidden RVO slot),
     // self-correcting on observed offsets. Built once per function; consulted by slot_name/slot_type.
-    let param_off_map = super::decompile::build_param_off_map(f, &instrs);
-    let ctx = Ctx { f, refs, instrs: &instrs, super_ctor, ret_ty, fields, param_types, class_name, local_types, float_slots, param_off_map };
+    let (param_off_map, rvo_off) = super::decompile::build_param_off_map_rvo(f, &instrs, refs);
+    let ctx = Ctx { f, refs, instrs: &instrs, super_ctor, ret_ty, fields, param_types, class_name, local_types, float_slots, param_off_map, rvo_off };
     let idx_of: HashMap<usize, usize> =
         g.blocks.iter().enumerate().map(|(i, b)| (b.start_dw, i)).collect();
     let mut body = String::new();
@@ -153,6 +153,9 @@ struct Ctx<'a> {
     float_slots: std::collections::HashSet<i32>,
     /// AS_PTR_SIZE-aware frame-offset -> parameter-index map (see `model::param_slot_map`).
     param_off_map: HashMap<i32, usize>,
+    /// Frame offset of the hidden RVO out-pointer slot for a by-value-struct return, if any.
+    /// A `CopyScript` writing this slot is the function's `return <src>`.
+    rvo_off: Option<i32>,
 }
 
 /// Collect slots used as an operand of a float/double arithmetic or compare op. Every word
@@ -182,6 +185,12 @@ impl Ctx<'_> {
         }
         if self.f.is_method && off == 0 {
             return "this".into();
+        }
+        // The hidden RVO out-pointer slot is NOT a parameter — naming it via the param fallback
+        // mislabels it as parameter 0 (e.g. `_QuestClass`). Give it a distinct synthetic name so
+        // a stray reference is recognisable; the CopyScript-to-return rewrite normally consumes it.
+        if self.rvo_off == Some(off) {
+            return "__return".into();
         }
         self.param_or_arg(self.param_idx(off))
     }
@@ -407,8 +416,15 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         // existing `$beh0`/`opCast` PSF out-slot arms) instead of dropping the result. Run BEFORE
         // the arity trim: the hidden out-slot inflates the arg count one past `arity`, so removing
         // it first restores the correct count (else the trim drops a real leading arg).
+        //
+        // EXCLUDE operator-overload methods (opAssign/opAdd/opEquals/...): they return their
+        // operand type (often a struct/template returned BY REFERENCE, not via an RVO out-slot)
+        // and are lowered as `recv <op> arg` below. Their PSF'd value arg can share the return
+        // type's head (e.g. `member.opAssign(states)` returning `TArray` with a PSF'd `TArray`
+        // value), which would falsely match the out-slot probe and rewrite `states = opAssign()`.
         fn head(s: &str) -> &str { s.split('<').next().unwrap_or(s) }
-        if let Some(rh) = ret_ty.map(head) {
+        let is_operator = assign_op(f).is_some() || binop_method(f).is_some();
+        if let Some(rh) = ret_ty.map(head).filter(|_| !is_operator) {
             if matches!(rh.bytes().next(), Some(b'F') | Some(b'T') | Some(b'E')) {
                 // the RVO out-slot = a PSF arg whose type head equals the return-type head
                 if let Some(pos) = a.iter().position(|x| x.is_psf
@@ -1325,19 +1341,29 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             "PshListElmnt" => stack.push(Arg::int(name(w(ins, 0)))), // +2: list element
             "COPY" => { stack.pop(); }                           // -2: pop the source ptr
             // asBC_CopyScript (QW_ARG = object-type ptr; stack -2): a script value-type / struct
-            // copy = the source-level assignment `dest = src;`. Stack top = SRC, next = DEST
-            // (target pushed first). Both operands arrive as fully-rendered member/local exprs.
-            // Dropping it left the destination (member or RVO temp) unwritten -> garbage/null.
+            // copy = the source-level assignment `dest = src;`. Per asBC_COPY (as_context.cpp) the
+            // DESTINATION pointer is popped FIRST (it is the stack TOP), the SOURCE is the next
+            // entry below it. The compiler pushes SRC first then DEST, so DEST ends up on top —
+            // e.g. `PSF <localSrc>; PshVPtr this; ADDSi <member>; CopyScript` is `this.member =
+            // localSrc;`, and the RVO struct-return `PSF <local>; PshVPtr <retSlot>; CopyScript`
+            // is `<retSlot> = <local>;`. (Earlier this arm had src/dst swapped, which emitted
+            // every struct copy/member-init/RVO-return BACKWARDS — `local = this.member` and
+            // `local = retSlot`.) Both operands arrive as fully-rendered member/local exprs;
+            // dropping it left the destination (member or RVO temp) unwritten -> garbage/null.
             "CopyScript" => {
-                let src = stack.pop();
                 let dst = stack.pop();
+                let src = stack.pop();
                 if let (Some(dst), Some(src)) = (dst, src) {
-                    if !dst.s.is_empty() && dst.s != UNRESOLVED
-                        && !src.s.is_empty() && src.s != UNRESOLVED
-                        && dst.s != src.s
-                    {
-                        flush!();
-                        out.push(format!("{} = {};", dst.s, src.s));
+                    if !src.s.is_empty() && src.s != UNRESOLVED {
+                        // RVO struct-return: a copy whose DEST is the hidden return slot is the
+                        // function's `return <src>;` — capture it as the return value (the slot
+                        // itself has no source name) instead of emitting `__return = <src>;`.
+                        if dst.s == "__return" {
+                            ret_val = Some(src.s);
+                        } else if !dst.s.is_empty() && dst.s != UNRESOLVED && dst.s != src.s {
+                            flush!();
+                            out.push(format!("{} = {};", dst.s, src.s));
+                        }
                     }
                 }
             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -91,7 +91,10 @@ pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, supe
     };
     let g = cfg::build(&instrs);
     let float_slots = float_operand_slots(&instrs);
-    let ctx = Ctx { f, refs, instrs: &instrs, super_ctor, ret_ty, fields, param_types, class_name, local_types, float_slots };
+    // AS_PTR_SIZE-aware frame-offset -> param-index map (2-dword handles/refs + hidden RVO slot),
+    // self-correcting on observed offsets. Built once per function; consulted by slot_name/slot_type.
+    let param_off_map = super::decompile::build_param_off_map(f, &instrs);
+    let ctx = Ctx { f, refs, instrs: &instrs, super_ctor, ret_ty, fields, param_types, class_name, local_types, float_slots, param_off_map };
     let idx_of: HashMap<usize, usize> =
         g.blocks.iter().enumerate().map(|(i, b)| (b.start_dw, i)).collect();
     let mut body = String::new();
@@ -148,6 +151,8 @@ struct Ctx<'a> {
     /// Slots that appear as an operand of a float/double arithmetic or compare op, so a
     /// `SetV4`/`SetV8` constant written to one is rendered as a float literal, not raw int bits.
     float_slots: std::collections::HashSet<i32>,
+    /// AS_PTR_SIZE-aware frame-offset -> parameter-index map (see `model::param_slot_map`).
+    param_off_map: HashMap<i32, usize>,
 }
 
 /// Collect slots used as an operand of a float/double arithmetic or compare op. Every word
@@ -175,15 +180,10 @@ impl Ctx<'_> {
         if off > 0 {
             return format!("local_{off}");
         }
-        if self.f.is_method {
-            if off == 0 {
-                return "this".into();
-            }
-            let idx = (-off - AS_PTR_SIZE) as usize;
-            return self.param_or_arg(idx);
+        if self.f.is_method && off == 0 {
+            return "this".into();
         }
-        // free function: params at off 0, -1, -2, ...
-        self.param_or_arg((-off) as usize)
+        self.param_or_arg(self.param_idx(off))
     }
 
     /// Recovered base type name for a slot: object-local type for `off > 0`, parameter type
@@ -192,15 +192,24 @@ impl Ctx<'_> {
         if off > 0 {
             return self.local_types.and_then(|m| m.get(&off)).cloned();
         }
-        let idx = if self.f.is_method {
-            (-off - AS_PTR_SIZE) as usize
-        } else {
-            (-off) as usize
-        };
+        let idx = self.param_idx(off);
         self.param_types
             .and_then(|p| p.get(idx))
             .filter(|t| !t.is_empty())
             .cloned()
+    }
+
+    /// Resolve a negative frame offset to its parameter index via the AS_PTR_SIZE-aware map,
+    /// falling back to the old linear formula for an unmapped (variadic/defaulted-tail) slot.
+    fn param_idx(&self, off: i32) -> usize {
+        if let Some(&idx) = self.param_off_map.get(&off) {
+            return idx;
+        }
+        if self.f.is_method {
+            (-off - AS_PTR_SIZE) as usize
+        } else {
+            (-off) as usize
+        }
     }
 
     /// Name for parameter slot `idx`: the stored name, else `arg{idx}` — which MUST match

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -323,7 +323,8 @@ struct Cmp {
 /// last-pushed entry (top of stack); the rest are args in push order. Operator-overload
 /// methods (opAssign/opAdd/opEquals/...) render as the source operator. Returns None for
 /// compiler-generated behaviors ($behN construct/destruct) that have no source form.
-fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option<&str>, params: Option<&[DataType]>, native_arity: Option<usize>, trusted_arity: Option<usize>, refs: &RefResolver) -> Option<String> {
+#[allow(clippy::too_many_arguments)]
+fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option<&str>, params: Option<&[DataType]>, native_arity: Option<usize>, trusted_arity: Option<usize>, target_owner: Option<&str>, cur_class: Option<&str>, non_virtual: bool, ret_ty: Option<&str>, refs: &RefResolver) -> Option<String> {
     if f.starts_with('$') || f.starts_with('~') || f == "__STATIC_NAME" {
         // EDIT C (the dominant FName form): `__STATIC_NAME` is the synthesized name-table accessor
         // that produces an FName from a pushed name-table INDEX into the return register; a
@@ -368,7 +369,12 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     // (script param count, which is authoritative; or Binds native arity), take ONLY the top
     // `need` entries (this call's receiver + args) and LEAVE deeper entries for the enclosing call.
     // Untrusted -> keep the original take-all (cache native param counts are unreliable).
-    let need = trusted_arity.map(|n| n + is_method as usize);
+    // A method returning a struct BY VALUE (F*/T* head) also pushes a hidden RVO out-slot, so its
+    // frame is params + receiver + 1; account for it or the split drops a real leading arg.
+    let rvo_slot = is_method && ret_ty
+        .map(|t| matches!(t.split('<').next().unwrap_or(t).bytes().next(), Some(b'F') | Some(b'T')))
+        .unwrap_or(false);
+    let need = trusted_arity.map(|n| n + is_method as usize + rvo_slot as usize);
     let mut a: Vec<Arg> = match need {
         Some(k) if stack.len() > k => {
             // Split off this call's own operands (top `k`); the deeper entries belong to an
@@ -394,6 +400,29 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     let has_recv = is_method && !a.is_empty();
     if has_recv {
         let recv = a.pop().unwrap();
+        // Fix b3 — RVO STRUCT-RETURN: a script method returning a struct BY VALUE
+        // (`FQuestRequirement MakeRequirement(...)`) is lowered as: push real args; push a hidden
+        // `PSF <out_slot>` RVO destination; push receiver; CALL/CALLINTF. The callee writes its
+        // return into `<out_slot>`. Recover it as `out_slot = f(real_args);` (analogous to the
+        // existing `$beh0`/`opCast` PSF out-slot arms) instead of dropping the result. Run BEFORE
+        // the arity trim: the hidden out-slot inflates the arg count one past `arity`, so removing
+        // it first restores the correct count (else the trim drops a real leading arg).
+        fn head(s: &str) -> &str { s.split('<').next().unwrap_or(s) }
+        if let Some(rh) = ret_ty.map(head) {
+            if matches!(rh.bytes().next(), Some(b'F') | Some(b'T') | Some(b'E')) {
+                // the RVO out-slot = a PSF arg whose type head equals the return-type head
+                if let Some(pos) = a.iter().position(|x| x.is_psf
+                    && x.ty.as_deref().map(head) == Some(rh)) {
+                    let out = a.remove(pos).s;
+                    if let Some(w) = arity {
+                        let w = w.min(a.len());
+                        if a.len() > w { a.drain(..a.len() - w); }
+                    }
+                    maybe_reverse_args(&mut a, params, refs);
+                    return Some(format!("{out} = {f}({})", render_args(&a, params, refs)));
+                }
+            }
+        }
         // trim phantom extras: keep only the last `w` user args (the cache arity may include the
         // now-popped `this`, so cap below the popped count, never above).
         if let Some(w) = arity {
@@ -406,6 +435,16 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         // super name is itself a type name).
         if super_ctor == Some(f) && recv.s == "this" {
             return Some(format!("super({})", render_args(&a, params, refs)));
+        }
+        // BUG (a) — SUPER-CALL: a NON-VIRTUAL (`CALL`) dispatch on `this` to a method owned by a
+        // STRICT ANCESTOR of the current class is a `Super::method()` call, not `this.method()`
+        // (a genuine virtual self-call compiles to CALLINTF, never a CALL to the base func-id).
+        if non_virtual && recv.s == "this" {
+            if let (Some(owner), Some(cur)) = (target_owner, cur_class) {
+                if owner != cur && refs.is_subclass(cur, owner) {
+                    return Some(format!("Super::{f}({})", render_args(&a, params, refs)));
+                }
+            }
         }
         // a call whose name is a type = an in-place constructor (member struct default ctor) —
         // implicit in AS source, emit nothing.
@@ -744,6 +783,24 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
         };
     }
 
+    // Fix b2 — flush a still-pending statement-position call result before the NEXT call would
+    // overwrite/drop it (e.g. `MakeRequirement(...)` then `Add(...)`, then a dtor that returns
+    // None). UNLIKE `flush!`, this DROPS a pending that carries an ARGMISMATCH sentinel (\u{2})
+    // or is unresolved: at the call boundary such a result was previously silently overwritten by
+    // the next call's `pending = ...`. Surfacing it as an emitted statement would propagate the
+    // sentinel and force-stub the whole function (regression). So only genuinely-recovered,
+    // statement-valid results are emitted; bad ones stay dropped exactly as before.
+    macro_rules! flush_b2 {
+        () => {
+            if let Some(p) = pending.take() {
+                if !p.contains('\u{2}') && !p.contains(UNRESOLVED) {
+                    out.push(format!("{p};"));
+                }
+            }
+            pending_ty = None;
+        };
+    }
+
     let insns = &ctx.instrs[lo..hi];
     for k in 0..insns.len() {
         let ins = &insns[k];
@@ -983,10 +1040,15 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             "TNP" => { if let Some(c) = &mut cmp { c.op = Some("<="); } }
             // ---- calls ----
             "CALL" | "CALLINTF" | "CALLBND" => {
+                // Fix b2 — FLUSH a pending statement-position call result before this call starts,
+                // so a chained statement call (e.g. MakeRequirement then Add) isn't silently
+                // overwritten. Drops sentinel/unresolved pendings (see flush_b2 doc).
+                flush_b2!();
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let f = ctx.refs.func_by_id(id).unwrap_or("func?").to_string();
                 pending = if f == "StaticClass" {
-                    stack.clear();
+                    // Fix b1 — StaticClass takes 0 operands; the stack holds the ENCLOSING call's
+                    // already-pushed args. Do NOT clear it (clearing destroys those args).
                     pending_ty = None;
                     // The class is the StaticClass func's NAMESPACE last-segment (objtype is
                     // NULL for StaticClass; the target class lives in the namespace), not the
@@ -1001,10 +1063,14 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // SCRIPT call by id: the cache FunctionReference param count is authoritative
                     // (only NATIVE param lists undercount), so trust it for the EDIT B-PRIME split.
                     let trusted = ctx.refs.func_params_by_id(id).map(|p| p.len());
-                    build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, ctx.refs)
+                    let owner = ctx.refs.func_owner_by_id(id);
+                    build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, owner, ctx.class_name, n == "CALL", pending_ty.as_deref(), ctx.refs)
                 };
             }
             "CALLSYS" | "Thiscall1" => {
+                // Fix b2 — flush a pending statement-position call result before this call begins
+                // (e.g. MakeRequirement's result must be emitted before `Add(...)` overwrites it).
+                flush_b2!();
                 let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
                 let f = ctx.refs.func_by_ptr(ptr).unwrap_or("syscall?").to_string();
                 if f == "opCast" {
@@ -1053,7 +1119,15 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                             let ty = recv.ty.clone().unwrap();
                             stack.pop(); // remove the receiver; the rest are the ctor args
                             let params = ctx.refs.func_params_by_ptr(ptr);
-                            let args: Vec<Arg> = std::mem::take(&mut stack).into_iter()
+                            // Consume ONLY this ctor's own args from the TOP (mirror build_call's
+                            // EDIT A/B-PRIME) — a whole-stack `mem::take` would also drain the
+                            // ENCLOSING call's operands (the 4 EQuestState args of MakeRequirement),
+                            // re-dropping them once Fix b1 keeps them on the stack.
+                            let args: Vec<Arg> = match params.map(|p| p.len()) {
+                                Some(k) if stack.len() > k => stack.split_off(stack.len() - k),
+                                _ => std::mem::take(&mut stack),
+                            }
+                                .into_iter()
                                 .filter(|x| !x.s.is_empty() && x.s != UNRESOLVED).collect();
                             // Gate (b): no arg is itself a PSF slot — that is a copy/convert ctor
                             // whose true source is an unrecovered pending call result; rendering it
@@ -1078,7 +1152,8 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // not a recoverable in-place construct -> fall through to the generic `$` drop.
                 }
                 pending = if f == "StaticClass" {
-                    stack.clear();
+                    // Fix b1 — do NOT clear the stack; StaticClass takes 0 operands and the entries
+                    // present belong to an ENCLOSING call.
                     pending_ty = None;
                     let cls = ctx.refs.staticclass_class_by_ptr(ptr)
                         .or_else(|| ctx.refs.func_owner_by_ptr(ptr))
@@ -1098,13 +1173,13 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // NATIVE call by ptr: the cache param list undercounts, so trust ONLY the
                     // Binds native arity (`na`) for the EDIT B-PRIME split; None falls back to
                     // take-all (byte-identical to today when Binds is absent).
-                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, na, ctx.refs)
+                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, na, None, ctx.class_name, false, pending_ty.as_deref(), ctx.refs)
                 };
             }
             "CallPtr" => {
                 let f = name(w(ins, 0));
                 pending_ty = None;
-                pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, ctx.refs);
+                pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, None, ctx.class_name, false, None, ctx.refs);
             }
             // ---- object construction ----
             "ALLOC" => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -31,19 +31,28 @@ struct Arg {
     /// Raw bits if this is an integer CONSTANT (`PshC4`/`PshC8`) — so a constant feeding a
     /// float/double parameter can be reinterpreted as its real IEEE-754 value.
     cbits: Option<ConstBits>,
+    /// True when this arg was pushed via `PSF` (push stack-frame address of a local) — i.e. it
+    /// is the ADDRESS of a slot, used as an out / RVO / in-place-ctor receiver. Lets the CALLSYS
+    /// handler recover `slot = T(args)` from a `$beh0` construct behaviour instead of dropping it.
+    is_psf: bool,
 }
 impl Arg {
     fn int(s: String) -> Arg {
-        Arg { s, is_int: true, ty: None, cbits: None }
+        Arg { s, is_int: true, ty: None, cbits: None, is_psf: false }
     }
     fn iconst(s: String, cbits: ConstBits) -> Arg {
-        Arg { s, is_int: true, ty: None, cbits: Some(cbits) }
+        Arg { s, is_int: true, ty: None, cbits: Some(cbits), is_psf: false }
     }
     fn obj(s: String) -> Arg {
-        Arg { s, is_int: false, ty: None, cbits: None }
+        Arg { s, is_int: false, ty: None, cbits: None, is_psf: false }
     }
     fn typed(s: String, ty: Option<String>) -> Arg {
-        Arg { s, is_int: false, ty, cbits: None }
+        Arg { s, is_int: false, ty, cbits: None, is_psf: false }
+    }
+    /// A `PSF`-pushed slot address (out / RVO / in-place-ctor receiver), carrying the slot's
+    /// recovered type so the construct can render `slot = <ty>(args)`.
+    fn psf(s: String, ty: Option<String>) -> Arg {
+        Arg { s, is_int: false, ty, cbits: None, is_psf: true }
     }
 }
 
@@ -677,7 +686,8 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 // &local, unless it's the destination of a following ALLOC
                 if insns.get(k + 1).map(|i| i.op.name) != Some("ALLOC") {
                     // &local at the AS source level is implicit (param decides &in/&out) — no `&`.
-                    stack.push(Arg::typed(name(w(ins, 0)), ctx.slot_type(w(ins, 0))));
+                    // Tag is_psf so a following `$beh0` construct can recover `slot = T(args)`.
+                    stack.push(Arg::psf(name(w(ins, 0)), ctx.slot_type(w(ins, 0))));
                 }
                 // else: this PSF is the destination local for the following ALLOC; don't push.
             }
@@ -906,6 +916,49 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         out.push(format!("{dst} = {rhs};"));
                     }
                     continue;
+                }
+                if f == "$beh0" {
+                    // `$beh0` is the AngelScript value-type / struct in-place CONSTRUCT behaviour:
+                    // `PSF <slot> ; <args...> ; CALLSYS $beh0` constructs the value AT the PSF'd
+                    // slot (the receiver, top of stack). build_call drops every `$`-prefixed
+                    // behaviour and clears the stack, so the construct AND its write to the slot
+                    // vanished, leaving the slot uninitialised (then read downstream as garbage /
+                    // passed to a call). Recover it as `slot = T(args);` so the value FLOWS.
+                    if let Some(recv) = stack.last().cloned() {
+                        // Gate (a): receiver is a PSF'd slot with a known VALUE/struct/template
+                        // type (F*/T*/E*). Never a `$`/`?` placeholder, never an object (U*/A*):
+                        // object construction uses ALLOC, not this in-place behaviour.
+                        let is_value = recv.ty.as_deref()
+                            .and_then(|t| t.bytes().next())
+                            .map(|b| matches!(b, b'F' | b'T' | b'E'))
+                            .unwrap_or(false);
+                        if recv.is_psf && is_value {
+                            let ty = recv.ty.clone().unwrap();
+                            stack.pop(); // remove the receiver; the rest are the ctor args
+                            let params = ctx.refs.func_params_by_ptr(ptr);
+                            let args: Vec<Arg> = std::mem::take(&mut stack).into_iter()
+                                .filter(|x| !x.s.is_empty() && x.s != UNRESOLVED).collect();
+                            // Gate (b): no arg is itself a PSF slot — that is a copy/convert ctor
+                            // whose true source is an unrecovered pending call result; rendering it
+                            // as `T(&slot)` would be wrong, so drop (prior behaviour).
+                            let any_psf_arg = args.iter().any(|a| a.is_psf);
+                            // Gate (c): arg count matches the ctor's declared param count (no
+                            // spurious leftover operands on the stack).
+                            let count_ok = params.map(|p| p.len() == args.len()).unwrap_or(false);
+                            if !args.is_empty() && !any_psf_arg && count_ok {
+                                let rendered = render_args(&args, params, ctx.refs);
+                                // Gate (d): a definite arg-type mismatch -> drop (keep prior
+                                // behaviour: slot unwritten) rather than emit the `\u{2}` sentinel
+                                // that would force-stub the whole function.
+                                if !rendered.contains('\u{2}') {
+                                    flush!();
+                                    out.push(format!("{} = {ty}({rendered});", recv.s));
+                                }
+                            }
+                            continue;
+                        }
+                    }
+                    // not a recoverable in-place construct -> fall through to the generic `$` drop.
                 }
                 pending = if f == "StaticClass" {
                     stack.clear();

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -228,6 +228,24 @@ fn scan_back_retval(ctx: &Ctx, before: usize) -> Option<String> {
     None
 }
 
+/// Resolve a Cast/TYPEID operand to a target typename. AngelScript bytecode typeids carry
+/// flag bits in the high word — most notably `asTYPEID_OBJHANDLE` (0x40000000) and
+/// `asTYPEID_HANDLETOCONST` (0x20000000) — that are NOT part of the key stored in the cache's
+/// TypeIdReferenceToPointer table (which keys on the object-type id incl. SCRIPTOBJECT/TEMPLATE
+/// bits but WITHOUT the handle/const flags). Strip those flags before lookup, trying the raw id
+/// first for robustness. Returns the resolved typename, or None if unresolvable.
+pub(crate) fn resolve_cast_typeid(refs: &RefResolver, tid: i32) -> Option<String> {
+    const OBJHANDLE: u32 = 0x4000_0000;
+    const HANDLETOCONST: u32 = 0x2000_0000;
+    let raw = tid as u32;
+    for cand in [raw, raw & !OBJHANDLE, raw & !(OBJHANDLE | HANDLETOCONST)] {
+        if let Some(t) = refs.type_by_id(cand as i32) {
+            return Some(t.to_string());
+        }
+    }
+    None
+}
+
 /// A primitive numeric-conversion opcode (`dst = (cast) src`); the cast is implicit in
 /// type-erased AngelScript source, so we render the plain copy `dst = src`.
 fn is_numeric_cast(n: &str) -> bool {
@@ -607,6 +625,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
     let mut pending: Option<String> = None; // unconsumed call/ctor result
     let mut pending_ty: Option<String> = None; // recovered type of `pending` (call return type)
     let mut ret_val: Option<String> = None;
+    // Target type of the most recent TYPEID push — the implicit type operand of the following
+    // `opCast` behaviour call (the lowered form of `Cast<T>(x)`). Resolved to a typename so the
+    // opCast can be rendered as `Cast<T>(src)` instead of a discarded `src.opCast(out)`.
+    let mut last_typeid: Option<String> = None;
     let name = |off: i32| ctx.slot_name(off);
     let w = |ins: &Instr, i: usize| s16(ins.words.get(i).copied().unwrap_or(0));
 
@@ -858,6 +880,33 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             "CALLSYS" | "Thiscall1" => {
                 let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
                 let f = ctx.refs.func_by_ptr(ptr).unwrap_or("syscall?").to_string();
+                if f == "opCast" {
+                    // `opCast` is the AngelScript handle-downcast behaviour — the lowered form of
+                    // `T@ dst = Cast<T>(src)`. The cache renders it `src.opCast(out)` with the cast
+                    // RESULT written into the `out` arg slot, then a following RefCpyV copies that
+                    // slot into the real destination/return local. Emitting the bare `opCast` call
+                    // (and dropping the out-write) leaves the destination unwritten → the function
+                    // returns null. Recover it as an assignment `out = Cast<T>(src);` so the value
+                    // FLOWS into the store/return. T comes from the preceding TYPEID.
+                    let src = stack.pop().map(|a| a.s); // top = receiver = source handle
+                    let dst = stack.pop().map(|a| a.s); // next = the `out` destination slot
+                    let t = last_typeid.take();
+                    if let (Some(dst), Some(src)) = (dst, src) {
+                        flush!();
+                        // Emit a typed `Cast<T>(src)` only for a real object/script target type
+                        // (U*/A*); fall back to a bare passthrough `dst = src` when T is
+                        // unresolved or not an object — the value must still FLOW into the store
+                        // so the destination/return local is written (never a discarded cast).
+                        let rhs = match &t {
+                            Some(ty) if ty.starts_with('U') || ty.starts_with('A') => {
+                                format!("Cast<{ty}>({src})")
+                            }
+                            _ => src,
+                        };
+                        out.push(format!("{dst} = {rhs};"));
+                    }
+                    continue;
+                }
                 pending = if f == "StaticClass" {
                     stack.clear();
                     pending_ty = None;
@@ -955,14 +1004,41 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     ref_reg_ty = top.ty;
                 }
             }
-            // Handle-copy (asBC stack_inc -2): pop the source pointer to BALANCE the operand
-            // stack (the dominant phantom-arg cause). We deliberately do NOT emit `slot = src`:
-            // the source is often a const/derived handle whose direct assignment to the dest
-            // local fails to compile, and the value is re-read where it's actually used.
-            "RefCpyV" | "REFCPY" => { stack.pop(); }
+            // RefCpyV (wW_ARG): copy the top-of-stack handle into the destination slot named by
+            // the word operand — `dst_slot = src`. This is the step that moves an opCast result
+            // (or any local handle) from a temp into the real destination/return local; dropping
+            // it was a primary cause of `return`ing an unwritten (null) local. Emit it as a
+            // statement (NOT a stack push) so it cannot reintroduce phantom call args.
+            //
+            // GUARD: only emit when the source is a recovered local slot (`local_N`) or a
+            // `Cast<...>` expression — a genuine temporary whose copy completes a recovered
+            // dataflow. Copying a const PARAMETER (rendered as its bare name) into a non-const
+            // local yields "Can't implicitly convert from 'const X' to 'X'", so those stay
+            // dropped (the prior conservative behaviour); the value is re-read where used.
+            "RefCpyV" => {
+                let dst = name(w(ins, 0));
+                if let Some(top) = stack.pop() {
+                    let ok = !top.s.is_empty()
+                        && top.s != dst
+                        && (top.s.starts_with("local_") || top.s.starts_with("Cast<"));
+                    if ok {
+                        flush!();
+                        out.push(format!("{dst} = {};", top.s));
+                    }
+                }
+            }
+            // REFCPY (NO_ARG): a pure stack handle-copy with no destination slot operand — just
+            // balance the operand stack (the dominant phantom-arg cause); the value is re-read
+            // where it is actually used.
+            "REFCPY" => { stack.pop(); }
             // The TYPEID push is the implicit type operand of the following opCast/cast syscall
-            // (NOT counted in the cache param list) — drop it so the cast block stays balanced.
-            "TYPEID" => {}
+            // (NOT counted in the cache param list) — it is not a real stack arg, so don't push
+            // it. Capture its resolved typename as the target T of the upcoming `opCast` so the
+            // cast renders `Cast<T>(src)` instead of a discarded `src.opCast(out)`.
+            "TYPEID" => {
+                let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
+                last_typeid = resolve_cast_typeid(ctx.refs, tid);
+            }
             // primitive numeric conversions (iTOf/fTOi/dTOf/sbTOi/...): `dst = src`. A
             // float/double -> integer narrowing must be made EXPLICIT (`dst = int(src)`) or the
             // compiler rejects it as an implicit precision loss; widenings stay implicit.
@@ -984,7 +1060,24 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             "OBJTYPE" => stack.push(Arg::obj("objtype".into())), // +2: RTTI objtype ptr
             "STR" => stack.push(Arg::obj("\"\"".into())),         // +3: string-constant push
             "PshListElmnt" => stack.push(Arg::int(name(w(ins, 0)))), // +2: list element
-            "COPY" | "Cast" => { stack.pop(); }                  // -2: pop the source ptr
+            "COPY" => { stack.pop(); }                           // -2: pop the source ptr
+            // asBC_Cast (DW_ARG=target typeid): a script-handle DOWNCAST. Pop the source handle
+            // and push the cast RESULT `Cast<T>(src)` (typed) so the following store writes the
+            // real object instead of dropping it. T is the instruction's own typeid operand.
+            // (This opcode is unused by the current cache — the fork lowers casts to the `opCast`
+            // behaviour above — but is handled for completeness/robustness.) Fall back to a bare
+            // passthrough when T is unresolved or not an object, so the value always FLOWS.
+            "Cast" => {
+                if let Some(src) = stack.pop() {
+                    let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
+                    match resolve_cast_typeid(ctx.refs, tid) {
+                        Some(ty) if ty.starts_with('U') || ty.starts_with('A') => {
+                            stack.push(Arg::typed(format!("Cast<{ty}>({})", src.s), Some(ty)));
+                        }
+                        _ => stack.push(src),
+                    }
+                }
+            }
             // conditional jump: if no comparison was recovered, the tested value is the live
             // call result / bool register — use it as the branch condition (consume so it's
             // not flushed as a stray statement).

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1330,6 +1330,11 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             n2 if is_numeric_cast(n2) => {
                 flush!();
                 let (dst, src) = (name(w(ins, 0)), name(w(ins, 1)));
+                // a numeric conversion FROM an enum source needs an explicit int(enum) — AS has
+                // no implicit enum->int (e.g. sbTOi of an EQuestState param into an int slot).
+                let src = if ctx.slot_type(w(ins, 1)).as_deref().map(is_enum_name).unwrap_or(false) {
+                    format!("int({src})")
+                } else { src };
                 match narrowing_cast_target(n2) {
                     Some(t) => out.push(format!("{dst} = {t}({src});")),
                     None => out.push(format!("{dst} = {src};")),

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -309,6 +309,21 @@ fn fmt_float(b: ConstBits, double: bool) -> String {
         ConstBits::W4(x) => f32::from_bits(x) as f64,
         ConstBits::W8(x) => f64::from_bits(x),
     };
+    // Rust's `{:?}` prints non-finite floats as `inf`/`-inf`/`NaN`, and the float32 branch then
+    // appends `f` -> `inff`, neither of which is a valid AngelScript literal ("'inff' is not
+    // declared"). AS has no inf/nan literal, so emit the closest compile-valid magnitude: the
+    // type's max finite value for ±inf (preserves the "very large / forever" sentinel intent
+    // these constants carry), and 0 for NaN.
+    if !v.is_finite() {
+        return match (v.is_nan(), v.is_sign_negative(), double) {
+            (true, _, true) => "0.0".into(),
+            (true, _, false) => "0.0f".into(),
+            (false, false, true) => format!("{:?}", f64::MAX),
+            (false, true, true) => format!("{:?}", f64::MIN),
+            (false, false, false) => format!("{:?}f", f32::MAX),
+            (false, true, false) => format!("{:?}f", f32::MIN),
+        };
+    }
     if double { format!("{v:?}") } else { format!("{:?}f", v as f32) }
 }
 

--- a/crates/gore-as/src/cache/walk_modules.rs
+++ b/crates/gore-as/src/cache/walk_modules.rs
@@ -8,6 +8,7 @@
 //! are 4 bytes; `DataType` is a fixed 36 bytes.
 
 use super::header::CacheHeader;
+use super::types::DataType;
 use super::wire::{Cursor, WireError};
 
 /// `FAngelscriptPrecompiledDataType` = 6×bool(24) + int64 TypeInfo.Old(8) + int32 Token(4).
@@ -81,6 +82,12 @@ pub struct FuncCode {
     pub is_method: bool,
     /// Source parameter names in declaration order (locals are NOT stored in the cache).
     pub param_names: Vec<String>,
+    /// Parameter types in declaration order — needed to compute AS_PTR_SIZE-aware frame slot
+    /// widths so a param's frame offset maps to the correct index (see `model::param_slot_map`).
+    pub param_types: Vec<DataType>,
+    /// Return type — its by-value-struct shape decides whether a hidden RVO out-pointer slot
+    /// shifts every parameter's frame offset.
+    pub ret: DataType,
     /// Raw `TArray<int32>` bytecode (the asBC dword stream).
     pub bytecode: Vec<i32>,
 }
@@ -106,8 +113,12 @@ fn read_function_c(
 ) -> Result<(), WireError> {
     let name = c.read_sia()?;
     c.read_sia()?; // Namespace
-    read_data_type(c)?; // ReturnType
-    c.skip_tarray_fixed(DATA_TYPE_SIZE, "ParameterTypes")?;
+    let ret = DataType::read(c)?; // ReturnType
+    let nptypes = c.read_count("ParameterTypes")?;
+    let mut param_types = Vec::with_capacity(nptypes);
+    for _ in 0..nptypes {
+        param_types.push(DataType::read(c)?);
+    }
     let param_names = c.read_tarray_sia("ParameterNames")?;
     c.skip_tarray_fixed(4, "ParameterFlags")?;
     c.skip_tarray_sia("ParameterDefaultArgs")?;
@@ -135,6 +146,8 @@ fn read_function_c(
         func: format!("{scope}::{name}"),
         is_method,
         param_names,
+        param_types,
+        ret,
         bytecode,
     });
     Ok(())

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -1,7 +1,30 @@
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::Subcommand;
+
+/// Rename whole-word free occurrences of `name` to `newname` in `src` — occurrences NOT preceded
+/// by `.` (so member calls `obj.name(...)` are left alone; only the decl + free calls change).
+fn rename_free_fn(src: &str, name: &str, newname: &str) -> String {
+    let (b, nb) = (src.as_bytes(), name.as_bytes());
+    let word = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+    let mut out: Vec<u8> = Vec::with_capacity(b.len());
+    let mut i = 0;
+    while i < b.len() {
+        let hit = b[i..].starts_with(nb)
+            && (i == 0 || (!word(b[i - 1]) && b[i - 1] != b'.' && b[i - 1] != b':'))
+            && (i + nb.len() >= b.len() || !word(b[i + nb.len()]));
+        if hit {
+            out.extend_from_slice(newname.as_bytes());
+            i += nb.len();
+        } else {
+            out.push(b[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| src.to_string())
+}
 use gore_as::cache::header::CacheHeader;
 use gore_as::cache::scan::scan_strings;
 use gore_as::cache::splice::splice_auto;
@@ -163,9 +186,45 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             // cache paths against that real root. (create_dir_all so canonicalize succeeds.)
             std::fs::create_dir_all(&outdir).with_context(|| format!("creating {}", outdir.display()))?;
             let outdir = outdir.canonicalize().with_context(|| format!("resolving {}", outdir.display()))?;
+            // Cross-module free-function collisions: AngelScript compiles all loose .as into ONE
+            // global scope, so two modules each defining `Foo(<same params>)` (even with different
+            // return types) collide as "a function with the same name and parameters already
+            // exists". Find such names and rename each per-module — a function's decl and its
+            // intra-module free calls live in the same emitted file, so a file-local rename
+            // de-collides without breaking resolution (cross-module calls of these don't occur).
+            let mut sig_mods: HashMap<String, HashSet<usize>> = HashMap::new();
+            for (i, m) in mods.iter().enumerate() {
+                for f in &m.functions {
+                    // generated factory accessors are skipped at emit (not free-emitted) — never
+                    // rename them, or free CALLS to the native binding would be broken.
+                    if matches!(f.name.as_str(),
+                        "Spawn" | "Get" | "GetOrCreate" | "Create" | "GetG1R" | "StaticClass") {
+                        continue;
+                    }
+                    // precise signature (render, not base_name) so only GENUINE same-signature
+                    // collisions are flagged — a coarse match falsely flags distinct overloads and
+                    // would rename (and break) functions that are validly called cross-module.
+                    let ptys: Vec<String> = f.params.iter().map(|p| p.ty.render(&refs)).collect();
+                    sig_mods.entry(format!("{}({})", f.name, ptys.join(","))).or_default().insert(i);
+                }
+            }
+            let mut colliding_in: HashMap<usize, HashSet<String>> = HashMap::new();
+            for (sig, modset) in &sig_mods {
+                if modset.len() > 1 {
+                    let name = sig.split('(').next().unwrap_or("").to_string();
+                    for &i in modset {
+                        colliding_in.entry(i).or_default().insert(name.clone());
+                    }
+                }
+            }
             let (mut written, mut stubbed) = (0usize, 0usize);
-            for m in &mods {
-                let src = gore_as::cache::emit::emit_module(m, &refs);
+            for (mi, m) in mods.iter().enumerate() {
+                let mut src = gore_as::cache::emit::emit_module(m, &refs);
+                if let Some(names) = colliding_in.get(&mi) {
+                    for name in names {
+                        src = rename_free_fn(&src, name, &format!("{name}_g{mi}"));
+                    }
+                }
                 if src.contains("not fully recovered") {
                     stubbed += 1;
                 }

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -235,12 +235,37 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                     sig_mods.entry(format!("{}({})", f.name, ptys.join(","))).or_default().insert(i);
                 }
             }
+            // A name is safe to file-locally rename in a module only if EVERY emittable free
+            // function of that name in the module has a colliding signature. If the module also has
+            // a NON-colliding same-name overload, the name-based `rename_free_fn` would rewrite that
+            // overload's decl + calls too, breaking other modules that call it by its original name.
+            // In that mixed case leave the name un-renamed: the genuine collision then surfaces at
+            // generate as a "already exists" stub (rare, safe) instead of silently breaking a valid
+            // cross-module call to the non-colliding overload.
+            let colliding_sigs: HashSet<&str> = sig_mods
+                .iter()
+                .filter(|(_, modset)| modset.len() > 1)
+                .map(|(sig, _)| sig.as_str())
+                .collect();
             let mut colliding_in: HashMap<usize, HashSet<String>> = HashMap::new();
-            for (sig, modset) in &sig_mods {
-                if modset.len() > 1 {
-                    let name = sig.split('(').next().unwrap_or("").to_string();
-                    for &i in modset {
-                        colliding_in.entry(i).or_default().insert(name.clone());
+            for (i, m) in mods.iter().enumerate() {
+                let mut sigs_by_name: HashMap<&str, Vec<String>> = HashMap::new();
+                for f in &m.functions {
+                    if matches!(f.name.as_str(),
+                        "Spawn" | "Get" | "GetOrCreate" | "Create" | "GetG1R" | "StaticClass") {
+                        continue;
+                    }
+                    let ptys: Vec<String> = f.params.iter().map(|p| p.ty.render(&refs)).collect();
+                    sigs_by_name
+                        .entry(f.name.as_str())
+                        .or_default()
+                        .push(format!("{}({})", f.name, ptys.join(",")));
+                }
+                for (name, sigs) in sigs_by_name {
+                    if sigs.iter().any(|s| colliding_sigs.contains(s.as_str()))
+                        && sigs.iter().all(|s| colliding_sigs.contains(s.as_str()))
+                    {
+                        colliding_in.entry(i).or_default().insert(name.to_string());
                     }
                 }
             }

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -91,6 +91,33 @@ pub enum AsCmd {
         #[arg(short, long)]
         out: PathBuf,
     },
+    /// Extract one module into a standalone 1-module mini-cache (module + full tail tables).
+    /// Lets a dependency-heavy edited module be pulled from a full-tree regen and Replace'd
+    /// into the vanilla base.
+    Extract {
+        /// Source cache (e.g. a full-tree regen).
+        cache: PathBuf,
+        /// Module name (the Modules TMap key) to extract.
+        module: String,
+        /// Output path for the 1-module mini-cache.
+        #[arg(short, long)]
+        out: PathBuf,
+    },
+    /// Extract one module from a regen cache AND remap its bytecode refs to a base (vanilla)
+    /// cache's keys, emitting a 1-module mini with EMPTY tail tables. The result can be
+    /// Replace'd into the base without growing the cache (no duplicate global tables). This is
+    /// the key step for editing EXISTING modules. See work/reversing/gore-as/specs/ref-remap.md.
+    ExtractRemap {
+        /// Regen cache (full-tree -as-generate-precompiled-data output) containing the edit.
+        regen_cache: PathBuf,
+        /// Module name (the Modules TMap key) to extract + remap.
+        module: String,
+        /// Base (vanilla) cache whose keys the module's refs are rewritten to.
+        base_cache: PathBuf,
+        /// Output path for the remapped 1-module mini-cache (empty tail tables).
+        #[arg(short, long)]
+        out: PathBuf,
+    },
 }
 
 /// Build the script-class hierarchy (class name -> super class name) from parsed modules.
@@ -325,6 +352,40 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 base_b.len(),
                 spliced.len(),
                 out.display()
+            );
+        }
+        AsCmd::Extract { cache, module, out } => {
+            let b = std::fs::read(&cache).with_context(|| format!("reading {}", cache.display()))?;
+            let n = module_count(&b);
+            let mini = gore_as::cache::splice::extract_module(&b, &module).context("extract")?;
+            std::fs::write(&out, &mini).with_context(|| format!("writing {}", out.display()))?;
+            println!(
+                "extracted {:?} from {} modules -> 1-module mini ; {} bytes ; wrote {}",
+                module, n, mini.len(), out.display()
+            );
+        }
+        AsCmd::ExtractRemap { regen_cache, module, base_cache, out } => {
+            let regen_b = std::fs::read(&regen_cache)
+                .with_context(|| format!("reading {}", regen_cache.display()))?;
+            let base_b = std::fs::read(&base_cache)
+                .with_context(|| format!("reading {}", base_cache.display()))?;
+            let n = module_count(&regen_b);
+            let mini = gore_as::cache::splice::extract_module(&regen_b, &module)
+                .context("extract")?;
+            let (remapped, counts) =
+                gore_as::cache::remap::remap_module_to_base(&mini, &base_b)
+                    .context("remap")?;
+            std::fs::write(&out, &remapped)
+                .with_context(|| format!("writing {}", out.display()))?;
+            println!(
+                "extract-remap {:?} from {} modules -> remapped 1-module mini ; {} bytes ; wrote {}",
+                module, n, remapped.len(), out.display()
+            );
+            println!(
+                "refs remapped: {} total (bytecode: global={} func_ptr={} type_ptr={} func_id={} type_id={} ; embedded: type_ptr={} func_id={})",
+                counts.total(),
+                counts.global_ptr, counts.func_ptr, counts.type_ptr, counts.func_id, counts.type_id,
+                counts.embed_type_ptr, counts.embed_func_id
             );
         }
     }

--- a/docs/superpowers/specs/2026-06-23-standalone-as-checker-design.md
+++ b/docs/superpowers/specs/2026-06-23-standalone-as-checker-design.md
@@ -1,0 +1,203 @@
+# Standalone AngelScript compile-checker for gore-as
+
+**Status:** design (approved-pending review)
+**Date:** 2026-06-23
+**Scope:** Phase 1 — an offline compile-CHECKER. Replaces the game-launch loop used to
+validate the decompiler's emitted `.as`. NOT a cache generator (that is a later phase).
+
+## 1. Goal
+
+Today, validating that the decompiler's emitted `.as` tree compiles requires launching
+`G1R-Win64-Shipping.exe` with `-as-development-mode -as-generate-precompiled-data`, injecting a
+DLL to scrape the compile diagnostics, and killing the process — ~5 minutes per iteration, not
+CI-able, needs the game installed.
+
+Replace that with `gore as check <dir-of-.as>`: embed the **real** AngelScript compiler (the
+Hazelight UnrealEngine-Angelscript fork, the exact one the game uses), register the native API
+surface offline, compile the `.as` tree, and emit diagnostics in the **same format** the game
+loop produces. No game process, runs in CI, sub-second-to-seconds per run.
+
+Non-goal (Phase 1): producing a game-loadable `PrecompiledScript_Shipping.Cache`. That needs
+bytecode serialization + exact type-IDs and is deferred (see §10).
+
+## 2. Key findings that make this feasible
+
+(From the reverse-engineering research pass — recorded so the plan rests on evidence.)
+
+- **The fork compiler is decoupled from live UE reflection.** It is lightly-patched vanilla
+  AngelScript 2.33 (`asCBuilder`/`asCCompiler`/`asCScriptEngine`). Type resolution goes entirely
+  through the engine's own registration tables (`GetObjectMethodDescriptions`,
+  `FindMatchingFuncdef`, `asCObjectType`/`asCDataType`). UE reflection is consulted only at
+  *registration time* (`BindScriptTypes()`), never inside `Build()`. The "UClass" special-cases
+  in the compiler key on the *registered type's name string*, not a live UObject lookup. So a
+  standalone build that registers the same surface compiles identically — pure vanilla-AS usage:
+  `RegisterObjectType/Method/Property` → `AddScriptSection` → `Build` → message callback.
+- **Compiler source is not shipped** (statically linked into the exe). Public mirror
+  `WillGordon9999/UNREANGEL` is UE 5.4.x, `ANGELSCRIPT_VERSION 23300` ("2.33.0 WIP") — matches.
+  AS core lives under `Angelscript/Source/AngelscriptCode/Public/source/angelscript/`.
+- **Diagnostics already match.** The engine routes all compile errors through
+  `asIScriptEngine::SetMessageCallback` → `asSMessageInfo { section, row, col, type, message }`
+  = file:line:col + message, exactly what the game loop captures.
+- **Binds.Cache covers ~99% of the registration surface** (11,189 types, 16,371 full signatures,
+  properties+types, global functions, namespaces, templates). Property offsets and type-IDs are
+  **not needed** for type-checking (dummy values are fine). Two gaps require a supplement:
+  native **enum enumerators+values** (36 native enums) and native **base-class edges**; plus the
+  **GameplayTag namespace** (synthesized at runtime from project tag data).
+- **The emitted code uses fork-only syntax** — `UFUNCTION()`/`UPROPERTY()` (empty-arg only),
+  `n"..."` FName literal, `Cast<T>()`, `TSubclassOf<>`/`TArray<>`/`TMap<>`, `super()`,
+  `Type::StaticClass()`, `nullptr`, bare `U*`/`A*` references (no `@`). Stock AngelScript rejects
+  most of these → the vendored compiler must be the fork (or vanilla + these patches).
+- **FFI pattern already exists in-repo.** `crates/gore-oodle` links a large C++ codebase (`ooz`)
+  via the `cc` crate + a hand-written `extern "C"` shim, no bindgen/cxx. Mirror it exactly.
+- **The checker never executes scripts** — only `Build()`. Native methods can be registered with
+  `asCALL_GENERIC` / dummy function pointers, avoiding the MASM calling-convention layer entirely.
+
+## 3. Architecture
+
+```
+gore as check <dir-of-.as> [--binds Binds.Cache] [--ue4ss <dump>] [--format capture|native]
+  │
+  1. RegistrationSurface  (Rust)
+  │     ├─ binds.rs  (EXTENDED: expose full decl strings + namespace, not just arity)
+  │     │     → object types (ref/value), methods, properties, global fns, namespaces, templates
+  │     ├─ supplements (UE4SS dump): native enum values, native base-class edges, gameplay tags
+  │     └─ ue-as prelude: template types (TArray/TSubclassOf/TMap…), native value-type operators
+  │
+  2. C++ AngelScript engine  (vendored fork, built via cc + extern "C" shim)
+  │     create engine (same engine properties as the game: floatIsFloat64, automaticImports…)
+  │     → register the surface (asCALL_GENERIC / declaration-only)
+  │     → module->AddScriptSection(relpath, source) for every .as
+  │     → module->Build()
+  │     → SetMessageCallback collects asSMessageInfo into a vector
+  │
+  3. Diagnostics  (Rust)
+        drain messages → group by section → emit "=== file.as ===\n<error>…"
+        (byte-compatible with work/reversing/gore-as/ashook/as_errors_capture.txt)
+```
+
+### Components
+
+- **`crates/gore-as/vendor/angelscript/`** — vendored fork AS core (front-end + engine tables;
+  no VM/JIT/callfunc-asm needed for a checker). Acquisition: §4.
+- **`crates/gore-as/csrc/as_shim.cpp`** — `extern "C"` shim over the engine. ~15 functions
+  (create/destroy, register_type/method/property/global/funcdef/enum_value, start_module,
+  add_section, build, message_count/section/row/col/type/text). Mirrors `gore-oodle`'s
+  `ooz_shim.cpp`.
+- **`crates/gore-as/build.rs`** — `cc::Build` compiling the vendor `.cpp` + the shim (C++17,
+  MSVC, warning suppressions like gore-oodle). New `[build-dependencies] cc`.
+- **`crates/gore-as/src/check/engine.rs`** — safe Rust wrapper: `unsafe extern "C"` block + an
+  `Engine` newtype with `Drop`, paralleling `gore-oodle/src/lib.rs`.
+- **`crates/gore-as/src/check/registration.rs`** — builds the `RegistrationSurface` from
+  `NativeApi` + supplements + prelude and drives the shim's register_* calls.
+- **`crates/gore-as/src/check/supplements.rs`** — parses the UE4SS dump for native enum
+  values + base-class edges; loads the gameplay-tag list.
+- **`crates/gore-as/src/cache/binds.rs`** (extend) — retain & expose the full method/property
+  **decl strings** and the function **namespace** (currently parsed then discarded after arity).
+- **`crates/gore/src/cmd/as_cache.rs`** — new `AsCmd::Check` variant + `run` arm, reusing the
+  existing `load_native_api()` helper.
+
+## 4. Compiler source acquisition (try in order)
+
+User decision: "whatever works best, try multiple if needed." Strategy:
+
+1. **Primary — vendor from the public mirror** `WillGordon9999/UNREANGEL`: clone, extract the AS
+   core (`Public/source/angelscript/` + `angelscript.h` + `as_config.h`), drop into
+   `crates/gore-as/vendor/angelscript/`. It is AS 23300, matching the build.
+2. **If the mirror diverges** from the shipped fork (it lacks the `0x9e377abe` container magic;
+   the ABI is Hazelight-modified) such that the checker mis-reports vs. the oracle (§7): port
+   the needed fork patches onto **vanilla AngelScript 2.33** (local samples already exist under
+   `work/reversing/gore-as/_src/`) — the fork patches we need are the *parser/semantic*
+   extensions (UFUNCTION/UPROPERTY tokens, `n"..."` literal, `Cast<>`, template handling, bare
+   object refs, `nullptr`). We do NOT need the fork's UE-binding or precompiled-data writer.
+3. **Last resort — exact Hazelight fork** (Epic-org-gated): request access/checkout from the
+   user only if 1 and 2 cannot be tuned to match the oracle.
+
+The **validation oracle (§7) decides** which source is "good enough" — we do not guess.
+
+## 5. Registration pipeline details
+
+- **Order:** register all object *types* (names, ref/value flag) first, then methods /
+  properties / behaviours / global functions, then compile. Order within each phase is free;
+  forward references resolve at `Build()`.
+- **Ref vs value:** `F*` → value type (`asOBJ_VALUE | asOBJ_POD`, dummy size); `U*`/`A*` →
+  reference type (`asOBJ_REF | asOBJ_NOCOUNT`) so they are used as handles.
+- **Dummy offsets / IDs:** `RegisterObjectProperty(obj, "int A", 0)` — the checker consults only
+  the decl for name+type; offset/type-ID never compared to the shipped cache. Safe.
+- **No execution:** register methods/globals with `asCALL_GENERIC` and a single shared no-op
+  generic stub (or null where the fork permits declaration-only). Avoids the MASM thunks.
+- **Namespaces:** `SetDefaultNamespace(ns)` around global-function / mixin registration; `ns`
+  comes from the Binds.Cache function-field slot (the extended parser exposes it).
+- **Templates:** pre-register `TArray<T>`, `TSubclassOf<T>`, `TMap<K,V>`, `TPair<…>` as
+  `asOBJ_TEMPLATE` in the prelude; subtype resolved from the decl string.
+- **Operators:** a small hand-written UE-AS prelude registers the standard native value-type
+  operators (`FVector` arithmetic, `==`, indexers) the dump doesn't carry.
+- **Supplements:** enums via `RegisterEnum`+`RegisterEnumValue`; native base edges so inherited
+  members resolve; the `GameplayTag` namespace populated with the project tag list.
+
+## 6. Diagnostics output
+
+Default `--format capture`: reproduce the game-loop capture exactly —
+```
+=== <ScriptRelativeFilename>.as ===
+<message line>
+<message line>
+```
+grouped by section (the `.as` relative path used as the AddScriptSection name). This is a
+drop-in for `work/reversing/gore-as/ashook/as_errors_capture.txt`, so the existing
+`gen_stublist.py` consumes it unchanged. (If `gen_stublist.py` needs the `Compiling <ret>
+Name(...)` context lines, the checker synthesizes them per function, or we adapt the script —
+decided during implementation.) `--format native` emits raw `section (row, col) : Error : text`.
+
+## 7. Validation strategy — the oracle
+
+We already have **ground truth**: the real game-compile diagnostics for the full 7264-module
+emitted tree (the captured `as_errors_capture.txt` from the game loop, and the converged
+stublist). The checker is correct when, run on the **same emitted tree**, it reports the **same
+set of failing functions/files** the game does (~630 failures in the current decompiler output).
+
+Procedure:
+1. Emit the full tree (`gore as emit-all`, no stublist).
+2. Run `gore as check` on it; diff its diagnostics against the game capture.
+3. Triage divergences: **false errors** (checker rejects what the game accepts) = a registration
+   gap (missing enum/base-edge/operator/namespace) → fix the surface. **Missing errors** (checker
+   accepts what the game rejects) = the checker is too lax (e.g. wrong engine property) → fix.
+4. Iterate until the diff is empty (or within a documented, understood residual).
+
+This makes correctness **measurable**, not a matter of judgement, and it is how we decide whether
+the mirror source (§4.1) is faithful or we must fall back (§4.2).
+
+## 8. Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Mirror source diverges from shipped fork → mis-reports | The oracle (§7) catches it; fall back to vanilla + patches (§4.2). |
+| Registration surface incomplete → false "unknown symbol" errors | Oracle-driven gap-fixing; supplements from UE4SS dump; operator/template prelude. |
+| `GameplayTag::Tag` / `Type::StaticClass()` resolution (needs the reflected DB) | StaticClass() auto-resolves once the type is registered; GameplayTag namespace populated from the project tag list (UE4SS / `DefaultGameplayTags.ini`). |
+| Fork requires non-null fn pointer at registration even if never called | Register with `asCALL_GENERIC` + one shared no-op generic function. Confirm against the fork early. |
+| C++ build under cargo/MSVC | Proven by gore-oodle (same toolchain, `cc`, C++17, `/wd…`). |
+| Engine-property mismatch (e.g. `floatIsFloat64`) changes diagnostics | Replicate the game's `asCreateScriptEngine` init flags exactly (known: floatIsFloat64=true, automaticImports=1). |
+
+## 9. Milestones
+
+1. **Vendor + build** the fork AS core standalone (cc + minimal shim that just creates an engine
+   and compiles a trivial `.as`) — proves the toolchain.
+2. **binds.rs extension** — expose full decls + namespaces; unit-tested against real Binds.Cache.
+3. **Registration surface** from Binds.Cache + UE-AS prelude; register, compile one small module.
+4. **Supplements** — UE4SS enum/base-edge/gameplay-tag loader.
+5. **`gore as check`** command + capture-format output.
+6. **Oracle tuning** — run on the full tree, drive the diff to empty.
+
+## 10. Future (out of scope here)
+
+A cache GENERATOR reuses this phase wholesale: same engine + registration, then
+`asIScriptModule::SaveByteCode` produces a real mini-cache module, handed to the **already-working**
+`crates/gore-as/src/cache/splice.rs` (`replace_module`/`splice_case_a`) to write into the 122 MB
+container. The hard remaining piece there is exact type-ID matching, deferred.
+
+## 11. Testing
+
+- Unit: binds.rs decl/namespace extraction (against real Binds.Cache, gated on file presence).
+- Unit: supplement parsing (enum values, base edges) against the UE4SS dump.
+- Integration: `gore as check` on a tiny hand-written `.as` set (known good + known bad) →
+  expected diagnostics.
+- System: the §7 oracle diff on the full emitted tree (the acceptance gate).


### PR DESCRIPTION
## What

`gore-as`: decode, disassemble, and decompile the Gothic 1 Remake precompiled AngelScript cache (`PrecompiledScript_Shipping.Cache`, Hazelight UE-AS fork) back to recompilable `.as`, plus a splice-based modding path.

## Capabilities
- **Decode/disasm/decompile** — full stack-machine decompiler (`gore as decompile/disasm/emit/emit-all`).
- **Splice modding** — `gore as splice` (add dep-free module) / `replace` (swap existing) into the vanilla cache; runs in normal mode, fully playable (proven in-game).
- **Edit existing dep-heavy modules** — `gore as extract-remap` (commit dadfec6): extract one module from a full-tree regen and remap all its table-key refs to vanilla keys, then `replace` into vanilla without global-table corruption. Invariant fails loud on any surviving regen key.

## Validated in-game
- Value/logic edits + adding a new NPC spawn at game start (edit level script → generate → extract-remap → replace into vanilla → playable).

## Notes
- Full-tree regen is fundamentally fragile (rebuilt global tables corrupt native subsystems); splice into the vanilla base is the correct modding architecture.
- New NPC identity/body = DataAsset/asset modding, out of scope for the script cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Ref remapping and bytecode patching are on the critical boot path—wrong operands or surviving regen keys can crash the game; the decompiler/emitter changes are broad and affect whether thousands of recovered functions compile after splice.
> 
> **Overview**
> This PR extends the **edit-existing-module** workflow: new **`remap`** rewrites a single extracted module’s bytecode and embedded type/func refs from regen tail-table keys to **vanilla keys by symbol identity**, then ships **empty global tail tables** so `replace_module` does not balloon the cache. **`extract_module`** / CLI **`extract-remap`** wire this up; a post-condition scan **fails hard** if any regen pointer key survives.
> 
> **Frame ABI** is centralized in **`model`** (`slot_width_dwords`, enum vs struct width, **`param_slot_map`**, RVO out-slot) and used in **`decompile`** / **`structure`** so params and the hidden **`__return`** slot name correctly instead of linear `-1,-2` guessing.
> 
> The **structured decompiler** (`structure.rs`) gains large behavior fixes: correct **`CopyScript`** src/dst, **`opCast`** / **`Cast<T>`**, **`$beh0`** in-place constructs, chained calls without wiping enclosing arg stacks, RVO struct returns, **`Super::`**, namespaced **`CALLSYS`**, **`StaticClass`** target class, member-driven and consumer-driven local typing, enum/int casts, and related edge cases. **`emit`** deduplicates overloads, skips UE-generated **Spawn/Get/StaticClass** shapes, infers locals/`argN` types, declares **`__return`**, and strips meaningless return **`const`**. **`emit-all`** renames colliding free functions per module file.
> 
> Also adds a **design doc** for a future standalone **`gore as check`** (vendored fork compiler); not implemented in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 399bd56c739a4a3cb4cfc6a81f864d70800de8e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->