### PR TITLE
feat(save-editor): armor support — display, add, equipped badge, upgrades

### DIFF
--- a/apps/save-editor/assets/item_catalog.json
+++ b/apps/save-editor/assets/item_catalog.json
@@ -1,5 +1,80 @@
 [
   {
+    "category": "armor",
+    "id": "Armor_BC_BAN_Arlin_852",
+    "path": "/Script/Angelscript.Armor_BC_BAN_Arlin_852"
+  },
+  {
+    "category": "armor",
+    "id": "Armor_BC_BAN_Arlin_852_02",
+    "path": "/Script/Angelscript.Armor_BC_BAN_Arlin_852_02"
+  },
+  {
+    "category": "armor",
+    "id": "Armor_OCR_GRD_Stone_219",
+    "path": "/Script/Angelscript.Armor_OCR_GRD_Stone_219"
+  },
+  {
+    "category": "armor",
+    "id": "Armor_OCR_GRD_Stone_219_03",
+    "path": "/Script/Angelscript.Armor_OCR_GRD_Stone_219_03"
+  },
+  {
+    "category": "armor",
+    "id": "Armor_OC_EBR_Gomez_100",
+    "path": "/Script/Angelscript.Armor_OC_EBR_Gomez_100"
+  },
+  {
+    "category": "armor",
+    "id": "Armor_SC_VLK_Melvin_582",
+    "path": "/Script/Angelscript.Armor_SC_VLK_Melvin_582"
+  },
+  {
+    "category": "armor",
+    "id": "Armor_SK_OC_WOC_Velaya_108_02",
+    "path": "/Script/Angelscript.Armor_SK_OC_WOC_Velaya_108_02"
+  },
+  {
+    "category": "armor",
+    "id": "Crw_Armor_H",
+    "path": "/Script/Angelscript.Crw_Armor_H"
+  },
+  {
+    "category": "armor",
+    "id": "Dmb_Armor_M",
+    "path": "/Script/Angelscript.Dmb_Armor_M"
+  },
+  {
+    "category": "armor",
+    "id": "Ebr_Armor_H_01",
+    "path": "/Script/Angelscript.Ebr_Armor_H_01"
+  },
+  {
+    "category": "armor",
+    "id": "Ebr_Armor_H_02",
+    "path": "/Script/Angelscript.Ebr_Armor_H_02"
+  },
+  {
+    "category": "armor",
+    "id": "Ebr_Armor_M",
+    "path": "/Script/Angelscript.Ebr_Armor_M"
+  },
+  {
+    "category": "armor",
+    "id": "Grd_Armor",
+    "path": "/Script/Angelscript.Grd_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "Gur_Armor_H",
+    "path": "/Script/Angelscript.Gur_Armor_H"
+  },
+  {
+    "category": "armor",
+    "id": "Gur_Armor_M",
+    "path": "/Script/Angelscript.Gur_Armor_M"
+  },
+  {
     "category": "ammunition",
     "id": "ItAm_Arrow",
     "path": "/Script/Angelscript.ItAm_Arrow"
@@ -3988,5 +4063,95 @@
     "category": "writing",
     "id": "ItWr_Scroll_TransformSwampshark",
     "path": "/Script/Angelscript.ItWr_Scroll_TransformSwampshark"
+  },
+  {
+    "category": "armor",
+    "id": "Kdf_Armor_H",
+    "path": "/Script/Angelscript.Kdf_Armor_H"
+  },
+  {
+    "category": "armor",
+    "id": "Kdf_Armor_L",
+    "path": "/Script/Angelscript.Kdf_Armor_L"
+  },
+  {
+    "category": "armor",
+    "id": "Kdw_Armor_H",
+    "path": "/Script/Angelscript.Kdw_Armor_H"
+  },
+  {
+    "category": "armor",
+    "id": "Kdw_Armor_L",
+    "path": "/Script/Angelscript.Kdw_Armor_L"
+  },
+  {
+    "category": "armor",
+    "id": "Law_Armor",
+    "path": "/Script/Angelscript.Law_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "NH_Armor",
+    "path": "/Script/Angelscript.NH_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "Nov_Armor",
+    "path": "/Script/Angelscript.Nov_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "Ore_Armor_H",
+    "path": "/Script/Angelscript.Ore_Armor_H"
+  },
+  {
+    "category": "armor",
+    "id": "Ore_Armor_M",
+    "path": "/Script/Angelscript.Ore_Armor_M"
+  },
+  {
+    "category": "armor",
+    "id": "Org_Armor",
+    "path": "/Script/Angelscript.Org_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "QA_Armor",
+    "path": "/Script/Angelscript.QA_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "Ryl_Armor",
+    "path": "/Script/Angelscript.Ryl_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "Sfb_Armor_L",
+    "path": "/Script/Angelscript.Sfb_Armor_L"
+  },
+  {
+    "category": "armor",
+    "id": "Sld_Armor",
+    "path": "/Script/Angelscript.Sld_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "Stt_Armor",
+    "path": "/Script/Angelscript.Stt_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "Tpl_Armor",
+    "path": "/Script/Angelscript.Tpl_Armor"
+  },
+  {
+    "category": "armor",
+    "id": "Vlk_Armor_L",
+    "path": "/Script/Angelscript.Vlk_Armor_L"
+  },
+  {
+    "category": "armor",
+    "id": "Vlk_Armor_M",
+    "path": "/Script/Angelscript.Vlk_Armor_M"
   }
 ]

--- a/apps/save-editor/lib/features/editor/domain/editor_models.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_models.dart
@@ -614,6 +614,7 @@ class PrivateInventorySummary {
     this.itemScope,
     this.items = const [],
     this.mainContainerPaths = const [],
+    this.equippedArmorPaths = const [],
     this.scriptPaths = const [],
     this.properties = const [],
     this.writable = const [],
@@ -638,6 +639,11 @@ class PrivateInventorySummary {
               ?.whereType<String>()
               .toList() ??
           const [],
+      equippedArmorPaths:
+          (json?['equippedArmorPaths'] as List?)
+              ?.whereType<String>()
+              .toList() ??
+          const [],
       scriptPaths:
           (json?['scriptPaths'] as List?)?.whereType<String>().toList() ??
           const [],
@@ -658,6 +664,11 @@ class PrivateInventorySummary {
   // Complete set of MainContainer item paths (uncapped), used to exclude
   // already-owned items from the add picker even when [items] is truncated.
   final List<String> mainContainerPaths;
+  // Worn-armor item paths (uncapped, from the typed tree). Excluded from the add
+  // picker so the user cannot add a duplicate of the currently-equipped armor —
+  // which would make the equipped badge/upgrades ambiguous. Reliable even when
+  // [items] is truncated and the worn row falls outside it.
+  final List<String> equippedArmorPaths;
   final List<String> scriptPaths;
   final List<String> properties;
   final List<String> writable;

--- a/apps/save-editor/lib/features/editor/domain/editor_models.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_models.dart
@@ -671,6 +671,12 @@ class PrivateInventorySummary {
       properties.isNotEmpty;
 }
 
+class ArmorUpgrade {
+  const ArmorUpgrade({required this.key, required this.value});
+  final String key;
+  final String value;
+}
+
 class PrivateInventoryItem {
   const PrivateInventoryItem({
     required this.id,
@@ -678,6 +684,7 @@ class PrivateInventoryItem {
     this.count,
     this.removable = false,
     this.equipped = false,
+    this.upgrades = const [],
   });
 
   factory PrivateInventoryItem.fromJson(Map<Object?, Object?> json) {
@@ -687,6 +694,14 @@ class PrivateInventoryItem {
       count: (json['count'] as num?)?.toInt(),
       removable: json['removable'] as bool? ?? false,
       equipped: json['equipped'] as bool? ?? false,
+      upgrades: (json['upgrades'] as List?)
+              ?.whereType<Map<Object?, Object?>>()
+              .map((u) => ArmorUpgrade(
+                    key: u['key'] as String? ?? '',
+                    value: u['value'] as String? ?? '',
+                  ))
+              .toList() ??
+          const [],
     );
   }
 
@@ -699,6 +714,10 @@ class PrivateInventoryItem {
 
   /// True for the worn armor (the item in the player's ArmorSlot container).
   final bool equipped;
+
+  /// Armor upgrade slots (part/tier pairs), populated only on the equipped
+  /// armor row; empty for all other items.
+  final List<ArmorUpgrade> upgrades;
 }
 
 class InventoryItemCountChange {

--- a/apps/save-editor/lib/features/editor/domain/editor_models.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_models.dart
@@ -677,6 +677,7 @@ class PrivateInventoryItem {
     required this.path,
     this.count,
     this.removable = false,
+    this.equipped = false,
   });
 
   factory PrivateInventoryItem.fromJson(Map<Object?, Object?> json) {
@@ -685,6 +686,7 @@ class PrivateInventoryItem {
       path: json['path'] as String? ?? '',
       count: (json['count'] as num?)?.toInt(),
       removable: json['removable'] as bool? ?? false,
+      equipped: json['equipped'] as bool? ?? false,
     );
   }
 
@@ -694,6 +696,9 @@ class PrivateInventoryItem {
   // True only for rows in the player's MainContainer, which the core's
   // removeItem op can delete. Rows from other containers are not removable.
   final bool removable;
+
+  /// True for the worn armor (the item in the player's ArmorSlot container).
+  final bool equipped;
 }
 
 class InventoryItemCountChange {

--- a/apps/save-editor/lib/features/editor/domain/item_categories.dart
+++ b/apps/save-editor/lib/features/editor/domain/item_categories.dart
@@ -140,8 +140,11 @@ bool _isArmorId(String id) {
   final parts = id.split('_');
   if (parts.length < 2) return false;
   final head = parts.first;
+  // The segment after the head must be exactly `Armor` (a tier suffix follows in
+  // a later segment) — not merely start with `Armor`, which would also match an
+  // `Armory` segment such as `NC_Armory_Door`. Mirrors the Rust classifiers.
   return head.length >= 2 &&
       head.length <= 4 &&
       RegExp(r'^[A-Za-z]+$').hasMatch(head) &&
-      parts[1].startsWith('Armor');
+      parts[1] == 'Armor';
 }

--- a/apps/save-editor/lib/features/editor/domain/item_categories.dart
+++ b/apps/save-editor/lib/features/editor/domain/item_categories.dart
@@ -9,6 +9,7 @@ import 'package:goresave/l10n/app_localizations.dart';
 enum ItemCategory {
   meleeWeapon('Melee weapons'),
   rangedWeapon('Ranged weapons'),
+  armor('Armor'),
   ammunition('Ammunition'),
   rune('Runes'),
   scroll('Spell scrolls'),
@@ -36,6 +37,8 @@ String localizedItemCategoryLabel(AppLocalizations l10n, ItemCategory category) 
       return l10n.itemCategoryMeleeWeapon;
     case ItemCategory.rangedWeapon:
       return l10n.itemCategoryRangedWeapon;
+    case ItemCategory.armor:
+      return l10n.itemCategoryArmor;
     case ItemCategory.ammunition:
       return l10n.itemCategoryAmmunition;
     case ItemCategory.rune:
@@ -64,6 +67,7 @@ String localizedItemCategoryLabel(AppLocalizations l10n, ItemCategory category) 
 }
 
 ItemCategory itemCategoryFromId(String id) {
+  if (_isArmorId(id)) return ItemCategory.armor;
   if (id.startsWith('ItMw_')) return ItemCategory.meleeWeapon;
   if (id.startsWith('ItRw_')) return ItemCategory.rangedWeapon;
   // ItAm_ is ammunition (ItAm_Arrow/ItAm_Bolt); amulets live under ItAt_.
@@ -126,4 +130,18 @@ List<InventoryItemGroup> groupInventoryItems(
           items: byCategory[category]!..sort((a, b) => a.id.compareTo(b.id)),
         ),
   ];
+}
+
+/// True for any armor class name (base, per-NPC, or tier piece). Mirrors the
+/// Rust `gore_catalog::is_armor_id` display-side classifier.
+bool _isArmorId(String id) {
+  if (!id.contains('Armor')) return false;
+  if (id.startsWith('Armor_')) return true;
+  final parts = id.split('_');
+  if (parts.length < 2) return false;
+  final head = parts.first;
+  return head.length >= 2 &&
+      head.length <= 4 &&
+      RegExp(r'^[A-Za-z]+$').hasMatch(head) &&
+      parts[1].startsWith('Armor');
 }

--- a/apps/save-editor/lib/features/editor/ui/editor_page.dart
+++ b/apps/save-editor/lib/features/editor/ui/editor_page.dart
@@ -1957,17 +1957,51 @@ class _PrivateInventorySummaryCardState
                                         leading: const Icon(
                                           Icons.category_outlined,
                                         ),
-                                        title: Text(
-                                          localizedGameName(
-                                                locCatalog,
-                                                lang,
-                                                item.id,
-                                              ) ??
-                                              (item.id.isEmpty
-                                                  ? item.path
-                                                  : item.id),
-                                          maxLines: 1,
-                                          overflow: TextOverflow.ellipsis,
+                                        title: Row(
+                                          children: [
+                                            Flexible(
+                                              child: Text(
+                                                localizedGameName(
+                                                      locCatalog,
+                                                      lang,
+                                                      item.id,
+                                                    ) ??
+                                                    (item.id.isEmpty
+                                                        ? item.path
+                                                        : item.id),
+                                                maxLines: 1,
+                                                overflow: TextOverflow.ellipsis,
+                                              ),
+                                            ),
+                                            if (item.equipped) ...[
+                                              const SizedBox(width: 8),
+                                              Container(
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                      horizontal: 6,
+                                                      vertical: 2,
+                                                    ),
+                                                decoration: BoxDecoration(
+                                                  color: theme
+                                                      .colorScheme
+                                                      .primaryContainer,
+                                                  borderRadius:
+                                                      BorderRadius.circular(4),
+                                                ),
+                                                child: Text(
+                                                  l10n.equippedBadge,
+                                                  style: theme
+                                                      .textTheme
+                                                      .labelSmall
+                                                      ?.copyWith(
+                                                        color: theme
+                                                            .colorScheme
+                                                            .onPrimaryContainer,
+                                                      ),
+                                                ),
+                                              ),
+                                            ],
+                                          ],
                                         ),
                                         subtitle: item.path.isEmpty
                                             ? null

--- a/apps/save-editor/lib/features/editor/ui/editor_page.dart
+++ b/apps/save-editor/lib/features/editor/ui/editor_page.dart
@@ -1716,7 +1716,15 @@ class _PrivateInventorySummaryCardState
     final result = await showDialog<InventoryItemAdd>(
       context: context,
       builder: (_) => AddInventoryItemDialog(
-        excludePaths: widget.inventory.mainContainerPaths.toSet(),
+        // Exclude both MainContainer paths (addItem rejects duplicates there)
+        // and the currently-equipped armor: adding a second copy of the worn
+        // armor would duplicate its definition path and make the equipped
+        // badge/upgrades ambiguous, so it must not be offered.
+        excludePaths: {
+          ...widget.inventory.mainContainerPaths,
+          for (final item in widget.inventory.items)
+            if (item.equipped) item.path,
+        },
       ),
     );
     if (result == null) return;

--- a/apps/save-editor/lib/features/editor/ui/editor_page.dart
+++ b/apps/save-editor/lib/features/editor/ui/editor_page.dart
@@ -2049,15 +2049,31 @@ class _PrivateInventorySummaryCardState
                                                           ),
                                                           for (final u
                                                               in item.upgrades)
-                                                            Chip(
-                                                              visualDensity:
-                                                                  VisualDensity
-                                                                      .compact,
-                                                              materialTapTargetSize:
-                                                                  MaterialTapTargetSize
-                                                                      .shrinkWrap,
-                                                              label: Text(
+                                                            Container(
+                                                              padding:
+                                                                  const EdgeInsets.symmetric(
+                                                                    horizontal: 6,
+                                                                    vertical: 1,
+                                                                  ),
+                                                              decoration: BoxDecoration(
+                                                                color: theme
+                                                                    .colorScheme
+                                                                    .surfaceContainerHighest,
+                                                                borderRadius:
+                                                                    BorderRadius.circular(
+                                                                      4,
+                                                                    ),
+                                                              ),
+                                                              child: Text(
                                                                 '${_upgradePart(u.key)}: ${_upgradeTier(u.value)}',
+                                                                style: theme
+                                                                    .textTheme
+                                                                    .labelSmall
+                                                                    ?.copyWith(
+                                                                      color: theme
+                                                                          .colorScheme
+                                                                          .onSurfaceVariant,
+                                                                    ),
                                                               ),
                                                             ),
                                                         ],

--- a/apps/save-editor/lib/features/editor/ui/editor_page.dart
+++ b/apps/save-editor/lib/features/editor/ui/editor_page.dart
@@ -1719,11 +1719,12 @@ class _PrivateInventorySummaryCardState
         // Exclude both MainContainer paths (addItem rejects duplicates there)
         // and the currently-equipped armor: adding a second copy of the worn
         // armor would duplicate its definition path and make the equipped
-        // badge/upgrades ambiguous, so it must not be offered.
+        // badge/upgrades ambiguous, so it must not be offered. Both lists are
+        // uncapped (from the typed tree), so the exclusion is correct even when
+        // the displayed row list is truncated.
         excludePaths: {
           ...widget.inventory.mainContainerPaths,
-          for (final item in widget.inventory.items)
-            if (item.equipped) item.path,
+          ...widget.inventory.equippedArmorPaths,
         },
       ),
     );

--- a/apps/save-editor/lib/features/editor/ui/editor_page.dart
+++ b/apps/save-editor/lib/features/editor/ui/editor_page.dart
@@ -2003,12 +2003,58 @@ class _PrivateInventorySummaryCardState
                                             ],
                                           ],
                                         ),
-                                        subtitle: item.path.isEmpty
+                                        subtitle:
+                                            item.path.isEmpty &&
+                                                item.upgrades.isEmpty
                                             ? null
-                                            : Text(
-                                                item.path,
-                                                maxLines: 1,
-                                                overflow: TextOverflow.ellipsis,
+                                            : Column(
+                                                crossAxisAlignment:
+                                                    CrossAxisAlignment.start,
+                                                mainAxisSize: MainAxisSize.min,
+                                                children: [
+                                                  if (item.path.isNotEmpty)
+                                                    Text(
+                                                      item.path,
+                                                      maxLines: 1,
+                                                      overflow:
+                                                          TextOverflow.ellipsis,
+                                                    ),
+                                                  if (item.upgrades.isNotEmpty)
+                                                    Padding(
+                                                      padding:
+                                                          const EdgeInsets.only(
+                                                            top: 4,
+                                                          ),
+                                                      child: Wrap(
+                                                        spacing: 4,
+                                                        runSpacing: 2,
+                                                        crossAxisAlignment:
+                                                            WrapCrossAlignment
+                                                                .center,
+                                                        children: [
+                                                          Text(
+                                                            l10n.armorUpgradesLabel,
+                                                            style: theme
+                                                                .textTheme
+                                                                .labelSmall,
+                                                          ),
+                                                          for (final u
+                                                              in item.upgrades)
+                                                            Chip(
+                                                              visualDensity:
+                                                                  VisualDensity
+                                                                      .compact,
+                                                              materialTapTargetSize:
+                                                                  MaterialTapTargetSize
+                                                                      .shrinkWrap,
+                                                              label: Text(
+                                                                '${_upgradePart(u.key)}: ${_upgradeTier(u.value)}',
+                                                              ),
+                                                            ),
+                                                        ],
+                                                      ),
+                                                    ),
+                                                ],
                                               ),
                                         trailing: _inventoryItemTrailing(
                                           theme,
@@ -2111,6 +2157,24 @@ enum _PendingTone { add, remove }
 /// A human-readable id fragment derived from an item asset path.
 String _itemDisplayFromPath(String path) =>
     path.contains('.') ? path.split('.').last : path.split('/').last;
+
+String _upgradePart(String key) {
+  if (key.contains('Upper')) return 'Upper';
+  if (key.contains('Mid')) return 'Mid';
+  if (key.contains('Lower')) return 'Lower';
+  return key;
+}
+
+String _upgradeTier(String value) {
+  var v = value;
+  for (final p in const ['m_UpperBody_', 'm_MidBody_', 'm_LowerBody_']) {
+    if (v.startsWith(p)) {
+      v = v.substring(p.length);
+      break;
+    }
+  }
+  return v.replaceAll('_ArmorUpgrade', '');
+}
 
 /// A highlighted card shown when there is a pending structural inventory edit
 /// (add or remove) awaiting save. Mirrors how a not-yet-saved item is

--- a/apps/save-editor/lib/features/editor/ui/sidebar_tile.dart
+++ b/apps/save-editor/lib/features/editor/ui/sidebar_tile.dart
@@ -65,6 +65,8 @@ IconData iconForItemCategory(ItemCategory category) {
       return Icons.gavel;
     case ItemCategory.rangedWeapon:
       return Icons.gps_fixed;
+    case ItemCategory.armor:
+      return Icons.shield_outlined;
     case ItemCategory.ammunition:
       return Icons.arrow_outward;
     case ItemCategory.rune:

--- a/apps/save-editor/lib/l10n/app_de.arb
+++ b/apps/save-editor/lib/l10n/app_de.arb
@@ -21,6 +21,7 @@
   "confirm": "Bestätigen",
   "close": "Schließen",
   "add": "Hinzufügen",
+  "equippedBadge": "Angelegt",
   "browse": "Durchsuchen",
   "noSavFilesFound": "Keine .sav-Dateien gefunden",
   "profile": "Profil",

--- a/apps/save-editor/lib/l10n/app_de.arb
+++ b/apps/save-editor/lib/l10n/app_de.arb
@@ -22,6 +22,7 @@
   "close": "Schließen",
   "add": "Hinzufügen",
   "equippedBadge": "Angelegt",
+  "armorUpgradesLabel": "Verbesserungen",
   "browse": "Durchsuchen",
   "noSavFilesFound": "Keine .sav-Dateien gefunden",
   "profile": "Profil",

--- a/apps/save-editor/lib/l10n/app_de.arb
+++ b/apps/save-editor/lib/l10n/app_de.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "Nahkampfwaffen",
   "itemCategoryRangedWeapon": "Fernkampfwaffen",
   "itemCategoryAmmunition": "Munition",
+  "itemCategoryArmor": "Rüstungen",
   "itemCategoryRune": "Runen",
   "itemCategoryScroll": "Zauberschriftrollen",
   "itemCategoryFood": "Essen & Tränke",

--- a/apps/save-editor/lib/l10n/app_en.arb
+++ b/apps/save-editor/lib/l10n/app_en.arb
@@ -177,6 +177,7 @@
   "itemCategoryMeleeWeapon": "Melee weapons",
   "itemCategoryRangedWeapon": "Ranged weapons",
   "itemCategoryAmmunition": "Ammunition",
+  "itemCategoryArmor": "Armor",
   "itemCategoryRune": "Runes",
   "itemCategoryScroll": "Spell scrolls",
   "itemCategoryFood": "Food & potions",

--- a/apps/save-editor/lib/l10n/app_en.arb
+++ b/apps/save-editor/lib/l10n/app_en.arb
@@ -28,6 +28,7 @@
   "confirm": "Confirm",
   "close": "Close",
   "add": "Add",
+  "equippedBadge": "Equipped",
   "browse": "Browse",
   "noSavFilesFound": "No .sav files found",
   "profile": "Profile",

--- a/apps/save-editor/lib/l10n/app_en.arb
+++ b/apps/save-editor/lib/l10n/app_en.arb
@@ -29,6 +29,7 @@
   "close": "Close",
   "add": "Add",
   "equippedBadge": "Equipped",
+  "armorUpgradesLabel": "Upgrades",
   "browse": "Browse",
   "noSavFilesFound": "No .sav files found",
   "profile": "Profile",

--- a/apps/save-editor/lib/l10n/app_es.arb
+++ b/apps/save-editor/lib/l10n/app_es.arb
@@ -22,6 +22,7 @@
   "close": "Cerrar",
   "add": "Añadir",
   "equippedBadge": "Equipado",
+  "armorUpgradesLabel": "Mejoras",
   "browse": "Examinar",
   "noSavFilesFound": "No se encontraron archivos .sav",
   "profile": "Perfil",

--- a/apps/save-editor/lib/l10n/app_es.arb
+++ b/apps/save-editor/lib/l10n/app_es.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "Armas cuerpo a cuerpo",
   "itemCategoryRangedWeapon": "Armas a distancia",
   "itemCategoryAmmunition": "Munición",
+  "itemCategoryArmor": "Armaduras",
   "itemCategoryRune": "Runas",
   "itemCategoryScroll": "Pergaminos de hechizo",
   "itemCategoryFood": "Comida y pociones",

--- a/apps/save-editor/lib/l10n/app_es.arb
+++ b/apps/save-editor/lib/l10n/app_es.arb
@@ -21,6 +21,7 @@
   "confirm": "Confirmar",
   "close": "Cerrar",
   "add": "Añadir",
+  "equippedBadge": "Equipado",
   "browse": "Examinar",
   "noSavFilesFound": "No se encontraron archivos .sav",
   "profile": "Perfil",

--- a/apps/save-editor/lib/l10n/app_fr.arb
+++ b/apps/save-editor/lib/l10n/app_fr.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "Armes de mêlée",
   "itemCategoryRangedWeapon": "Armes à distance",
   "itemCategoryAmmunition": "Munitions",
+  "itemCategoryArmor": "Armures",
   "itemCategoryRune": "Runes",
   "itemCategoryScroll": "Parchemins de sort",
   "itemCategoryFood": "Nourriture et potions",

--- a/apps/save-editor/lib/l10n/app_fr.arb
+++ b/apps/save-editor/lib/l10n/app_fr.arb
@@ -22,6 +22,7 @@
   "close": "Fermer",
   "add": "Ajouter",
   "equippedBadge": "Équipé",
+  "armorUpgradesLabel": "Améliorations",
   "browse": "Parcourir",
   "noSavFilesFound": "Aucun fichier .sav trouvé",
   "profile": "Profil",

--- a/apps/save-editor/lib/l10n/app_fr.arb
+++ b/apps/save-editor/lib/l10n/app_fr.arb
@@ -21,6 +21,7 @@
   "confirm": "Confirmer",
   "close": "Fermer",
   "add": "Ajouter",
+  "equippedBadge": "Équipé",
   "browse": "Parcourir",
   "noSavFilesFound": "Aucun fichier .sav trouvé",
   "profile": "Profil",

--- a/apps/save-editor/lib/l10n/app_it.arb
+++ b/apps/save-editor/lib/l10n/app_it.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "Armi da mischia",
   "itemCategoryRangedWeapon": "Armi a distanza",
   "itemCategoryAmmunition": "Munizioni",
+  "itemCategoryArmor": "Armature",
   "itemCategoryRune": "Rune",
   "itemCategoryScroll": "Pergamene magiche",
   "itemCategoryFood": "Cibo e pozioni",

--- a/apps/save-editor/lib/l10n/app_it.arb
+++ b/apps/save-editor/lib/l10n/app_it.arb
@@ -21,6 +21,7 @@
   "confirm": "Conferma",
   "close": "Chiudi",
   "add": "Aggiungi",
+  "equippedBadge": "Equipaggiato",
   "browse": "Sfoglia",
   "noSavFilesFound": "Nessun file .sav trovato",
   "profile": "Profilo",

--- a/apps/save-editor/lib/l10n/app_it.arb
+++ b/apps/save-editor/lib/l10n/app_it.arb
@@ -22,6 +22,7 @@
   "close": "Chiudi",
   "add": "Aggiungi",
   "equippedBadge": "Equipaggiato",
+  "armorUpgradesLabel": "Potenziamenti",
   "browse": "Sfoglia",
   "noSavFilesFound": "Nessun file .sav trovato",
   "profile": "Profilo",

--- a/apps/save-editor/lib/l10n/app_ja.arb
+++ b/apps/save-editor/lib/l10n/app_ja.arb
@@ -22,6 +22,7 @@
   "close": "閉じる",
   "add": "追加",
   "equippedBadge": "装備中",
+  "armorUpgradesLabel": "強化",
   "browse": "参照",
   "noSavFilesFound": ".sav ファイルが見つかりません",
   "profile": "プロファイル",

--- a/apps/save-editor/lib/l10n/app_ja.arb
+++ b/apps/save-editor/lib/l10n/app_ja.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "近接武器",
   "itemCategoryRangedWeapon": "遠隔武器",
   "itemCategoryAmmunition": "弾薬",
+  "itemCategoryArmor": "鎧",
   "itemCategoryRune": "ルーン",
   "itemCategoryScroll": "呪文の巻物",
   "itemCategoryFood": "食料・ポーション",

--- a/apps/save-editor/lib/l10n/app_ja.arb
+++ b/apps/save-editor/lib/l10n/app_ja.arb
@@ -21,6 +21,7 @@
   "confirm": "確定",
   "close": "閉じる",
   "add": "追加",
+  "equippedBadge": "装備中",
   "browse": "参照",
   "noSavFilesFound": ".sav ファイルが見つかりません",
   "profile": "プロファイル",

--- a/apps/save-editor/lib/l10n/app_localizations.dart
+++ b/apps/save-editor/lib/l10n/app_localizations.dart
@@ -248,6 +248,12 @@ abstract class AppLocalizations {
   /// **'Equipped'**
   String get equippedBadge;
 
+  /// No description provided for @armorUpgradesLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Upgrades'**
+  String get armorUpgradesLabel;
+
   /// No description provided for @browse.
   ///
   /// In en, this message translates to:

--- a/apps/save-editor/lib/l10n/app_localizations.dart
+++ b/apps/save-editor/lib/l10n/app_localizations.dart
@@ -242,6 +242,12 @@ abstract class AppLocalizations {
   /// **'Add'**
   String get add;
 
+  /// No description provided for @equippedBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'Equipped'**
+  String get equippedBadge;
+
   /// No description provided for @browse.
   ///
   /// In en, this message translates to:

--- a/apps/save-editor/lib/l10n/app_localizations.dart
+++ b/apps/save-editor/lib/l10n/app_localizations.dart
@@ -680,6 +680,12 @@ abstract class AppLocalizations {
   /// **'Ammunition'**
   String get itemCategoryAmmunition;
 
+  /// No description provided for @itemCategoryArmor.
+  ///
+  /// In en, this message translates to:
+  /// **'Armor'**
+  String get itemCategoryArmor;
+
   /// No description provided for @itemCategoryRune.
   ///
   /// In en, this message translates to:

--- a/apps/save-editor/lib/l10n/app_localizations_de.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_de.dart
@@ -74,6 +74,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get add => 'Hinzufügen';
 
   @override
+  String get equippedBadge => 'Angelegt';
+
+  @override
   String get browse => 'Durchsuchen';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_de.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_de.dart
@@ -328,6 +328,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get itemCategoryAmmunition => 'Munition';
 
   @override
+  String get itemCategoryArmor => 'Rüstungen';
+
+  @override
   String get itemCategoryRune => 'Runen';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_de.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_de.dart
@@ -77,6 +77,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get equippedBadge => 'Angelegt';
 
   @override
+  String get armorUpgradesLabel => 'Verbesserungen';
+
+  @override
   String get browse => 'Durchsuchen';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_en.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_en.dart
@@ -326,6 +326,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get itemCategoryAmmunition => 'Ammunition';
 
   @override
+  String get itemCategoryArmor => 'Armor';
+
+  @override
   String get itemCategoryRune => 'Runes';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_en.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_en.dart
@@ -77,6 +77,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get equippedBadge => 'Equipped';
 
   @override
+  String get armorUpgradesLabel => 'Upgrades';
+
+  @override
   String get browse => 'Browse';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_en.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_en.dart
@@ -74,6 +74,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get add => 'Add';
 
   @override
+  String get equippedBadge => 'Equipped';
+
+  @override
   String get browse => 'Browse';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_es.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_es.dart
@@ -77,6 +77,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get equippedBadge => 'Equipado';
 
   @override
+  String get armorUpgradesLabel => 'Mejoras';
+
+  @override
   String get browse => 'Examinar';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_es.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_es.dart
@@ -74,6 +74,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get add => 'Añadir';
 
   @override
+  String get equippedBadge => 'Equipado';
+
+  @override
   String get browse => 'Examinar';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_es.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_es.dart
@@ -329,6 +329,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get itemCategoryAmmunition => 'Munición';
 
   @override
+  String get itemCategoryArmor => 'Armaduras';
+
+  @override
   String get itemCategoryRune => 'Runas';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_fr.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_fr.dart
@@ -77,6 +77,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get equippedBadge => 'Équipé';
 
   @override
+  String get armorUpgradesLabel => 'Améliorations';
+
+  @override
   String get browse => 'Parcourir';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_fr.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_fr.dart
@@ -331,6 +331,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get itemCategoryAmmunition => 'Munitions';
 
   @override
+  String get itemCategoryArmor => 'Armures';
+
+  @override
   String get itemCategoryRune => 'Runes';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_fr.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_fr.dart
@@ -74,6 +74,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get add => 'Ajouter';
 
   @override
+  String get equippedBadge => 'Équipé';
+
+  @override
   String get browse => 'Parcourir';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_it.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_it.dart
@@ -74,6 +74,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get add => 'Aggiungi';
 
   @override
+  String get equippedBadge => 'Equipaggiato';
+
+  @override
   String get browse => 'Sfoglia';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_it.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_it.dart
@@ -329,6 +329,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get itemCategoryAmmunition => 'Munizioni';
 
   @override
+  String get itemCategoryArmor => 'Armature';
+
+  @override
   String get itemCategoryRune => 'Rune';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_it.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_it.dart
@@ -77,6 +77,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get equippedBadge => 'Equipaggiato';
 
   @override
+  String get armorUpgradesLabel => 'Potenziamenti';
+
+  @override
   String get browse => 'Sfoglia';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_ja.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ja.dart
@@ -74,6 +74,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get add => '追加';
 
   @override
+  String get equippedBadge => '装備中';
+
+  @override
   String get browse => '参照';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_ja.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ja.dart
@@ -77,6 +77,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get equippedBadge => '装備中';
 
   @override
+  String get armorUpgradesLabel => '強化';
+
+  @override
   String get browse => '参照';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_ja.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ja.dart
@@ -324,6 +324,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get itemCategoryAmmunition => '弾薬';
 
   @override
+  String get itemCategoryArmor => '鎧';
+
+  @override
   String get itemCategoryRune => 'ルーン';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_pl.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pl.dart
@@ -327,6 +327,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get itemCategoryAmmunition => 'Amunicja';
 
   @override
+  String get itemCategoryArmor => 'Zbroje';
+
+  @override
   String get itemCategoryRune => 'Runy';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_pl.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pl.dart
@@ -77,6 +77,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get equippedBadge => 'Założone';
 
   @override
+  String get armorUpgradesLabel => 'Ulepszenia';
+
+  @override
   String get browse => 'Przeglądaj';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_pl.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pl.dart
@@ -74,6 +74,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get add => 'Dodaj';
 
   @override
+  String get equippedBadge => 'Założone';
+
+  @override
   String get browse => 'Przeglądaj';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_pt.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pt.dart
@@ -74,6 +74,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get add => 'Adicionar';
 
   @override
+  String get equippedBadge => 'Equipado';
+
+  @override
   String get browse => 'Procurar';
 
   @override
@@ -1052,6 +1055,9 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get add => 'Adicionar';
+
+  @override
+  String get equippedBadge => 'Equipado';
 
   @override
   String get browse => 'Procurar';

--- a/apps/save-editor/lib/l10n/app_localizations_pt.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pt.dart
@@ -327,6 +327,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get itemCategoryAmmunition => 'Munição';
 
   @override
+  String get itemCategoryArmor => 'Armaduras';
+
+  @override
   String get itemCategoryRune => 'Runas';
 
   @override
@@ -1302,6 +1305,9 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get itemCategoryAmmunition => 'Munição';
+
+  @override
+  String get itemCategoryArmor => 'Armaduras';
 
   @override
   String get itemCategoryRune => 'Runas';

--- a/apps/save-editor/lib/l10n/app_localizations_pt.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pt.dart
@@ -77,6 +77,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get equippedBadge => 'Equipado';
 
   @override
+  String get armorUpgradesLabel => 'Melhorias';
+
+  @override
   String get browse => 'Procurar';
 
   @override
@@ -1058,6 +1061,9 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get equippedBadge => 'Equipado';
+
+  @override
+  String get armorUpgradesLabel => 'Melhorias';
 
   @override
   String get browse => 'Procurar';

--- a/apps/save-editor/lib/l10n/app_localizations_ru.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ru.dart
@@ -327,6 +327,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get itemCategoryAmmunition => 'Боеприпасы';
 
   @override
+  String get itemCategoryArmor => 'Броня';
+
+  @override
   String get itemCategoryRune => 'Руны';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_ru.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ru.dart
@@ -77,6 +77,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get equippedBadge => 'Надето';
 
   @override
+  String get armorUpgradesLabel => 'Улучшения';
+
+  @override
   String get browse => 'Обзор';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_ru.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ru.dart
@@ -74,6 +74,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get add => 'Добавить';
 
   @override
+  String get equippedBadge => 'Надето';
+
+  @override
   String get browse => 'Обзор';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_zh.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_zh.dart
@@ -319,6 +319,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get itemCategoryAmmunition => '弹药';
 
   @override
+  String get itemCategoryArmor => '护甲';
+
+  @override
   String get itemCategoryRune => '符文';
 
   @override
@@ -1261,6 +1264,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get itemCategoryAmmunition => '弹药';
+
+  @override
+  String get itemCategoryArmor => '护甲';
 
   @override
   String get itemCategoryRune => '符文';

--- a/apps/save-editor/lib/l10n/app_localizations_zh.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_zh.dart
@@ -74,6 +74,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get add => '添加';
 
   @override
+  String get equippedBadge => '已装备';
+
+  @override
   String get browse => '浏览';
 
   @override
@@ -1019,6 +1022,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get add => '添加';
+
+  @override
+  String get equippedBadge => '已装备';
 
   @override
   String get browse => '浏览';

--- a/apps/save-editor/lib/l10n/app_localizations_zh.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_zh.dart
@@ -77,6 +77,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get equippedBadge => '已装备';
 
   @override
+  String get armorUpgradesLabel => '升级';
+
+  @override
   String get browse => '浏览';
 
   @override
@@ -1025,6 +1028,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get equippedBadge => '已装备';
+
+  @override
+  String get armorUpgradesLabel => '升级';
 
   @override
   String get browse => '浏览';

--- a/apps/save-editor/lib/l10n/app_pl.arb
+++ b/apps/save-editor/lib/l10n/app_pl.arb
@@ -21,6 +21,7 @@
   "confirm": "Potwierdź",
   "close": "Zamknij",
   "add": "Dodaj",
+  "equippedBadge": "Założone",
   "browse": "Przeglądaj",
   "noSavFilesFound": "Nie znaleziono plików .sav",
   "profile": "Profil",

--- a/apps/save-editor/lib/l10n/app_pl.arb
+++ b/apps/save-editor/lib/l10n/app_pl.arb
@@ -22,6 +22,7 @@
   "close": "Zamknij",
   "add": "Dodaj",
   "equippedBadge": "Założone",
+  "armorUpgradesLabel": "Ulepszenia",
   "browse": "Przeglądaj",
   "noSavFilesFound": "Nie znaleziono plików .sav",
   "profile": "Profil",

--- a/apps/save-editor/lib/l10n/app_pl.arb
+++ b/apps/save-editor/lib/l10n/app_pl.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "Broń biała",
   "itemCategoryRangedWeapon": "Broń dystansowa",
   "itemCategoryAmmunition": "Amunicja",
+  "itemCategoryArmor": "Zbroje",
   "itemCategoryRune": "Runy",
   "itemCategoryScroll": "Zwoje zaklęć",
   "itemCategoryFood": "Jedzenie i mikstury",

--- a/apps/save-editor/lib/l10n/app_pt.arb
+++ b/apps/save-editor/lib/l10n/app_pt.arb
@@ -21,6 +21,7 @@
   "confirm": "Confirmar",
   "close": "Fechar",
   "add": "Adicionar",
+  "equippedBadge": "Equipado",
   "browse": "Procurar",
   "noSavFilesFound": "Nenhum arquivo .sav encontrado",
   "profile": "Perfil",

--- a/apps/save-editor/lib/l10n/app_pt.arb
+++ b/apps/save-editor/lib/l10n/app_pt.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "Armas corpo a corpo",
   "itemCategoryRangedWeapon": "Armas à distância",
   "itemCategoryAmmunition": "Munição",
+  "itemCategoryArmor": "Armaduras",
   "itemCategoryRune": "Runas",
   "itemCategoryScroll": "Pergaminhos de magia",
   "itemCategoryFood": "Comida e poções",

--- a/apps/save-editor/lib/l10n/app_pt.arb
+++ b/apps/save-editor/lib/l10n/app_pt.arb
@@ -22,6 +22,7 @@
   "close": "Fechar",
   "add": "Adicionar",
   "equippedBadge": "Equipado",
+  "armorUpgradesLabel": "Melhorias",
   "browse": "Procurar",
   "noSavFilesFound": "Nenhum arquivo .sav encontrado",
   "profile": "Perfil",

--- a/apps/save-editor/lib/l10n/app_pt_BR.arb
+++ b/apps/save-editor/lib/l10n/app_pt_BR.arb
@@ -21,6 +21,7 @@
   "confirm": "Confirmar",
   "close": "Fechar",
   "add": "Adicionar",
+  "equippedBadge": "Equipado",
   "browse": "Procurar",
   "noSavFilesFound": "Nenhum arquivo .sav encontrado",
   "profile": "Perfil",

--- a/apps/save-editor/lib/l10n/app_pt_BR.arb
+++ b/apps/save-editor/lib/l10n/app_pt_BR.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "Armas corpo a corpo",
   "itemCategoryRangedWeapon": "Armas à distância",
   "itemCategoryAmmunition": "Munição",
+  "itemCategoryArmor": "Armaduras",
   "itemCategoryRune": "Runas",
   "itemCategoryScroll": "Pergaminhos de magia",
   "itemCategoryFood": "Comida e poções",

--- a/apps/save-editor/lib/l10n/app_pt_BR.arb
+++ b/apps/save-editor/lib/l10n/app_pt_BR.arb
@@ -22,6 +22,7 @@
   "close": "Fechar",
   "add": "Adicionar",
   "equippedBadge": "Equipado",
+  "armorUpgradesLabel": "Melhorias",
   "browse": "Procurar",
   "noSavFilesFound": "Nenhum arquivo .sav encontrado",
   "profile": "Perfil",

--- a/apps/save-editor/lib/l10n/app_ru.arb
+++ b/apps/save-editor/lib/l10n/app_ru.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "Оружие ближнего боя",
   "itemCategoryRangedWeapon": "Дальнобойное оружие",
   "itemCategoryAmmunition": "Боеприпасы",
+  "itemCategoryArmor": "Броня",
   "itemCategoryRune": "Руны",
   "itemCategoryScroll": "Свитки заклинаний",
   "itemCategoryFood": "Еда и зелья",

--- a/apps/save-editor/lib/l10n/app_ru.arb
+++ b/apps/save-editor/lib/l10n/app_ru.arb
@@ -22,6 +22,7 @@
   "close": "Закрыть",
   "add": "Добавить",
   "equippedBadge": "Надето",
+  "armorUpgradesLabel": "Улучшения",
   "browse": "Обзор",
   "noSavFilesFound": "Файлы .sav не найдены",
   "profile": "Профиль",

--- a/apps/save-editor/lib/l10n/app_ru.arb
+++ b/apps/save-editor/lib/l10n/app_ru.arb
@@ -21,6 +21,7 @@
   "confirm": "Подтвердить",
   "close": "Закрыть",
   "add": "Добавить",
+  "equippedBadge": "Надето",
   "browse": "Обзор",
   "noSavFilesFound": "Файлы .sav не найдены",
   "profile": "Профиль",

--- a/apps/save-editor/lib/l10n/app_zh.arb
+++ b/apps/save-editor/lib/l10n/app_zh.arb
@@ -22,6 +22,7 @@
   "close": "关闭",
   "add": "添加",
   "equippedBadge": "已装备",
+  "armorUpgradesLabel": "升级",
   "browse": "浏览",
   "noSavFilesFound": "未找到 .sav 文件",
   "profile": "存档配置",

--- a/apps/save-editor/lib/l10n/app_zh.arb
+++ b/apps/save-editor/lib/l10n/app_zh.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "近战武器",
   "itemCategoryRangedWeapon": "远程武器",
   "itemCategoryAmmunition": "弹药",
+  "itemCategoryArmor": "护甲",
   "itemCategoryRune": "符文",
   "itemCategoryScroll": "法术卷轴",
   "itemCategoryFood": "食物与药水",

--- a/apps/save-editor/lib/l10n/app_zh.arb
+++ b/apps/save-editor/lib/l10n/app_zh.arb
@@ -21,6 +21,7 @@
   "confirm": "确认",
   "close": "关闭",
   "add": "添加",
+  "equippedBadge": "已装备",
   "browse": "浏览",
   "noSavFilesFound": "未找到 .sav 文件",
   "profile": "存档配置",

--- a/apps/save-editor/lib/l10n/app_zh_Hans.arb
+++ b/apps/save-editor/lib/l10n/app_zh_Hans.arb
@@ -22,6 +22,7 @@
   "close": "关闭",
   "add": "添加",
   "equippedBadge": "已装备",
+  "armorUpgradesLabel": "升级",
   "browse": "浏览",
   "noSavFilesFound": "未找到 .sav 文件",
   "profile": "存档配置",

--- a/apps/save-editor/lib/l10n/app_zh_Hans.arb
+++ b/apps/save-editor/lib/l10n/app_zh_Hans.arb
@@ -94,6 +94,7 @@
   "itemCategoryMeleeWeapon": "近战武器",
   "itemCategoryRangedWeapon": "远程武器",
   "itemCategoryAmmunition": "弹药",
+  "itemCategoryArmor": "护甲",
   "itemCategoryRune": "符文",
   "itemCategoryScroll": "法术卷轴",
   "itemCategoryFood": "食物与药水",

--- a/apps/save-editor/lib/l10n/app_zh_Hans.arb
+++ b/apps/save-editor/lib/l10n/app_zh_Hans.arb
@@ -21,6 +21,7 @@
   "confirm": "确认",
   "close": "关闭",
   "add": "添加",
+  "equippedBadge": "已装备",
   "browse": "浏览",
   "noSavFilesFound": "未找到 .sav 文件",
   "profile": "存档配置",

--- a/apps/save-editor/test/features/editor/domain/editor_models_test.dart
+++ b/apps/save-editor/test/features/editor/domain/editor_models_test.dart
@@ -318,6 +318,23 @@ void main() {
     ]);
   });
 
+  test('PrivateInventoryItem parses equipped flag', () {
+    final equipped = PrivateInventoryItem.fromJson({
+      'id': 'Ore_Armor_H',
+      'path': '/Script/Angelscript.Ore_Armor_H',
+      'count': 1,
+      'equipped': true,
+    });
+    expect(equipped.equipped, isTrue);
+
+    final plain = PrivateInventoryItem.fromJson({
+      'id': 'ItMi_Orenugget',
+      'path': '/Script/Angelscript.ItMi_Orenugget',
+      'count': 5,
+    });
+    expect(plain.equipped, isFalse);
+  });
+
   test('SaveInspection reads structured progression overview', () {
     final inspection = SaveInspection.fromJson({
       'format': 'GSAV',

--- a/apps/save-editor/test/features/editor/domain/editor_models_test.dart
+++ b/apps/save-editor/test/features/editor/domain/editor_models_test.dart
@@ -335,6 +335,24 @@ void main() {
     expect(plain.equipped, isFalse);
   });
 
+  test('PrivateInventoryItem parses armor upgrades', () {
+    final item = PrivateInventoryItem.fromJson({
+      'id': 'Org_Armor',
+      'path': '/Script/Angelscript.Org_Armor',
+      'count': 1,
+      'equipped': true,
+      'upgrades': [
+        {'key': 'm_CurrentUpperBodyUpgrade', 'value': 'm_UpperBody_Heavy02_ArmorUpgrade'},
+      ],
+    });
+    expect(item.upgrades.length, 1);
+    expect(item.upgrades.first.key, 'm_CurrentUpperBodyUpgrade');
+    expect(item.upgrades.first.value, 'm_UpperBody_Heavy02_ArmorUpgrade');
+
+    final plain = PrivateInventoryItem.fromJson({'id': 'X', 'path': 'p'});
+    expect(plain.upgrades, isEmpty);
+  });
+
   test('SaveInspection reads structured progression overview', () {
     final inspection = SaveInspection.fromJson({
       'format': 'GSAV',

--- a/apps/save-editor/test/features/editor/domain/item_categories_test.dart
+++ b/apps/save-editor/test/features/editor/domain/item_categories_test.dart
@@ -31,6 +31,8 @@ void main() {
     // non-armor unaffected
     expect(itemCategoryFromId('ItMi_Orenugget'), ItemCategory.misc);
     expect(itemCategoryFromId('SomethingElse'), ItemCategory.other);
+    // an "Armory" segment (room/building) is not armor
+    expect(itemCategoryFromId('NC_Armory_Door'), ItemCategory.other);
   });
 
   test('unknown ids map to other', () {

--- a/apps/save-editor/test/features/editor/domain/item_categories_test.dart
+++ b/apps/save-editor/test/features/editor/domain/item_categories_test.dart
@@ -23,8 +23,17 @@ void main() {
     expect(itemCategoryFromId('ItAt_Ring_OfLife'), ItemCategory.ring);
   });
 
+  test('armor classes categorize as armor', () {
+    expect(itemCategoryFromId('Ore_Armor_H'), ItemCategory.armor);
+    expect(itemCategoryFromId('Org_Armor'), ItemCategory.armor);
+    expect(itemCategoryFromId('Armor_OC_Gomez'), ItemCategory.armor);
+    expect(itemCategoryFromId('Org_Armor_Top_H_01'), ItemCategory.armor);
+    // non-armor unaffected
+    expect(itemCategoryFromId('ItMi_Orenugget'), ItemCategory.misc);
+    expect(itemCategoryFromId('SomethingElse'), ItemCategory.other);
+  });
+
   test('unknown ids map to other', () {
-    expect(itemCategoryFromId('Armor_OC_EBR_Gomez_100'), ItemCategory.other);
     expect(itemCategoryFromId(''), ItemCategory.other);
     expect(itemCategoryFromId('ItIg_Worldsplitter'), ItemCategory.other);
   });

--- a/crates/gore-catalog/src/lib.rs
+++ b/crates/gore-catalog/src/lib.rs
@@ -81,9 +81,11 @@ pub fn is_armor_id(id: &str) -> bool {
     let mut parts = id.splitn(2, '_');
     let head = parts.next().unwrap_or("");
     let tail = parts.next().unwrap_or("");
+    // Tail must be exactly `Armor` or start with `Armor_`; `starts_with("Armor")`
+    // alone would also match an `Armory` segment (e.g. `NC_Armory_Door`).
     (2..=4).contains(&head.len())
         && head.chars().all(|c| c.is_ascii_alphabetic())
-        && tail.starts_with("Armor")
+        && (tail == "Armor" || tail.starts_with("Armor_"))
 }
 
 /// Classify an item id by its Angelscript class-name prefix. The ordering of
@@ -234,6 +236,10 @@ mod tests {
         assert_eq!(item_category_from_id("Armor_OC_Gomez"), ItemCategory::Armor);
         assert_eq!(category_for_id("Ore_Armor_H"), ItemCategory::Armor);
         assert_eq!(category_for_id("Armor_OC_Gomez"), ItemCategory::Armor);
+        // An "Armory" segment is not armor.
+        assert!(!is_armor_id("NC_Armory_Door"));
+        assert_eq!(item_category_from_id("NC_Armory_Door"), ItemCategory::Other);
+        assert_eq!(category_for_id("NC_Armory_Door"), ItemCategory::Unknown);
     }
 
     #[test]

--- a/crates/gore-catalog/src/lib.rs
+++ b/crates/gore-catalog/src/lib.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 pub enum ItemCategory {
     MeleeWeapon,
     RangedWeapon,
+    /// Wearable armor (`<Fac>_Armor_*`, `Armor_<Camp>_<NPC>_*`).
+    Armor,
     Ammunition,
     Rune,
     Scroll,
@@ -44,6 +46,7 @@ impl ItemCategory {
         match self {
             ItemCategory::MeleeWeapon => "Melee weapons",
             ItemCategory::RangedWeapon => "Ranged weapons",
+            ItemCategory::Armor => "Armor",
             ItemCategory::Ammunition => "Ammunition",
             ItemCategory::Rune => "Runes",
             ItemCategory::Scroll => "Spell scrolls",
@@ -65,13 +68,33 @@ impl ItemCategory {
     }
 }
 
+/// Display-side armor classifier: true for any armor class name (base, per-NPC,
+/// or tier piece). Broader than the catalog generator's `is_armor_item_class`,
+/// which additionally excludes tier pieces from the *addable* set.
+pub fn is_armor_id(id: &str) -> bool {
+    if !id.contains("Armor") {
+        return false;
+    }
+    if id.starts_with("Armor_") {
+        return true;
+    }
+    let mut parts = id.splitn(2, '_');
+    let head = parts.next().unwrap_or("");
+    let tail = parts.next().unwrap_or("");
+    (2..=4).contains(&head.len())
+        && head.chars().all(|c| c.is_ascii_alphabetic())
+        && tail.starts_with("Armor")
+}
+
 /// Classify an item id by its Angelscript class-name prefix. The ordering of
 /// checks is significant (`ItAm_`, `ItAr_Rune_`/`ItAr_Scroll_`, and the
 /// `ItAt_Amulet_`/`ItAt_Ring_` specializations before the generic `ItAt_`).
 ///
 /// This is the original fine-grained classification used by gore-save.
 pub fn item_category_from_id(id: &str) -> ItemCategory {
-    if id.starts_with("ItMw_") {
+    if is_armor_id(id) {
+        ItemCategory::Armor
+    } else if id.starts_with("ItMw_") {
         ItemCategory::MeleeWeapon
     } else if id.starts_with("ItRw_") {
         ItemCategory::RangedWeapon
@@ -112,6 +135,9 @@ pub fn item_category_from_id(id: &str) -> ItemCategory {
 /// Uses combined categories (RuneOrScroll, Jewelry, Potion) suited to the
 /// modding toolchain. Returns `ItemCategory::Unknown` for unrecognized prefixes.
 pub fn category_for_id(id: &str) -> ItemCategory {
+    if is_armor_id(id) {
+        return ItemCategory::Armor;
+    }
     if id.starts_with("ItFo_") {
         return ItemCategory::Food;
     }
@@ -197,9 +223,17 @@ mod tests {
 
     #[test]
     fn unknown_ids_map_to_other() {
-        assert_eq!(item_category_from_id("Armor_OC_Gomez"), ItemCategory::Other);
         assert_eq!(item_category_from_id(""), ItemCategory::Other);
         assert_eq!(item_category_from_id("ItIg_Worldsplitter"), ItemCategory::Other);
+    }
+
+    #[test]
+    fn armor_ids_map_to_armor() {
+        assert_eq!(item_category_from_id("Ore_Armor_H"), ItemCategory::Armor);
+        assert_eq!(item_category_from_id("Org_Armor"), ItemCategory::Armor);
+        assert_eq!(item_category_from_id("Armor_OC_Gomez"), ItemCategory::Armor);
+        assert_eq!(category_for_id("Ore_Armor_H"), ItemCategory::Armor);
+        assert_eq!(category_for_id("Armor_OC_Gomez"), ItemCategory::Armor);
     }
 
     #[test]

--- a/crates/gore-catalog/src/pipeline.rs
+++ b/crates/gore-catalog/src/pipeline.rs
@@ -62,14 +62,17 @@ fn is_armor_item_class(name: &str) -> bool {
     if NON_ITEM_PREFIXES.iter().any(|p| name.starts_with(p)) {
         return false;
     }
-    // Item families: `<2-4 alpha>_Armor...` or `Armor_<CAMP>_...`.
+    // Item families: `<2-4 alpha>_Armor...` or `Armor_<CAMP>_...`. The tail must
+    // be exactly `Armor` or start with `Armor_` — `starts_with("Armor")` alone
+    // would also accept non-item names like `NC_Armory_Door` (an "Armory"
+    // segment), which must not enter the catalog/allow-list.
     let faction_armor = {
         let mut parts = name.splitn(2, '_');
         let head = parts.next().unwrap_or("");
         let tail = parts.next().unwrap_or("");
         (2..=4).contains(&head.len())
             && head.chars().all(|c| c.is_ascii_alphabetic())
-            && tail.starts_with("Armor")
+            && (tail == "Armor" || tail.starts_with("Armor_"))
     };
     faction_armor || name.starts_with("Armor_")
 }
@@ -484,6 +487,10 @@ mod tests {
         assert!(!is_armor_item_class("GE_Crw_Armor_H"));
         assert!(!is_armor_item_class("GothicAchievement_Armor_01"));
         assert!(!is_armor_item_class("OC_Armory_Door"));
+    // An "Armory" segment (room/building) is not an armor item, even with a
+    // short prefix not covered by NON_ITEM_PREFIXES.
+    assert!(!is_armor_item_class("NC_Armory_Door"));
+    assert!(!is_armor_item_class("Vlk_Armory"));
         assert!(!is_armor_item_class("Spawner_OC_Castle_Armory_Misc_01"));
         assert!(!is_armor_item_class("Hit_SuperArmor_Player"));
         assert!(!is_armor_item_class("CharacterVisualsDefinition_OreArmor"));

--- a/crates/gore-catalog/src/pipeline.rs
+++ b/crates/gore-catalog/src/pipeline.rs
@@ -25,6 +25,55 @@ use serde::Serialize;
 
 // ─── Item catalog ────────────────────────────────────────────────────────────
 
+/// True when an Angelscript class name is an armor *item* class (a class that
+/// can occupy an inventory slot), as opposed to its paired visual-definition
+/// companion, an upgrade-component tier piece, or unrelated noise that merely
+/// contains "Armor".
+///
+/// Armor item classes are NOT `It*`. They are faction-armor families
+/// (`<Fac>_Armor[_suffix]`, e.g. `Ore_Armor_H`, `Org_Armor`) and per-NPC
+/// armors (`Armor_<CAMP>_<NPC>_NNN`). Each is paired with a
+/// `*_VisualsDefinition` / `*_VisualDefinition` companion that is NOT an item.
+/// The `_{Top,Mid,Bot}_` tier pieces are armor-customization components stored
+/// in `BoughtArmorUpgrades.AvailableUpgrades` and applied via the worn armor's
+/// upgrade string-map (Tier C) — they are not standalone bag items.
+fn is_armor_item_class(name: &str) -> bool {
+    if !name.contains("Armor") {
+        return false;
+    }
+    // Companions / bases / non-item definitions.
+    if name.ends_with("Definition") || name.ends_with("_Base") {
+        return false;
+    }
+    if name.starts_with("ArmorVisualsDefinition") {
+        return false;
+    }
+    // Upgrade-component tier pieces (Org_Armor_Top_H_01, Sld_Armor_Mid_L_02 ...).
+    if name.contains("_Top_") || name.contains("_Mid_") || name.contains("_Bot_") {
+        return false;
+    }
+    // Non-item families that contain "Armor"/"Armory"/"SuperArmor".
+    const NON_ITEM_PREFIXES: &[&str] = &[
+        "GE_", "GA_", "GC_", "GVL_", "CS_", "Choice", "Document", "Conversation",
+        "DailyRoutine", "Module_", "AIAgent", "CharacterDefinition",
+        "CharacterVisuals", "AllArmors", "Quest", "Memory", "Spawner",
+        "Glossary", "Gothic", "Hit_", "SpawnAIAgent", "SpawnMeshes", "OC_",
+    ];
+    if NON_ITEM_PREFIXES.iter().any(|p| name.starts_with(p)) {
+        return false;
+    }
+    // Item families: `<2-4 alpha>_Armor...` or `Armor_<CAMP>_...`.
+    let faction_armor = {
+        let mut parts = name.splitn(2, '_');
+        let head = parts.next().unwrap_or("");
+        let tail = parts.next().unwrap_or("");
+        (2..=4).contains(&head.len())
+            && head.chars().all(|c| c.is_ascii_alphabetic())
+            && tail.starts_with("Armor")
+    };
+    faction_armor || name.starts_with("Armor_")
+}
+
 /// Regex-equivalent: capture group 1 of `ASClass /Script/Angelscript.(It[A-Za-z0-9_]+)`.
 fn parse_item_classes(lines: &[&str]) -> Vec<String> {
     let prefix = "ASClass /Script/Angelscript.";
@@ -36,7 +85,7 @@ fn parse_item_classes(lines: &[&str]) -> Vec<String> {
                 .chars()
                 .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
                 .collect();
-            if name.starts_with("It") {
+            if name.starts_with("It") || is_armor_item_class(&name) {
                 names.insert(name);
             }
         }
@@ -405,6 +454,40 @@ mod tests {
         let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
         assert!(ids.contains(&"ChoiceDiegoStart"), "got: {ids:?}");
         assert!(!ids.contains(&"Choice"), "bare Choice must be excluded: {ids:?}");
+    }
+
+    #[test]
+    fn armor_discriminator_accepts_items_rejects_companions() {
+        // Real base/per-NPC armor item classes -> accepted.
+        assert!(is_armor_item_class("Ore_Armor_H"));
+        assert!(is_armor_item_class("Ore_Armor_M"));
+        assert!(is_armor_item_class("Crw_Armor_H"));
+        assert!(is_armor_item_class("Org_Armor"));
+        assert!(is_armor_item_class("Vlk_Armor_L"));
+        assert!(is_armor_item_class("Ebr_Armor_H_01"));
+        assert!(is_armor_item_class("Armor_SK_OC_WOC_Velaya_108_02"));
+        assert!(is_armor_item_class("Armor_OC_EBR_Gomez_100"));
+
+        // Visual-definition companions and bases -> rejected.
+        assert!(!is_armor_item_class("Ore_Armor_H_VisualsDefinition"));
+        assert!(!is_armor_item_class("Armor_OC_EBR_Gomez_100_VisualDefinition"));
+        assert!(!is_armor_item_class("BaseArmorDefinition"));
+        assert!(!is_armor_item_class("ArmorVisualsDefinition_Human"));
+
+        // Upgrade-component tier pieces -> rejected (edited via Tier C, not added).
+        assert!(!is_armor_item_class("Org_Armor_Top_H_01"));
+        assert!(!is_armor_item_class("Sld_Armor_Mid_L_02"));
+
+        // Non-item noise that merely contains "Armor" -> rejected.
+        assert!(!is_armor_item_class("GE_Crw_Armor_H"));
+        assert!(!is_armor_item_class("GothicAchievement_Armor_01"));
+        assert!(!is_armor_item_class("OC_Armory_Door"));
+        assert!(!is_armor_item_class("Spawner_OC_Castle_Armory_Misc_01"));
+        assert!(!is_armor_item_class("Hit_SuperArmor_Player"));
+        assert!(!is_armor_item_class("CharacterVisualsDefinition_OreArmor"));
+
+        // Ordinary It* items are not armor.
+        assert!(!is_armor_item_class("ItMi_Orenugget"));
     }
 
     #[test]

--- a/crates/gore-catalog/src/pipeline.rs
+++ b/crates/gore-catalog/src/pipeline.rs
@@ -157,7 +157,9 @@ pub fn build_item_catalog(lines: &[&str]) -> (Vec<ItemEntry>, Vec<String>) {
             skipped.push(name.clone());
             continue;
         }
-        let category: String = if let Some(cat) = item_explicit(name) {
+        let category: String = if is_armor_item_class(name) {
+            "armor".to_string()
+        } else if let Some(cat) = item_explicit(name) {
             cat.to_string()
         } else {
             let mut found = None;
@@ -488,6 +490,28 @@ mod tests {
 
         // Ordinary It* items are not armor.
         assert!(!is_armor_item_class("ItMi_Orenugget"));
+    }
+
+    #[test]
+    fn armor_entries_get_armor_category() {
+        let lines = [
+            "[0001] ASClass /Script/Angelscript.Ore_Armor_H [n: 1] [c: 2]",
+            "[0002] ASClass /Script/Angelscript.Ore_Armor_H_VisualsDefinition [n: 1] [c: 2]",
+            "[0003] ASClass /Script/Angelscript.Armor_OC_EBR_Gomez_100 [n: 1] [c: 2]",
+            "[0004] ASClass /Script/Angelscript.ItMi_Orenugget [n: 1] [c: 2]",
+            "[0005] ASClass /Script/Angelscript.Org_Armor_Top_H_01 [n: 1] [c: 2]",
+        ];
+        let (entries, _skipped) = build_item_catalog(&lines);
+        let by_id: std::collections::HashMap<&str, &ItemEntry> =
+            entries.iter().map(|e| (e.id.as_str(), e)).collect();
+
+        assert_eq!(by_id["Ore_Armor_H"].category, "armor");
+        assert_eq!(by_id["Ore_Armor_H"].path, "/Script/Angelscript.Ore_Armor_H");
+        assert_eq!(by_id["Armor_OC_EBR_Gomez_100"].category, "armor");
+        assert_eq!(by_id["ItMi_Orenugget"].category, "misc");
+        // companion + tier piece are not catalog entries at all
+        assert!(!by_id.contains_key("Ore_Armor_H_VisualsDefinition"));
+        assert!(!by_id.contains_key("Org_Armor_Top_H_01"));
     }
 
     #[test]

--- a/crates/gore-catalog/tests/catalog_test.rs
+++ b/crates/gore-catalog/tests/catalog_test.rs
@@ -43,6 +43,12 @@ fn category_key_and_mission() {
 }
 
 #[test]
+fn category_armor_for_armor_classes() {
+    assert_eq!(category_for_id("Armor_OC_Gomez"), ItemCategory::Armor);
+    assert_eq!(category_for_id("Ore_Armor_H"), ItemCategory::Armor);
+}
+
+#[test]
 fn category_unknown_for_unrecognized() {
-    assert_eq!(category_for_id("Armor_OC_Gomez"), ItemCategory::Unknown);
+    assert_eq!(category_for_id("TotallyUnknownClass"), ItemCategory::Unknown);
 }

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -2985,18 +2985,27 @@ fn private_player_writable_edits(payload: &[u8], refs: &[FStringRef]) -> Vec<&'s
 }
 
 /// Mark the worn-armor row `equipped` and attach the worn armor's upgrade
-/// chips. Membership is by item-definition path, but the player can carry a
-/// second copy of the worn armor class in the bag (e.g. via addItem, whose
-/// dialog only excludes MainContainer paths), so only the FIRST row of each
-/// equipped path is flagged — later duplicates are a bag copy, not the worn
-/// item, and must show neither the badge nor the upgrades.
+/// chips. Membership is by item-definition path. The player can carry a second
+/// copy of the worn armor class in the bag (e.g. via addItem, whose dialog only
+/// excludes MainContainer paths), and the scanned rows carry no container/slot
+/// identity — so when the worn path occurs more than once we cannot tell the
+/// worn slot from a carried copy. In that ambiguous case we withhold the badge
+/// and upgrades entirely rather than risk attributing them to a bag copy; the
+/// flag is set only when the worn path occurs exactly once across the scan.
 fn apply_equipped_and_upgrades(items: &mut [Value], armor_slot: Option<&ArmorSlotSummary>) {
-    let mut equipped_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut path_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for item in items.iter() {
+        let path = item["path"].as_str().unwrap_or("");
+        if !path.is_empty() {
+            *path_counts.entry(path.to_string()).or_default() += 1;
+        }
+    }
     for item in items.iter_mut() {
         let path = item["path"].as_str().unwrap_or("").to_string();
         let is_equipped = !path.is_empty()
             && armor_slot.is_some_and(|a| a.equipped_paths.contains(&path))
-            && equipped_seen.insert(path);
+            && path_counts.get(&path) == Some(&1);
         item["equipped"] = json!(is_equipped);
         item["upgrades"] = if is_equipped {
             json!(armor_slot
@@ -7317,31 +7326,39 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn equipped_marking_skips_duplicate_bag_copy() {
+    fn equipped_marking_withholds_on_duplicate_path() {
         let armor = ArmorSlotSummary {
-            equipped_paths: ["/Script/Angelscript.Org_Armor".to_string()]
-                .into_iter()
-                .collect(),
+            equipped_paths: [
+                "/Script/Angelscript.Org_Armor".to_string(),
+                "/Script/Angelscript.Crw_Armor_H".to_string(),
+            ]
+            .into_iter()
+            .collect(),
             upgrades: vec![(
                 "m_CurrentUpperBodyUpgrade".to_string(),
                 "m_UpperBody_Heavy02_ArmorUpgrade".to_string(),
             )],
         };
         let mut items = vec![
-            // worn copy (first occurrence — e.g. the ArmorSlot container row)
+            // worn class also carried in the bag -> path duplicated -> ambiguous
             json!({ "path": "/Script/Angelscript.Org_Armor", "id": "Org_Armor" }),
-            // a second copy in the bag with the same path
             json!({ "path": "/Script/Angelscript.Org_Armor", "id": "Org_Armor" }),
+            // worn class present exactly once -> unambiguous
+            json!({ "path": "/Script/Angelscript.Crw_Armor_H", "id": "Crw_Armor_H" }),
             json!({ "path": "/Script/Angelscript.ItMi_Orenugget", "id": "ItMi_Orenugget" }),
         ];
         apply_equipped_and_upgrades(&mut items, Some(&armor));
-        assert_eq!(items[0]["equipped"], json!(true));
-        assert_eq!(items[0]["upgrades"].as_array().unwrap().len(), 1);
-        // the duplicate bag copy must NOT be flagged equipped or carry upgrades
+        // duplicated worn path -> neither row flagged, no upgrades attributed
+        assert_eq!(items[0]["equipped"], json!(false));
         assert_eq!(items[1]["equipped"], json!(false));
+        assert_eq!(items[0]["upgrades"].as_array().unwrap().len(), 0);
         assert_eq!(items[1]["upgrades"].as_array().unwrap().len(), 0);
-        assert_eq!(items[2]["equipped"], json!(false));
-        assert_eq!(items[2]["upgrades"].as_array().unwrap().len(), 0);
+        // unique worn path -> flagged with upgrades
+        assert_eq!(items[2]["equipped"], json!(true));
+        assert_eq!(items[2]["upgrades"].as_array().unwrap().len(), 1);
+        // non-armor row -> never flagged
+        assert_eq!(items[3]["equipped"], json!(false));
+        assert_eq!(items[3]["upgrades"].as_array().unwrap().len(), 0);
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -5508,6 +5508,9 @@ fn apply_private_knowledge_add_character_to_payload(
 /// always be looked up by value, never hardcoded.
 const MAIN_CONTAINER_ENUM_LABEL: &str = "EInventoryTypes::MainContainer";
 
+/// Enum label of the player's worn-armor container in the inventory map.
+const ARMOR_SLOT_ENUM_LABEL: &str = "EInventoryTypes::ArmorSlot";
+
 /// `m_PlayerID` of the controlled player among `m_SavedPlayers`. A save may hold
 /// several saved players (party members); inventory edits target this one — the
 /// same anchor the transform/attribute editors use.
@@ -5629,6 +5632,49 @@ struct MainContainerSummary {
     /// addItem can use as a template. Without one, addItem cannot succeed, so it
     /// must not be advertised.
     has_clean_template: bool,
+}
+
+/// The item-definition paths currently in the player's `ArmorSlot` container —
+/// i.e. the worn armor. At most one in practice, modeled as a set for
+/// robustness. `None` when the inventory or the ArmorSlot container is absent.
+struct ArmorSlotSummary {
+    equipped_paths: std::collections::HashSet<String>,
+}
+
+/// Resolve the player's `ArmorSlot` container and collect the item-definition
+/// paths it holds. Mirrors `main_container_summary`'s container resolution.
+fn armor_slot_summary(root: &properties::RootObject) -> Option<ArmorSlotSummary> {
+    let inventory_path = resolve_inventory_path(root)?;
+    let resolve_child = |suffix: &[&str]| -> Option<properties::PropertyValue> {
+        let mut segs = inventory_path.clone();
+        segs.extend(suffix.iter().map(|s| s.to_string()));
+        let parsed = properties::parse_path(&segs).ok()?;
+        properties::resolve(&root.properties, &parsed)
+            .ok()
+            .map(|prop| prop.value.clone())
+    };
+    let properties::PropertyValue::Array { elements: keys } = resolve_child(&["m_Keys"])? else {
+        return None;
+    };
+    let index = keys.iter().position(|element| {
+        matches!(element, properties::PropertyValue::Enum(label)
+            if label == ARMOR_SLOT_ENUM_LABEL)
+    })?;
+    let segment = format!("[{index}]");
+    let properties::PropertyValue::Array { elements: slots } =
+        resolve_child(&["m_Values", "Items", &segment, "m_Slots"])?
+    else {
+        return None;
+    };
+    let mut equipped_paths = std::collections::HashSet::new();
+    for slot in &slots {
+        if let Some(path) = slot_item_definition(slot) {
+            if !path.is_empty() {
+                equipped_paths.insert(path.to_string());
+            }
+        }
+    }
+    Some(ArmorSlotSummary { equipped_paths })
 }
 
 /// Summarize the player's MainContainer. addItem and removeItem only operate on
@@ -10679,6 +10725,18 @@ mod tests {
         assert_eq!(root.consumed, payload.len(), "byte-faithful: no trailing/lost bytes");
         let summary = main_container_summary(&root).expect("main container");
         assert!(summary.all_paths.contains(armor_path), "armor now in MainContainer");
+    }
+
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn armor_slot_summary_finds_equipped_armor() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let root = properties::parse_private_root(&payload).unwrap();
+        let summary = armor_slot_summary(&root).expect("armor slot container resolves");
+        assert!(summary.equipped_paths.contains("/Script/Angelscript.Ore_Armor_H"));
+        assert!(!summary.equipped_paths.contains("/Script/Angelscript.Crw_Armor_H"));
+        assert!(!summary.equipped_paths.contains("/Script/Angelscript.Ore_Armor_M"));
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -2985,27 +2985,17 @@ fn private_player_writable_edits(payload: &[u8], refs: &[FStringRef]) -> Vec<&'s
 }
 
 /// Mark the worn-armor row `equipped` and attach the worn armor's upgrade
-/// chips. Membership is by item-definition path. The player can carry a second
-/// copy of the worn armor class in the bag (e.g. via addItem, whose dialog only
-/// excludes MainContainer paths), and the scanned rows carry no container/slot
-/// identity — so when the worn path occurs more than once we cannot tell the
-/// worn slot from a carried copy. In that ambiguous case we withhold the badge
-/// and upgrades entirely rather than risk attributing them to a bag copy; the
-/// flag is set only when the worn path occurs exactly once across the scan.
+/// chips. The player can carry a second copy of the worn armor class in the bag
+/// (e.g. via addItem, whose dialog only excludes MainContainer paths), and the
+/// scanned rows carry no container/slot identity — so a row is flagged only
+/// when its path is in `unambiguous_equipped_paths` (worn AND globally unique
+/// across the uncapped inventory). A worn class with any carried copy is
+/// withheld rather than risk tagging a bag copy.
 fn apply_equipped_and_upgrades(items: &mut [Value], armor_slot: Option<&ArmorSlotSummary>) {
-    let mut path_counts: std::collections::HashMap<String, usize> =
-        std::collections::HashMap::new();
-    for item in items.iter() {
-        let path = item["path"].as_str().unwrap_or("");
-        if !path.is_empty() {
-            *path_counts.entry(path.to_string()).or_default() += 1;
-        }
-    }
     for item in items.iter_mut() {
-        let path = item["path"].as_str().unwrap_or("").to_string();
+        let path = item["path"].as_str().unwrap_or("");
         let is_equipped = !path.is_empty()
-            && armor_slot.is_some_and(|a| a.equipped_paths.contains(&path))
-            && path_counts.get(&path) == Some(&1);
+            && armor_slot.is_some_and(|a| a.unambiguous_equipped_paths.contains(path));
         item["equipped"] = json!(is_equipped);
         item["upgrades"] = if is_equipped {
             json!(armor_slot
@@ -5730,6 +5720,13 @@ struct MainContainerSummary {
 /// robustness. `None` when the inventory or the ArmorSlot container is absent.
 struct ArmorSlotSummary {
     equipped_paths: std::collections::HashSet<String>,
+    /// Worn-armor paths that occur exactly once across the ENTIRE typed
+    /// inventory (no carried copy in any other container). The display rows are
+    /// keyed only by item-definition path and carry no slot identity, so only a
+    /// globally-unique worn path can be flagged equipped without risk of tagging
+    /// a bag copy. Computed from the uncapped typed tree — not the 200-row
+    /// display cap, which could hide a later duplicate.
+    unambiguous_equipped_paths: std::collections::HashSet<String>,
     /// `(key, value)` upgrade pairs from the worn armor's `m_GenericData`,
     /// non-empty values only. Empty when not upgraded or no armor worn.
     upgrades: Vec<(String, String)>,
@@ -5750,6 +5747,29 @@ fn armor_slot_summary(root: &properties::RootObject) -> Option<ArmorSlotSummary>
     let properties::PropertyValue::Array { elements: keys } = resolve_child(&["m_Keys"])? else {
         return None;
     };
+    // Count how many times each item-definition path appears across EVERY
+    // container's slots (the full, uncapped inventory). Used to decide whether a
+    // worn armor path is unambiguous (no carried duplicate anywhere).
+    let mut global_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    if let Some(properties::PropertyValue::Array { elements: containers }) =
+        resolve_child(&["m_Values", "Items"])
+    {
+        for container_index in 0..containers.len() {
+            let container_segment = format!("[{container_index}]");
+            if let Some(properties::PropertyValue::Array { elements: container_slots }) =
+                resolve_child(&["m_Values", "Items", &container_segment, "m_Slots"])
+            {
+                for slot in &container_slots {
+                    if let Some(path) = slot_item_definition(slot) {
+                        if !path.is_empty() {
+                            *global_counts.entry(path.to_string()).or_default() += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
     let index = keys.iter().position(|element| {
         matches!(element, properties::PropertyValue::Enum(label)
             if label == ARMOR_SLOT_ENUM_LABEL)
@@ -5775,7 +5795,16 @@ fn armor_slot_summary(root: &properties::RootObject) -> Option<ArmorSlotSummary>
             }
         }
     }
-    Some(ArmorSlotSummary { equipped_paths, upgrades })
+    let unambiguous_equipped_paths = equipped_paths
+        .iter()
+        .filter(|path| global_counts.get(*path).copied() == Some(1))
+        .cloned()
+        .collect();
+    Some(ArmorSlotSummary {
+        equipped_paths,
+        unambiguous_equipped_paths,
+        upgrades,
+    })
 }
 
 /// Summarize the player's MainContainer. addItem and removeItem only operate on
@@ -7327,6 +7356,8 @@ mod tests {
 
     #[test]
     fn equipped_marking_withholds_on_duplicate_path() {
+        // Org_Armor is worn but also carried (so it is NOT unambiguous);
+        // Crw_Armor_H is worn and globally unique.
         let armor = ArmorSlotSummary {
             equipped_paths: [
                 "/Script/Angelscript.Org_Armor".to_string(),
@@ -7334,6 +7365,9 @@ mod tests {
             ]
             .into_iter()
             .collect(),
+            unambiguous_equipped_paths: ["/Script/Angelscript.Crw_Armor_H".to_string()]
+                .into_iter()
+                .collect(),
             upgrades: vec![(
                 "m_CurrentUpperBodyUpgrade".to_string(),
                 "m_UpperBody_Heavy02_ArmorUpgrade".to_string(),

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -5610,6 +5610,50 @@ fn slot_item_definition(slot: &properties::PropertyValue) -> Option<&str> {
         })
 }
 
+/// Read non-empty `(key, value)` upgrade pairs from a slot's
+/// `m_Payload.m_GenericData` ReplicatedStringMap (parallel `m_Keys`/`m_Values`).
+fn slot_upgrade_pairs(slot: &properties::PropertyValue) -> Vec<(String, String)> {
+    use properties::PropertyValue;
+    let Some(payload) = struct_element_property(slot, "m_Payload") else {
+        return Vec::new();
+    };
+    let PropertyValue::Struct(properties::StructValue::Properties(payload_props)) = &payload.value
+    else {
+        return Vec::new();
+    };
+    let Some(generic) = payload_props.iter().find(|p| p.name == "m_GenericData") else {
+        return Vec::new();
+    };
+    let PropertyValue::Struct(properties::StructValue::Properties(map_props)) = &generic.value
+    else {
+        return Vec::new();
+    };
+    let array_strings = |name: &str| -> Vec<String> {
+        map_props
+            .iter()
+            .find(|p| p.name == name)
+            .and_then(|p| match &p.value {
+                PropertyValue::Array { elements } => Some(
+                    elements
+                        .iter()
+                        .map(|e| match e {
+                            PropertyValue::Name(s) | PropertyValue::Str(s) => s.clone(),
+                            _ => String::new(),
+                        })
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .unwrap_or_default()
+    };
+    let keys = array_strings("m_Keys");
+    let values = array_strings("m_Values");
+    keys.into_iter()
+        .zip(values)
+        .filter(|(_, v)| !v.is_empty())
+        .collect()
+}
+
 fn slot_id(slot: &properties::PropertyValue) -> Option<i32> {
     match struct_element_property(slot, "m_Id")?.value {
         properties::PropertyValue::Int(id) => Some(id),
@@ -5655,6 +5699,9 @@ struct MainContainerSummary {
 /// robustness. `None` when the inventory or the ArmorSlot container is absent.
 struct ArmorSlotSummary {
     equipped_paths: std::collections::HashSet<String>,
+    /// `(key, value)` upgrade pairs from the worn armor's `m_GenericData`,
+    /// non-empty values only. Empty when not upgraded or no armor worn.
+    upgrades: Vec<(String, String)>,
 }
 
 /// Resolve the player's `ArmorSlot` container and collect the item-definition
@@ -5683,14 +5730,18 @@ fn armor_slot_summary(root: &properties::RootObject) -> Option<ArmorSlotSummary>
         return None;
     };
     let mut equipped_paths = std::collections::HashSet::new();
+    let mut upgrades = Vec::new();
     for slot in &slots {
         if let Some(path) = slot_item_definition(slot) {
             if !path.is_empty() {
                 equipped_paths.insert(path.to_string());
             }
         }
+        if upgrades.is_empty() {
+            upgrades = slot_upgrade_pairs(slot);
+        }
     }
-    Some(ArmorSlotSummary { equipped_paths })
+    Some(ArmorSlotSummary { equipped_paths, upgrades })
 }
 
 /// Summarize the player's MainContainer. addItem and removeItem only operate on
@@ -10786,6 +10837,30 @@ mod tests {
             let p = i["path"].as_str().unwrap_or("");
             !p.contains("ItMi_") || i["equipped"].as_bool() == Some(false)
         }));
+    }
+
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn armor_upgrades_read_from_worn_armor() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let root = properties::parse_private_root(&payload).unwrap();
+        let summary = armor_slot_summary(&root).expect("armor slot resolves");
+        let ups = &summary.upgrades;
+        let find = |k: &str| ups.iter().find(|(key, _)| key == k).map(|(_, v)| v.as_str());
+        assert_eq!(find("m_CurrentUpperBodyUpgrade"), Some("m_UpperBody_Heavy02_ArmorUpgrade"));
+        assert_eq!(find("m_CurrentMidBodyUpgrade"), Some("m_MidBody_Heavy02_ArmorUpgrade"));
+        assert_eq!(find("m_CurrentLowerBodyUpgrade"), Some("m_LowerBody_Heavy02_ArmorUpgrade"));
+    }
+
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn armor_upgrades_empty_when_not_upgraded() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let root = properties::parse_private_root(&payload).unwrap();
+        let summary = armor_slot_summary(&root).expect("armor slot resolves");
+        assert!(summary.upgrades.is_empty(), "expected no upgrades, got {:?}", summary.upgrades);
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -2821,8 +2821,16 @@ fn inspect_private_payload(
                 .as_ref()
                 .and_then(|r| r.as_ref().ok())
                 .and_then(main_container_summary);
-            let inventory =
-                summarize_private_inventory_payload(&payload, &refs, main_container.as_ref());
+            let armor_slot = typed_result
+                .as_ref()
+                .and_then(|r| r.as_ref().ok())
+                .and_then(armor_slot_summary);
+            let inventory = summarize_private_inventory_payload(
+                &payload,
+                &refs,
+                main_container.as_ref(),
+                armor_slot.as_ref(),
+            );
             let typed_parse = summarize_typed_parse_result(&payload, typed_result.as_ref());
             let typed_ok = typed_parse["status"] == "ok";
             let progression = summarize_private_progression_overview(
@@ -2980,6 +2988,7 @@ fn summarize_private_inventory_payload(
     payload: &[u8],
     refs: &[FStringRef],
     main_container: Option<&MainContainerSummary>,
+    armor_slot: Option<&ArmorSlotSummary>,
 ) -> Value {
     let script_paths = unique_strings(
         refs.iter().map(|r| r.value.as_str()).filter(|value| {
@@ -3010,6 +3019,13 @@ fn summarize_private_inventory_payload(
         let path = item["path"].as_str().unwrap_or("");
         item["removable"] = json!(
             !path.is_empty() && main_container.is_some_and(|mc| mc.removable_paths.contains(path))
+        );
+    }
+    for item in &mut items {
+        let path = item["path"].as_str().unwrap_or("");
+        item["equipped"] = json!(
+            !path.is_empty()
+                && armor_slot.is_some_and(|a| a.equipped_paths.contains(path))
         );
     }
     // setItemCount patches an existing scanned stack in place, so it depends on
@@ -9646,12 +9662,14 @@ mod tests {
                     "path": "/Script/Angelscript.ItMi_Orenugget",
                     "count": 99,
                     "removable": false,
+                    "equipped": false,
                 },
                 {
                     "id": "ItFo_Cheese",
                     "path": "/Script/Angelscript.ItFo_Cheese",
                     "count": 1,
                     "removable": false,
+                    "equipped": false,
                 }
             ])
         );
@@ -10361,6 +10379,7 @@ mod tests {
                 "path": "/Script/Angelscript.ItMi_Orenugget",
                 "count": 42,
                 "removable": false,
+                "equipped": false,
             })
         );
     }
@@ -10462,6 +10481,7 @@ mod tests {
                 "path": "/Script/Angelscript.ItMi_Orenugget",
                 "count": 23,
                 "removable": false,
+                "equipped": false,
             }])
         );
     }
@@ -10737,6 +10757,35 @@ mod tests {
         assert!(summary.equipped_paths.contains("/Script/Angelscript.Ore_Armor_H"));
         assert!(!summary.equipped_paths.contains("/Script/Angelscript.Crw_Armor_H"));
         assert!(!summary.equipped_paths.contains("/Script/Angelscript.Ore_Armor_M"));
+    }
+
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn inventory_rows_flag_equipped_armor() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let refs = scan_fstrings(&payload, 0);
+        let root = properties::parse_private_root(&payload).unwrap();
+        let main_container = main_container_summary(&root);
+        let armor_slot = armor_slot_summary(&root);
+        let inv = summarize_private_inventory_payload(
+            &payload,
+            &refs,
+            main_container.as_ref(),
+            armor_slot.as_ref(),
+        );
+        let items = inv["items"].as_array().unwrap();
+        let equipped: Vec<&str> = items
+            .iter()
+            .filter(|i| i["equipped"].as_bool() == Some(true))
+            .map(|i| i["path"].as_str().unwrap_or(""))
+            .collect();
+        assert!(equipped.contains(&"/Script/Angelscript.Ore_Armor_H"));
+        assert!(!equipped.contains(&"/Script/Angelscript.Crw_Armor_H"));
+        assert!(items.iter().all(|i| {
+            let p = i["path"].as_str().unwrap_or("");
+            !p.contains("ItMi_") || i["equipped"].as_bool() == Some(false)
+        }));
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -10666,6 +10666,22 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn add_armor_item_roundtrips_on_real_payload() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let mut payload = std::fs::read(path).unwrap();
+        // An armor NOT already in this save's MainContainer.
+        let armor_path = "/Script/Angelscript.Vlk_Armor_L";
+        assert!(is_item_definition_class(armor_path), "armor must be in the catalog allow-list");
+        let edit = PrivateInventoryAddItemEdit { path: armor_path.to_string(), count: 1 };
+        apply_private_inventory_add_item_to_payload(&mut payload, &edit).unwrap();
+        let root = properties::parse_private_root(&payload).unwrap();
+        assert_eq!(root.consumed, payload.len(), "byte-faithful: no trailing/lost bytes");
+        let summary = main_container_summary(&root).expect("main container");
+        assert!(summary.all_paths.contains(armor_path), "armor now in MainContainer");
+    }
+
+    #[test]
     fn typed_container_edits_apply_and_validate() {
         let mut payload = fstring("/Script/Test.Save");
         payload.push(0);

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -3023,10 +3023,20 @@ fn summarize_private_inventory_payload(
     }
     for item in &mut items {
         let path = item["path"].as_str().unwrap_or("");
-        item["equipped"] = json!(
-            !path.is_empty()
-                && armor_slot.is_some_and(|a| a.equipped_paths.contains(path))
-        );
+        let is_equipped = !path.is_empty()
+            && armor_slot.is_some_and(|a| a.equipped_paths.contains(path));
+        item["equipped"] = json!(is_equipped);
+        item["upgrades"] = if is_equipped {
+            json!(armor_slot
+                .map(|a| a
+                    .upgrades
+                    .iter()
+                    .map(|(k, v)| json!({ "key": k, "value": v }))
+                    .collect::<Vec<_>>())
+                .unwrap_or_default())
+        } else {
+            json!([])
+        };
     }
     // setItemCount patches an existing scanned stack in place, so it depends on
     // the FString scan finding at least one stack in the player region.
@@ -9714,6 +9724,7 @@ mod tests {
                     "count": 99,
                     "removable": false,
                     "equipped": false,
+                    "upgrades": [],
                 },
                 {
                     "id": "ItFo_Cheese",
@@ -9721,6 +9732,7 @@ mod tests {
                     "count": 1,
                     "removable": false,
                     "equipped": false,
+                    "upgrades": [],
                 }
             ])
         );
@@ -10431,6 +10443,7 @@ mod tests {
                 "count": 42,
                 "removable": false,
                 "equipped": false,
+                "upgrades": [],
             })
         );
     }
@@ -10533,6 +10546,7 @@ mod tests {
                 "count": 23,
                 "removable": false,
                 "equipped": false,
+                "upgrades": [],
             }])
         );
     }
@@ -10861,6 +10875,27 @@ mod tests {
         let root = properties::parse_private_root(&payload).unwrap();
         let summary = armor_slot_summary(&root).expect("armor slot resolves");
         assert!(summary.upgrades.is_empty(), "expected no upgrades, got {:?}", summary.upgrades);
+    }
+
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn equipped_row_carries_upgrades() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let refs = scan_fstrings(&payload, 0);
+        let root = properties::parse_private_root(&payload).unwrap();
+        let main_container = main_container_summary(&root);
+        let armor_slot = armor_slot_summary(&root);
+        let inv = summarize_private_inventory_payload(
+            &payload, &refs, main_container.as_ref(), armor_slot.as_ref(),
+        );
+        let items = inv["items"].as_array().unwrap();
+        let worn = items.iter().find(|i| i["equipped"].as_bool() == Some(true)).expect("an equipped row");
+        let ups = worn["upgrades"].as_array().expect("upgrades array");
+        assert_eq!(ups.len(), 3);
+        assert!(ups.iter().any(|u| u["value"].as_str() == Some("m_UpperBody_Heavy02_ArmorUpgrade")));
+        let other = items.iter().find(|i| i["equipped"].as_bool() != Some(true)).unwrap();
+        assert_eq!(other["upgrades"].as_array().map(|a| a.len()), Some(0));
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -2984,6 +2984,34 @@ fn private_player_writable_edits(payload: &[u8], refs: &[FStringRef]) -> Vec<&'s
     writable
 }
 
+/// Mark the worn-armor row `equipped` and attach the worn armor's upgrade
+/// chips. Membership is by item-definition path, but the player can carry a
+/// second copy of the worn armor class in the bag (e.g. via addItem, whose
+/// dialog only excludes MainContainer paths), so only the FIRST row of each
+/// equipped path is flagged — later duplicates are a bag copy, not the worn
+/// item, and must show neither the badge nor the upgrades.
+fn apply_equipped_and_upgrades(items: &mut [Value], armor_slot: Option<&ArmorSlotSummary>) {
+    let mut equipped_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for item in items.iter_mut() {
+        let path = item["path"].as_str().unwrap_or("").to_string();
+        let is_equipped = !path.is_empty()
+            && armor_slot.is_some_and(|a| a.equipped_paths.contains(&path))
+            && equipped_seen.insert(path);
+        item["equipped"] = json!(is_equipped);
+        item["upgrades"] = if is_equipped {
+            json!(armor_slot
+                .map(|a| a
+                    .upgrades
+                    .iter()
+                    .map(|(k, v)| json!({ "key": k, "value": v }))
+                    .collect::<Vec<_>>())
+                .unwrap_or_default())
+        } else {
+            json!([])
+        };
+    }
+}
+
 fn summarize_private_inventory_payload(
     payload: &[u8],
     refs: &[FStringRef],
@@ -3021,23 +3049,7 @@ fn summarize_private_inventory_payload(
             !path.is_empty() && main_container.is_some_and(|mc| mc.removable_paths.contains(path))
         );
     }
-    for item in &mut items {
-        let path = item["path"].as_str().unwrap_or("");
-        let is_equipped = !path.is_empty()
-            && armor_slot.is_some_and(|a| a.equipped_paths.contains(path));
-        item["equipped"] = json!(is_equipped);
-        item["upgrades"] = if is_equipped {
-            json!(armor_slot
-                .map(|a| a
-                    .upgrades
-                    .iter()
-                    .map(|(k, v)| json!({ "key": k, "value": v }))
-                    .collect::<Vec<_>>())
-                .unwrap_or_default())
-        } else {
-            json!([])
-        };
-    }
+    apply_equipped_and_upgrades(&mut items, armor_slot);
     // setItemCount patches an existing scanned stack in place, so it depends on
     // the FString scan finding at least one stack in the player region.
     // addItem/removeItem are structural edits on the *typed* MainContainer and
@@ -7303,6 +7315,34 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
     use tempfile::tempdir;
+
+    #[test]
+    fn equipped_marking_skips_duplicate_bag_copy() {
+        let armor = ArmorSlotSummary {
+            equipped_paths: ["/Script/Angelscript.Org_Armor".to_string()]
+                .into_iter()
+                .collect(),
+            upgrades: vec![(
+                "m_CurrentUpperBodyUpgrade".to_string(),
+                "m_UpperBody_Heavy02_ArmorUpgrade".to_string(),
+            )],
+        };
+        let mut items = vec![
+            // worn copy (first occurrence — e.g. the ArmorSlot container row)
+            json!({ "path": "/Script/Angelscript.Org_Armor", "id": "Org_Armor" }),
+            // a second copy in the bag with the same path
+            json!({ "path": "/Script/Angelscript.Org_Armor", "id": "Org_Armor" }),
+            json!({ "path": "/Script/Angelscript.ItMi_Orenugget", "id": "ItMi_Orenugget" }),
+        ];
+        apply_equipped_and_upgrades(&mut items, Some(&armor));
+        assert_eq!(items[0]["equipped"], json!(true));
+        assert_eq!(items[0]["upgrades"].as_array().unwrap().len(), 1);
+        // the duplicate bag copy must NOT be flagged equipped or carry upgrades
+        assert_eq!(items[1]["equipped"], json!(false));
+        assert_eq!(items[1]["upgrades"].as_array().unwrap().len(), 0);
+        assert_eq!(items[2]["equipped"], json!(false));
+        assert_eq!(items[2]["upgrades"].as_array().unwrap().len(), 0);
+    }
 
     #[test]
     fn summarize_typed_parse_reports_status() {

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -3076,6 +3076,14 @@ fn summarize_private_inventory_payload(
         .map(|mc| mc.all_paths.iter().collect())
         .unwrap_or_default();
     main_paths.sort();
+    // The worn-armor paths (from the typed tree, uncapped) so the add dialog can
+    // also exclude the currently-equipped armor even when the displayed row list
+    // is truncated — adding a worn-armor duplicate would make the equipped
+    // badge/upgrades ambiguous.
+    let mut equipped_armor_paths: Vec<&String> = armor_slot
+        .map(|a| a.equipped_paths.iter().collect())
+        .unwrap_or_default();
+    equipped_armor_paths.sort();
     json!({
         "candidateCount": candidates.len(),
         "candidates": candidates,
@@ -3083,6 +3091,7 @@ fn summarize_private_inventory_payload(
         "itemScope": item_scope,
         "items": items,
         "mainContainerPaths": main_paths,
+        "equippedArmorPaths": equipped_armor_paths,
         "scriptPaths": script_paths,
         "properties": properties,
         "writable": writable,
@@ -10945,6 +10954,15 @@ mod tests {
             let p = i["path"].as_str().unwrap_or("");
             !p.contains("ItMi_") || i["equipped"].as_bool() == Some(false)
         }));
+        // The uncapped equipped-armor path set (used by the add picker) lists
+        // the worn armor regardless of the row cap.
+        let equipped_paths: Vec<&str> = inv["equippedArmorPaths"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p.as_str().unwrap_or(""))
+            .collect();
+        assert!(equipped_paths.contains(&"/Script/Angelscript.Ore_Armor_H"));
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -5745,10 +5745,13 @@ fn armor_slot_summary(root: &properties::RootObject) -> Option<ArmorSlotSummary>
         if let Some(path) = slot_item_definition(slot) {
             if !path.is_empty() {
                 equipped_paths.insert(path.to_string());
+                // Read upgrades from the slot that actually holds the worn armor
+                // item, not merely the first slot whose generic data yields
+                // pairs — an empty template slot must not supply upgrade data.
+                if upgrades.is_empty() {
+                    upgrades = slot_upgrade_pairs(slot);
+                }
             }
-        }
-        if upgrades.is_empty() {
-            upgrades = slot_upgrade_pairs(slot);
         }
     }
     Some(ArmorSlotSummary { equipped_paths, upgrades })

--- a/docs/superpowers/plans/2026-06-29-armor-support-tier-a.md
+++ b/docs/superpowers/plans/2026-06-29-armor-support-tier-a.md
@@ -381,7 +381,7 @@ grep -c 'VisualsDefinition\|VisualDefinition' apps/save-editor/assets/item_catal
 grep -E '"id": "(Ore_Armor_H|Crw_Armor_H|Ore_Armor_M|Org_Armor)"' apps/save-editor/assets/item_catalog.json
 ```
 
-Expected: first count > 0 (roughly ~110, base armors only — tier pieces excluded); second count == 0; the four known real-save armors all present.
+Expected: first count > 0 (~33 for the 2026-06-12 dump — base + per-NPC armors only, tier pieces and visual-defs excluded); second count == 0; the four known real-save armors all present.
 
 - [ ] **Step 3: Confirm the Rust core embed still compiles (catalog is `include_str!`-embedded)**
 

--- a/docs/superpowers/plans/2026-06-29-armor-support-tier-a.md
+++ b/docs/superpowers/plans/2026-06-29-armor-support-tier-a.md
@@ -1,0 +1,646 @@
+# Armor Support — Tier A (Catalog Item + Category) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make armor a first-class inventory item in the save editor — armor appears under its own "Armor" category (instead of "Other") and can be added to the bag like any other item.
+
+**Architecture:** Armor classes are `<Faction>_Armor[...]` / `Armor_<Camp>_<NPC>_NNN` (not `It*`). Teach the catalog generator to recognize armor item classes and tag them `armor`; regenerate the bundled `item_catalog.json` (the Rust core's addItem allow-list embeds it via `include_str!`); add an `Armor` category to the catalog model and the save-editor Flutter UI. The core display scan already returns armor rows — no scan change needed for Tier A. Equipped indicator, equip/unequip, and upgrade editing are Tiers B and C (separate plans).
+
+**Tech Stack:** Rust (`gore-catalog`, `gore-save`), `cargo test`; Flutter/Dart (`apps/save-editor`), `flutter test` + `flutter gen-l10n`.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-inventory-armor-support-design.md`
+
+**Test fixtures:** real decompressed payloads in `work/decompressed/G1R-0{16,19,20}.host.bin` (gitignored scratch, already present in this worktree). G1R-019 carries three armors: `Ore_Armor_H` (equipped), `Crw_Armor_H`, `Ore_Armor_M` (bag).
+
+---
+
+## File Structure
+
+- `crates/gore-catalog/src/pipeline.rs` — add `is_armor_item_class` + armor discriminator; integrate into `parse_item_classes` and `build_item_catalog` (category `"armor"`).
+- `crates/gore-catalog/src/lib.rs` — add `ItemCategory::Armor`; map armor ids in `item_category_from_id` and `category_for_id`; update the two `Armor_OC_Gomez` assertions.
+- `crates/gore-catalog/tests/catalog_test.rs` — update `category_unknown_for_unrecognized` (armor now `Armor`).
+- `apps/save-editor/assets/item_catalog.json` — regenerated artifact (now includes armor entries).
+- `apps/save-editor/lib/features/editor/domain/item_categories.dart` — `ItemCategory.armor` enum variant; `_isArmorId` helper; `itemCategoryFromId` armor branch; `localizedItemCategoryLabel` case.
+- `apps/save-editor/lib/features/editor/ui/sidebar_tile.dart` — `iconForItemCategory` armor case.
+- `apps/save-editor/lib/l10n/app_*.arb` (12 files) + regenerated `app_localizations*.dart` — new `itemCategoryArmor` key.
+- Tests: `crates/gore-catalog/src/pipeline.rs` (`#[cfg(test)] mod tests`), `crates/gore-catalog/src/lib.rs` (`#[cfg(test)] mod tests`), `crates/gore-save/src/lib.rs` (real-payload add test), `apps/save-editor/test/features/editor/domain/item_categories_test.dart`.
+
+---
+
+## Task 1: Armor item-class discriminator (catalog generator)
+
+**Files:**
+- Modify: `crates/gore-catalog/src/pipeline.rs` (add `is_armor_item_class`, extend `parse_item_classes`)
+- Test: `crates/gore-catalog/src/pipeline.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block in `crates/gore-catalog/src/pipeline.rs`:
+
+```rust
+#[test]
+fn armor_discriminator_accepts_items_rejects_companions() {
+    // Real base/per-NPC armor item classes -> accepted.
+    assert!(is_armor_item_class("Ore_Armor_H"));
+    assert!(is_armor_item_class("Ore_Armor_M"));
+    assert!(is_armor_item_class("Crw_Armor_H"));
+    assert!(is_armor_item_class("Org_Armor"));
+    assert!(is_armor_item_class("Vlk_Armor_L"));
+    assert!(is_armor_item_class("Ebr_Armor_H_01"));
+    assert!(is_armor_item_class("Armor_SK_OC_WOC_Velaya_108_02"));
+    assert!(is_armor_item_class("Armor_OC_EBR_Gomez_100"));
+
+    // Visual-definition companions and bases -> rejected.
+    assert!(!is_armor_item_class("Ore_Armor_H_VisualsDefinition"));
+    assert!(!is_armor_item_class("Armor_OC_EBR_Gomez_100_VisualDefinition"));
+    assert!(!is_armor_item_class("BaseArmorDefinition"));
+    assert!(!is_armor_item_class("ArmorVisualsDefinition_Human"));
+
+    // Upgrade-component tier pieces -> rejected (edited via Tier C, not added).
+    assert!(!is_armor_item_class("Org_Armor_Top_H_01"));
+    assert!(!is_armor_item_class("Sld_Armor_Mid_L_02"));
+
+    // Non-item noise that merely contains "Armor" -> rejected.
+    assert!(!is_armor_item_class("GE_Crw_Armor_H"));
+    assert!(!is_armor_item_class("GothicAchievement_Armor_01"));
+    assert!(!is_armor_item_class("OC_Armory_Door"));
+    assert!(!is_armor_item_class("Spawner_OC_Castle_Armory_Misc_01"));
+    assert!(!is_armor_item_class("Hit_SuperArmor_Player"));
+    assert!(!is_armor_item_class("CharacterVisualsDefinition_OreArmor"));
+
+    // Ordinary It* items are not armor.
+    assert!(!is_armor_item_class("ItMi_Orenugget"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p gore-catalog armor_discriminator_accepts_items_rejects_companions`
+Expected: FAIL — `cannot find function `is_armor_item_class``.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add above `parse_item_classes` in `crates/gore-catalog/src/pipeline.rs`:
+
+```rust
+/// True when an Angelscript class name is an armor *item* class (a class that
+/// can occupy an inventory slot), as opposed to its paired visual-definition
+/// companion, an upgrade-component tier piece, or unrelated noise that merely
+/// contains "Armor".
+///
+/// Armor item classes are NOT `It*`. They are faction-armor families
+/// (`<Fac>_Armor[_suffix]`, e.g. `Ore_Armor_H`, `Org_Armor`) and per-NPC
+/// armors (`Armor_<CAMP>_<NPC>_NNN`). Each is paired with a
+/// `*_VisualsDefinition` / `*_VisualDefinition` companion that is NOT an item.
+/// The `_{Top,Mid,Bot}_` tier pieces are armor-customization components stored
+/// in `BoughtArmorUpgrades.AvailableUpgrades` and applied via the worn armor's
+/// upgrade string-map (Tier C) — they are not standalone bag items.
+fn is_armor_item_class(name: &str) -> bool {
+    if !name.contains("Armor") {
+        return false;
+    }
+    // Companions / bases / non-item definitions.
+    if name.ends_with("Definition") || name.ends_with("_Base") {
+        return false;
+    }
+    if name.starts_with("ArmorVisualsDefinition") {
+        return false;
+    }
+    // Upgrade-component tier pieces (Org_Armor_Top_H_01, Sld_Armor_Mid_L_02 ...).
+    if name.contains("_Top_") || name.contains("_Mid_") || name.contains("_Bot_") {
+        return false;
+    }
+    // Non-item families that contain "Armor"/"Armory"/"SuperArmor".
+    const NON_ITEM_PREFIXES: &[&str] = &[
+        "GE_", "GA_", "GC_", "GVL_", "CS_", "Choice", "Document", "Conversation",
+        "DailyRoutine", "Module_", "AIAgent", "CharacterDefinition",
+        "CharacterVisuals", "AllArmors", "Quest", "Memory", "Spawner",
+        "Glossary", "Gothic", "Hit_", "SpawnAIAgent", "SpawnMeshes", "OC_",
+    ];
+    if NON_ITEM_PREFIXES.iter().any(|p| name.starts_with(p)) {
+        return false;
+    }
+    // Item families: `<2-4 alpha>_Armor...` or `Armor_<CAMP>_...`.
+    let faction_armor = {
+        let mut parts = name.splitn(2, '_');
+        let head = parts.next().unwrap_or("");
+        let tail = parts.next().unwrap_or("");
+        (2..=4).contains(&head.len())
+            && head.chars().all(|c| c.is_ascii_alphabetic())
+            && tail.starts_with("Armor")
+    };
+    faction_armor || name.starts_with("Armor_")
+}
+```
+
+Then change the filter inside `parse_item_classes` (line ~39):
+
+```rust
+            if name.starts_with("It") || is_armor_item_class(&name) {
+                names.insert(name);
+            }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p gore-catalog armor_discriminator_accepts_items_rejects_companions`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/gore-catalog/src/pipeline.rs
+git commit -m "feat(catalog): recognize armor item classes in the dump parser"
+```
+
+---
+
+## Task 2: Tag armor entries with category "armor" in the generated catalog
+
+**Files:**
+- Modify: `crates/gore-catalog/src/pipeline.rs` (`build_item_catalog` category resolution)
+- Test: `crates/gore-catalog/src/pipeline.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block in `pipeline.rs`:
+
+```rust
+#[test]
+fn armor_entries_get_armor_category() {
+    let lines = [
+        "[0001] ASClass /Script/Angelscript.Ore_Armor_H [n: 1] [c: 2]",
+        "[0002] ASClass /Script/Angelscript.Ore_Armor_H_VisualsDefinition [n: 1] [c: 2]",
+        "[0003] ASClass /Script/Angelscript.Armor_OC_EBR_Gomez_100 [n: 1] [c: 2]",
+        "[0004] ASClass /Script/Angelscript.ItMi_Orenugget [n: 1] [c: 2]",
+        "[0005] ASClass /Script/Angelscript.Org_Armor_Top_H_01 [n: 1] [c: 2]",
+    ];
+    let (entries, _skipped) = build_item_catalog(&lines);
+    let by_id: std::collections::HashMap<&str, &ItemEntry> =
+        entries.iter().map(|e| (e.id.as_str(), e)).collect();
+
+    assert_eq!(by_id["Ore_Armor_H"].category, "armor");
+    assert_eq!(by_id["Ore_Armor_H"].path, "/Script/Angelscript.Ore_Armor_H");
+    assert_eq!(by_id["Armor_OC_EBR_Gomez_100"].category, "armor");
+    assert_eq!(by_id["ItMi_Orenugget"].category, "misc");
+    // companion + tier piece are not catalog entries at all
+    assert!(!by_id.contains_key("Ore_Armor_H_VisualsDefinition"));
+    assert!(!by_id.contains_key("Org_Armor_Top_H_01"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p gore-catalog armor_entries_get_armor_category`
+Expected: FAIL — `Ore_Armor_H` resolves to `"special"` (unmatched prefix), not `"armor"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `build_item_catalog` (`pipeline.rs`), change the category resolution so armor is detected before the `It*` prefix table. Replace the `let category: String = if let Some(cat) = item_explicit(name) {` block's head with:
+
+```rust
+        let category: String = if is_armor_item_class(name) {
+            "armor".to_string()
+        } else if let Some(cat) = item_explicit(name) {
+            cat.to_string()
+        } else {
+```
+
+(The rest of the `else` body — the prefix-table loop and the `"special"` fallback — is unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p gore-catalog armor_entries_get_armor_category`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full crate test suite (catch regressions in existing pipeline tests)**
+
+Run: `cargo test -p gore-catalog`
+Expected: PASS except the two pre-existing `Armor_OC_Gomez` assertions, fixed in Task 3. If they fail here, that is expected and addressed next.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/gore-catalog/src/pipeline.rs
+git commit -m "feat(catalog): tag armor classes with the armor category"
+```
+
+---
+
+## Task 3: Add `ItemCategory::Armor` to the catalog model
+
+**Files:**
+- Modify: `crates/gore-catalog/src/lib.rs` (`ItemCategory` enum, `label`, `item_category_from_id`, `category_for_id`, inline `unknown_ids_map_to_other` test)
+- Modify: `crates/gore-catalog/tests/catalog_test.rs` (`category_unknown_for_unrecognized`)
+
+- [ ] **Step 1: Write/Update the failing tests**
+
+In `crates/gore-catalog/src/lib.rs` `#[cfg(test)] mod tests`, replace the body of `unknown_ids_map_to_other` (the line asserting `Armor_OC_Gomez` → `Other`) and add an armor test:
+
+```rust
+    #[test]
+    fn unknown_ids_map_to_other() {
+        assert_eq!(item_category_from_id(""), ItemCategory::Other);
+        assert_eq!(item_category_from_id("ItIg_Worldsplitter"), ItemCategory::Other);
+    }
+
+    #[test]
+    fn armor_ids_map_to_armor() {
+        assert_eq!(item_category_from_id("Ore_Armor_H"), ItemCategory::Armor);
+        assert_eq!(item_category_from_id("Org_Armor"), ItemCategory::Armor);
+        assert_eq!(item_category_from_id("Armor_OC_Gomez"), ItemCategory::Armor);
+        assert_eq!(category_for_id("Ore_Armor_H"), ItemCategory::Armor);
+        assert_eq!(category_for_id("Armor_OC_Gomez"), ItemCategory::Armor);
+    }
+```
+
+In `crates/gore-catalog/tests/catalog_test.rs`, replace `category_unknown_for_unrecognized`:
+
+```rust
+#[test]
+fn category_armor_for_armor_classes() {
+    assert_eq!(category_for_id("Armor_OC_Gomez"), ItemCategory::Armor);
+    assert_eq!(category_for_id("Ore_Armor_H"), ItemCategory::Armor);
+}
+
+#[test]
+fn category_unknown_for_unrecognized() {
+    assert_eq!(category_for_id("TotallyUnknownClass"), ItemCategory::Unknown);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p gore-catalog armor_ids_map_to_armor`
+Expected: FAIL — no `ItemCategory::Armor` variant.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `crates/gore-catalog/src/lib.rs`:
+
+(a) Add the variant to the `ItemCategory` enum — place it right after `RangedWeapon` so weapons and armor sit together (declaration order drives UI order in the mirrored Dart enum; keep them consistent):
+
+```rust
+    MeleeWeapon,
+    RangedWeapon,
+    /// Wearable armor (`<Fac>_Armor_*`, `Armor_<Camp>_<NPC>_*`).
+    Armor,
+    Ammunition,
+```
+
+(b) Add a `label()` arm (find the `label` match and add):
+
+```rust
+            ItemCategory::Armor => "Armor",
+```
+
+(c) In `item_category_from_id`, add an armor branch. Armor ids are not `It*`, so add it as the first check (before the `ItMw_` chain), reusing a shared helper:
+
+```rust
+pub fn item_category_from_id(id: &str) -> ItemCategory {
+    if is_armor_id(id) {
+        ItemCategory::Armor
+    } else if id.starts_with("ItMw_") {
+        ItemCategory::MeleeWeapon
+    } else if id.starts_with("ItRw_") {
+```
+
+(d) In `category_for_id`, add at the top (before the `ItFo_` check):
+
+```rust
+pub fn category_for_id(id: &str) -> ItemCategory {
+    if is_armor_id(id) {
+        return ItemCategory::Armor;
+    }
+    if id.starts_with("ItFo_") {
+```
+
+(e) Add the shared `is_armor_id` helper (display-side classifier — broader than the catalog's `is_armor_item_class`: it also classifies tier pieces as armor so any armor already in a save is grouped correctly):
+
+```rust
+/// Display-side armor classifier: true for any armor class name (base, per-NPC,
+/// or tier piece). Broader than the catalog's `is_armor_item_class`, which
+/// additionally excludes tier pieces from the *addable* set.
+pub fn is_armor_id(id: &str) -> bool {
+    if !id.contains("Armor") {
+        return false;
+    }
+    if id.starts_with("Armor_") {
+        return true;
+    }
+    let mut parts = id.splitn(2, '_');
+    let head = parts.next().unwrap_or("");
+    let tail = parts.next().unwrap_or("");
+    (2..=4).contains(&head.len())
+        && head.chars().all(|c| c.is_ascii_alphabetic())
+        && tail.starts_with("Armor")
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p gore-catalog`
+Expected: PASS (all tests, including the updated assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/gore-catalog/src/lib.rs crates/gore-catalog/tests/catalog_test.rs
+git commit -m "feat(catalog): add Armor category to the catalog model"
+```
+
+---
+
+## Task 4: Regenerate the bundled item catalog
+
+**Files:**
+- Modify (regenerated artifact): `apps/save-editor/assets/item_catalog.json`
+
+The catalog is generated from the UE4SS object dump on the user's machine:
+`D:\SteamLibrary\steamapps\common\Gothic 1 Remake\G1R\Binaries\Win64\ue4ss\UE4SS_ObjectDump.txt`
+
+- [ ] **Step 1: Regenerate the catalog**
+
+Run (from the worktree root):
+
+```bash
+cargo run -p gore -- catalog --kind item \
+  "D:/SteamLibrary/steamapps/common/Gothic 1 Remake/G1R/Binaries/Win64/ue4ss/UE4SS_ObjectDump.txt" \
+  -o apps/save-editor/assets/item_catalog.json
+```
+
+Expected: prints skipped classes to stderr; writes the JSON. (If the dump path differs, use the actual `UE4SS_ObjectDump.txt`.)
+
+- [ ] **Step 2: Verify armor is present and companions are absent**
+
+Run:
+
+```bash
+grep -c '"category": "armor"' apps/save-editor/assets/item_catalog.json
+grep -c 'VisualsDefinition\|VisualDefinition' apps/save-editor/assets/item_catalog.json
+grep -E '"id": "(Ore_Armor_H|Crw_Armor_H|Ore_Armor_M|Org_Armor)"' apps/save-editor/assets/item_catalog.json
+```
+
+Expected: first count > 0 (roughly ~110, base armors only — tier pieces excluded); second count == 0; the four known real-save armors all present.
+
+- [ ] **Step 3: Confirm the Rust core embed still compiles (catalog is `include_str!`-embedded)**
+
+Run: `cargo build -p gore-save`
+Expected: builds (the larger JSON is parsed at runtime by `item_catalog_paths`; no compile impact).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/save-editor/assets/item_catalog.json
+git commit -m "chore(catalog): regenerate item_catalog.json with armor entries"
+```
+
+---
+
+## Task 5: Verify armor is addable through the core (real-payload test)
+
+**Files:**
+- Test: `crates/gore-save/src/lib.rs` `#[cfg(test)] mod tests`
+
+This proves the regenerated catalog makes `addItem` accept an armor path and that the splice round-trips byte-faithfully on a real save.
+
+- [ ] **Step 1: Write the failing (ignored, real-payload) test**
+
+Add to the `#[cfg(test)] mod tests` block in `crates/gore-save/src/lib.rs`:
+
+```rust
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn add_armor_item_roundtrips_on_real_payload() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let mut payload = std::fs::read(path).unwrap();
+        // An armor NOT already in this save's MainContainer.
+        let armor_path = "/Script/Angelscript.Vlk_Armor_L";
+        assert!(is_item_definition_class(armor_path), "armor must be in the catalog allow-list");
+        let edit = PrivateInventoryAddItemEdit { path: armor_path.to_string(), count: 1 };
+        apply_private_inventory_add_item_to_payload(&mut payload, &edit).unwrap();
+        let root = properties::parse_private_root(&payload).unwrap();
+        assert_eq!(root.consumed, payload.len(), "byte-faithful: no trailing/lost bytes");
+        let summary = main_container_summary(&root).expect("main container");
+        assert!(summary.all_paths.contains(armor_path), "armor now in MainContainer");
+    }
+```
+
+- [ ] **Step 2: Run it (must fail before Task 4's catalog regen, pass after)**
+
+Run:
+
+```bash
+GORESAVE_PAYLOAD_BIN="work/decompressed/G1R-016.host.bin" \
+  cargo test -p gore-save add_armor_item_roundtrips_on_real_payload -- --ignored --nocapture
+```
+
+Expected: PASS once the regenerated catalog (Task 4) contains `Vlk_Armor_L`. (If it fails on `is_item_definition_class`, Task 4 did not include that armor — re-check the discriminator/regen.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gore-save/src/lib.rs
+git commit -m "test(gore-save): armor addItem round-trips on a real payload"
+```
+
+---
+
+## Task 6: Add the `Armor` category to the save-editor UI enum + mapping
+
+**Files:**
+- Modify: `apps/save-editor/lib/features/editor/domain/item_categories.dart`
+- Test: `apps/save-editor/test/features/editor/domain/item_categories_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/save-editor/test/features/editor/domain/item_categories_test.dart`:
+
+```dart
+  test('armor classes categorize as armor', () {
+    expect(itemCategoryFromId('Ore_Armor_H'), ItemCategory.armor);
+    expect(itemCategoryFromId('Org_Armor'), ItemCategory.armor);
+    expect(itemCategoryFromId('Armor_OC_Gomez'), ItemCategory.armor);
+    expect(itemCategoryFromId('Org_Armor_Top_H_01'), ItemCategory.armor);
+    // non-armor unaffected
+    expect(itemCategoryFromId('ItMi_Orenugget'), ItemCategory.misc);
+    expect(itemCategoryFromId('SomethingElse'), ItemCategory.other);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/save-editor && flutter test test/features/editor/domain/item_categories_test.dart`
+Expected: FAIL — no `ItemCategory.armor`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/save-editor/lib/features/editor/domain/item_categories.dart`:
+
+(a) Add the variant right after `rangedWeapon` (matches the Rust enum order):
+
+```dart
+  meleeWeapon('Melee weapons'),
+  rangedWeapon('Ranged weapons'),
+  armor('Armor'),
+  ammunition('Ammunition'),
+```
+
+(b) Add the armor branch at the TOP of `itemCategoryFromId` (armor ids are not `It*`):
+
+```dart
+ItemCategory itemCategoryFromId(String id) {
+  if (_isArmorId(id)) return ItemCategory.armor;
+  if (id.startsWith('ItMw_')) return ItemCategory.meleeWeapon;
+```
+
+(c) Add the helper (mirrors the Rust `is_armor_id`) at the bottom of the file:
+
+```dart
+/// True for any armor class name (base, per-NPC, or tier piece). Mirrors the
+/// Rust `gore_catalog::is_armor_id` display-side classifier.
+bool _isArmorId(String id) {
+  if (!id.contains('Armor')) return false;
+  if (id.startsWith('Armor_')) return true;
+  final parts = id.split('_');
+  if (parts.length < 2) return false;
+  final head = parts.first;
+  return head.length >= 2 &&
+      head.length <= 4 &&
+      RegExp(r'^[A-Za-z]+$').hasMatch(head) &&
+      parts[1].startsWith('Armor');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/save-editor && flutter test test/features/editor/domain/item_categories_test.dart`
+Expected: FAIL to COMPILE — `localizedItemCategoryLabel` and `iconForItemCategory` switches are now non-exhaustive. That is fixed in Tasks 7-8. (If you prefer a green checkpoint here, do Tasks 7 and 8 before re-running.)
+
+- [ ] **Step 5: Commit (after Tasks 7-8 make it compile — see note)**
+
+This task's commit is combined with Tasks 7-8 (they must land together for the app to compile). Proceed to Task 7.
+
+---
+
+## Task 7: Add the `itemCategoryArmor` localization key
+
+**Files:**
+- Modify: `apps/save-editor/lib/l10n/app_en.arb` (+ the other 11 `app_*.arb` files)
+- Regenerated: `apps/save-editor/lib/l10n/app_localizations*.dart`
+- Modify: `apps/save-editor/lib/features/editor/domain/item_categories.dart` (`localizedItemCategoryLabel`)
+
+- [ ] **Step 1: Add the key to every ARB file**
+
+Add `"itemCategoryArmor"` next to `"itemCategoryAmmunition"` in each file. Use these values:
+
+- `app_en.arb`: `"itemCategoryArmor": "Armor",`
+- `app_de.arb`: `"itemCategoryArmor": "Rüstungen",`
+- `app_es.arb`: `"itemCategoryArmor": "Armaduras",`
+- `app_fr.arb`: `"itemCategoryArmor": "Armures",`
+- `app_it.arb`: `"itemCategoryArmor": "Armature",`
+- `app_ja.arb`: `"itemCategoryArmor": "鎧",`
+- `app_pl.arb`: `"itemCategoryArmor": "Zbroje",`
+- `app_pt.arb`: `"itemCategoryArmor": "Armaduras",`
+- `app_pt_BR.arb`: `"itemCategoryArmor": "Armaduras",`
+- `app_ru.arb`: `"itemCategoryArmor": "Броня",`
+- `app_zh.arb`: `"itemCategoryArmor": "护甲",`
+- `app_zh_Hans.arb`: `"itemCategoryArmor": "护甲",`
+
+(Match the exact JSON formatting/trailing-comma style of each file. ARB entries with no placeholders need no metadata block.)
+
+- [ ] **Step 2: Regenerate localizations**
+
+Run: `cd apps/save-editor && flutter gen-l10n`
+Expected: regenerates `app_localizations*.dart` with a `String get itemCategoryArmor;` getter and per-locale overrides. No errors.
+
+- [ ] **Step 3: Wire the label switch**
+
+In `apps/save-editor/lib/features/editor/domain/item_categories.dart`, add to `localizedItemCategoryLabel`'s switch, next to the ammunition case:
+
+```dart
+    ItemCategory.armor => l10n.itemCategoryArmor,
+```
+
+- [ ] **Step 4: Verify (defer running until Task 8 completes the other switch)**
+
+Proceed to Task 8; the analyzer will be green once both switches are exhaustive.
+
+---
+
+## Task 8: Add the armor icon
+
+**Files:**
+- Modify: `apps/save-editor/lib/features/editor/ui/sidebar_tile.dart` (`iconForItemCategory`)
+
+- [ ] **Step 1: Add the icon case**
+
+In `apps/save-editor/lib/features/editor/ui/sidebar_tile.dart`, add to `iconForItemCategory`'s switch, next to the weapon cases:
+
+```dart
+    ItemCategory.armor => Icons.shield_outlined,
+```
+
+- [ ] **Step 2: Analyze + run the domain tests**
+
+Run:
+
+```bash
+cd apps/save-editor && flutter analyze lib/features/editor/domain/item_categories.dart lib/features/editor/ui/sidebar_tile.dart && flutter test test/features/editor/domain/item_categories_test.dart
+```
+
+Expected: analyze clean (both switches exhaustive); the armor categorization test passes.
+
+- [ ] **Step 3: Commit Tasks 6-8 together**
+
+```bash
+git add apps/save-editor/lib/features/editor/domain/item_categories.dart \
+        apps/save-editor/lib/features/editor/ui/sidebar_tile.dart \
+        apps/save-editor/lib/l10n/
+git commit -m "feat(save-editor): show armor under its own Armor category"
+```
+
+---
+
+## Task 9: Full verification
+
+- [ ] **Step 1: Rust suites**
+
+Run: `cargo test -p gore-catalog && cargo test -p gore-save`
+Expected: PASS.
+
+- [ ] **Step 2: Real-payload armor add**
+
+Run:
+
+```bash
+GORESAVE_PAYLOAD_BIN="work/decompressed/G1R-016.host.bin" \
+  cargo test -p gore-save add_armor_item_roundtrips_on_real_payload -- --ignored
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Flutter analyze + tests**
+
+Run: `cd apps/save-editor && flutter analyze && flutter test`
+Expected: analyze clean; tests pass.
+
+- [ ] **Step 4: Manual smoke (optional, real app)**
+
+Launch the save editor, open the user's `G1R-019.sav`. Expected: an **Armor** category (shield icon) in the inventory sidebar listing `Ore_Armor_H`, `Crw_Armor_H`, `Ore_Armor_M`; the Add-item dialog has an Armor category listing addable armors. (Equipped badge + equip/unequip are Tier B; upgrades are Tier C.)
+
+---
+
+## Self-Review notes
+
+- **Spec coverage (Tier A):** catalog discriminator (Task 1), armor category in JSON (Task 2) + model (Task 3), regen (Task 4), addable verified (Task 5), UI category/label/icon (Tasks 6-8). Tier A's "equipped indicator" is intentionally deferred to Tier B (it requires the same container-aware core work as equip/unequip).
+- **Two classifiers, on purpose:** `is_armor_item_class` (catalog/addable — excludes tier pieces) vs `is_armor_id` (display — includes tier pieces). Names differ; both documented.
+- **No new core display code in Tier A** — armor rows already return from `summarize_private_inventory_items` (verified via `inspect_save` probe on G1R-019).
+- **Catalog regen has no snapshot-gate test** — Task 4 is a manual artifact regen; the only tests that move are the two `Armor_OC_Gomez` assertions (Task 3).
+
+---
+
+## Roadmap (subsequent plans)
+
+- **Tier B — Equipped indicator + equip/unequip:** core surfaces each row's `EInventoryTypes` container (so the UI can flag the `ArmorSlot` item as equipped); new `private.inventory.equipArmor` / `unequipArmor` edit op that relocates a slot between `MainContainer` and `ArmorSlot` `m_Slots` (single-occupancy, swap on replace), reusing the `donor_slot_template_bytes` / `ArrayInsertBytes` + `ArrayRemove` splice machinery and extending the standalone-structural-edit batch guards. UI: equipped badge + equip/unequip control. Authored as its own plan after Tier A lands.
+- **Tier C — Armor upgrades:** read/edit the worn armor slot's `m_Payload.m_GenericData` string-map (`m_Current{Upper,Mid,Lower}BodyUpgrade`). UI upgrade editor. Authored after Tier B.

--- a/docs/superpowers/plans/2026-06-29-armor-support-tier-b1-equipped-indicator.md
+++ b/docs/superpowers/plans/2026-06-29-armor-support-tier-b1-equipped-indicator.md
@@ -1,0 +1,414 @@
+# Armor Support — Tier B1 (Equipped Indicator) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Show which armor is currently equipped (worn) in the inventory — the armor that lives in the player's `ArmorSlot` container is flagged with an "Equipped" badge.
+
+**Architecture:** The player inventory is a `TMap<EInventoryTypes, Container>`. The worn armor is the item in the `ArmorSlot` container's `m_Slots`; carried items are in `MainContainer`. The core already returns all armor rows; this plan adds container-awareness: a typed-tree helper `armor_slot_summary` collects the equipped armor paths, the inventory summary marks each row `equipped`, and the Flutter UI renders a badge. Read-only — no save edits (equip/unequip is Tier B2).
+
+**Tech Stack:** Rust (`gore-save`), `cargo test`; Flutter/Dart (`apps/save-editor`), `flutter test` + `flutter analyze`.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-inventory-armor-support-design.md`
+
+**Fixtures:** `work/decompressed/G1R-019.host.bin` — ArmorSlot=`Ore_Armor_H` (equipped), MainContainer=`Crw_Armor_H`,`Ore_Armor_M`. Use ABSOLUTE paths for `GORESAVE_PAYLOAD_BIN` (cargo's cwd differs from the worktree root).
+
+---
+
+## File Structure
+
+- `crates/gore-save/src/lib.rs` — add `ARMOR_SLOT_ENUM_LABEL` const, `ArmorSlotSummary` struct, `armor_slot_summary` fn (mirrors `main_container_summary`); thread an `armor_slot: Option<&ArmorSlotSummary>` param into `summarize_private_inventory_payload` and mark each row `equipped`; compute it at the inspect call site (~line 2820).
+- `apps/save-editor/lib/features/editor/domain/editor_models.dart` — `PrivateInventoryItem.equipped` field + `fromJson`.
+- `apps/save-editor/lib/features/editor/ui/editor_page.dart` — equipped badge in the inventory item row.
+- Tests: `crates/gore-save/src/lib.rs` (real-payload), `apps/save-editor/test/...` (model + optional widget).
+
+---
+
+## Task 1: `armor_slot_summary` — collect equipped armor paths (core)
+
+**Files:**
+- Modify: `crates/gore-save/src/lib.rs` (add const + struct + fn near `main_container_summary` ~line 5639; `MAIN_CONTAINER_ENUM_LABEL` is at ~5509)
+- Test: `crates/gore-save/src/lib.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing real-payload test**
+
+Add to the `#[cfg(test)] mod tests` block (near the other `#[ignore]` real-payload tests):
+
+```rust
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn armor_slot_summary_finds_equipped_armor() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let root = properties::parse_private_root(&payload).unwrap();
+        let summary = armor_slot_summary(&root).expect("armor slot container resolves");
+        // G1R-019: the worn armor is Ore_Armor_H; the other two are in the bag.
+        assert!(summary.equipped_paths.contains("/Script/Angelscript.Ore_Armor_H"));
+        assert!(!summary.equipped_paths.contains("/Script/Angelscript.Crw_Armor_H"));
+        assert!(!summary.equipped_paths.contains("/Script/Angelscript.Ore_Armor_M"));
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-019.host.bin" cargo test -p gore-save armor_slot_summary_finds_equipped_armor -- --ignored`
+Expected: FAIL — `cannot find function `armor_slot_summary``.
+
+- [ ] **Step 3: Implement**
+
+Add near `MAIN_CONTAINER_ENUM_LABEL` (the `const` ~line 5509):
+
+```rust
+/// Enum label of the player's worn-armor container in the inventory map.
+const ARMOR_SLOT_ENUM_LABEL: &str = "EInventoryTypes::ArmorSlot";
+```
+
+Add near `main_container_summary` (mirror its container-resolution shape):
+
+```rust
+/// The item-definition paths currently in the player's `ArmorSlot` container —
+/// i.e. the worn armor. At most one in practice, modeled as a set for
+/// robustness. `None` when the inventory or the ArmorSlot container is absent.
+struct ArmorSlotSummary {
+    equipped_paths: std::collections::HashSet<String>,
+}
+
+/// Resolve the player's `ArmorSlot` container and collect the item-definition
+/// paths it holds. Mirrors `main_container_summary`'s container resolution.
+fn armor_slot_summary(root: &properties::RootObject) -> Option<ArmorSlotSummary> {
+    let inventory_path = resolve_inventory_path(root)?;
+    let resolve_child = |suffix: &[&str]| -> Option<properties::PropertyValue> {
+        let mut segs = inventory_path.clone();
+        segs.extend(suffix.iter().map(|s| s.to_string()));
+        let parsed = properties::parse_path(&segs).ok()?;
+        properties::resolve(&root.properties, &parsed)
+            .ok()
+            .map(|prop| prop.value.clone())
+    };
+    let properties::PropertyValue::Array { elements: keys } = resolve_child(&["m_Keys"])? else {
+        return None;
+    };
+    let index = keys.iter().position(|element| {
+        matches!(element, properties::PropertyValue::Enum(label)
+            if label == ARMOR_SLOT_ENUM_LABEL)
+    })?;
+    let segment = format!("[{index}]");
+    let properties::PropertyValue::Array { elements: slots } =
+        resolve_child(&["m_Values", "Items", &segment, "m_Slots"])?
+    else {
+        return None;
+    };
+    let mut equipped_paths = std::collections::HashSet::new();
+    for slot in &slots {
+        if let Some(path) = slot_item_definition(slot) {
+            if !path.is_empty() {
+                equipped_paths.insert(path.to_string());
+            }
+        }
+    }
+    Some(ArmorSlotSummary { equipped_paths })
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-019.host.bin" cargo test -p gore-save armor_slot_summary_finds_equipped_armor -- --ignored`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/gore-save/src/lib.rs
+git commit -m "feat(gore-save): resolve the equipped-armor (ArmorSlot) container"
+```
+
+---
+
+## Task 2: Mark inventory rows `equipped` in the summary (core)
+
+**Files:**
+- Modify: `crates/gore-save/src/lib.rs` — `summarize_private_inventory_payload` signature + the per-row marking loop (~line 3009); the inspect call site (~line 2820-2825)
+- Test: `crates/gore-save/src/lib.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing real-payload test**
+
+```rust
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn inventory_rows_flag_equipped_armor() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let refs = scan_fstrings(&payload, 0);
+        let root = properties::parse_private_root(&payload).unwrap();
+        let main_container = main_container_summary(&root);
+        let armor_slot = armor_slot_summary(&root);
+        let inv = summarize_private_inventory_payload(
+            &payload,
+            &refs,
+            main_container.as_ref(),
+            armor_slot.as_ref(),
+        );
+        let items = inv["items"].as_array().unwrap();
+        let equipped: Vec<&str> = items
+            .iter()
+            .filter(|i| i["equipped"].as_bool() == Some(true))
+            .map(|i| i["path"].as_str().unwrap_or(""))
+            .collect();
+        // G1R-019: exactly the worn Ore_Armor_H is flagged equipped.
+        assert!(equipped.contains(&"/Script/Angelscript.Ore_Armor_H"));
+        assert!(!equipped.contains(&"/Script/Angelscript.Crw_Armor_H"));
+        // a non-armor row is never equipped
+        assert!(items.iter().all(|i| {
+            let p = i["path"].as_str().unwrap_or("");
+            !p.contains("ItMi_") || i["equipped"].as_bool() == Some(false)
+        }));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-019.host.bin" cargo test -p gore-save inventory_rows_flag_equipped_armor -- --ignored`
+Expected: FAIL to COMPILE — `summarize_private_inventory_payload` takes 3 args, not 4.
+
+- [ ] **Step 3: Implement**
+
+(a) Change the signature of `summarize_private_inventory_payload` (~line 2979) to add the param:
+
+```rust
+fn summarize_private_inventory_payload(
+    payload: &[u8],
+    refs: &[FStringRef],
+    main_container: Option<&MainContainerSummary>,
+    armor_slot: Option<&ArmorSlotSummary>,
+) -> Value {
+```
+
+(b) In the per-row loop (~line 3009, right after the `removable` marking), add:
+
+```rust
+    for item in &mut items {
+        let path = item["path"].as_str().unwrap_or("");
+        item["equipped"] = json!(
+            !path.is_empty()
+                && armor_slot.is_some_and(|a| a.equipped_paths.contains(path))
+        );
+    }
+```
+
+(Keep this as a second loop after the existing `removable` loop, or fold the assignment into the existing loop — either is fine; do not disturb the `removable` logic.)
+
+(c) At the inspect call site (~line 2820), compute `armor_slot` alongside `main_container` and pass it:
+
+```rust
+            let main_container = typed_result
+                .as_ref()
+                .and_then(|r| r.as_ref().ok())
+                .and_then(main_container_summary);
+            let armor_slot = typed_result
+                .as_ref()
+                .and_then(|r| r.as_ref().ok())
+                .and_then(armor_slot_summary);
+            let inventory = summarize_private_inventory_payload(
+                &payload,
+                &refs,
+                main_container.as_ref(),
+                armor_slot.as_ref(),
+            );
+```
+
+- [ ] **Step 4: Fix any other call sites**
+
+Run: `cargo build -p gore-save`. If any other caller of `summarize_private_inventory_payload` exists (e.g. an existing unit test), update it to pass `None` for the new `armor_slot` argument. Report any such site.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-019.host.bin" cargo test -p gore-save inventory_rows_flag_equipped_armor -- --ignored`
+Expected: PASS.
+
+- [ ] **Step 6: Run the whole crate suite (no regressions)**
+
+Run: `cargo test -p gore-save`
+Expected: PASS (181+ tests; the two new ones are `#[ignore]`-gated).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/gore-save/src/lib.rs
+git commit -m "feat(gore-save): flag equipped armor rows in the inventory summary"
+```
+
+---
+
+## Task 3: `PrivateInventoryItem.equipped` (Dart model)
+
+**Files:**
+- Modify: `apps/save-editor/lib/features/editor/domain/editor_models.dart` (`PrivateInventoryItem` ~line 674)
+- Test: `apps/save-editor/test/features/editor/domain/editor_models_test.dart` (create if absent, else add to the existing inventory model test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add (in the appropriate existing test file for `PrivateInventoryItem`, or create `editor_models_test.dart` with the standard `flutter_test` import):
+
+```dart
+  test('PrivateInventoryItem parses equipped flag', () {
+    final equipped = PrivateInventoryItem.fromJson({
+      'id': 'Ore_Armor_H',
+      'path': '/Script/Angelscript.Ore_Armor_H',
+      'count': 1,
+      'equipped': true,
+    });
+    expect(equipped.equipped, isTrue);
+
+    final plain = PrivateInventoryItem.fromJson({
+      'id': 'ItMi_Orenugget',
+      'path': '/Script/Angelscript.ItMi_Orenugget',
+      'count': 5,
+    });
+    expect(plain.equipped, isFalse); // defaults false when absent
+  });
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/save-editor && flutter test test/features/editor/domain/editor_models_test.dart`
+Expected: FAIL — `equipped` getter not defined.
+
+- [ ] **Step 3: Implement**
+
+In `PrivateInventoryItem` (~line 674), add the field, constructor param, and fromJson line, mirroring the existing `removable` handling:
+
+```dart
+  const PrivateInventoryItem({
+    required this.id,
+    required this.path,
+    this.count,
+    this.removable = false,
+    this.equipped = false,
+  });
+
+  factory PrivateInventoryItem.fromJson(Map<Object?, Object?> json) {
+    return PrivateInventoryItem(
+      id: json['id'] as String? ?? '',
+      path: json['path'] as String? ?? '',
+      count: (json['count'] as num?)?.toInt(),
+      removable: json['removable'] as bool? ?? false,
+      equipped: json['equipped'] as bool? ?? false,
+    );
+  }
+
+  final String id;
+  final String path;
+  final int? count;
+  final bool removable;
+  /// True for the worn armor (the item in the player's ArmorSlot container).
+  final bool equipped;
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/save-editor && flutter test test/features/editor/domain/editor_models_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/save-editor/lib/features/editor/domain/editor_models.dart apps/save-editor/test/features/editor/domain/editor_models_test.dart
+git commit -m "feat(save-editor): parse the equipped flag on inventory items"
+```
+
+---
+
+## Task 4: Equipped badge in the inventory row (Dart UI)
+
+**Files:**
+- Modify: `apps/save-editor/lib/features/editor/ui/editor_page.dart` — the inventory `ListTile` (~line 1940-1992) / `_inventoryItemTrailing` (~line 2016)
+- Modify: `apps/save-editor/lib/l10n/app_*.arb` (12) + regenerate — new `equippedBadge` label
+- Test: `apps/save-editor/test/widget_test.dart` (extend existing inventory widget test if practical)
+
+- [ ] **Step 1: Add the localized label**
+
+Add `"equippedBadge"` to each of the 12 `app_*.arb` files near other inventory labels:
+- en: `"equippedBadge": "Equipped",`
+- de: `"equippedBadge": "Angelegt",`
+- es: `"equippedBadge": "Equipado",`
+- fr: `"equippedBadge": "Équipé",`
+- it: `"equippedBadge": "Equipaggiato",`
+- ja: `"equippedBadge": "装備中",`
+- pl: `"equippedBadge": "Założone",`
+- pt: `"equippedBadge": "Equipado",`
+- pt_BR: `"equippedBadge": "Equipado",`
+- ru: `"equippedBadge": "Надето",`
+- zh: `"equippedBadge": "已装备",`
+- zh_Hans: `"equippedBadge": "已装备",`
+
+Then: `cd apps/save-editor && flutter gen-l10n` (expect `String get equippedBadge;` generated, no errors).
+
+- [ ] **Step 2: Render the badge**
+
+In the inventory `ListTile` building (the row in `_PrivateInventorySummaryCard.build`, around the `ListTile` with `title:` from `localizedGameName(...) ?? item.id`), add a small badge when `item.equipped`. Add it to the `title` row as a trailing `Chip`/`Container`, e.g. wrap the title:
+
+```dart
+title: Row(
+  children: [
+    Flexible(child: Text(localizedGameName(context, item.id) ?? item.id)),
+    if (item.equipped) ...[
+      const SizedBox(width: 8),
+      Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primaryContainer,
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text(
+          AppLocalizations.of(context)!.equippedBadge,
+          style: Theme.of(context).textTheme.labelSmall,
+        ),
+      ),
+    ],
+  ],
+),
+```
+
+(Match the exact existing `title:` expression and surrounding widget style in editor_page.dart; the above shows the intended structure — adapt to how the row currently builds its title. Keep the existing subtitle/trailing untouched.)
+
+- [ ] **Step 3: Analyze + test**
+
+Run: `cd apps/save-editor && flutter analyze lib && flutter test`
+Expected: analyze clean; all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/save-editor/lib/features/editor/ui/editor_page.dart apps/save-editor/lib/l10n/
+git commit -m "feat(save-editor): show an Equipped badge on the worn armor row"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Rust**
+
+Run: `cargo test -p gore-save` and the two ignored tests with the absolute fixture path:
+```bash
+GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-019.host.bin" \
+  cargo test -p gore-save armor_slot_summary_finds_equipped_armor inventory_rows_flag_equipped_armor -- --ignored
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Flutter**
+
+Run: `cd apps/save-editor && flutter analyze lib && flutter test`
+Expected: analyze clean; tests pass.
+
+- [ ] **Step 3: Manual smoke (optional)**
+
+Open `G1R-019.sav`: the Armor category shows `Ore_Armor_H` with an "Equipped" badge; `Crw_Armor_H` and `Ore_Armor_M` without.
+
+---
+
+## Self-Review notes
+
+- `armor_slot_summary` is a faithful structural mirror of `main_container_summary` (same `resolve_child` + enum-label-match pattern) — only the enum label and the collected field differ.
+- `equipped` defaults `false` everywhere (absent JSON, non-armor rows, saves with no ArmorSlot container) — purely additive, no behavior change for existing rows.
+- Read-only: no new edit ops, no `writable` changes. Equip/unequip is Tier B2.
+- Duplicate-path edge case: if the same armor class is both worn and in the bag, both rows flag equipped (path-based). Acceptable for an indicator; Tier B2's equip op operates per-container, not per-row-path.

--- a/docs/superpowers/plans/2026-06-30-armor-support-tier-c1-upgrade-display.md
+++ b/docs/superpowers/plans/2026-06-30-armor-support-tier-c1-upgrade-display.md
@@ -1,0 +1,418 @@
+# Armor Support — Tier C1 (Upgrade Display) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Show the worn armor's applied upgrades (read-only) — e.g. the equipped armor displays "Upper: Heavy02, Mid: Heavy02, Lower: Heavy02", or nothing when un-upgraded.
+
+**Architecture:** The worn armor (the single item in the `ArmorSlot` container) carries its upgrade state in `m_Payload.m_GenericData`, a `ReplicatedStringMap` struct with parallel arrays: `m_Keys` (`m_CurrentUpperBodyUpgrade`/`m_CurrentMidBodyUpgrade`/`m_CurrentLowerBodyUpgrade`) and `m_Values` (e.g. `m_UpperBody_Heavy02_ArmorUpgrade`, or empty = none). The core reads these arrays from the typed tree and attaches them to the equipped armor's inventory row; the UI renders chips. Read-only (editing upgrades = Tier C2, which needs a new array-element-replace patch primitive — out of scope here).
+
+**Tech Stack:** Rust (`gore-save`); Flutter/Dart (`apps/save-editor`).
+
+**Spec:** `docs/superpowers/specs/2026-06-29-inventory-armor-support-design.md`
+
+**Fixtures (ABSOLUTE paths for `GORESAVE_PAYLOAD_BIN`):**
+- `C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-020.host.bin` — worn `Org_Armor` WITH upgrades (all three `Heavy02`).
+- `C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-016.host.bin` — worn `Org_Armor` with NO upgrades (empty values).
+
+---
+
+## File Structure
+
+- `crates/gore-save/src/lib.rs` — extend `ArmorSlotSummary` with the worn armor's upgrade pairs; a helper `slot_upgrade_pairs(slot)` that walks `m_Payload.m_GenericData.m_Keys`/`m_Values`; attach an `upgrades` field to the equipped inventory row in `summarize_private_inventory_payload`.
+- `apps/save-editor/lib/features/editor/domain/editor_models.dart` — `PrivateInventoryItem.upgrades` (a `List<ArmorUpgrade>` or `Map<String,String>`).
+- `apps/save-editor/lib/features/editor/ui/editor_page.dart` — render upgrade chips on the equipped armor row.
+- Tests: `crates/gore-save/src/lib.rs` (real-payload, 020 + 016), `apps/save-editor/test/...` (model).
+
+---
+
+## Task 1: Read worn-armor upgrade pairs (core)
+
+**Files:**
+- Modify: `crates/gore-save/src/lib.rs` — `ArmorSlotSummary`, `armor_slot_summary`, new helper `slot_upgrade_pairs`
+- Test: `crates/gore-save/src/lib.rs` `#[cfg(test)] mod tests`
+
+The worn armor's `m_Payload.m_GenericData` is a `ReplicatedStringMap` struct with `m_Keys` (Array of `Name`) and `m_Values` (Array of `Str`). Pair them positionally; keep only entries whose value is non-empty. Helper walks the typed slot value via `struct_element_property` (which returns a `&Property` from a struct element) and reads the two arrays.
+
+- [ ] **Step 1: Write the failing real-payload tests**
+
+```rust
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn armor_upgrades_read_from_worn_armor() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let root = properties::parse_private_root(&payload).unwrap();
+        let summary = armor_slot_summary(&root).expect("armor slot resolves");
+        // G1R-020: worn Org_Armor has all three Heavy02 upgrades.
+        let ups = &summary.upgrades;
+        let find = |k: &str| ups.iter().find(|(key, _)| key == k).map(|(_, v)| v.as_str());
+        assert_eq!(find("m_CurrentUpperBodyUpgrade"), Some("m_UpperBody_Heavy02_ArmorUpgrade"));
+        assert_eq!(find("m_CurrentMidBodyUpgrade"), Some("m_MidBody_Heavy02_ArmorUpgrade"));
+        assert_eq!(find("m_CurrentLowerBodyUpgrade"), Some("m_LowerBody_Heavy02_ArmorUpgrade"));
+    }
+
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn armor_upgrades_empty_when_not_upgraded() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let root = properties::parse_private_root(&payload).unwrap();
+        let summary = armor_slot_summary(&root).expect("armor slot resolves");
+        // G1R-016: worn Org_Armor has empty upgrade values -> no non-empty pairs.
+        assert!(summary.upgrades.is_empty(), "expected no upgrades, got {:?}", summary.upgrades);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run (020 case):
+`GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-020.host.bin" cargo test -p gore-save armor_upgrades_read_from_worn_armor -- --ignored`
+Expected: FAIL — `ArmorSlotSummary` has no `upgrades` field.
+
+- [ ] **Step 3: Implement**
+
+(a) Add a field to `ArmorSlotSummary`:
+
+```rust
+struct ArmorSlotSummary {
+    equipped_paths: std::collections::HashSet<String>,
+    /// `(key, value)` upgrade pairs from the worn armor's `m_GenericData`,
+    /// non-empty values only (e.g. `("m_CurrentUpperBodyUpgrade",
+    /// "m_UpperBody_Heavy02_ArmorUpgrade")`). Empty when not upgraded or no
+    /// armor is worn.
+    upgrades: Vec<(String, String)>,
+}
+```
+
+(b) Add a helper that extracts the non-empty upgrade pairs from one slot's payload. Place it near `slot_item_definition`:
+
+```rust
+/// Read the non-empty `(key, value)` upgrade pairs from a slot's
+/// `m_Payload.m_GenericData` ReplicatedStringMap (parallel `m_Keys`/`m_Values`
+/// arrays). Returns empty when the slot has no payload map or all values empty.
+fn slot_upgrade_pairs(slot: &PropertyValue) -> Vec<(String, String)> {
+    let Some(payload) = struct_element_property(slot, "m_Payload") else {
+        return Vec::new();
+    };
+    let PropertyValue::Struct(properties::StructValue::Properties(payload_props)) = &payload.value
+    else {
+        return Vec::new();
+    };
+    let Some(generic) = payload_props.iter().find(|p| p.name == "m_GenericData") else {
+        return Vec::new();
+    };
+    let PropertyValue::Struct(properties::StructValue::Properties(map_props)) = &generic.value
+    else {
+        return Vec::new();
+    };
+    let array_strings = |name: &str| -> Vec<String> {
+        map_props
+            .iter()
+            .find(|p| p.name == name)
+            .and_then(|p| match &p.value {
+                PropertyValue::Array { elements } => Some(
+                    elements
+                        .iter()
+                        .map(|e| match e {
+                            PropertyValue::Name(s) | PropertyValue::Str(s) => s.clone(),
+                            _ => String::new(),
+                        })
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .unwrap_or_default()
+    };
+    let keys = array_strings("m_Keys");
+    let values = array_strings("m_Values");
+    keys.into_iter()
+        .zip(values)
+        .filter(|(_, v)| !v.is_empty())
+        .collect()
+}
+```
+
+(c) In `armor_slot_summary`, after collecting `equipped_paths`, also collect upgrades from the first armor slot that has any. Change the slot loop to capture upgrades:
+
+```rust
+    let mut equipped_paths = std::collections::HashSet::new();
+    let mut upgrades = Vec::new();
+    for slot in &slots {
+        if let Some(path) = slot_item_definition(slot) {
+            if !path.is_empty() {
+                equipped_paths.insert(path.to_string());
+            }
+        }
+        if upgrades.is_empty() {
+            upgrades = slot_upgrade_pairs(slot);
+        }
+    }
+    Some(ArmorSlotSummary { equipped_paths, upgrades })
+```
+
+Confirm `properties::StructValue` and `PropertyValue::{Name,Str,Array}` are imported/in-scope (the file already uses `PropertyValue` and `properties::` extensively; add a `use` only if the helper doesn't compile).
+
+- [ ] **Step 4: Run to verify both tests pass**
+
+Run 020: `GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-020.host.bin" cargo test -p gore-save armor_upgrades_read_from_worn_armor -- --ignored` → PASS
+Run 016: `GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-016.host.bin" cargo test -p gore-save armor_upgrades_empty_when_not_upgraded -- --ignored` → PASS
+
+- [ ] **Step 5: Build (the new struct field may be unused until Task 2)**
+
+Run: `cargo build -p gore-save`. If a `field never read` warning blocks the build, proceed to Task 2 (which consumes it) or add `#[allow(dead_code)]` temporarily and remove in Task 2.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/gore-save/src/lib.rs
+git commit -m "feat(gore-save): read worn-armor upgrade pairs from m_GenericData"
+```
+
+---
+
+## Task 2: Attach `upgrades` to the equipped armor row (core)
+
+**Files:**
+- Modify: `crates/gore-save/src/lib.rs` — `summarize_private_inventory_payload` (the `equipped` loop)
+- Test: `crates/gore-save/src/lib.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing real-payload test**
+
+```rust
+    #[test]
+    #[ignore = "needs GORESAVE_PAYLOAD_BIN=<a decompressed host.bin>"]
+    fn equipped_row_carries_upgrades() {
+        let path = std::env::var("GORESAVE_PAYLOAD_BIN").expect("set GORESAVE_PAYLOAD_BIN");
+        let payload = std::fs::read(path).unwrap();
+        let refs = scan_fstrings(&payload, 0);
+        let root = properties::parse_private_root(&payload).unwrap();
+        let main_container = main_container_summary(&root);
+        let armor_slot = armor_slot_summary(&root);
+        let inv = summarize_private_inventory_payload(
+            &payload, &refs, main_container.as_ref(), armor_slot.as_ref(),
+        );
+        let items = inv["items"].as_array().unwrap();
+        // G1R-020: the equipped Org_Armor row carries 3 upgrade entries.
+        let worn = items
+            .iter()
+            .find(|i| i["equipped"].as_bool() == Some(true))
+            .expect("an equipped row");
+        let ups = worn["upgrades"].as_array().expect("upgrades array");
+        assert_eq!(ups.len(), 3);
+        assert!(ups.iter().any(|u| u["value"].as_str() == Some("m_UpperBody_Heavy02_ArmorUpgrade")));
+        // a non-equipped row has an empty upgrades array
+        let other = items.iter().find(|i| i["equipped"].as_bool() != Some(true)).unwrap();
+        assert_eq!(other["upgrades"].as_array().map(|a| a.len()), Some(0));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run with 020 path. Expected: FAIL — no `upgrades` key on rows.
+
+- [ ] **Step 3: Implement**
+
+In `summarize_private_inventory_payload`, in the loop that sets `equipped`, also set `upgrades` — the upgrade pairs only on the equipped row, an empty array otherwise:
+
+```rust
+    for item in &mut items {
+        let path = item["path"].as_str().unwrap_or("");
+        let is_equipped = !path.is_empty()
+            && armor_slot.is_some_and(|a| a.equipped_paths.contains(path));
+        item["equipped"] = json!(is_equipped);
+        item["upgrades"] = if is_equipped {
+            json!(armor_slot
+                .map(|a| a
+                    .upgrades
+                    .iter()
+                    .map(|(k, v)| json!({ "key": k, "value": v }))
+                    .collect::<Vec<_>>())
+                .unwrap_or_default())
+        } else {
+            json!([])
+        };
+    }
+```
+
+(Replace the existing `equipped`-only loop body with this; keep it a separate loop after the `removable` loop.)
+
+- [ ] **Step 4: Update golden tests**
+
+Run `cargo test -p gore-save`. Rows now always carry an `upgrades: []` field; the three golden-comparison tests updated for `equipped` (`write_save_updates_private_inventory_item_count_by_id`, `inspect_save_prefers_item_stacks_inside_private_inventory_region`, `inspect_save_reports_private_inventory_summary`) will need `"upgrades": []` added next to their `"equipped": false`. Add ONLY that field. Report which tests you touched.
+
+- [ ] **Step 5: Run to verify**
+
+Run the new test with 020 → PASS. Run full `cargo test -p gore-save` → all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/gore-save/src/lib.rs
+git commit -m "feat(gore-save): attach upgrades to the equipped armor inventory row"
+```
+
+---
+
+## Task 3: `PrivateInventoryItem.upgrades` (Dart model)
+
+**Files:**
+- Modify: `apps/save-editor/lib/features/editor/domain/editor_models.dart`
+- Test: `apps/save-editor/test/features/editor/domain/editor_models_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+  test('PrivateInventoryItem parses armor upgrades', () {
+    final item = PrivateInventoryItem.fromJson({
+      'id': 'Org_Armor',
+      'path': '/Script/Angelscript.Org_Armor',
+      'count': 1,
+      'equipped': true,
+      'upgrades': [
+        {'key': 'm_CurrentUpperBodyUpgrade', 'value': 'm_UpperBody_Heavy02_ArmorUpgrade'},
+      ],
+    });
+    expect(item.upgrades.length, 1);
+    expect(item.upgrades.first.key, 'm_CurrentUpperBodyUpgrade');
+    expect(item.upgrades.first.value, 'm_UpperBody_Heavy02_ArmorUpgrade');
+
+    final plain = PrivateInventoryItem.fromJson({'id': 'X', 'path': 'p'});
+    expect(plain.upgrades, isEmpty);
+  });
+```
+
+- [ ] **Step 2: Run → fail** (`cd apps/save-editor && flutter test test/features/editor/domain/editor_models_test.dart`).
+
+- [ ] **Step 3: Implement**
+
+Add a small value type and the field. Near `PrivateInventoryItem`:
+
+```dart
+class ArmorUpgrade {
+  const ArmorUpgrade({required this.key, required this.value});
+  final String key;
+  final String value;
+}
+```
+
+In `PrivateInventoryItem`: constructor param `this.upgrades = const [],`; field `final List<ArmorUpgrade> upgrades;`; in `fromJson`:
+
+```dart
+      upgrades: (json['upgrades'] as List?)
+              ?.whereType<Map<Object?, Object?>>()
+              .map((u) => ArmorUpgrade(
+                    key: u['key'] as String? ?? '',
+                    value: u['value'] as String? ?? '',
+                  ))
+              .toList() ??
+          const [],
+```
+
+- [ ] **Step 4: Run → pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/save-editor/lib/features/editor/domain/editor_models.dart apps/save-editor/test/features/editor/domain/editor_models_test.dart
+git commit -m "feat(save-editor): parse armor upgrades on inventory items"
+```
+
+---
+
+## Task 4: Render upgrade chips on the equipped armor row (Dart UI)
+
+**Files:**
+- Modify: `apps/save-editor/lib/features/editor/ui/editor_page.dart`
+- Modify: `apps/save-editor/lib/l10n/app_*.arb` (12) + regenerate — `armorUpgradesLabel`
+
+- [ ] **Step 1: Add l10n label**
+
+Add `armorUpgradesLabel` to all 12 arb files (en "Upgrades", de "Verbesserungen", es "Mejoras", fr "Améliorations", it "Potenziamenti", ja "強化", pl "Ulepszenia", pt "Melhorias", pt_BR "Melhorias", ru "Улучшения", zh "升级", zh_Hans "升级"). Then `cd apps/save-editor && flutter gen-l10n`.
+
+- [ ] **Step 2: Render in the subtitle**
+
+In the inventory `ListTile` (the same one with the Equipped badge), when `item.upgrades.isNotEmpty`, extend the `subtitle` to show the upgrade tiers. Prettify each value: strip the `m_<Part>Body_` prefix and `_ArmorUpgrade` suffix, leaving e.g. `Heavy02`; label the part from the key (`Upper`/`Mid`/`Lower`). Build a `Wrap` of small `Chip`s under the existing subtitle path. Keep the existing subtitle (path) and add the chips below it via a `Column`:
+
+```dart
+subtitle: Column(
+  crossAxisAlignment: CrossAxisAlignment.start,
+  mainAxisSize: MainAxisSize.min,
+  children: [
+    Text(item.path), // or the existing subtitle expression, preserved verbatim
+    if (item.upgrades.isNotEmpty)
+      Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Wrap(
+          spacing: 4,
+          runSpacing: 2,
+          children: [
+            for (final u in item.upgrades)
+              Chip(
+                visualDensity: VisualDensity.compact,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                label: Text('${_upgradePart(u.key)}: ${_upgradeTier(u.value)}'),
+              ),
+          ],
+        ),
+      ),
+  ],
+),
+```
+
+Add two top-level prettifier helpers in editor_page.dart (or a small private util):
+
+```dart
+String _upgradePart(String key) {
+  if (key.contains('Upper')) return 'Upper';
+  if (key.contains('Mid')) return 'Mid';
+  if (key.contains('Lower')) return 'Lower';
+  return key;
+}
+
+String _upgradeTier(String value) {
+  // m_UpperBody_Heavy02_ArmorUpgrade -> Heavy02
+  var v = value;
+  for (final p in ['m_UpperBody_', 'm_MidBody_', 'm_LowerBody_']) {
+    if (v.startsWith(p)) { v = v.substring(p.length); break; }
+  }
+  return v.replaceAll('_ArmorUpgrade', '');
+}
+```
+
+IMPORTANT: read the ACTUAL current `subtitle:` expression first and preserve it verbatim as the first child of the Column. Do not disturb the title (Equipped badge) or trailing.
+
+- [ ] **Step 3: Analyze + test**
+
+Run: `cd apps/save-editor && flutter analyze lib && flutter test`
+Expected: analyze clean; all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/save-editor/lib/features/editor/ui/editor_page.dart apps/save-editor/lib/l10n/
+git commit -m "feat(save-editor): show armor upgrade tiers on the equipped row"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Rust** — both fixtures:
+```bash
+GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-020.host.bin" cargo test -p gore-save armor_upgrades_read_from_worn_armor equipped_row_carries_upgrades -- --ignored
+GORESAVE_PAYLOAD_BIN="C:/sbx/goresave/.claude/worktrees/gracious-tu-652deb/work/decompressed/G1R-016.host.bin" cargo test -p gore-save armor_upgrades_empty_when_not_upgraded -- --ignored
+cargo test -p gore-save
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Flutter** — `cd apps/save-editor && flutter analyze lib && flutter test` → clean + pass.
+
+- [ ] **Step 3: Manual smoke (optional)** — open `G1R-020.sav`: the equipped `Org_Armor` shows three upgrade chips (Upper/Mid/Lower: Heavy02). `G1R-016.sav`: equipped armor, no chips.
+
+---
+
+## Self-Review notes
+
+- Read-only — no edit ops, no `writable` changes. Editing upgrades (C2) needs a new array-element-replace patch primitive (`resolve` currently refuses to end on an array element, properties.rs:316) and is a separate plan.
+- `upgrades` is additive on every row (empty array for non-equipped) — same pattern as `equipped`/`removable`; golden tests updated accordingly.
+- Core emits raw `key`/`value`; the UI does the prettifying (Upper/Mid/Lower + tier), keeping the core dumb and stable.

--- a/docs/superpowers/specs/2026-06-29-inventory-armor-support-design.md
+++ b/docs/superpowers/specs/2026-06-29-inventory-armor-support-design.md
@@ -5,19 +5,30 @@ Status: Draft (pending user review)
 
 ## Problem
 
-The save editor neither displays armor the player owns nor lets the user add
-armor. Reported by the user: "the player can have multiple armors and switch
-them, so armor must be carried in the bag too — but the editor shows nothing
-and offers no way to add it."
+The save editor does not surface armor as armor and offers no way to add it.
+Reported by the user: "the player can have multiple armors and switch them, so
+armor must be carried in the bag too — but the editor shows nothing and offers
+no way to add it."
 
-Root cause: every layer of the inventory pipeline is hard-wired to the `It*`
-item-class prefix. Armor item classes are **not** `It*` — they are
-`<Faction>_Armor_*` (e.g. `Ore_Armor_H`, `Crw_Armor_H`, `Org_Armor`) and
-per-NPC `Armor_<Camp>_<NPC>_NNN`. So armor is filtered out at catalog-build
-time (never addable) and at display-scan time (never shown).
+Verified actual behavior (probed `inspect_save` on the user's G1R-019):
 
-This was a scoping gap, not an intentional exclusion — the original item
-catalog was defined as "the `It*` class universe" and armor lives outside it.
+- **Display**: armor rows ARE returned by the core scan (the display filter
+  `looks_item_definition_path` accepts any `/Script/Angelscript.*` path). All
+  three of the save's armors appear in `private.inventory.items`. But the UI
+  categorizes by class-name prefix (`itemCategoryFromId`), and armor classes
+  match no `It*` prefix, so they fall into the **`Other`** category with an
+  auto-generated name and no equipped indicator — effectively invisible to a
+  user looking for an "Armor" section.
+- **Add**: armor is genuinely not addable. The add picker and the core's
+  addItem allow-list are both built from `item_catalog.json`, generated with a
+  hard `name.starts_with("It")` filter — armor (`<Faction>_Armor_*`,
+  `Armor_<Camp>_<NPC>_NNN`) is excluded, so it never appears in the picker and
+  `addItem` rejects the path.
+- **Equip / upgrades**: not represented at all.
+
+Root cause for the catalog/category gaps: the item pipeline was defined as "the
+`It*` class universe" and armor lives outside it. A scoping gap, not an
+intentional exclusion.
 
 ## Verified data model
 
@@ -129,13 +140,15 @@ Full feature (user-approved A+B+C):
 
 ### Layer 2 — Display scan (`crates/gore-save`)
 
-- `looks_inventory_candidate` / `looks_item_definition_path`
-  (`lib.rs:~4043`): recognize armor class names so armor rows survive the scan
-  (covers armor already present in any container).
+- The display filter already passes armor (`looks_item_definition_path` accepts
+  any `/Script/Angelscript.*`), so NO change is needed to make armor rows
+  appear — verified: all three G1R-019 armors are returned today.
 - `summarize_private_inventory_items` (`lib.rs:~3829`): surface each row's
   owning container type (`EInventoryTypes`) so the UI can mark the `ArmorSlot`
-  item as equipped. (The scan already walks the player inventory region; add
-  the container/inventory-type to each emitted row.)
+  item as equipped. The current FString-ref scan does not know the container;
+  the equipped indicator requires deriving the container per row (either by
+  extending the scan, or by a typed-tree pass that maps item path → container
+  enum). This is the only core display change.
 
 ### Layer 3 — Add (existing path, now armor-eligible)
 

--- a/docs/superpowers/specs/2026-06-29-inventory-armor-support-design.md
+++ b/docs/superpowers/specs/2026-06-29-inventory-armor-support-design.md
@@ -1,0 +1,208 @@
+# Inventory Armor Support — Design
+
+Date: 2026-06-29
+Status: Draft (pending user review)
+
+## Problem
+
+The save editor neither displays armor the player owns nor lets the user add
+armor. Reported by the user: "the player can have multiple armors and switch
+them, so armor must be carried in the bag too — but the editor shows nothing
+and offers no way to add it."
+
+Root cause: every layer of the inventory pipeline is hard-wired to the `It*`
+item-class prefix. Armor item classes are **not** `It*` — they are
+`<Faction>_Armor_*` (e.g. `Ore_Armor_H`, `Crw_Armor_H`, `Org_Armor`) and
+per-NPC `Armor_<Camp>_<NPC>_NNN`. So armor is filtered out at catalog-build
+time (never addable) and at display-scan time (never shown).
+
+This was a scoping gap, not an intentional exclusion — the original item
+catalog was defined as "the `It*` class universe" and armor lives outside it.
+
+## Verified data model
+
+Reverse-engineered from real saves (`work/decompressed/G1R-016/019/020.host.bin`,
+decoded from the user's `G1R-0{16,19,20}.sav`) and the UE4SS object dump.
+
+### Armor is a normal inventory item
+
+Armor occupies a standard inventory slot, structurally identical to every other
+item:
+
+```
+m_SlotData (ItemSlot) → m_ItemDefinition (ObjectProperty) = /Script/Angelscript.<ArmorClass>
+                      → m_ItemCount (IntProperty)
+                      → m_Payload (ItemPayload)
+```
+
+The item-definition class carries gameplay tags `Item.Armor`,
+`Item.Property.Wereable`, `Item.Property.NonDroppable`.
+
+### Inventory is a map of typed containers
+
+The player inventory is a `TMap<EInventoryTypes, Container>`:
+
+- `m_Keys` — array of `EInventoryTypes` enum values
+- `m_Values.Items[i].m_Slots` — that container's slot array
+
+Container types observed: `MainContainer` (the bag), `ArmorSlot`, `MeleeSlot`,
+`RangedSlot`, `RingLeft`, `RingRight`, `Amulet`, `TorchSlot`, `Pouch`,
+`QuickItems`, `Trader`, `TradingBalance`.
+
+### Equipped vs carried = which container
+
+The worn armor is the item in the **`ArmorSlot`** container; carried armors sit
+in **`MainContainer`**. Verified:
+
+| Save | `ArmorSlot` container (worn) | `MainContainer` (bag) |
+|------|------------------------------|------------------------|
+| G1R-019 | `Ore_Armor_H` | `Crw_Armor_H`, `Ore_Armor_M` |
+| G1R-016 | `Org_Armor` (no upgrades) | — |
+| G1R-020 | `Org_Armor` (Heavy02 upgrades) | — |
+
+`ArmorSlot` holds at most one armor. (Each slot also carries an inline
+`m_InventoryType` enum field matching its container key; the container key is
+the authoritative grouping the existing code resolves via `m_Keys`/`m_Values`.)
+
+### Armor upgrades = string-map on the worn slot's payload
+
+Upgrades are stored on the worn armor slot's `m_Payload.m_GenericData`
+(`ReplicatedStringMap`):
+
+- Keys (`m_Keys`, NameProperty): `m_CurrentUpperBodyUpgrade`,
+  `m_CurrentMidBodyUpgrade`, `m_CurrentLowerBodyUpgrade`
+- Values (`m_Values`, StrProperty):
+  - G1R-016 (un-upgraded): all empty
+  - G1R-020 (upgraded): `m_UpperBody_Heavy02_ArmorUpgrade`,
+    `m_MidBody_Heavy02_ArmorUpgrade`, `m_LowerBody_Heavy02_ArmorUpgrade`
+
+This reuses the existing generic `ItemPayload.m_GenericData` mechanism — no new
+property type. The available upgrade variants per armor (e.g. the
+`Org_Armor_Top/Mid/Bot_{L,M,H}_0{1,2}` set) are listed in a separate
+`BoughtArmorUpgrades` struct, but the *applied* selection is the three
+string-map values above.
+
+### Armor item-class discriminator (for the catalog)
+
+From the UE4SS object dump, armor classes appear as `ASClass` entries. The
+clean discriminator:
+
+- **Include**: classes whose name matches an armor family
+  (`<Fac>_Armor[...]` such as Ore/Crw/Org/Vlk/Sfb/Dmb/Ebr/Gur/Kdf/Kdw/Grd/
+  Nov/Sld/Stt/Tpl/Law/NH/Ryl/QA, with optional `_{Top,Mid,Bot}_{L,M,H}_NN`
+  tier suffixes) **or** per-NPC `Armor_<CAMP>_<NPC>_NNN`.
+- **Exclude**: the paired non-item classes — anything ending in
+  `_VisualsDefinition` / `_VisualDefinition`, plus `ArmorVisualsDefinition_*`,
+  `BaseArmorDefinition`, and the existing non-item noise families (`GE_*`,
+  `GA_*`, `GC_*`, `CS_*`, `Choice*`, `Document*`, `Conversation*`,
+  `DailyRoutine*`, `Module_*`, `AIAgent*`, `CharacterDefinition*`,
+  `CharacterVisuals*`, `AllArmors*`, `Quest*`, `Memory*`, `Spawner*`).
+
+This yields ~116 armor item classes. The filter MUST be validated against the
+three known real-save armors (`Ore_Armor_H`, `Crw_Armor_H`, `Ore_Armor_M`,
+`Org_Armor`) — they must all be present in the generated catalog.
+
+## Scope
+
+Full feature (user-approved A+B+C):
+
+- **A. Display + add to bag** — show all armor (worn + carried) with an
+  "equipped" indicator; add armor to `MainContainer`.
+- **B. Equip / unequip** — move armor between `MainContainer` and `ArmorSlot`.
+- **C. Upgrade editing** — view and edit the worn armor's three upgrade
+  string-map values.
+
+## Design
+
+### Layer 1 — Catalog (`crates/gore-catalog`)
+
+- `pipeline.rs`: extend `parse_item_classes` (or add a parallel armor pass) to
+  collect armor item classes per the discriminator above; exclude the
+  visual-definition pairs. Assign category `armor`.
+- Add `Armor` to the category model: `ItemCategory` enum
+  (`crates/gore-catalog/src/lib.rs`) + `item_category_from_id` /
+  `category_for_id` mapping (armor classes → `Armor`).
+- Regenerate `apps/save-editor/assets/item_catalog.json` (the Rust core embeds
+  this via `include_str!`, so the core allow-list updates with it).
+- Update existing catalog tests that assert armor → `Other`/`Unknown`; they
+  now expect `Armor`.
+
+### Layer 2 — Display scan (`crates/gore-save`)
+
+- `looks_inventory_candidate` / `looks_item_definition_path`
+  (`lib.rs:~4043`): recognize armor class names so armor rows survive the scan
+  (covers armor already present in any container).
+- `summarize_private_inventory_items` (`lib.rs:~3829`): surface each row's
+  owning container type (`EInventoryTypes`) so the UI can mark the `ArmorSlot`
+  item as equipped. (The scan already walks the player inventory region; add
+  the container/inventory-type to each emitted row.)
+
+### Layer 3 — Add (existing path, now armor-eligible)
+
+- Add validation (`is_item_definition_class` / `parse_private_inventory_add_item_edit`)
+  is satisfied automatically once armor is in the embedded catalog. Adding
+  armor targets `MainContainer` exactly like any other item — no new code, but
+  add an armor case to the add tests.
+
+### Layer 4 — Equip / unequip (new structural edit)
+
+- New edit op that relocates an armor slot between the `MainContainer` and
+  `ArmorSlot` containers' `m_Slots` arrays (the same typed-tree splice approach
+  `addItem`/`removeItem` use on `MainContainer`).
+- Invariants: `ArmorSlot` holds at most one armor. Equipping when one is
+  already worn moves the previously-worn armor back to `MainContainer`
+  (swap, no item loss). Unequipping moves the worn armor to `MainContainer`.
+- Keep the slot's inline `m_InventoryType` field consistent with its new
+  container key.
+
+### Layer 5 — Upgrade editing (new payload edit)
+
+- View: read the worn armor slot's `m_Payload.m_GenericData` map
+  (`m_CurrentUpper/Mid/LowerBodyUpgrade`).
+- Edit: set each of the three values to a chosen upgrade string (or empty =
+  none). Validate values against the armor's available upgrade set where it can
+  be derived; otherwise allow the known `m_<Part>_<Tier>_ArmorUpgrade` form.
+
+### UI (`apps/save-editor`)
+
+- New `Armor` category in the inventory grouping (`item_categories.dart`),
+  rendered in the inventory panel.
+- Armor rows show an equipped badge when in `ArmorSlot`.
+- Equip / unequip control per armor row.
+- Upgrade editor for the worn armor (three slots: upper / mid / lower).
+- "Add item" dialog now lists armor (drawn from the regenerated catalog).
+
+## Testing & validation
+
+- **Catalog**: generated catalog includes the four known real-save armors and
+  excludes every `*_VisualsDefinition`. Snapshot count sanity (~116 armor
+  classes).
+- **Display**: parsing G1R-019 yields three armor rows — one flagged equipped
+  (`Ore_Armor_H`), two carried. G1R-016/020 each yield one equipped
+  `Org_Armor`.
+- **Add**: adding an armor to a fixture's `MainContainer` round-trips
+  byte-consistently and re-parses.
+- **Equip/unequip**: moving `Crw_Armor_H` from bag to `ArmorSlot` in G1R-019
+  bumps `Ore_Armor_H` back to `MainContainer`; re-parse confirms exactly one
+  armor in `ArmorSlot`.
+- **Upgrades**: setting the three upgrade values on G1R-016's worn `Org_Armor`
+  reproduces the G1R-020 Heavy02 string-map; clearing them reproduces G1R-016.
+- All edits verified against real decompressed payloads
+  (`work/decompressed/*.host.bin`) with `parse_private_root` re-parse, per the
+  existing byte-faithfulness discipline.
+
+## Out of scope
+
+- Other equip slots (weapons, rings, amulet, torch) — same `m_InventoryType`
+  mechanism, but not requested here.
+- Editing the `BoughtArmorUpgrades` available-upgrade *catalog* (which upgrade
+  variants are unlocked) — only the applied selection is edited.
+
+## Open implementation question
+
+The equip/unequip splice (Layer 4) operates on the `ArmorSlot` container's
+`m_Slots`, which the current code only ever reads, never mutates. The first
+implementation task is to confirm — against the real typed tree — that the
+`ArmorSlot` container slot can be spliced with the same clone/relocate approach
+`addItem` uses for `MainContainer`, including keeping `m_Keys`/`m_Values`
+parallel and the inline `m_InventoryType` consistent.


### PR DESCRIPTION
## Summary

Fixes armor being invisible and unaddable in the save editor. Armor item classes are not `It*` (they are `<Faction>_Armor_*` / `Armor_<Camp>_<NPC>_*`), so every layer that assumed the `It*` prefix excluded them. RE'd the full armor data model from real saves (G1R-016/019/020) and implemented three tiers:

- **Tier A — armor as a catalog item:** new `is_armor_item_class` discriminator in the catalog generator, `ItemCategory::Armor` in the model, regenerated `item_catalog.json` (+33 armor classes, tier-pieces/visual-defs excluded). Armor now shows under its own **Armor** category (shield icon, 12 locales) and is **addable** to the bag.
- **Tier B1 — equipped indicator:** `armor_slot_summary` resolves the player's `ArmorSlot` container; inventory rows carry an `equipped` flag; UI shows an **Equipped** badge on the worn armor.
- **Tier C1 — upgrade display:** `slot_upgrade_pairs` reads the worn armor's `m_Payload.m_GenericData` upgrade string-map; rows carry `upgrades`; UI shows **Upper/Mid/Lower: tier** chips.

Design + per-tier plans under `docs/superpowers/{specs,plans}/2026-06-*armor*`.

## Out of scope (need a new patch primitive — `resolve` can't end on an array element)

- **B2** equip/unequip (atomic cross-container slot move)
- **C2** edit upgrades (array-element-replace)

## Test Plan

- [x] `cargo test -p gore-catalog` (24) and `cargo test -p gore-save` (181 + 9 ignored real-payload armor tests pass on G1R-016/019/020)
- [x] `cd apps/save-editor && flutter analyze lib` clean + `flutter test` (142)
- [ ] Manual: open `G1R-020.sav` → equipped `Org_Armor` shows badge + 3 Heavy02 chips; `G1R-019.sav` → 3 armors, one equipped, others addable/removable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inventory inspection JSON and the embedded addItem allow-list; incorrect armor classification or equipped-path logic could mislead users or allow awkward duplicate armor adds, though edits follow existing structural-edit patterns and display logic is conservative on ambiguous paths.
> 
> **Overview**
> Armor is treated as a first-class item end-to-end: the catalog generator recognizes non-`It*` armor classes, **regenerates `item_catalog.json`**, and maps them to a new **Armor** category in Rust and Flutter (shield icon, l10n).
> 
> **`gore-save`** resolves the player's **`ArmorSlot`** via the typed inventory tree, exposes **`equippedArmorPaths`** for the add dialog, and enriches inventory rows with **`equipped`** and **`upgrades`**. Equipped marking uses **`unambiguous_equipped_paths`** (worn path unique across all containers) so duplicate bag copies are not mislabeled; upgrade pairs come from the worn slot's **`m_GenericData`** string-map.
> 
> The save editor parses those fields, shows an **Equipped** badge and **Upper/Mid/Lower** upgrade chips on inventory rows, and **excludes main-container and equipped-armor paths** when adding items. Tests and design/plan docs under **`docs/superpowers/`** accompany the change. Equip/unequip and editing upgrades remain out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d5834faceea45918b2782fd745edf2a88069aef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->