### PR TITLE
gore-as: AngelScript decompiler — compile-clean + semantic byte-faithfulness

### DIFF
--- a/crates/gore-as/src/cache/binds.rs
+++ b/crates/gore-as/src/cache/binds.rs
@@ -78,6 +78,14 @@ impl NativeApi {
         self.by_name.get(name).copied().flatten()
     }
 
+    /// True if `name` appears as ANY native function/method signature name in the printable-run
+    /// scan — `contains_key`, NOT `arity_by_name`: ambiguous-arity overloads still count as
+    /// "exists". Batch-24b shadow gate (a script global sharing a name with any native member
+    /// must be `::`-qualified inside classes).
+    pub fn has_name(&self, name: &str) -> bool {
+        self.by_name.contains_key(name)
+    }
+
     /// Number of distinct names in the by-name table (diagnostic).
     pub fn name_count(&self) -> usize {
         self.by_name.len()

--- a/crates/gore-as/src/cache/binds.rs
+++ b/crates/gore-as/src/cache/binds.rs
@@ -46,6 +46,12 @@ pub struct NativeApi {
     /// `name -> Some(arity)` when every signature with that name shares one arity, else `None`.
     /// Built from the printable-run scan (full coverage, class-agnostic).
     by_name: HashMap<String, Option<usize>>,
+    /// Plain STRUCT-FIELD value types: `(class, field) -> type` from the two-token
+    /// `"<TYPE> <Name>"` decls (no parens = not a signature). Conflicting keys are dropped,
+    /// same policy as the arity map. batch-25a (specs/batch23-cantconvert.md G2): resolves
+    /// native-struct enum field types the script cache cannot (PropertyReferences.OldTypeId
+    /// is the OWNER struct, not the field's value type).
+    field_types: HashMap<(String, String), String>,
 }
 
 impl NativeApi {
@@ -56,13 +62,13 @@ impl NativeApi {
         if data.len() < 8 {
             return None;
         }
-        let by_class = parse_records(&data);
+        let (by_class, field_types) = parse_records(&data);
         let by_name = scan_by_name(&data);
         // A partially readable cache may populate only one table; keep it if either has data.
         if by_name.is_empty() && by_class.is_empty() {
             return None;
         }
-        Some(NativeApi { by_class, by_name })
+        Some(NativeApi { by_class, by_name, field_types })
     }
 
     /// Exact `(class, name)` arity if known and unambiguous.
@@ -84,6 +90,19 @@ impl NativeApi {
     /// must be `::`-qualified inside classes).
     pub fn has_name(&self, name: &str) -> bool {
         self.by_name.contains_key(name)
+    }
+
+    /// Plain struct-field VALUE type for an exact `(class, field)` key, if unambiguous.
+    /// batch-25a: `("FWidgetAlignment", "VerticalAlignment") -> "EVerticalAlignment"`.
+    pub fn field_type(&self, class: &str, field: &str) -> Option<&str> {
+        self.field_types
+            .get(&(class.to_string(), field.to_string()))
+            .map(|s| s.as_str())
+    }
+
+    /// Number of distinct `(class, field)` plain-field type entries (diagnostic).
+    pub fn field_type_count(&self) -> usize {
+        self.field_types.len()
     }
 
     /// Number of distinct names in the by-name table (diagnostic).
@@ -272,14 +291,21 @@ fn find_record_starts(data: &[u8]) -> Vec<usize> {
     starts
 }
 
-/// Tolerant record parse -> `(class, name) -> arity`, dropping any conflicting keys.
-fn parse_records(data: &[u8]) -> HashMap<(String, String), usize> {
+/// Tolerant record parse -> (`(class, name) -> arity`, `(class, field) -> plain-field type`),
+/// dropping any conflicting keys from either map.
+fn parse_records(
+    data: &[u8],
+) -> (HashMap<(String, String), usize>, HashMap<(String, String), String>) {
     let n = data.len();
     let starts = find_record_starts(data);
     let start_set: std::collections::HashSet<usize> = starts.iter().copied().collect();
 
     let mut map: HashMap<(String, String), usize> = HashMap::new();
     let mut conflicting: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::new();
+    // plain two-token field decls `"<TYPE> <Name>"` (no parens): value type per (class, field).
+    let mut ftypes: HashMap<(String, String), String> = HashMap::new();
+    let mut ftype_conflicts: std::collections::HashSet<(String, String)> =
         std::collections::HashSet::new();
 
     for (ri, &o) in starts.iter().enumerate() {
@@ -344,6 +370,26 @@ fn parse_records(data: &[u8]) -> HashMap<(String, String), usize> {
                         }
                     }
                 }
+            } else {
+                // Plain STRUCT-FIELD decl: strictly two whitespace-separated tokens with the
+                // second token equal to the bare field name -> the first token is the value
+                // type (`"EVerticalAlignment VerticalAlignment"`). Anything wider (const,
+                // templates with spaces, property accessors) is skipped — strict two-token
+                // keeps the map free of misparses (batch-25a).
+                let mut toks = decl.split_whitespace();
+                if let (Some(ty), Some(fname), None) = (toks.next(), toks.next(), toks.next()) {
+                    if fname == name && !ty.is_empty() {
+                        let key = (tn.clone(), name.clone());
+                        match ftypes.get(&key) {
+                            Some(prev) if prev != ty => {
+                                ftype_conflicts.insert(key);
+                            }
+                            _ => {
+                                ftypes.insert(key, ty.to_string());
+                            }
+                        }
+                    }
+                }
             }
 
             // Re-sync over the variable-width metadata slot: scan forward to the next
@@ -374,7 +420,10 @@ fn parse_records(data: &[u8]) -> HashMap<(String, String), usize> {
     for key in conflicting {
         map.remove(&key);
     }
-    map
+    for key in ftype_conflicts {
+        ftypes.remove(&key);
+    }
+    (map, ftypes)
 }
 
 /// Class-agnostic printable-run scan -> `name -> Some(arity)|None(conflict)`.
@@ -497,5 +546,40 @@ mod tests {
         // (class,name) exact lookups from the record parse.
         assert_eq!(api.arity("UGameplayAbility_CharacterAI", "AssessEvent"), Some(2));
         assert_eq!(api.arity("UGameplayAbility", "GetAvatarActorFromActorInfo"), Some(0));
+    }
+
+    /// batch-25a: the in-crate `refs::native_field_type` table must MATCH the shipped
+    /// Binds.Cache field decls — this is the verification path for the production source
+    /// (the production emit runs without Binds, so the hardcoded table is load-bearing).
+    /// Skipped when the game install is absent.
+    #[test]
+    fn validate_field_types_against_real_binds_cache() {
+        let path = Path::new(REAL_BINDS);
+        if !path.exists() {
+            eprintln!("skipping: {REAL_BINDS} not present");
+            return;
+        }
+        let api = NativeApi::load(path).expect("load Binds.Cache");
+        eprintln!("distinct (class,field) type entries: {}", api.field_type_count());
+        // mirror of refs.rs KNOWN_NATIVE_FIELD_TYPES (keep in sync)
+        for (cls, field, want) in [
+            ("FWidgetAlignment", "VerticalAlignment", "EVerticalAlignment"),
+            ("FWidgetAlignment", "HorizontalAlignment", "EHorizontalAlignment"),
+            ("FPerceivedAgent", "Relationship", "ERelationship"),
+            ("FPerceivedAgent", "Hostility", "ERelationshipHostility"),
+            ("FPerceivedAgent", "RelativeRank", "ERelationshipRelativeRank"),
+            ("FFXPerceptionSoundArea", "PerceptionLoudness", "EPerceptionNoiseLoudness"),
+            ("FALoadingScreenSettings", "Layout", "EAsyncLoadingScreenLayout"),
+            ("FALoadingScreenSettings", "PlaybackType", "EMoviePlaybackType"),
+            ("FTextAppearance", "Justification", "ETextJustify"),
+            ("FInteractionAnimTransition", "TransitionKind", "EInteractionInputKind"),
+            ("FWeatherSaveGame", "CurrentWeather", "EWeather"),
+        ] {
+            assert_eq!(
+                api.field_type(cls, field),
+                Some(want),
+                "table entry ({cls}, {field}) disagrees with the shipped Binds.Cache"
+            );
+        }
     }
 }

--- a/crates/gore-as/src/cache/binds.rs
+++ b/crates/gore-as/src/cache/binds.rs
@@ -584,4 +584,74 @@ mod tests {
             );
         }
     }
+
+    /// batch-40b: the in-crate `refs` `KNOWN_NATIVE_FLOAT_FIELDS` table must MATCH the shipped
+    /// Binds.Cache field decls. Same verification path as
+    /// `validate_field_types_against_real_binds_cache` above (the production emit runs without
+    /// Binds, so the hardcoded float-field table is load-bearing). This proves the baked-in
+    /// float types are authoritative rather than guessed. Skipped when the game install is absent.
+    #[test]
+    fn validate_float_field_types_against_real_binds_cache() {
+        let path = Path::new(REAL_BINDS);
+        if !path.exists() {
+            eprintln!("skipping: {REAL_BINDS} not present");
+            return;
+        }
+        let api = NativeApi::load(path).expect("load Binds.Cache");
+        // mirror of refs.rs KNOWN_NATIVE_FLOAT_FIELDS (keep in sync)
+        for (cls, field, want) in [
+            ("FALoadingScreenSettings", "MinimumLoadingScreenDisplayTime", "float32"),
+            ("FAlphaBlendArgs", "BlendTime", "float32"),
+            ("FCameraBehaviour", "m_ArmLength", "float32"),
+            ("FCameraBehaviour", "m_LagSpeed", "float32"),
+            ("FCameraBehaviour", "m_SpellPitchLimit", "float32"),
+            ("FCameraBehaviour", "m_SpellYawLimit", "float32"),
+            ("FDodgeData", "m_SuperArmorResistanceMultiplier", "float32"),
+            ("FFreezeParams", "m_BlendOutDuration", "float32"),
+            ("FFreezeParams", "m_CustomTimeDilation", "float32"),
+            ("FFreezeParams", "m_FreezeDuration", "float32"),
+            ("FGameplayCueParameters", "NormalizedMagnitude", "float32"),
+            ("FGameplayCueParameters", "RawMagnitude", "float32"),
+            ("FGameplayEffectContext_HitResponse", "BowStretch", "float32"),
+            ("FGameplayEffectContext_HitResponse", "MultiplierSuperArmor", "float32"),
+            ("FGothicFlyDiveSettings", "AdaptToCollisionSampleZDistance", "float32"),
+            ("FGothicFlyDiveSettings", "CharacterZDivergeOffset", "float32"),
+            ("FGothicFlyDiveSettings", "GroundedMoveBeforeGoalDistance", "float32"),
+            ("FGothicFlyDiveSettings", "UseFlyDiveMinDistance", "float32"),
+            ("FGothicPathfollowSettings", "AgentRadiusMultiplier", "float32"),
+            ("FGothicPathfollowSettings", "CrowdAgentRadiusMultiplier", "float32"),
+            ("FGothicPathfollowSettings", "CrowdAgentSeparationWeight", "float32"),
+            ("FInteractionAnimTransition", "BlockOtherTransitionsForSeconds", "float32"),
+            ("FInteractionAnimTransition", "CooldownSeconds", "float32"),
+            ("FInteractionAnimTransition", "Probability", "float32"),
+            ("FInteractionAnimTransition", "Weight", "float32"),
+            ("FLightSet", "BarnDoorAngle", "float32"),
+            ("FLightSet", "BarnDoorLength", "float32"),
+            ("FLightSet", "IndirectLightingIntensity", "float32"),
+            ("FLightSet", "VolumetricScatteringIntensity", "float32"),
+            ("FLightValues", "AttenuationRadius", "float32"),
+            ("FLightValues", "SourceHeight", "float32"),
+            ("FLightValues", "SourceWidth", "float32"),
+            ("FMemorizedEvent", "Magnitude", "float32"),
+            ("FPathfollowModifyAvoidVelocitySettings", "FastSpeedVelocityMultiplier", "float32"),
+            ("FPathfollowModifyAvoidVelocitySettings", "MediumRangeVelocityMultiplier", "float32"),
+            ("FPathfollowModifyAvoidVelocitySettings", "ShortRangeVelocityMultiplier", "float32"),
+            ("FPathfollowMoveFocusSettings", "FocalPointHeightMultiplier", "float32"),
+            ("FPerceptionHandler", "DelaySeconds", "float32"),
+            ("FRelativeCrimeDataEntry", "BaseSeverity", "float32"),
+            ("FRememberedPerception", "Magnitude", "float32"),
+            ("FRememberedPerception", "TimeUpdated", "float32"),
+            ("FScalableFloat", "Value", "float32"),
+            ("FScoredItemAction", "Score", "float32"),
+            ("FSlateFontInfo", "Size", "float32"),
+            ("FTipSettings", "TipSwapTime", "float32"),
+            ("FTipSettings", "TipWrapAt", "float32"),
+        ] {
+            assert_eq!(
+                api.field_type(cls, field),
+                Some(want),
+                "float-field table entry ({cls}, {field}) disagrees with the shipped Binds.Cache"
+            );
+        }
+    }
 }

--- a/crates/gore-as/src/cache/binds.rs
+++ b/crates/gore-as/src/cache/binds.rs
@@ -574,6 +574,8 @@ mod tests {
             ("FTextAppearance", "Justification", "ETextJustify"),
             ("FInteractionAnimTransition", "TransitionKind", "EInteractionInputKind"),
             ("FWeatherSaveGame", "CurrentWeather", "EWeather"),
+            ("FLetterboxLayoutSettings", "VerticalLoadingWidgetPosition", "EVerticalAlignment"),
+            ("FLetterboxLayoutSettings", "VerticalTipWidgetPosition", "EVerticalAlignment"),
         ] {
             assert_eq!(
                 api.field_type(cls, field),

--- a/crates/gore-as/src/cache/bytediff.rs
+++ b/crates/gore-as/src/cache/bytediff.rs
@@ -138,12 +138,28 @@ pub struct NormOpts {
     pub n2_slots: bool,
     pub n3_jumps: bool,
     pub n4_consts: bool,
+    /// N5 (`n5_scope`): one-sided vanilla strip of the `FScopeCycleCounter` RAII profiler-scope
+    /// pair + the `FStatID` temp dtor — pure CPU-timing instrumentation, provably behavior-neutral
+    /// (`specs/final-residue.md §B.2`). Default ON.
+    pub n5_scope: bool,
+    /// N6 (`n6_reguard`): one-sided vanilla fold of a short-circuit boolean-cascade re-guard that
+    /// is PROVABLY DOMINATED by an identical earlier same-slot null-guard with no intervening write
+    /// (`specs/final-residue.md §B.1`). Default ON.
+    pub n6_reguard: bool,
 }
 
 impl Default for NormOpts {
     fn default() -> Self {
-        // All ON except N2 (slot renumber) — the spec default.
-        NormOpts { n1_refs: true, n2_slots: false, n3_jumps: true, n4_consts: true }
+        // All ON except N2 (slot renumber) — the spec default. N5/N6 (benign-attribution strips)
+        // are ON by default, mirroring N1/N3/N4.
+        NormOpts {
+            n1_refs: true,
+            n2_slots: false,
+            n3_jumps: true,
+            n4_consts: true,
+            n5_scope: true,
+            n6_reguard: true,
+        }
     }
 }
 
@@ -482,6 +498,8 @@ pub struct NormFired {
     pub n2_slots: bool,
     pub n3_jumps: bool,
     pub n4_consts: bool,
+    pub n5_scope: bool,
+    pub n6_reguard: bool,
 }
 
 impl NormFired {
@@ -499,10 +517,21 @@ impl NormFired {
         if self.n4_consts {
             v.push("N4:consts");
         }
+        if self.n5_scope {
+            v.push("N5:scope");
+        }
+        if self.n6_reguard {
+            v.push("N6:reguard");
+        }
         v
     }
     fn any(&self) -> bool {
-        self.n1_refs || self.n2_slots || self.n3_jumps || self.n4_consts
+        self.n1_refs
+            || self.n2_slots
+            || self.n3_jumps
+            || self.n4_consts
+            || self.n5_scope
+            || self.n6_reguard
     }
 }
 
@@ -550,6 +579,268 @@ fn strip_jitentry(instrs: &[NormInstr]) -> Vec<NormInstr> {
     instrs.iter().filter(|ni| !is_benign_only_op(ni.op)).cloned().collect()
 }
 
+// =================================================================================================
+// N5 / N6 — benign-attribution ONE-SIDED VANILLA strips (`specs/final-residue.md` PART B).
+//
+// Both remove a PROVEN-INERT subsequence from the VANILLA normalized list only (regen already
+// lacks it), so they can only ever SHORTEN vanilla toward the (shorter) regen — never pad, never
+// manufacture a match by insertion. Governing safety rule (`bytediff.rs:12`): a false BENIGN hides
+// a real bug (catastrophic); when a pattern cannot be PROVEN inert/dominated, it is left in place
+// and the length mismatch keeps the function SEMANTIC.
+// =================================================================================================
+
+/// The (owner-type-name, method-name) of a normalized CALLSYS/CALL instruction's callee, if it
+/// resolved to a `Named` function identity. Keys N5 on a cache-INDEPENDENT identity (the raw
+/// func-ptr drifts across builds; the resolved owner+method does not — mirrors GAP-B/GAP-C keying
+/// on `callee_name`). Returns `None` for a non-call op or an unresolved callee.
+fn callsys_owner_method(ni: &NormInstr) -> Option<(&str, &str)> {
+    if !matches!(ni.op, "CALLSYS" | "CALL" | "CALLBND" | "CALLINTF" | "Thiscall1" | "FuncPtr") {
+        return None;
+    }
+    ni.operands.iter().find_map(|o| match o {
+        Operand::Ref(id) => id.func_owner_method(),
+        _ => None,
+    })
+}
+
+/// N5 — `FScopeCycleCounter` RAII profiler-scope strip (`specs/final-residue.md §B.2`).
+///
+/// Removes, from the VANILLA list, each `[PSF <slot>; CALLSYS <inert-scope-callee>]` PAIR where the
+/// callee resolves EXACTLY to one of the three inert RAII identities:
+///   * `FScopeCycleCounter::$beh0`  — the RAII scope-counter CTOR (snapshots `Cycles()`)
+///   * `FScopeCycleCounter::$beh2`  — the RAII scope-counter DTOR (accumulates elapsed cycles)
+///   * `FStatID::$beh2`             — the transient `FStatID` temp DTOR that only fed the ctor
+///
+/// The `FStatID::$beh0` CTOR is KEPT (both sides emit it — NOT stripped). Each CALLSYS is removed
+/// together with its immediately-preceding `PSF <same-or-any slot>` frame-push (that push exists
+/// only to address the RAII object for this call); if the preceding op is not a `PSF`, only the
+/// CALLSYS is removed (defensive — never remove an unrelated op).
+///
+/// Behaviour proof (§B.2): the three callees touch no game object / ability / actor / return
+/// register — they read `FPlatformTime::Cycles()` and accumulate into a named `TStatId` CPU
+/// counter (compiled-in `SCOPE_CYCLE_COUNTER` instrumentation). Removing them changes only the
+/// stats-HUD timing readout. Provably behavior-neutral.
+///
+/// Returns the number of CALLSYS scope-ops removed (each with its paired push).
+fn strip_benign_scopes(v: &mut Vec<NormInstr>) -> usize {
+    // Identify the indices of the inert scope CALLSYS ops and their paired preceding PSF.
+    let mut drop: Vec<bool> = vec![false; v.len()];
+    let mut removed = 0usize;
+    for i in 0..v.len() {
+        let is_scope = matches!(
+            callsys_owner_method(&v[i]),
+            Some(("FScopeCycleCounter", "$beh0"))
+                | Some(("FScopeCycleCounter", "$beh2"))
+                | Some(("FStatID", "$beh2"))
+        );
+        if !is_scope {
+            continue;
+        }
+        drop[i] = true;
+        removed += 1;
+        // Pair the immediately-preceding PSF frame-push (only if it is a PSF and not already
+        // claimed by another dropped call).
+        if i > 0 && v[i - 1].op == "PSF" && !drop[i - 1] {
+            drop[i - 1] = true;
+        }
+    }
+    if removed > 0 {
+        let mut idx = 0usize;
+        v.retain(|_| {
+            let keep = !drop[idx];
+            idx += 1;
+            keep
+        });
+    }
+    removed
+}
+
+/// True if a normalized op WRITES the object/ref frame slot `slot` — the anti-false-benign clause-3
+/// scan for N6. Any op that reassigns / re-references the guarded slot between the dominating guard
+/// and the re-guard breaks domination (the guarded value may have changed), so the re-guard is NOT
+/// redundant and must NOT be folded. Conservative: an op we are unsure about is treated as a write.
+fn writes_slot(ni: &NormInstr, slot: i32) -> bool {
+    // Ops whose FIRST slot operand is a destination (write) of an object/ref slot.
+    let dst_first = matches!(
+        ni.op,
+        "RefCpyV"        // ref-copy INTO a slot (the re-guard's own load target — a write)
+            | "STOREOBJ" // store an object handle INTO a slot
+            | "CpyVtoV4" | "CpyRtoV4" | "CpyGtoV4" | "LdGRdR4"
+            | "SetV1" | "SetV2" | "SetV4" | "SetV8"
+            | "FreeV" | "FreeNullV8" | "AllocMem"
+    );
+    if dst_first {
+        if let Some(Operand::Slot(s)) = ni.operands.first() {
+            if *s == slot {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// N6 — dominated short-circuit boolean-cascade re-guard fold (`specs/final-residue.md §B.1`).
+///
+/// A re-guard is a null-check on a STABLE object slot that was ALREADY null-checked earlier in the
+/// SAME boolean cascade, on a value that has NOT been reassigned since:
+///   S1 (object slot):  PshVPtr <slot X> ; RefCpyV <slot Y> ; CmpPtrNull <slot Y> ; TNZ
+/// The 4-op S1 window is stripped from the VANILLA list ONLY when PROVABLY DOMINATED:
+///   (clause 1) an identical earlier guard on the SAME source slot X exists in this function, AND
+///   (clause 3) no write to slot X intervenes between the dominating guard and the re-guard.
+/// (Clause 2 of the spec — the re-guard sits in an accumulator-merge term — is subsumed here by
+/// requiring the exact S1 op-shape AND a `TNZ` terminator, which only the cascade emits.)
+///
+/// The S2 form (`STOREOBJ <slot>; CmpPtrNull <slot>; TNZ`) is DELIBERATELY NOT folded: its own
+/// `STOREOBJ` reassigns the slot with a FRESH call result, so it guards a new value — a genuine
+/// safe-nav null-check, never a redundant re-check. Folding it would risk hiding a real dropped
+/// guard on a fresh result (catastrophic). Conservatism over coverage (`bytediff.rs:12`).
+///
+/// Behaviour proof (§B.1): in an `&&`/`||` short-circuit chain, term-k's guard `X != null` is
+/// reached only when term-(k-1) held, and the earlier identical guard already established
+/// `X != null`; with no intervening write to X, the value is unchanged → the re-guard is provably
+/// dead. Clause 3 is the load-bearing anti-false-benign guard: a *genuine* dropped null-check (slot
+/// never guarded earlier, clause 1 fails; or reassigned since, clause 3 fails) is left in place and
+/// the length mismatch keeps the function SEMANTIC.
+///
+/// One-sided (vanilla only — regen's decompiled accumulator emits one guard per slot, never the
+/// per-term re-guards). Returns the number of re-guard windows folded.
+fn fold_dominated_reguards(v: &mut Vec<NormInstr>) -> usize {
+    let mut drop: Vec<bool> = vec![false; v.len()];
+    let mut folded = 0usize;
+
+    let mut i = 0usize;
+    while i < v.len() {
+        // Try S1 at i: PshVPtr <X> ; RefCpyV <Y> ; CmpPtrNull <Y> ; TNZ
+        if let Some((src, _guard_slot, win_len)) = match_reguard(v, i) {
+            // clause 1 + clause 3: an identical earlier guard on the SAME source with no
+            // intervening write to that slot.
+            if dominating_guard_exists(v, i, &src) {
+                for slot in drop.iter_mut().take(i + win_len).skip(i) {
+                    *slot = true;
+                }
+                folded += 1;
+                i += win_len;
+                continue;
+            }
+        }
+        i += 1;
+    }
+
+    if folded > 0 {
+        let mut idx = 0usize;
+        v.retain(|_| {
+            let keep = !drop[idx];
+            idx += 1;
+            keep
+        });
+    }
+    folded
+}
+
+/// The identity of a re-guard's SOURCE — what value is being re-checked. For an S1 re-guard the
+/// source is the `PshVPtr <slot X>` operand (a stable frame/member object slot). Compared on the
+/// NORMALIZED operand (post-N1/N2).
+#[derive(Debug, Clone, PartialEq)]
+enum ReguardSrc {
+    /// S1: `PshVPtr <slot>` re-loaded a stack/frame object slot for a null-check.
+    Push(Operand),
+}
+
+/// If a FOLDABLE S1 re-guard window begins at `pos`, return `(source, guarded_slot, window_len)`.
+/// Only the S1 4-op `PshVPtr X; RefCpyV Y; CmpPtrNull Y; TNZ` form is foldable (S2 is never folded
+/// — see [`fold_dominated_reguards`] docs). Otherwise `None`.
+fn match_reguard(v: &[NormInstr], pos: usize) -> Option<(ReguardSrc, i32, usize)> {
+    if pos + 3 < v.len()
+        && v[pos].op == "PshVPtr"
+        && v[pos + 1].op == "RefCpyV"
+        && v[pos + 2].op == "CmpPtrNull"
+        && v[pos + 3].op == "TNZ"
+    {
+        let push = v[pos].operands.first()?.clone();
+        // Only a slot-addressed push is a stable, trackable source (clause-3 needs a slot).
+        if !matches!(push, Operand::Slot(_)) {
+            return None;
+        }
+        let y = slot_of(&v[pos + 1])?;
+        // The CmpPtrNull must test the SAME slot Y that RefCpyV loaded.
+        if slot_of(&v[pos + 2]) == Some(y) {
+            return Some((ReguardSrc::Push(push), y, 4));
+        }
+    }
+    None
+}
+
+/// The first `Slot` operand of an instruction (the addressed frame slot), if any.
+fn slot_of(ni: &NormInstr) -> Option<i32> {
+    ni.operands.iter().find_map(|o| match o {
+        Operand::Slot(s) => Some(*s),
+        _ => None,
+    })
+}
+
+/// Clause 1 + clause 3 of the domination gate: scanning BACKWARD from the re-guard at `pos`, is
+/// there an EARLIER guard on the identical source, with NO write to that source's slot in between?
+///
+/// For an S1 `Push(slot X)` source the dominating guard is an earlier S1 window (term `TNZ` form or
+/// cascade-head `JNZ` form) whose `PshVPtr` operand equals `X`. If a write to slot X is found before
+/// a matching guard, the re-guard is NOT dominated (clause 3 fails) → return false (leave SEMANTIC).
+fn dominating_guard_exists(v: &[NormInstr], pos: usize, src: &ReguardSrc) -> bool {
+    // The slot whose non-null-ness must be preserved (for the intervening-write scan).
+    let ReguardSrc::Push(Operand::Slot(guard_slot)) = src else { return false };
+    let guard_slot = *guard_slot;
+
+    let mut j = pos;
+    while j > 0 {
+        j -= 1;
+        // clause 3: any intervening WRITE to the guarded slot breaks domination — UNLESS the write
+        // op is itself the START of the matching earlier guard window (a dominator's own load is
+        // not a hostile reassignment). Check for the guard shape at `j` first.
+        if writes_slot(&v[j], guard_slot) {
+            if guard_matches_source(v, j, src) {
+                return true;
+            }
+            return false;
+        }
+        // clause 1: an earlier guard on the identical source dominates.
+        if guard_matches_source(v, j, src) {
+            return true;
+        }
+    }
+    false
+}
+
+/// True if a guard window starting at index `j` guards the SAME source as `src` — an S1 term guard
+/// (`...; TNZ`) whose push equals `src`'s push, OR the cascade-HEAD guard (`...; JNZ`) on the same
+/// push. Both establish `X != null`, so either dominates a later re-guard on `X`.
+fn guard_matches_source(v: &[NormInstr], j: usize, src: &ReguardSrc) -> bool {
+    if let Some((ReguardSrc::Push(b), _slot, _len)) = match_reguard(v, j) {
+        let ReguardSrc::Push(a) = src;
+        return *a == b;
+    }
+    // Also accept the CASCADE-HEAD guard shape `PshVPtr X; RefCpyV Y; CmpPtrNull Y; JNZ` (the very
+    // first term branches into the merge with JNZ, not TNZ) as a dominator for an S1 source.
+    head_guard_matches(v, j, src)
+}
+
+/// The FIRST term of an `&&` cascade guards with `... ; JNZ` (branch into the accumulator merge)
+/// rather than `TNZ`. Recognise `PshVPtr X ; RefCpyV Y ; CmpPtrNull Y ; JNZ` as a dominating guard
+/// for an S1 `Push(X)` source (clause 1), so a later `TNZ` re-guard on the same X is dominated.
+fn head_guard_matches(v: &[NormInstr], j: usize, src: &ReguardSrc) -> bool {
+    let ReguardSrc::Push(push) = src;
+    if j + 3 < v.len()
+        && v[j].op == "PshVPtr"
+        && v[j + 1].op == "RefCpyV"
+        && v[j + 2].op == "CmpPtrNull"
+        && is_jump_op(v[j + 3].op)
+    {
+        let y = slot_of(&v[j + 1]);
+        if y.is_some() && slot_of(&v[j + 2]) == y {
+            return v[j].operands.first() == Some(push);
+        }
+    }
+    false
+}
+
 /// Classify one aligned function pair given both sides' normalized + raw instruction lists.
 #[allow(clippy::too_many_arguments)]
 fn classify(
@@ -585,12 +876,19 @@ fn classify(
         opts.n2_slots && distinct_slot_count(v_norm) != distinct_slot_count(r_norm);
 
     // Compare normalized lists, tolerating JitEntry scaffolding.
-    let (v_cmp, r_cmp, jit_fired) = {
+    let (mut v_cmp, r_cmp, jit_fired) = {
         let vj = strip_jitentry(v_norm);
         let rj = strip_jitentry(r_norm);
         let fired = vj.len() != v_norm.len() || rj.len() != r_norm.len();
         (vj, rj, fired)
     };
+
+    // N5/N6 — benign-attribution ONE-SIDED VANILLA strips (`specs/final-residue.md` PART B). Apply
+    // #2 (scope strip) BEFORE #1 (re-guard fold) per §B.3 (disjoint, but scope-first keeps the
+    // re-guard scanner's contiguous windows intact). Each only ever SHORTENS the vanilla side, so
+    // neither can pad a match into existence.
+    let scope_fired = if opts.n5_scope { strip_benign_scopes(&mut v_cmp) > 0 } else { false };
+    let reguard_fired = if opts.n6_reguard { fold_dominated_reguards(&mut v_cmp) > 0 } else { false };
 
     let norm_identical = !n2_slot_mismatch
         && v_cmp.len() == r_cmp.len()
@@ -598,9 +896,11 @@ fn classify(
 
     if norm_identical {
         // BENIGN: determine WHICH normalizers were responsible by re-diffing raw operand roles.
-        let fired = which_normalizers_fired(v_raw, r_raw, v_norm, r_norm, opts, jit_fired);
-        // Defensive: if raw differs but NO normalizer is credited and no JitEntry fired, that is a
-        // classifier blind spot — treat as SEMANTIC rather than silently benign.
+        let mut fired = which_normalizers_fired(v_raw, r_raw, v_norm, r_norm, opts, jit_fired);
+        fired.n5_scope = scope_fired;
+        fired.n6_reguard = reguard_fired;
+        // Defensive: if raw differs but NO normalizer is credited and no JitEntry/N5/N6 fired, that
+        // is a classifier blind spot — treat as SEMANTIC rather than silently benign.
         if !fired.any() && !jit_fired {
             return semantic(name, v_raw, r_raw, v_norm, r_norm, context, opts);
         }
@@ -1354,5 +1654,276 @@ mod tests {
             vs2.iter().any(|(_, verd)| *verd == Verdict::Semantic),
             "UCBT_CompleteSequence::Tick must stay SEMANTIC, got {vs2:?}"
         );
+    }
+
+    // =============================================================================================
+    // N5 / N6 — benign-attribution one-sided vanilla strips (batch-48, `specs/final-residue.md` B).
+    // Synthetic unit tests operate DIRECTLY on `Vec<NormInstr>` (the strips' input), so they need
+    // no encoded bytecode — the exact op-shapes + a `Named` CALLSYS callee (via the remap
+    // test-constructor) suffice.
+    // =============================================================================================
+
+    /// A NO-operand normalized instruction (e.g. TNZ, PshRPtr).
+    fn ni(op: &'static str) -> NormInstr {
+        NormInstr { op, operands: vec![] }
+    }
+    /// A normalized instruction addressing a single frame slot.
+    fn ni_slot(op: &'static str, slot: i32) -> NormInstr {
+        NormInstr { op, operands: vec![Operand::Slot(slot)] }
+    }
+    /// A normalized CALLSYS whose callee resolves to `owner::method` (via the remap test ctor).
+    fn ni_callsys(owner: &str, method: &str) -> NormInstr {
+        NormInstr {
+            op: "CALLSYS",
+            operands: vec![Operand::Ref(OperandId::named_func_for_test(owner, method))],
+        }
+    }
+
+    /// An S1 re-guard window on object slot `x` loading into temp `y`, terminated by `TNZ`.
+    fn s1_reguard(x: i32, y: i32) -> Vec<NormInstr> {
+        vec![
+            ni_slot("PshVPtr", x),
+            ni_slot("RefCpyV", y),
+            ni_slot("CmpPtrNull", y),
+            ni("TNZ"),
+        ]
+    }
+    /// The cascade-HEAD guard (first term): same shape but `JNZ` into the merge instead of `TNZ`.
+    fn s1_head_guard(x: i32, y: i32) -> Vec<NormInstr> {
+        vec![
+            ni_slot("PshVPtr", x),
+            ni_slot("RefCpyV", y),
+            ni_slot("CmpPtrNull", y),
+            ni_slot("JNZ", 0), // jump target operand irrelevant to the guard shape
+        ]
+    }
+
+    /// N6: a dominated S1 re-guard (an identical earlier same-slot guard, no intervening write)
+    /// FOLDS — the strip removes its 4-op window.
+    #[test]
+    fn n6_dominated_s1_folds() {
+        let mut v = Vec::new();
+        v.extend(s1_head_guard(3, 7)); // dominating head guard on slot 3
+        v.push(ni("PshRPtr")); // some inert filler (no write to slot 3)
+        v.extend(s1_reguard(3, 7)); // the re-guard on the SAME slot 3 -> should fold
+        let before = v.len();
+        let folded = fold_dominated_reguards(&mut v);
+        assert_eq!(folded, 1, "the dominated re-guard must fold exactly once");
+        assert_eq!(v.len(), before - 4, "a 4-op S1 window is removed");
+        // The head guard survives (it is the dominator, not a re-guard).
+        assert_eq!(v[0].op, "PshVPtr");
+    }
+
+    /// N6 GUARD (clause 3 — the load-bearing anti-false-benign clause): the SAME S1 re-guard but
+    /// with an intervening WRITE to the guarded slot does NOT fold (the value may have changed).
+    #[test]
+    fn n6_reguard_with_intervening_write_stays() {
+        let mut v = Vec::new();
+        v.extend(s1_head_guard(3, 7)); // dominating guard on slot 3
+        v.push(ni_slot("STOREOBJ", 3)); // <-- REASSIGNS slot 3 (a real write)
+        v.extend(s1_reguard(3, 7)); // re-guard on slot 3 -> must NOT fold (not dominated)
+        let before = v.len();
+        let folded = fold_dominated_reguards(&mut v);
+        assert_eq!(folded, 0, "an intervening write to the guarded slot blocks the fold");
+        assert_eq!(v.len(), before, "nothing removed");
+    }
+
+    /// N6 GUARD (clause 1): an S1 re-guard with NO earlier guard on that slot does NOT fold — a
+    /// genuine first null-check must stay (a real dropped guard elsewhere would present this shape).
+    #[test]
+    fn n6_reguard_without_dominator_stays() {
+        let mut v = Vec::new();
+        v.push(ni("PshRPtr"));
+        v.extend(s1_reguard(3, 7)); // only guard on slot 3, nothing earlier -> not dominated
+        let before = v.len();
+        let folded = fold_dominated_reguards(&mut v);
+        assert_eq!(folded, 0, "a re-guard with no dominating earlier guard must stay");
+        assert_eq!(v.len(), before);
+    }
+
+    /// N6: a DIFFERENT-slot earlier guard does not dominate — the re-guard on slot 4 with an
+    /// earlier guard only on slot 3 stays (clause 1 requires the IDENTICAL source).
+    #[test]
+    fn n6_reguard_different_slot_stays() {
+        let mut v = Vec::new();
+        v.extend(s1_head_guard(3, 7)); // guard on slot 3
+        v.extend(s1_reguard(4, 7)); // re-guard on slot 4 -> different source, not dominated
+        let folded = fold_dominated_reguards(&mut v);
+        assert_eq!(folded, 0, "a re-guard on a different slot is not dominated");
+    }
+
+    /// N6 CONSERVATISM (S2 form): an S2 re-guard whose slot is RE-STORED (a fresh `STOREOBJ`, i.e.
+    /// a fresh call result) is NOT dominated — the store is a write that breaks clause 3, so the
+    /// re-guard stays. This is the correct safe behavior: an S2 `STOREOBJ; CmpPtrNull; TNZ` guards
+    /// a NEW value, never a proven-non-null earlier one. (A false fold here would hide a genuine
+    /// dropped null-check on a fresh call result — catastrophic.)
+    #[test]
+    fn n6_s2_restore_is_not_dominated() {
+        let mut v = Vec::new();
+        // earlier S2 guard on slot 5.
+        v.push(ni_slot("STOREOBJ", 5));
+        v.push(ni_slot("CmpPtrNull", 5));
+        v.push(ni("TNZ"));
+        v.push(ni("PshRPtr"));
+        // a SECOND S2 on slot 5 — its own STOREOBJ re-writes slot 5 (a fresh call result).
+        v.push(ni_slot("STOREOBJ", 5));
+        v.push(ni_slot("CmpPtrNull", 5));
+        v.push(ni("TNZ"));
+        let before = v.len();
+        let folded = fold_dominated_reguards(&mut v);
+        assert_eq!(folded, 0, "a re-stored S2 slot is a fresh value, never dominated");
+        assert_eq!(v.len(), before);
+    }
+
+    /// N6 (S1 dominated by an S1 head guard on a STORED slot): an S1 re-load+guard of a slot that
+    /// was guarded earlier by a HEAD guard (JNZ form) on the SAME slot, with no intervening write,
+    /// folds. This is the real cascade shape (a `self`/member object slot re-checked per term).
+    #[test]
+    fn n6_s1_dominated_by_head_guard_folds() {
+        let mut v = Vec::new();
+        v.extend(s1_head_guard(5, 1)); // head guard on slot 5 (PshVPtr v5; ...; JNZ)
+        v.push(ni("PshRPtr")); // inert, no write to slot 5
+        v.push(ni_slot("CpyVtoV4", 2)); // writes slot 2 (NOT slot 5) — irrelevant
+        v.extend(s1_reguard(5, 1)); // re-guard on slot 5 -> dominated, folds
+        let folded = fold_dominated_reguards(&mut v);
+        assert_eq!(folded, 1, "S1 re-guard on slot 5 dominated by the earlier head guard folds");
+    }
+
+    /// N5: the `FScopeCycleCounter` RAII ctor/dtor pair + `FStatID` temp dtor strip; the kept-on-
+    /// both-sides `FStatID::$beh0` ctor is NOT stripped.
+    #[test]
+    fn n5_scope_strips_raii_keeps_fstatid_ctor() {
+        let mut v = vec![
+            ni_slot("PSF", 0),
+            ni_callsys("FStatID", "$beh0"), // KEPT (both sides emit it)
+            ni_slot("PSF", 0),
+            ni_callsys("FScopeCycleCounter", "$beh0"), // strip (with its PSF)
+            ni_slot("PSF", 0),
+            ni_callsys("FStatID", "$beh2"), // strip (with its PSF)
+            ni("PshRPtr"), // body op
+            ni_slot("PSF", 1),
+            ni_callsys("FScopeCycleCounter", "$beh2"), // strip (with its PSF)
+            ni("RET"),
+        ];
+        let removed = strip_benign_scopes(&mut v);
+        assert_eq!(removed, 3, "three inert scope CALLSYS ops removed");
+        // Each removed CALLSYS took its paired PSF too: 3 pairs = 6 ops gone; 10 -> 4.
+        assert_eq!(v.len(), 4, "the FStatID::$beh0 ctor + its PSF + body + RET survive");
+        // The kept ctor is still present.
+        assert!(v.iter().any(|n| callsys_owner_method(n) == Some(("FStatID", "$beh0"))));
+        // No FScopeCycleCounter / FStatID::$beh2 op survives.
+        assert!(!v.iter().any(|n| matches!(
+            callsys_owner_method(n),
+            Some(("FScopeCycleCounter", _)) | Some(("FStatID", "$beh2"))
+        )));
+    }
+
+    /// N5 GUARD: a `CALLSYS` to an UNRELATED callee is never stripped.
+    #[test]
+    fn n5_scope_leaves_unrelated_callsys() {
+        let mut v = vec![
+            ni_slot("PSF", 0),
+            ni_callsys("AGothicCharacterState", "IsTrulyPartOfGuild"),
+            ni("RET"),
+        ];
+        let before = v.len();
+        let removed = strip_benign_scopes(&mut v);
+        assert_eq!(removed, 0);
+        assert_eq!(v.len(), before);
+    }
+
+    /// Self-identity MUST stay 162828/0/0 with N5/N6 ON — the raw-eq fast path returns IDENTICAL
+    /// before any normalization, so the strips never run on a self-diff (spec §B.4.1).
+    #[test]
+    #[ignore = "reads large gitignored sample caches; run with --ignored"]
+    fn self_identity_with_n5_n6() {
+        let base = format!("{}/../../work/reversing/gore-as/samples", env!("CARGO_MANIFEST_DIR"));
+        let Ok(b) = std::fs::read(format!("{base}/cache_A.Cache")) else { return };
+        // Default opts have N5/N6 ON; also assert with N2 on (the --norm-slots config).
+        for n2 in [false, true] {
+            let mut opts = NormOpts::default();
+            opts.n2_slots = n2;
+            let rep = run(&b, &b, &opts, &Filters::default(), 6).expect("run");
+            assert_eq!(rep.count(Verdict::Semantic), 0, "self-diff SEMANTIC must be 0 (n2={n2})");
+            assert_eq!(rep.count(Verdict::Benign), 0, "self-diff BENIGN must be 0 (n2={n2})");
+            assert_eq!(rep.count(Verdict::Identical), rep.diffs.len());
+        }
+    }
+
+    fn real_pair_47() -> Option<(Vec<u8>, Vec<u8>)> {
+        let base = format!("{}/../../work/reversing/gore-as/samples", env!("CARGO_MANIFEST_DIR"));
+        let v = std::fs::read(format!("{base}/cache_A.Cache")).ok()?;
+        let r = std::fs::read(format!("{base}/regen_batch47.Cache")).ok()?;
+        Some((v, r))
+    }
+
+    /// CURATED REAL-BUG REGRESSION (batch-48): the four functions that MUST stay SEMANTIC after
+    /// N5/N6 — a false BENIGN here would hide a real bug (catastrophic). None has a foldable
+    /// scope/re-guard-only diff, so the strips must not flip them.
+    #[test]
+    #[ignore = "reads large gitignored sample caches; run with --ignored"]
+    fn n5_n6_curated_regression_stays_semantic() {
+        let Some((v, r)) = real_pair_47() else { return };
+        for f in [
+            "LoadOrCreateDataGame_Implementation", // op-count divergence
+            "UCBT_CompleteSequence::Tick",          // 104->2 force-stub (has a dropped scope!)
+            "OnGracefulExitRequested",              // dropped this.<field>=true member-store
+            "DoWhenEventStarted",                   // documented dead-loop
+        ] {
+            let vs = verdict_of(&v, &r, f);
+            assert!(!vs.is_empty(), "expected functions matching {f:?}");
+            // SAFETY PROPERTY: no matched function may be marked BENIGN (a false BENIGN hides a
+            // real bug — catastrophic). Sibling IDENTICAL stubs (e.g. a 1-op `DoWhenEventStarted`
+            // override) are fine; the KNOWN-buggy one must remain SEMANTIC.
+            assert!(
+                vs.iter().all(|(_, verd)| *verd != Verdict::Benign),
+                "{f}: N5/N6 must NEVER flip a real-bug function to BENIGN, got {vs:?}"
+            );
+            assert!(
+                vs.iter().any(|(_, verd)| *verd == Verdict::Semantic),
+                "{f}: the known-buggy function must STAY SEMANTIC after N5/N6, got {vs:?}"
+            );
+        }
+    }
+
+    /// The N5 scope strip must actually ENGAGE on a real scope function: with N5 ON the vanilla
+    /// side loses its `FScopeCycleCounter`/`FStatID::$beh2` ops. We assert the mechanism works by
+    /// checking that a scope function's raw disasm CONTAINS the scope callees (so the strip has
+    /// something to remove) — proving the identity-keying resolves on real data, independent of
+    /// whether the function flips (it stays SEMANTIC due to additional accumulator/default-init
+    /// residue — documented in the batch-48 journal entry).
+    #[test]
+    #[ignore = "reads large gitignored sample caches; run with --ignored"]
+    fn n5_scope_engages_on_real_function() {
+        let Some((v, r)) = real_pair_47() else { return };
+        let v_side = Side::build(&v).expect("v side");
+        let _ = Side::build(&r);
+        let fns = crate::cache::walk_modules::collect_function_bytecodes(&v).expect("walk");
+        let opts = NormOpts::default();
+        let target = fns
+            .iter()
+            .find(|f| f.func.contains("UCBT_Inverter::Tick"))
+            .expect("UCBT_Inverter::Tick present in vanilla");
+        let raw = disassemble(&target.bytecode).expect("disasm");
+        let mut norm = normalize(&target.bytecode, &raw, &v_side, &opts);
+        // The scope callees resolve by identity on real data.
+        let scope_ops = norm
+            .iter()
+            .filter(|n| {
+                matches!(
+                    callsys_owner_method(n),
+                    Some(("FScopeCycleCounter", "$beh0"))
+                        | Some(("FScopeCycleCounter", "$beh2"))
+                        | Some(("FStatID", "$beh2"))
+                )
+            })
+            .count();
+        assert!(scope_ops >= 2, "UCBT_Inverter::Tick has ≥2 inert scope callees, found {scope_ops}");
+        let before = norm.len();
+        let removed = strip_benign_scopes(&mut norm);
+        assert_eq!(removed, scope_ops, "strip removes exactly the resolved scope callees");
+        assert!(norm.len() < before, "the strip shortened the vanilla stream");
+        // The kept FStatID::$beh0 ctor survives.
+        assert!(norm.iter().any(|n| callsys_owner_method(n) == Some(("FStatID", "$beh0"))));
     }
 }

--- a/crates/gore-as/src/cache/bytediff.rs
+++ b/crates/gore-as/src/cache/bytediff.rs
@@ -1,0 +1,1131 @@
+//! SEMANTIC-CORRECTNESS ORACLE — per-function bytecode byte-faithfulness between a VANILLA
+//! cache and a REGEN (re-compilation of our decompiled source). Implements `gore as bytediff`
+//! per `work/reversing/gore-as/specs/semantic-oracle.md`.
+//!
+//! Thesis: the AS compiler emits identical bytecode for identical source on the same engine
+//! build, MODULO a handful of build-non-determinism sources — ref/type-id keys (runtime
+//! pointers), jump absolutes (shift with instruction size), and constant raw encodings. This
+//! tool normalizes exactly those (N1/N3/N4, plus an opt-in slot-renumber N2) and classifies each
+//! aligned function IDENTICAL / BENIGN-DIFF / SEMANTIC-DIFF. A residual diff after normalization
+//! is a difference the compiler was FORCED to make by different SOURCE — a real behavior change.
+//!
+//! Governing safety rule (`spec §3`): a false BENIGN hides a real bug (catastrophic); a false
+//! SEMANTIC only wastes fix effort (cheap). Every normalizer is provably behavior-preserving; when
+//! in doubt, leave the diff SEMANTIC.
+
+use std::collections::HashMap;
+
+use super::disasm::{disassemble, Instr};
+use super::isa::BcType;
+use super::refs::RefResolver;
+use super::remap::{ref_sites, OperandId, RefIdentity, RefKind};
+
+// =================================================================================================
+// Operand role classification: split an instruction's positional words/dwords/qwords into roles
+// (slot / immediate-const / jump-target / ref) so each normalizer touches only its own operands.
+// =================================================================================================
+
+/// The 9 conditional/unconditional relative jumps whose single DW operand is a byte(dword) offset
+/// into the function — canonicalized to a target INSTRUCTION INDEX by N3.
+fn is_jump_op(name: &str) -> bool {
+    matches!(
+        name,
+        "JMP" | "JZ" | "JNZ" | "JS" | "JNS" | "JP" | "JNP" | "JLowZ" | "JLowNZ"
+    )
+}
+
+/// A single normalized operand token. Equality of two `Operand`s (across caches) means the
+/// operands are semantically the same after the relevant normalizer.
+#[derive(Debug, Clone, PartialEq)]
+enum Operand {
+    /// A frame slot (word). Raw slot number, or a canonical ordinal under N2.
+    Slot(i32),
+    /// A plain word arg that is neither a slot nor a ref (e.g. RET pop-size, GETOBJ offset).
+    Word(u16),
+    /// An integer immediate compared by decoded value (N4). `width` disambiguates 1/2/4/8-byte.
+    IntConst { value: i64, width: u8 },
+    /// A float immediate compared bit-exactly by decoded f64 (N4, floatIsFloat64 build).
+    FloatConst(u64),
+    /// A jump target as an instruction index into the (normalized) list (N3). `None` = a target
+    /// that has no counterpart instruction (dropped/added op) — always a SEMANTIC signal.
+    JumpIndex(Option<usize>),
+    /// A ref operand resolved to a portable identity (N1).
+    Ref(OperandId),
+    /// A resolved STR / __STATIC_NAME string literal, compared by text (N4).
+    StaticName(Option<String>),
+    /// A raw dword/qword the classifier does not model as slot/const/ref/jump — compared verbatim
+    /// (conservative: an unmodeled operand difference stays SEMANTIC).
+    RawDw(u32),
+    RawQw(u64),
+}
+
+/// One instruction after normalization: opcode name + ordered operand tokens.
+#[derive(Debug, Clone)]
+struct NormInstr {
+    op: &'static str,
+    operands: Vec<Operand>,
+}
+
+impl NormInstr {
+    /// Structural equality: same opcode AND same normalized operands.
+    fn norm_eq(&self, other: &NormInstr) -> bool {
+        self.op == other.op && self.operands == other.operands
+    }
+}
+
+/// Which normalizers were requested (spec `--normalize`; N2 off by default).
+#[derive(Debug, Clone, Copy)]
+pub struct NormOpts {
+    pub n1_refs: bool,
+    pub n2_slots: bool,
+    pub n3_jumps: bool,
+    pub n4_consts: bool,
+}
+
+impl Default for NormOpts {
+    fn default() -> Self {
+        // All ON except N2 (slot renumber) — the spec default.
+        NormOpts { n1_refs: true, n2_slots: false, n3_jumps: true, n4_consts: true }
+    }
+}
+
+/// Everything one side needs to normalize/resolve its functions.
+pub struct Side {
+    pub refs: RefResolver,
+    pub ident: RefIdentity,
+}
+
+impl Side {
+    pub fn build(bytes: &[u8]) -> anyhow::Result<Side> {
+        let refs = RefResolver::build(bytes)?;
+        let ident = RefIdentity::build(bytes)?;
+        Ok(Side { refs, ident })
+    }
+}
+
+/// Read a qword (2 dwords LE) from the bytecode at absolute dword offset.
+fn read_qw(code: &[i32], dw: usize) -> u64 {
+    let lo = code[dw] as u32 as u64;
+    let hi = code[dw + 1] as u32 as u64;
+    lo | (hi << 32)
+}
+
+/// Build the offset->instruction-index map for N3 jump canonicalization.
+fn offset_index_map(instrs: &[Instr]) -> HashMap<usize, usize> {
+    instrs.iter().enumerate().map(|(i, ins)| (ins.offset_dw, i)).collect()
+}
+
+/// Normalize one function's disassembled instructions into `NormInstr`s.
+///
+/// This applies N1 (refs->identity), N3 (jumps->index), N4 (consts by value; STR/__STATIC_NAME
+/// by string). N2 (slot renumber) is applied afterwards on the whole list if enabled.
+fn normalize(
+    code: &[i32],
+    instrs: &[Instr],
+    side: &Side,
+    opts: &NormOpts,
+) -> Vec<NormInstr> {
+    let off_to_idx = offset_index_map(instrs);
+    let mut out = Vec::with_capacity(instrs.len());
+
+    for ins in instrs {
+        let name = ins.op.name;
+        // Ref-operand dword indices (relative to the instruction start) → identity, via the
+        // SHARED ref_sites classification (N1). Collect into a per-dword-index lookup so the
+        // positional walk below can substitute them.
+        let mut ref_at_dw: HashMap<usize, OperandId> = HashMap::new();
+        if opts.n1_refs {
+            for site in ref_sites(name) {
+                let base = ins.offset_dw + site.dw_index;
+                if base >= code.len() {
+                    continue;
+                }
+                let id = match site.kind {
+                    RefKind::GlobalPtr | RefKind::FuncPtr | RefKind::TypePtr => {
+                        if base + 1 >= code.len() {
+                            continue;
+                        }
+                        side.ident.resolve_ptr(site.kind, read_qw(code, base) as i64)
+                    }
+                    RefKind::FuncId | RefKind::TypeId => {
+                        side.ident.resolve_id(site.kind, code[base])
+                    }
+                };
+                ref_at_dw.insert(site.dw_index, id);
+            }
+        }
+
+        let operands = normalize_operands(name, ins, &ref_at_dw, &off_to_idx, side, opts);
+        out.push(NormInstr { op: name, operands });
+    }
+
+    if opts.n2_slots {
+        renumber_slots(&mut out);
+    }
+    out
+}
+
+/// Turn one instruction's positional words/dwords/qwords into role-tagged `Operand` tokens.
+///
+/// Roles are decided by (opcode, BcType). The positional layout mirrors `disasm::disassemble`:
+/// words in source order, then dwords, then qwords. We map each positional operand to the dword
+/// index it occupies so N1 ref substitutions (keyed by dword index) apply.
+fn normalize_operands(
+    name: &str,
+    ins: &Instr,
+    ref_at_dw: &HashMap<usize, OperandId>,
+    off_to_idx: &HashMap<usize, usize>,
+    side: &Side,
+    opts: &NormOpts,
+) -> Vec<Operand> {
+    let mut out = Vec::new();
+
+    // --- Word operands (16-bit): occupy dword 0 (hi/lo) or dword 1 hi depending on BcType. ---
+    // For N1, ref operands are never in the word slots (all ref sites are dword/qword), so words
+    // are only Slot/Word roles. Classify slots vs plain words per BcType.
+    push_word_operands(name, ins, &mut out);
+
+    // --- Dword operands: jump target (N3), ref id (N1), int const (N4), static-name idx (N4),
+    //     or a plain raw dword. The dword operand's absolute dword index tells us which. ---
+    // Determine the dword-index of each positional dword operand from the BcType.
+    let dword_indices = dword_operand_indices(ins.op.fmt);
+    for (pos, &dw_idx) in dword_indices.iter().enumerate() {
+        let raw = *ins.dwords.get(pos).unwrap_or(&0);
+        // N1 ref (func-id / type-id) at this dword index?
+        if let Some(id) = ref_at_dw.get(&dw_idx) {
+            out.push(Operand::Ref(id.clone()));
+            continue;
+        }
+        // N3 jump target?
+        if opts.n3_jumps && is_jump_op(name) {
+            // Target byte(dword) offset is relative to the END of the jump instruction.
+            let target_off = (ins.offset_dw as i64 + ins.op.size_dwords as i64 + raw as i32 as i64) as usize;
+            out.push(Operand::JumpIndex(off_to_idx.get(&target_off).copied()));
+            continue;
+        }
+        // N4 constant?
+        match const_dword_role(name, pos) {
+            DwordRole::Int(width) => {
+                out.push(Operand::IntConst { value: raw as i32 as i64, width });
+            }
+            DwordRole::None => out.push(Operand::RawDw(raw)),
+        }
+    }
+
+    // --- Qword operands: ref ptr (N1), 64-bit const (N4 float/int), or raw. ---
+    let qword_indices = qword_operand_indices(ins.op.fmt);
+    for (pos, &dw_idx) in qword_indices.iter().enumerate() {
+        let raw = *ins.qwords.get(pos).unwrap_or(&0);
+        if let Some(id) = ref_at_dw.get(&dw_idx) {
+            out.push(Operand::Ref(id.clone()));
+            continue;
+        }
+        match const_qword_role(name) {
+            QwordRole::Float => out.push(Operand::FloatConst(raw)),
+            QwordRole::None => out.push(Operand::RawQw(raw)),
+        }
+    }
+
+    // STR (opcode 60) carries a W index into the string/name pool — resolve to text (N4).
+    if name == "STR" {
+        // The W arg was pushed as a word above (as Word); replace it with a resolved StaticName.
+        // STR's W is the pool index. Recompute here and swap the trailing Word.
+        if let Some(&w) = ins.words.first() {
+            let s = side.refs.static_name(w as i64).map(|s| s.to_string());
+            // Replace the first Word operand we pushed with the resolved name.
+            if let Some(first) = out.first_mut() {
+                *first = Operand::StaticName(s);
+            }
+        }
+    }
+
+    let _ = opts;
+    out
+}
+
+/// Push the word (16-bit) operands of an instruction as Slot/Word tokens per BcType.
+///
+/// `rW`/`wW` word slots are frame slots (Slot); a bare `W` arg is a plain word (Word). The
+/// per-BcType word roles mirror `disasm`'s word-collection order.
+fn push_word_operands(name: &str, ins: &Instr, out: &mut Vec<Operand>) {
+    use BcType::*;
+    // (is_slot?) per word position, in the order `disasm` collected them.
+    let roles: &[bool] = match ins.op.fmt {
+        W_ARG => &[false],            // plain word (e.g. RET size, ChkNullS var-is-actually-slot)
+        wW_ARG | rW_ARG => &[true],   // one slot
+        wW_rW_ARG | rW_rW_ARG => &[true, true],
+        wW_W_ARG => &[true, false],
+        W_rW_ARG => &[false, true],
+        wW_rW_rW_ARG => &[true, true, true],
+        rW_DW_ARG | wW_DW_ARG | rW_QW_ARG | wW_QW_ARG => &[true], // leading slot, then DW/QW
+        W_DW_ARG => &[false],        // leading plain word (ADDSi/LoadThisR: word=offset), then DW
+        wW_rW_DW_ARG | rW_W_DW_ARG => &[true, true],
+        rW_DW_DW_ARG => &[true],
+        // no word operands:
+        NO_ARG | INFO | DW_ARG | QW_ARG | DW_DW_ARG | QW_DW_ARG => &[],
+    };
+    // ChkNullS (W_ARG) actually addresses a slot; RET/ThrowException W is a plain size/int.
+    // Keep W_ARG conservative as Word EXCEPT the few W_ARG ops whose W is a slot.
+    let w_is_slot = matches!(name, "ChkNullS");
+    for (i, &is_slot) in roles.iter().enumerate() {
+        let w = *ins.words.get(i).unwrap_or(&0);
+        let slot = is_slot || (roles.len() == 1 && i == 0 && w_is_slot && ins.op.fmt == W_ARG);
+        if slot {
+            out.push(Operand::Slot(w as i16 as i32));
+        } else {
+            out.push(Operand::Word(w));
+        }
+    }
+}
+
+/// Absolute dword index (within the instruction) of each positional DW operand, per BcType.
+fn dword_operand_indices(fmt: BcType) -> Vec<usize> {
+    use BcType::*;
+    match fmt {
+        DW_ARG => vec![1],
+        rW_DW_ARG | wW_DW_ARG | W_DW_ARG => vec![1],
+        DW_DW_ARG => vec![1, 2],
+        wW_rW_DW_ARG | rW_W_DW_ARG => vec![2],
+        rW_DW_DW_ARG => vec![1, 2],
+        QW_DW_ARG => vec![3],
+        _ => vec![],
+    }
+}
+
+/// Absolute dword index of each positional QW operand, per BcType.
+fn qword_operand_indices(fmt: BcType) -> Vec<usize> {
+    use BcType::*;
+    match fmt {
+        QW_ARG | wW_QW_ARG | rW_QW_ARG | QW_DW_ARG => vec![1],
+        _ => vec![],
+    }
+}
+
+enum DwordRole {
+    Int(u8),
+    None,
+}
+
+/// Role of a positional DW operand for N4 (constants). `pos` is the index among the instruction's
+/// DW operands. Only ops whose DW is a genuine literal/value are Int; jump/ref DWs are handled
+/// upstream so they never reach here.
+fn const_dword_role(name: &str, pos: usize) -> DwordRole {
+    match name {
+        // 32-bit integer/float immediates pushed/set as values.
+        "PshC4" | "SetV4" | "SetV1" | "SetV2" => DwordRole::Int(4),
+        // SetG4: DW @ dword 3 is the literal value (the QW @1 is the global ptr, handled as ref).
+        "SetG4" => DwordRole::Int(4),
+        // immediate-arithmetic / immediate-compare literals.
+        "ADDIi" | "SUBIi" | "MULIi" | "ADDIf" | "SUBIf" | "MULIf" => DwordRole::Int(4),
+        "CMPIi" | "CMPIf" | "CMPIu" => DwordRole::Int(4),
+        // SetListSize (rW_DW_DW): both DWs are sizes (dword 1 = offset, dword 2 = size) — values.
+        "SetListSize" => DwordRole::Int(4),
+        // PshListElmnt (rW_DW): DW is an offset into the init list — a value.
+        "PshListElmnt" => DwordRole::Int(4),
+        // AllocMem (wW_DW): DW is a byte size — a value.
+        "AllocMem" => DwordRole::Int(4),
+        // GETOBJ/GETOBJREF/GETREF (W_rW): no DW operand; not reached.
+        _ => {
+            let _ = pos;
+            DwordRole::None
+        }
+    }
+}
+
+enum QwordRole {
+    Float,
+    None,
+}
+
+/// Role of the QW operand for N4. PshC8/SetV8 carry a 64-bit constant. This build is
+/// floatIsFloat64, so a `PshC8`/`SetV8` used for a `float`/`double` literal is a float bit
+/// pattern; but the same op also carries int64. We compare PshC8/SetV8 bit-exactly regardless
+/// (a float64 and an int64 with the same bits are indistinguishable at the operand level and
+/// compare identically either way), tagging them Float so NaN-payload bits are preserved.
+fn const_qword_role(name: &str) -> QwordRole {
+    match name {
+        "PshC8" | "SetV8" => QwordRole::Float,
+        _ => QwordRole::None,
+    }
+}
+
+/// N2 — first-use slot renumbering (opt-in). Walk the stream in order; assign each distinct raw
+/// slot a canonical ordinal on first appearance; rewrite `Slot` operands to their ordinal.
+/// Behavior-preserving ONLY when both sides share the same slot SHAPE — the caller GUARDS on
+/// distinct-slot-count equality before trusting an N2 BENIGN (see `classify`).
+fn renumber_slots(instrs: &mut [NormInstr]) {
+    let mut map: HashMap<i32, i32> = HashMap::new();
+    let mut next = 0i32;
+    for ni in instrs.iter_mut() {
+        for op in ni.operands.iter_mut() {
+            if let Operand::Slot(s) = op {
+                let canon = *map.entry(*s).or_insert_with(|| {
+                    let v = next;
+                    next += 1;
+                    v
+                });
+                *op = Operand::Slot(canon);
+            }
+        }
+    }
+}
+
+/// Distinct raw slot count in a normalized instruction list (for the N2 guard).
+fn distinct_slot_count(instrs: &[NormInstr]) -> usize {
+    let mut set = std::collections::HashSet::new();
+    for ni in instrs {
+        for op in &ni.operands {
+            if let Operand::Slot(s) = op {
+                set.insert(*s);
+            }
+        }
+    }
+    set.len()
+}
+
+// =================================================================================================
+// Verdict + classification.
+// =================================================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    Identical,
+    Benign,
+    Semantic,
+}
+
+/// Which normalizers were responsible for collapsing a difference (BENIGN audit trail).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NormFired {
+    pub n1_refs: bool,
+    pub n2_slots: bool,
+    pub n3_jumps: bool,
+    pub n4_consts: bool,
+}
+
+impl NormFired {
+    pub fn labels(&self) -> Vec<&'static str> {
+        let mut v = Vec::new();
+        if self.n1_refs {
+            v.push("N1:refs");
+        }
+        if self.n2_slots {
+            v.push("N2:slots");
+        }
+        if self.n3_jumps {
+            v.push("N3:jumps");
+        }
+        if self.n4_consts {
+            v.push("N4:consts");
+        }
+        v
+    }
+    fn any(&self) -> bool {
+        self.n1_refs || self.n2_slots || self.n3_jumps || self.n4_consts
+    }
+}
+
+/// Result of diffing one aligned function pair.
+#[derive(Debug, Clone)]
+pub struct FuncDiff {
+    pub name: String,
+    pub verdict: Verdict,
+    pub fired: NormFired,
+    pub v_ops: usize,
+    pub r_ops: usize,
+    /// For SEMANTIC: index of the first diverging normalized instruction (if lengths let us find
+    /// one), plus a human hint.
+    pub first_divergence: Option<usize>,
+    pub hint: Option<String>,
+    /// For SEMANTIC: rendered divergence window (both sides, ±context).
+    pub window: Option<String>,
+}
+
+/// Compare two RAW instruction lists element-wise (no normalization). True == byte/structure
+/// identical (same op + same raw words/dwords/qwords).
+fn raw_eq(a: &[Instr], b: &[Instr]) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b).all(|(x, y)| {
+            x.op.name == y.op.name
+                && x.words == y.words
+                && x.dwords == y.dwords
+                && x.qwords == y.qwords
+        })
+}
+
+/// The strictly-vetted benign OP-level tolerance set (spec §3.5). Currently: only `JitEntry`
+/// scaffolding (opcode 175) — a JIT hook the VM may or may not emit, no semantic effect. NOTE:
+/// dup null-check / CHKREF / ChkNullV are DELIBERATELY EXCLUDED (spec: benign in some fns, the
+/// real breaker in others). We only tolerate a `JitEntry` that appears on ONE side with no
+/// counterpart; anything else stays SEMANTIC.
+fn is_benign_only_op(name: &str) -> bool {
+    name == "JitEntry"
+}
+
+/// Filter a normalized list to drop `JitEntry` scaffolding (so a JIT-hook-only difference does
+/// not force SEMANTIC). Returns the filtered list; the caller notes it fired only if it changed
+/// the length.
+fn strip_jitentry(instrs: &[NormInstr]) -> Vec<NormInstr> {
+    instrs.iter().filter(|ni| !is_benign_only_op(ni.op)).cloned().collect()
+}
+
+/// Classify one aligned function pair given both sides' normalized + raw instruction lists.
+#[allow(clippy::too_many_arguments)]
+fn classify(
+    name: String,
+    v_raw: &[Instr],
+    r_raw: &[Instr],
+    v_norm: &[NormInstr],
+    r_norm: &[NormInstr],
+    opts: &NormOpts,
+    context: usize,
+) -> FuncDiff {
+    let v_ops = v_raw.len();
+    let r_ops = r_raw.len();
+
+    // Fast path: raw byte/structure identity ⇒ IDENTICAL (no normalizer needed).
+    if raw_eq(v_raw, r_raw) {
+        return FuncDiff {
+            name,
+            verdict: Verdict::Identical,
+            fired: NormFired::default(),
+            v_ops,
+            r_ops,
+            first_divergence: None,
+            hint: None,
+            window: None,
+        };
+    }
+
+    // N2 GUARD: if slot renumber is on but the two sides have a different distinct-slot COUNT, a
+    // real structural difference (added/dropped local) exists — DO NOT let N2 collapse it. We
+    // detect this and, if it's the only thing making them differ, still classify SEMANTIC.
+    let n2_slot_mismatch =
+        opts.n2_slots && distinct_slot_count(v_norm) != distinct_slot_count(r_norm);
+
+    // Compare normalized lists, tolerating JitEntry scaffolding.
+    let (v_cmp, r_cmp, jit_fired) = {
+        let vj = strip_jitentry(v_norm);
+        let rj = strip_jitentry(r_norm);
+        let fired = vj.len() != v_norm.len() || rj.len() != r_norm.len();
+        (vj, rj, fired)
+    };
+
+    let norm_identical = !n2_slot_mismatch
+        && v_cmp.len() == r_cmp.len()
+        && v_cmp.iter().zip(&r_cmp).all(|(a, b)| a.norm_eq(b));
+
+    if norm_identical {
+        // BENIGN: determine WHICH normalizers were responsible by re-diffing raw operand roles.
+        let fired = which_normalizers_fired(v_raw, r_raw, v_norm, r_norm, opts, jit_fired);
+        // Defensive: if raw differs but NO normalizer is credited and no JitEntry fired, that is a
+        // classifier blind spot — treat as SEMANTIC rather than silently benign.
+        if !fired.any() && !jit_fired {
+            return semantic(name, v_raw, r_raw, v_norm, r_norm, context, opts);
+        }
+        return FuncDiff {
+            name,
+            verdict: Verdict::Benign,
+            fired,
+            v_ops,
+            r_ops,
+            first_divergence: None,
+            hint: None,
+            window: None,
+        };
+    }
+
+    semantic(name, v_raw, r_raw, v_norm, r_norm, context, opts)
+}
+
+/// Build the SEMANTIC-DIFF result with a localized divergence window.
+fn semantic(
+    name: String,
+    v_raw: &[Instr],
+    r_raw: &[Instr],
+    v_norm: &[NormInstr],
+    r_norm: &[NormInstr],
+    context: usize,
+    opts: &NormOpts,
+) -> FuncDiff {
+    let v_ops = v_raw.len();
+    let r_ops = r_raw.len();
+    // First diverging normalized index (element-wise up to the shorter length).
+    let mut first = None;
+    let n = v_norm.len().min(r_norm.len());
+    for i in 0..n {
+        if !v_norm[i].norm_eq(&r_norm[i]) {
+            first = Some(i);
+            break;
+        }
+    }
+    if first.is_none() && v_norm.len() != r_norm.len() {
+        first = Some(n); // divergence is the length mismatch at the tail
+    }
+
+    let hint = semantic_hint(v_norm, r_norm, first, opts);
+    let window = render_window(v_norm, r_norm, first, context);
+
+    FuncDiff {
+        name,
+        verdict: Verdict::Semantic,
+        fired: NormFired::default(),
+        v_ops,
+        r_ops,
+        first_divergence: first,
+        hint: Some(hint),
+        window: Some(window),
+    }
+}
+
+/// Pattern-match the divergence against the spec §5 defect catalog for a fix-agent hint.
+fn semantic_hint(
+    v: &[NormInstr],
+    r: &[NormInstr],
+    first: Option<usize>,
+    _opts: &NormOpts,
+) -> String {
+    // Force-stub (RVODEF): regen body is a single typed return.
+    if r.len() <= 2 && v.len() > r.len() {
+        return "regen body is near-empty (≤2 ops) — likely force-stub / default-return (#6)"
+            .to_string();
+    }
+    // JZ/branch count inside a shorter regen ⇒ in-loop condition drop (emit_linear #1).
+    let vj = v.iter().filter(|n| is_jump_op(n.op)).count();
+    let rj = r.iter().filter(|n| is_jump_op(n.op)).count();
+    if rj < vj {
+        return format!(
+            "regen has FEWER jumps ({rj} vs {vj}) — likely emit_linear in-loop condition drop (#1) \
+             or dropped `if`"
+        );
+    }
+    // Extra/missing null-guard around the divergence.
+    if let Some(i) = first {
+        let near = |list: &[NormInstr], idx: usize| -> bool {
+            let lo = idx.saturating_sub(2);
+            let hi = (idx + 2).min(list.len());
+            list[lo..hi]
+                .iter()
+                .any(|n| matches!(n.op, "CHKREF" | "ChkNullV" | "ChkNullS" | "CmpPtrNull" | "ChkRefS"))
+        };
+        if near(v, i) != near(r, i.min(r.len())) {
+            return "extra/missing null-guard (CHKREF/ChkNullV/CmpPtrNull) near divergence — \
+                    classify SEMANTIC, human to decide (dup null-check is benign in some fns, the \
+                    real breaker in others)"
+                .to_string();
+        }
+        // Conversion-op mismatch (enum/int/float width, #2/#3).
+        let is_conv = |n: &&NormInstr| {
+            matches!(
+                n.op,
+                "sbTOi" | "swTOi" | "ubTOi" | "uwTOi" | "iTOb" | "iTOw" | "iTOf" | "fTOi"
+                    | "dTOf" | "fTOd" | "iTOd" | "dTOi" | "i64TOi" | "iTOi64" | "Cast"
+            )
+        };
+        let vc = v.iter().filter(is_conv).count();
+        let rc = r.iter().filter(is_conv).count();
+        if vc != rc {
+            return format!(
+                "conversion-op count differs ({rc} vs {vc}) — likely enum↔int / float-width cast \
+                 mismatch (#2/#3)"
+            );
+        }
+    }
+    // Arg-order swap heuristic: same op multiset but Push slot order differs before an aligned CALL.
+    "residual divergence survived N1–N4 — inspect the window (candidate: arg-order swap #0, \
+     cross-block carry #4, or struct-ctor grouping #5)"
+        .to_string()
+}
+
+/// Render both sides' ±context window around the first divergence, operands as resolved names.
+fn render_window(
+    v: &[NormInstr],
+    r: &[NormInstr],
+    first: Option<usize>,
+    context: usize,
+) -> String {
+    let center = first.unwrap_or(0);
+    let lo = center.saturating_sub(context);
+    let mut s = String::new();
+    s.push_str("    vanilla:\n");
+    render_side(&mut s, v, lo, center + context + 1);
+    s.push_str("    regen:\n");
+    render_side(&mut s, r, lo, center + context + 1);
+    s
+}
+
+fn render_side(s: &mut String, list: &[NormInstr], lo: usize, hi: usize) {
+    let hi = hi.min(list.len());
+    for (i, ni) in list.iter().enumerate().take(hi).skip(lo) {
+        let ops: Vec<String> = ni.operands.iter().map(render_operand).collect();
+        s.push_str(&format!("      [{i:04}] {:<14} {}\n", ni.op, ops.join(", ")));
+    }
+    if lo >= list.len() {
+        s.push_str("      <past end>\n");
+    }
+}
+
+fn render_operand(op: &Operand) -> String {
+    match op {
+        Operand::Slot(s) => format!("v{s}"),
+        Operand::Word(w) => format!("w{w}"),
+        Operand::IntConst { value, width } => format!("i{width}:{value}"),
+        Operand::FloatConst(bits) => {
+            let f = f64::from_bits(*bits);
+            format!("f64:{f}(0x{bits:x})")
+        }
+        Operand::JumpIndex(Some(i)) => format!("->[{i:04}]"),
+        Operand::JumpIndex(None) => "->[??]".to_string(),
+        Operand::Ref(id) => id.display(),
+        Operand::StaticName(Some(s)) => format!("n\"{s}\""),
+        Operand::StaticName(None) => "n<?>".to_string(),
+        Operand::RawDw(d) => format!("0x{d:x}"),
+        Operand::RawQw(q) => format!("0x{q:x}"),
+    }
+}
+
+/// Determine which normalizers actually collapsed a difference (for the BENIGN audit trail).
+/// A normalizer is "credited" if turning it off would make the normalized lists differ. We
+/// approximate this cheaply per operand-class by comparing raw operands vs normalized operands.
+fn which_normalizers_fired(
+    v_raw: &[Instr],
+    r_raw: &[Instr],
+    v_norm: &[NormInstr],
+    r_norm: &[NormInstr],
+    opts: &NormOpts,
+    jit_fired: bool,
+) -> NormFired {
+    let mut fired = NormFired::default();
+    // Only meaningful when normalized lists have equal length (they do — we're in the BENIGN arm).
+    let n = v_norm.len().min(r_norm.len());
+    for i in 0..n {
+        for (vo, ro) in v_norm[i].operands.iter().zip(&r_norm[i].operands) {
+            match (vo, ro) {
+                (Operand::Ref(a), Operand::Ref(b)) if a == b => {
+                    // A ref matched after N1. Did the RAW operand differ? If the raw dwords/qwords
+                    // of these instructions differ, N1 was responsible.
+                    if opts.n1_refs
+                        && (v_raw[i].qwords != r_raw[i].qwords || raw_id_differs(&v_raw[i], &r_raw[i]))
+                    {
+                        fired.n1_refs = true;
+                    }
+                }
+                (Operand::JumpIndex(a), Operand::JumpIndex(b)) if a == b => {
+                    if opts.n3_jumps && v_raw[i].dwords != r_raw[i].dwords {
+                        fired.n3_jumps = true;
+                    }
+                }
+                (Operand::FloatConst(a), Operand::FloatConst(b)) if a == b => {
+                    if opts.n4_consts && v_raw[i].qwords != r_raw[i].qwords {
+                        fired.n4_consts = true;
+                    }
+                }
+                (Operand::IntConst { value: a, .. }, Operand::IntConst { value: b, .. })
+                    if a == b => {}
+                (Operand::StaticName(a), Operand::StaticName(b)) if a == b => {
+                    if opts.n4_consts
+                        && (v_raw[i].words != r_raw[i].words || v_raw[i].dwords != r_raw[i].dwords)
+                    {
+                        fired.n4_consts = true;
+                    }
+                }
+                (Operand::Slot(a), Operand::Slot(b)) if a == b => {
+                    if opts.n2_slots && v_raw[i].words != r_raw[i].words {
+                        fired.n2_slots = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    // If N2 is on and any slot mapping was applied while raw words differ somewhere, credit it.
+    fired.n2_slots = fired.n2_slots && opts.n2_slots;
+    if jit_fired {
+        // JitEntry stripping is a benign op-level tolerance; not one of N1–N4 but note nothing
+        // extra (the report shows it via the fired labels being possibly empty + jit note).
+    }
+    fired
+}
+
+/// True if the func-id / type-id dword operand (dword 1 or 3) differs between two instructions —
+/// a proxy for "N1 had work to do" on id-based refs (whose raw ids differ across builds).
+fn raw_id_differs(a: &Instr, b: &Instr) -> bool {
+    a.dwords != b.dwords
+}
+
+// =================================================================================================
+// Alignment: modules by name, functions by DISPLAY name + name-resolved signature.
+// =================================================================================================
+//
+// Function source = the WALKER (`collect_function_bytecodes`), which yields EVERY Func the spec
+// §2.3 calls for (free fns, class methods, ctors, behavior fns, global-init fns) with the display
+// name already composed (`module.Class::method`). We key alignment by the full display name PLUS
+// the RESOLVED signature (param + ret base-names via each cache's RefResolver, so ptr differences
+// don't break alignment; overloads distinguished by the param-type list). Module ONLY-IN-* is a
+// separate name-set diff over `module_names`.
+
+/// A function's alignment key: `display\x1fparam-base-types->ret#is_method`, types resolved to
+/// NAMES via each cache's RefResolver so ptr differences don't break alignment (spec §2.3).
+fn func_key(fc: &super::walk_modules::FuncCode, refs: &RefResolver) -> String {
+    let params: Vec<String> = fc.param_types.iter().map(|p| p.base_name(refs)).collect();
+    format!(
+        "{}\u{1f}{}->{}#{}",
+        fc.func,
+        params.join(","),
+        fc.ret.base_name(refs),
+        fc.is_method as u8
+    )
+}
+
+/// A whole-cache diff report.
+#[derive(Debug, Default)]
+pub struct Report {
+    pub diffs: Vec<FuncDiff>,
+    pub only_in_vanilla_modules: Vec<String>,
+    pub only_in_regen_modules: Vec<String>,
+    pub only_in_vanilla_funcs: Vec<String>,
+    pub only_in_regen_funcs: Vec<String>,
+}
+
+impl Report {
+    pub fn count(&self, v: Verdict) -> usize {
+        self.diffs.iter().filter(|d| d.verdict == v).count()
+    }
+    pub fn any_semantic(&self) -> bool {
+        self.diffs.iter().any(|d| d.verdict == Verdict::Semantic)
+    }
+}
+
+/// Filters for which functions/modules to diff.
+#[derive(Debug, Default, Clone)]
+pub struct Filters {
+    pub module: Option<String>,
+    pub func: Option<String>,
+}
+
+/// Run the full bytediff over two caches. `context` = window size for SEMANTIC reports.
+pub fn run(
+    v_bytes: &[u8],
+    r_bytes: &[u8],
+    opts: &NormOpts,
+    filters: &Filters,
+    context: usize,
+) -> anyhow::Result<Report> {
+    let v_side = Side::build(v_bytes)?;
+    let r_side = Side::build(r_bytes)?;
+
+    let mut report = Report::default();
+
+    // --- Module alignment by name (a dropped/added module is a defect signal). ---
+    let v_modnames = super::walk_modules::module_names(v_bytes)?;
+    let r_modnames = super::walk_modules::module_names(r_bytes)?;
+    let v_modset: std::collections::HashSet<&str> = v_modnames.iter().map(|s| s.as_str()).collect();
+    let r_modset: std::collections::HashSet<&str> = r_modnames.iter().map(|s| s.as_str()).collect();
+    for m in &v_modnames {
+        if !r_modset.contains(m.as_str()) {
+            report.only_in_vanilla_modules.push(m.clone());
+        }
+    }
+    for m in &r_modnames {
+        if !v_modset.contains(m.as_str()) {
+            report.only_in_regen_modules.push(m.clone());
+        }
+    }
+
+    // --- Function alignment (WALKER: every Func the spec §2.3 lists). ---
+    let v_fns = super::walk_modules::collect_function_bytecodes(v_bytes)?;
+    let r_fns = super::walk_modules::collect_function_bytecodes(r_bytes)?;
+
+    // Substring filters (module = a substring of the display prefix; func = substring of display).
+    let want_v = |fc: &super::walk_modules::FuncCode| -> bool {
+        filters.module.as_ref().map_or(true, |m| fc.func.contains(m.as_str()))
+            && filters.func.as_ref().map_or(true, |f| fc.func.contains(f.as_str()))
+    };
+
+    // Index regen functions by alignment key (dup keys -> ordered Vec, consumed positionally so
+    // N overloads on each side pair up 1:1).
+    let mut r_index: HashMap<String, Vec<&super::walk_modules::FuncCode>> = HashMap::new();
+    for fc in &r_fns {
+        r_index.entry(func_key(fc, &r_side.refs)).or_default().push(fc);
+    }
+    let mut r_used: HashMap<String, usize> = HashMap::new();
+
+    for vfc in v_fns.iter().filter(|f| want_v(f)) {
+        let key = func_key(vfc, &v_side.refs);
+        let rfc = r_index.get(&key).and_then(|cs| {
+            let used = r_used.entry(key.clone()).or_insert(0);
+            let pick = cs.get(*used).copied();
+            if pick.is_some() {
+                *used += 1;
+            }
+            pick
+        });
+        match rfc {
+            Some(rfc) => {
+                let d = diff_one(&vfc.func, &vfc.bytecode, &rfc.bytecode, &v_side, &r_side, opts, context);
+                report.diffs.push(d);
+            }
+            None => report.only_in_vanilla_funcs.push(vfc.func.clone()),
+        }
+    }
+
+    // Regen functions with no vanilla counterpart (synthesized) — only when unfiltered, and count
+    // only the regen overloads beyond what vanilla had for the same key.
+    if filters.func.is_none() && filters.module.is_none() {
+        let mut v_cap: HashMap<String, usize> = HashMap::new();
+        for vfc in &v_fns {
+            *v_cap.entry(func_key(vfc, &v_side.refs)).or_default() += 1;
+        }
+        let mut r_seen: HashMap<String, usize> = HashMap::new();
+        for rfc in &r_fns {
+            let key = func_key(rfc, &r_side.refs);
+            let cap = v_cap.get(&key).copied().unwrap_or(0);
+            let seen = r_seen.entry(key).or_insert(0);
+            if *seen >= cap {
+                report.only_in_regen_funcs.push(rfc.func.clone());
+            }
+            *seen += 1;
+        }
+    }
+
+    Ok(report)
+}
+
+/// Diff one aligned function pair (disassemble both, normalize, classify). Disassembly failure on
+/// either side is itself a SEMANTIC signal (a malformed body), never a crash.
+fn diff_one(
+    name: &str,
+    v_code: &[i32],
+    r_code: &[i32],
+    v_side: &Side,
+    r_side: &Side,
+    opts: &NormOpts,
+    context: usize,
+) -> FuncDiff {
+    let v_raw = match disassemble(v_code) {
+        Ok(x) => x,
+        Err(e) => return disasm_fail(name, "vanilla", e.to_string(), v_code.len(), r_code.len()),
+    };
+    let r_raw = match disassemble(r_code) {
+        Ok(x) => x,
+        Err(e) => return disasm_fail(name, "regen", e.to_string(), v_raw.len(), r_code.len()),
+    };
+    let v_norm = normalize(v_code, &v_raw, v_side, opts);
+    let r_norm = normalize(r_code, &r_raw, r_side, opts);
+    classify(name.to_string(), &v_raw, &r_raw, &v_norm, &r_norm, opts, context)
+}
+
+fn disasm_fail(name: &str, which: &str, err: String, v_ops: usize, r_ops: usize) -> FuncDiff {
+    FuncDiff {
+        name: name.to_string(),
+        verdict: Verdict::Semantic,
+        fired: NormFired::default(),
+        v_ops,
+        r_ops,
+        first_divergence: None,
+        hint: Some(format!("{which} bytecode failed to disassemble: {err}")),
+        window: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(name: &str) -> Vec<u8> {
+        std::fs::read(format!(
+            "{}/../../work/reversing/gore-as/samples/{name}",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap_or_else(|_| panic!("read sample {name}"))
+    }
+
+    /// Self-identity on a small real cache: a cache vs itself must be PERFECTLY identical —
+    /// every function IDENTICAL, 0 BENIGN, 0 SEMANTIC, no alignment loss. This is the correctness
+    /// gate for N1/N3/N4.
+    #[test]
+    fn self_identity_richtest() {
+        let b = sample("PrecompiledScript.richtest.Cache");
+        let rep = run(&b, &b, &NormOpts::default(), &Filters::default(), 6).expect("run");
+        assert_eq!(rep.count(Verdict::Benign), 0, "self-diff must have 0 BENIGN");
+        assert_eq!(rep.count(Verdict::Semantic), 0, "self-diff must have 0 SEMANTIC");
+        assert!(rep.only_in_vanilla_funcs.is_empty(), "no dropped fns in self-diff");
+        assert!(rep.only_in_regen_funcs.is_empty(), "no added fns in self-diff");
+        assert!(!rep.diffs.is_empty(), "richtest has at least one function");
+        assert_eq!(rep.count(Verdict::Identical), rep.diffs.len());
+    }
+
+    /// Self-identity must ALSO hold with N2 (slot renumber) enabled — a cache vs itself has
+    /// identical slot shapes, so N2 is a no-op that keeps everything IDENTICAL (raw-eq fast path
+    /// actually short-circuits, but assert the N2 path doesn't regress).
+    #[test]
+    fn self_identity_richtest_with_n2() {
+        let b = sample("PrecompiledScript.richtest.Cache");
+        let mut opts = NormOpts::default();
+        opts.n2_slots = true;
+        let rep = run(&b, &b, &opts, &Filters::default(), 6).expect("run");
+        assert_eq!(rep.count(Verdict::Semantic), 0);
+        assert_eq!(rep.count(Verdict::Benign), 0);
+        assert_eq!(rep.count(Verdict::Identical), rep.diffs.len());
+    }
+
+    #[test]
+    fn self_identity_visproof() {
+        let b = sample("PrecompiledScript.visproof.Cache");
+        let rep = run(&b, &b, &NormOpts::default(), &Filters::default(), 6).expect("run");
+        assert_eq!(rep.count(Verdict::Semantic), 0);
+        assert_eq!(rep.count(Verdict::Benign), 0);
+        assert_eq!(rep.count(Verdict::Identical), rep.diffs.len());
+    }
+
+    // ---- Synthetic-bytecode normalizer unit tests (N3 jumps, N4 consts, N2 slots) ----
+
+    /// Encode a NO_ARG op (opcode in byte 0 of one dword).
+    fn no_arg(opcode: u8) -> Vec<i32> {
+        vec![opcode as i32]
+    }
+    /// Encode a DW_ARG op: opcode dword + 32-bit arg dword.
+    fn dw_arg(opcode: u8, arg: i32) -> Vec<i32> {
+        vec![opcode as i32, arg]
+    }
+    /// Encode an rW_ARG op: opcode | (slot in the high word of dword 0).
+    fn rw_arg(opcode: u8, slot: u16) -> Vec<i32> {
+        vec![opcode as i32 | ((slot as i32) << 16)]
+    }
+    /// Encode a QW_ARG op: opcode dword + 64-bit arg (2 dwords LE).
+    fn qw_arg(opcode: u8, arg: u64) -> Vec<i32> {
+        vec![opcode as i32, arg as u32 as i32, (arg >> 32) as u32 as i32]
+    }
+
+    // opcodes (from isa.rs): JMP=11, JZ=12, SUSPEND=63, RET=10 (W_ARG),
+    // PshC8=47 (QW), PshV4=3 (rW), PopPtr=0 (NO_ARG), TZ=18 (NO_ARG).
+
+    fn side() -> Side {
+        // N3/N4/N2 don't need real tail tables; a tiny sample gives a valid RefResolver/RefIdentity.
+        let b = sample("PrecompiledScript.richtest.Cache");
+        Side::build(&b).expect("side")
+    }
+
+    /// Build a normalized instruction list from raw bytecode (test helper).
+    fn norm(code: &[i32], side: &Side, opts: &NormOpts) -> Vec<NormInstr> {
+        let raw = disassemble(code).expect("disasm");
+        normalize(code, &raw, side, opts)
+    }
+
+    /// N3: two functions with the SAME instruction COUNT but where an earlier instruction has a
+    /// different SIZE (a benign const-width change: PshC4 2dw vs PshC8 3dw) — the JMP's absolute
+    /// byte(dword) offset shifts, but its target INSTRUCTION INDEX is the same, so N3 makes the
+    /// jump operand compare EQUAL (the control-flow edge is preserved).
+    #[test]
+    fn n3_jump_index_equal_despite_offset_shift() {
+        let side = side();
+        let opts = NormOpts::default();
+        // Layout (both sides, 4 instructions): [const][JMP -> RET][TZ][RET].
+        // Side A uses PshC4 (2 dwords); Side B uses PshC8 (3 dwords) — one dword bigger. The JMP's
+        // raw offset differs (same index distance, but computed the same relative way), yet both
+        // resolve to the RET at instruction index 3.
+        // A: PshC4@dw0(2) JMP@dw2(2,off1)->dw(2+2+1)=dw5 TZ@dw4? wait recompute below.
+        // Compute A: PshC4 dw0..1; JMP dw2..3; TZ dw4; RET dw5. JMP target index 3 (RET) => off =
+        //   target_dw(5) - (jmp_dw(2)+size(2)) = 1.
+        let mut a = Vec::new();
+        a.extend(dw_arg(2, 7)); // PshC4 7 @ dw0 (2 dwords)
+        a.extend(dw_arg(11, 1)); // JMP @ dw2 size2 off1 -> dw5 = RET (index 3)
+        a.extend(no_arg(18)); // TZ @ dw4
+        a.push(10); // RET @ dw5
+        // B: PshC8 dw0..2 (3 dwords); JMP dw3..4; TZ dw5; RET dw6. off = 6 - (3+2) = 1.
+        let mut b = Vec::new();
+        b.extend(qw_arg(47, 7)); // PshC8 7 @ dw0 (3 dwords)
+        b.extend(dw_arg(11, 1)); // JMP @ dw3 size2 off1 -> dw6 = RET (index 3)
+        b.extend(no_arg(18)); // TZ @ dw5
+        b.push(10); // RET @ dw6
+        let na = norm(&a, &side, &opts);
+        let nb = norm(&b, &side, &opts);
+        assert_eq!(na.len(), 4);
+        assert_eq!(nb.len(), 4);
+        let a_jmp = &na[1];
+        let b_jmp = &nb[1];
+        assert_eq!(a_jmp.op, "JMP");
+        assert_eq!(b_jmp.op, "JMP");
+        // Both jumps target the RET at instruction index 3 — equal despite different raw offset
+        // origin (A off computed from dw2, B from dw3).
+        assert_eq!(a_jmp.operands[0], Operand::JumpIndex(Some(3)));
+        assert_eq!(b_jmp.operands[0], Operand::JumpIndex(Some(3)));
+        assert_eq!(a_jmp.operands, b_jmp.operands, "jump edge preserved across size shift");
+    }
+
+    /// N3 guard: a jump whose target INDEX differs (branches to a structurally different
+    /// instruction) stays a real difference — the operands are NOT equal.
+    #[test]
+    fn n3_jump_to_different_index_differs() {
+        let side = side();
+        let opts = NormOpts::default();
+        // A: JMP skips 0 ops (targets the very next). B: JMP skips 1 op (targets one later).
+        let mut a = Vec::new();
+        a.extend(dw_arg(11, 0)); // JMP @ dw0 offset0 -> dw2
+        a.extend(no_arg(18)); // TZ @ dw2
+        a.push(10); // RET @ dw3
+        let mut b = Vec::new();
+        b.extend(dw_arg(11, 1)); // JMP @ dw0 offset1 -> dw3 (skips the TZ)
+        b.extend(no_arg(18)); // TZ @ dw2
+        b.push(10); // RET @ dw3
+        let na = norm(&a, &side, &opts);
+        let nb = norm(&b, &side, &opts);
+        assert_ne!(na[0].operands, nb[0].operands, "different jump target index must differ");
+    }
+
+    /// N4: a 64-bit float constant compares by DECODED value (bit pattern). Same value => equal;
+    /// a genuinely different value => not equal. (Same-value floats already share bits, so this
+    /// mainly asserts we decode + compare the qword, not a raw pass-through that could mis-handle.)
+    #[test]
+    fn n4_float_const_by_value() {
+        let side = side();
+        let opts = NormOpts::default();
+        let same_a = norm(&qw_arg(47, 3.5f64.to_bits()), &side, &opts);
+        let same_b = norm(&qw_arg(47, 3.5f64.to_bits()), &side, &opts);
+        assert_eq!(same_a[0].operands, same_b[0].operands);
+        assert_eq!(same_a[0].operands[0], Operand::FloatConst(3.5f64.to_bits()));
+        let diff = norm(&qw_arg(47, 4.5f64.to_bits()), &side, &opts);
+        assert_ne!(same_a[0].operands, diff[0].operands, "different float value must differ");
+    }
+
+    /// N4: a 32-bit integer immediate (PshC4=2, DW_ARG) compares by decoded value.
+    #[test]
+    fn n4_int_const_by_value() {
+        let side = side();
+        let opts = NormOpts::default();
+        let a = norm(&dw_arg(2, 42), &side, &opts);
+        let b = norm(&dw_arg(2, 42), &side, &opts);
+        assert_eq!(a[0].operands, b[0].operands);
+        assert_eq!(a[0].operands[0], Operand::IntConst { value: 42, width: 4 });
+        let c = norm(&dw_arg(2, 43), &side, &opts);
+        assert_ne!(a[0].operands, c[0].operands);
+    }
+
+    /// N2 (opt-in): two streams that use DIFFERENT raw slot numbers but in the SAME first-use
+    /// order canonicalize to identical ordinals. With N2 OFF they differ; with N2 ON they match.
+    #[test]
+    fn n2_slot_renumber_first_use() {
+        let side = side();
+        // A uses slots 5 then 8; B uses slots 2 then 9 — same first-use ORDER.
+        let mut a = Vec::new();
+        a.extend(rw_arg(3, 5)); // PshV4 v5
+        a.extend(rw_arg(3, 8)); // PshV4 v8
+        let mut b = Vec::new();
+        b.extend(rw_arg(3, 2)); // PshV4 v2
+        b.extend(rw_arg(3, 9)); // PshV4 v9
+
+        let off = NormOpts::default();
+        let na = norm(&a, &side, &off);
+        let nb = norm(&b, &side, &off);
+        assert_ne!(na[0].operands, nb[0].operands, "raw slots differ with N2 off");
+
+        let mut on = NormOpts::default();
+        on.n2_slots = true;
+        let na = norm(&a, &side, &on);
+        let nb = norm(&b, &side, &on);
+        assert_eq!(na[0].operands, nb[0].operands, "first-use order maps to same ordinal");
+        assert_eq!(na[1].operands, nb[1].operands);
+        assert_eq!(na[0].operands[0], Operand::Slot(0));
+        assert_eq!(na[1].operands[0], Operand::Slot(1));
+    }
+}

--- a/crates/gore-as/src/cache/bytediff.rs
+++ b/crates/gore-as/src/cache/bytediff.rs
@@ -34,6 +34,57 @@ fn is_jump_op(name: &str) -> bool {
     )
 }
 
+/// Read a qword (2 dwords LE) directly from a decoded instruction's collected qword operands.
+/// (The disassembler already collected the QW into `ins.qwords`; the first one is the ref ptr.)
+fn instr_first_qword(ins: &Instr) -> Option<u64> {
+    ins.qwords.first().copied()
+}
+
+/// Bare callee NAME of a call instruction, resolved via the side's `RefResolver`. `CALLSYS`
+/// carries a func-PTR (QW @ dword 1); `CALL`/`CALLBND`/`CALLINTF` carry a func-ID (DW @ dword 1).
+/// Returns `None` for a non-call op or an unresolved callee. Used by the batch-38 lookahead gates
+/// (GAP-B `__STATIC_NAME`, GAP-C `opCast`) to identify a specific native callee WITHOUT string-
+/// parsing the composed identity.
+fn callee_name<'a>(ins: &Instr, side: &'a Side) -> Option<&'a str> {
+    match ins.op.name {
+        "CALLSYS" | "FuncPtr" | "Thiscall1" => {
+            side.refs.func_by_ptr(instr_first_qword(ins)? as i64)
+        }
+        "CALL" | "CALLBND" | "CALLINTF" => {
+            side.refs.func_by_id(*ins.dwords.first()? as i32)
+        }
+        _ => None,
+    }
+}
+
+/// GAP-B gate: the instruction AFTER `pos` is a `CALLSYS` whose callee is the synthesized
+/// `__STATIC_NAME(int)` FName-pool accessor — i.e. the `PshC4` at `pos` pushed a StaticNames
+/// pool INDEX, not an integer value.
+fn next_is_static_name(instrs: &[Instr], pos: usize, side: &Side) -> bool {
+    instrs
+        .get(pos + 1)
+        .and_then(|nx| callee_name(nx, side))
+        .is_some_and(|n| n == "__STATIC_NAME")
+}
+
+/// GAP-C gate: the `TYPEID`/`Cast` at `pos` feeds an `opCast`/`Cast` call. Scan a SHORT forward
+/// window; the pushed type-id is consumed by the next call, which must be `opCast` (the pattern is
+/// `TYPEID; PSF; PshVPtr; CALLSYS opCast`). Stop at the first call op — if it is NOT `opCast`, the
+/// type-id feeds something else and the gate does NOT fire (stays a value-compared Primitive).
+fn feeds_matching_opcast(instrs: &[Instr], pos: usize, side: &Side) -> bool {
+    // Window kept tight (the opCast is 1–3 ops after the TYPEID in every observed case).
+    const WINDOW: usize = 4;
+    for k in 1..=WINDOW {
+        let Some(nx) = instrs.get(pos + k) else { return false };
+        let is_call = matches!(nx.op.name, "CALLSYS" | "CALL" | "CALLBND" | "CALLINTF");
+        if is_call {
+            // The FIRST call after the TYPEID must be the opCast that consumes it.
+            return callee_name(nx, side) == Some("opCast");
+        }
+    }
+    false
+}
+
 /// A single normalized operand token. Equality of two `Operand`s (across caches) means the
 /// operands are semantically the same after the relevant normalizer.
 #[derive(Debug, Clone, PartialEq)]
@@ -53,6 +104,13 @@ enum Operand {
     Ref(OperandId),
     /// A resolved STR / __STATIC_NAME string literal, compared by text (N4).
     StaticName(Option<String>),
+    /// A `TYPEID`/`Cast` operand that is a LARGE runtime object type-id feeding an `opCast`/`Cast`
+    /// whose callee identity matches on both sides (GAP-C, batch-38). The raw id is a
+    /// build-specific `asCTypeInfo` id that drifts across recompiles; the cast target is pinned by
+    /// the adjacent (matched) opCast signature, so two such operands compare EQUAL regardless of
+    /// the raw id. Only produced after the runtime-object-typeid + feeds-matching-opCast gate;
+    /// a genuine primitive type-id stays a value-compared `Ref(Primitive)`.
+    OpCastTypeId,
     /// A raw dword/qword the classifier does not model as slot/const/ref/jump — compared verbatim
     /// (conservative: an unmodeled operand difference stays SEMANTIC).
     RawDw(u32),
@@ -128,7 +186,7 @@ fn normalize(
     let off_to_idx = offset_index_map(instrs);
     let mut out = Vec::with_capacity(instrs.len());
 
-    for ins in instrs {
+    for (pos, ins) in instrs.iter().enumerate() {
         let name = ins.op.name;
         // Ref-operand dword indices (relative to the instruction start) → identity, via the
         // SHARED ref_sites classification (N1). Collect into a per-dword-index lookup so the
@@ -155,7 +213,7 @@ fn normalize(
             }
         }
 
-        let operands = normalize_operands(name, ins, &ref_at_dw, &off_to_idx, side, opts);
+        let operands = normalize_operands(name, ins, &ref_at_dw, &off_to_idx, side, opts, instrs, pos);
         out.push(NormInstr { op: name, operands });
     }
 
@@ -170,6 +228,7 @@ fn normalize(
 /// Roles are decided by (opcode, BcType). The positional layout mirrors `disasm::disassemble`:
 /// words in source order, then dwords, then qwords. We map each positional operand to the dword
 /// index it occupies so N1 ref substitutions (keyed by dword index) apply.
+#[allow(clippy::too_many_arguments)]
 fn normalize_operands(
     name: &str,
     ins: &Instr,
@@ -177,6 +236,8 @@ fn normalize_operands(
     off_to_idx: &HashMap<usize, usize>,
     side: &Side,
     opts: &NormOpts,
+    instrs: &[Instr],
+    pos: usize,
 ) -> Vec<Operand> {
     let mut out = Vec::new();
 
@@ -189,10 +250,20 @@ fn normalize_operands(
     //     or a plain raw dword. The dword operand's absolute dword index tells us which. ---
     // Determine the dword-index of each positional dword operand from the BcType.
     let dword_indices = dword_operand_indices(ins.op.fmt);
-    for (pos, &dw_idx) in dword_indices.iter().enumerate() {
-        let raw = *ins.dwords.get(pos).unwrap_or(&0);
+    for (dop, &dw_idx) in dword_indices.iter().enumerate() {
+        let raw = *ins.dwords.get(dop).unwrap_or(&0);
         // N1 ref (func-id / type-id) at this dword index?
         if let Some(id) = ref_at_dw.get(&dw_idx) {
+            // GAP-C (batch-38): a `TYPEID`/`Cast` operand that is a LARGE runtime object type-id
+            // (an `asCTypeInfo` id not in T2, mask bits set) is build-specific and drifts. When it
+            // feeds an `opCast`/`Cast` whose callee identity matches on both sides (verified at the
+            // opCast op's own index), the cast TARGET is pinned by that signature, so collapse the
+            // drifting id to a single canonical token. A genuine primitive type-id stays a
+            // value-compared Ref(Primitive).
+            if id.is_runtime_object_typeid() && feeds_matching_opcast(instrs, pos, side) {
+                out.push(Operand::OpCastTypeId);
+                continue;
+            }
             out.push(Operand::Ref(id.clone()));
             continue;
         }
@@ -203,8 +274,18 @@ fn normalize_operands(
             out.push(Operand::JumpIndex(off_to_idx.get(&target_off).copied()));
             continue;
         }
+        // GAP-B (batch-38): a `PshC4 <idx>` immediately followed by `CALLSYS __STATIC_NAME` is an
+        // FName-literal pool index, NOT an integer value. The StaticNames pool is rebuilt per-cache
+        // (different size), so the same name lands at a different slot — resolve the index to TEXT
+        // and compare by string (mirror the `STR` handling below). The tight next-instruction gate
+        // keeps a real integer literal (not feeding __STATIC_NAME) comparing by value.
+        if opts.n4_consts && name == "PshC4" && next_is_static_name(instrs, pos, side) {
+            let s = side.refs.static_name(raw as i32 as i64).map(|s| s.to_string());
+            out.push(Operand::StaticName(s));
+            continue;
+        }
         // N4 constant?
-        match const_dword_role(name, pos) {
+        match const_dword_role(name, dop) {
             DwordRole::Int(width) => {
                 out.push(Operand::IntConst { value: raw as i32 as i64, width });
             }
@@ -214,8 +295,8 @@ fn normalize_operands(
 
     // --- Qword operands: ref ptr (N1), 64-bit const (N4 float/int), or raw. ---
     let qword_indices = qword_operand_indices(ins.op.fmt);
-    for (pos, &dw_idx) in qword_indices.iter().enumerate() {
-        let raw = *ins.qwords.get(pos).unwrap_or(&0);
+    for (qop, &dw_idx) in qword_indices.iter().enumerate() {
+        let raw = *ins.qwords.get(qop).unwrap_or(&0);
         if let Some(id) = ref_at_dw.get(&dw_idx) {
             out.push(Operand::Ref(id.clone()));
             continue;
@@ -679,6 +760,7 @@ fn render_operand(op: &Operand) -> String {
         Operand::Ref(id) => id.display(),
         Operand::StaticName(Some(s)) => format!("n\"{s}\""),
         Operand::StaticName(None) => "n<?>".to_string(),
+        Operand::OpCastTypeId => "opcast-typeid".to_string(),
         Operand::RawDw(d) => format!("0x{d:x}"),
         Operand::RawQw(q) => format!("0x{q:x}"),
     }
@@ -727,6 +809,13 @@ fn which_normalizers_fired(
                         && (v_raw[i].words != r_raw[i].words || v_raw[i].dwords != r_raw[i].dwords)
                     {
                         fired.n4_consts = true;
+                    }
+                }
+                (Operand::OpCastTypeId, Operand::OpCastTypeId) => {
+                    // GAP-C: a large runtime opCast type-id collapsed by N1 (a ref-identity
+                    // refinement). Credit N1 when the raw type-id dword actually differed.
+                    if opts.n1_refs && v_raw[i].dwords != r_raw[i].dwords {
+                        fired.n1_refs = true;
                     }
                 }
                 (Operand::Slot(a), Operand::Slot(b)) if a == b => {
@@ -1127,5 +1216,143 @@ mod tests {
         assert_eq!(na[1].operands, nb[1].operands);
         assert_eq!(na[0].operands[0], Operand::Slot(0));
         assert_eq!(na[1].operands[0], Operand::Slot(1));
+    }
+
+    // ---- GAP-B / GAP-C gate tests (batch-38) ----
+
+    /// GAP-B negative gate: a bare `PshC4 <n>` NOT followed by a `CALLSYS __STATIC_NAME` is a
+    /// plain integer literal — it must stay `IntConst` (compared by value), never resolve through
+    /// the StaticNames pool. (The positive path — a real `__STATIC_NAME` callee — is covered by the
+    /// `#[ignore]`d real-cache regression `gap_b_static_name_index_benign`.)
+    #[test]
+    fn gap_b_lone_pshc4_stays_int_const() {
+        let side = side();
+        let opts = NormOpts::default();
+        // PshC4 4369 followed by TZ (opcode 18, NOT __STATIC_NAME) — a real integer literal.
+        let mut code = Vec::new();
+        code.extend(dw_arg(2, 4369)); // PshC4 4369
+        code.extend(no_arg(18)); // TZ
+        let n = norm(&code, &side, &opts);
+        assert_eq!(
+            n[0].operands[0],
+            Operand::IntConst { value: 4369, width: 4 },
+            "PshC4 not feeding __STATIC_NAME must stay an integer literal"
+        );
+    }
+
+    /// GAP-C negative gate: a `TYPEID <large>` whose value is a large runtime object type-id but
+    /// which does NOT feed an `opCast` (no matching call follows) must stay a value-compared
+    /// `Ref(Primitive)`, so two different large ids still differ (SEMANTIC). This proves the gate
+    /// requires the opCast, not merely a large id.
+    #[test]
+    fn gap_c_typeid_without_opcast_stays_primitive() {
+        let side = side();
+        let opts = NormOpts::default();
+        // TYPEID (opcode 76, DW_ARG) with a large runtime id, followed only by RET — no opCast.
+        let big_a = 1207972964u32 as i32;
+        let big_b = 1207972931u32 as i32;
+        let mut a = Vec::new();
+        a.extend(dw_arg(76, big_a)); // TYPEID <big_a>
+        a.push(10); // RET
+        let mut b = Vec::new();
+        b.extend(dw_arg(76, big_b)); // TYPEID <big_b>
+        b.push(10); // RET
+        let na = norm(&a, &side, &opts);
+        let nb = norm(&b, &side, &opts);
+        // Both resolve to Ref(Primitive(<id>)) (large id absent from richtest T2), compared by
+        // value → the two DIFFER (no opcast gate fired).
+        assert_ne!(
+            na[0].operands, nb[0].operands,
+            "a large TYPEID not feeding opCast must NOT be collapsed"
+        );
+        assert!(
+            matches!(na[0].operands[0], Operand::Ref(_)),
+            "unfed large TYPEID stays a value-compared Ref, got {:?}",
+            na[0].operands[0]
+        );
+    }
+
+    // ---- Real-cache GAP-A/B/C regression flips (batch-38) ----
+    // These read the large (gitignored, ~120 MB) vanilla + regen samples, so they are `#[ignore]`d
+    // to keep routine `cargo test` fast/portable. Run on demand:
+    //   cargo test --release -p gore-as --lib -- --ignored gap_
+    // Each asserts a KNOWN member of the gap-class flips SEMANTIC→(IDENTICAL|BENIGN), while a
+    // KNOWN real bug STAYS semantic.
+
+    fn real_pair() -> Option<(Vec<u8>, Vec<u8>)> {
+        let base = format!("{}/../../work/reversing/gore-as/samples", env!("CARGO_MANIFEST_DIR"));
+        let v = std::fs::read(format!("{base}/cache_A.Cache")).ok()?;
+        let r = std::fs::read(format!("{base}/regen_batch36.Cache")).ok()?;
+        Some((v, r))
+    }
+
+    fn verdict_of(v: &[u8], r: &[u8], func: &str) -> Vec<(String, Verdict)> {
+        // Match the measurement configuration: N2 slot-renumber ON (the `--norm-slots` scoreboard),
+        // so a pure first-use slot renumber (a separate benign class) doesn't mask the gap flip.
+        let mut opts = NormOpts::default();
+        opts.n2_slots = true;
+        let filters = Filters { module: None, func: Some(func.to_string()) };
+        let rep = run(v, r, &opts, &filters, 3).expect("run");
+        rep.diffs.iter().map(|d| (d.name.clone(), d.verdict)).collect()
+    }
+
+    /// GAP-A: the `GenericVoiclines::StaticClass` family (vanilla ns `G1R::GenericVoiceline`,
+    /// regen empty) collapses SEMANTIC→BENIGN.
+    #[test]
+    #[ignore = "reads large gitignored sample caches; run with --ignored"]
+    fn gap_a_namespace_drift_benign() {
+        let Some((v, r)) = real_pair() else { return };
+        let vs = verdict_of(&v, &r, "GenericVoiclines::StaticClass");
+        assert!(!vs.is_empty(), "expected StaticClass functions");
+        assert!(
+            vs.iter().all(|(_, verd)| *verd != Verdict::Semantic),
+            "GAP-A StaticClass ns-drift must be benign, got {vs:?}"
+        );
+    }
+
+    /// GAP-B: the `GetHero` topic-getter (PshC4 pool-index → __STATIC_NAME) collapses to BENIGN.
+    #[test]
+    #[ignore = "reads large gitignored sample caches; run with --ignored"]
+    fn gap_b_static_name_index_benign() {
+        let Some((v, r)) = real_pair() else { return };
+        let vs = verdict_of(&v, &r, "::GetHero");
+        assert!(!vs.is_empty(), "expected GetHero functions");
+        assert!(
+            vs.iter().all(|(_, verd)| *verd != Verdict::Semantic),
+            "GAP-B __STATIC_NAME index-drift must be benign, got a SEMANTIC in {vs:?}"
+        );
+    }
+
+    /// GAP-C: `AIAgentConfig_Biter::Spawn` (lone opCast TYPEID drift) collapses to BENIGN.
+    #[test]
+    #[ignore = "reads large gitignored sample caches; run with --ignored"]
+    fn gap_c_opcast_typeid_benign() {
+        let Some((v, r)) = real_pair() else { return };
+        let vs = verdict_of(&v, &r, "AIAgentConfig_Biter::Spawn");
+        assert!(vs.iter().any(|(n, _)| n.contains("Spawn")), "expected Spawn, got {vs:?}");
+        assert!(
+            vs.iter().filter(|(n, _)| n.contains("AIAgentConfig_Biter::Spawn")).all(|(_, verd)| *verd != Verdict::Semantic),
+            "GAP-C opCast type-id drift must be benign, got {vs:?}"
+        );
+    }
+
+    /// REGRESSION GUARD: a KNOWN real bug (op-count divergence) must STAY semantic after the
+    /// refinements — the metric-honesty fix must not hide a behavioral bug.
+    #[test]
+    #[ignore = "reads large gitignored sample caches; run with --ignored"]
+    fn real_bug_stays_semantic() {
+        let Some((v, r)) = real_pair() else { return };
+        // op-count divergence (v=20, r=30) — a genuine dropped/added-logic defect.
+        let vs = verdict_of(&v, &r, "LoadOrCreateDataGame_Implementation");
+        assert!(
+            vs.iter().any(|(_, verd)| *verd == Verdict::Semantic),
+            "LoadOrCreateDataGame must stay SEMANTIC, got {vs:?}"
+        );
+        // dropped-logic force-stub (UCBT_CompleteSequence::Tick, v=104 r=2).
+        let vs2 = verdict_of(&v, &r, "UCBT_CompleteSequence::Tick");
+        assert!(
+            vs2.iter().any(|(_, verd)| *verd == Verdict::Semantic),
+            "UCBT_CompleteSequence::Tick must stay SEMANTIC, got {vs2:?}"
+        );
     }
 }

--- a/crates/gore-as/src/cache/cfg.rs
+++ b/crates/gore-as/src/cache/cfg.rs
@@ -12,6 +12,30 @@ use std::collections::BTreeSet;
 
 use super::disasm::Instr;
 
+/// JMPP dispatch-row shape check (Hazelight `rW_DW_ARG` form, 2 dwords): the DW operand is
+/// `N-1` (max selector value); execution lands on row `jmpp_dw + 2 + 2*value`. The compiler
+/// emits rows 0..N-2 as `JMP` trampolines; row N-1 is either a `JMP` trampoline or the START
+/// of the last case body inlined in place (it is the highest row, so an inline body cannot
+/// overlap another row). Returns the N row start offsets when the shape holds, else None
+/// (leaving the JMPP successor-less, exactly the prior behavior).
+fn jmpp_rows(instrs: &[Instr], idx: usize) -> Option<Vec<usize>> {
+    let ins = &instrs[idx];
+    let n = (*ins.dwords.first()? as usize).checked_add(1)?;
+    let mut rows = Vec::with_capacity(n);
+    for k in 0..n {
+        let row = ins.offset_dw + 2 + 2 * k;
+        let ri = instrs.get(idx + 1 + k)?;
+        if ri.offset_dw != row {
+            return None; // rows must be adjacent 2-dword instructions
+        }
+        if k + 1 < n && ri.op.name != "JMP" {
+            return None; // all but the last row must be trampolines
+        }
+        rows.push(row);
+    }
+    Some(rows)
+}
+
 #[derive(Debug, Clone)]
 pub struct BasicBlock {
     /// Dword offset where the block starts.
@@ -83,6 +107,12 @@ pub fn build(instrs: &[Instr]) -> Cfg {
             if let Some(next) = instrs.get(i + 1) {
                 leaders.insert(next.offset_dw);
             }
+        } else if n == "JMPP" && jmpp_rows(instrs, i).is_some() {
+            // dispatch row 0 starts right after the JMPP; rows 1.. become leaders via the
+            // trampoline JMPs' own next-instruction rule, and row targets via the JMP rule.
+            if let Some(next) = instrs.get(i + 1) {
+                leaders.insert(next.offset_dw);
+            }
         }
     }
 
@@ -102,8 +132,15 @@ pub fn build(instrs: &[Instr]) -> Cfg {
         let last = &instrs[hi - 1];
         let n = last.op.name;
         let mut succs = Vec::new();
-        if is_return(n) || n == "JMPP" {
-            // RET: none; JMPP: table targets unknown here
+        if n == "JMPP" {
+            // Verified switch-dispatch shape: successors = the N dispatch-row start offsets
+            // (in selector-value order). Unverified shape: none (prior behavior — the
+            // structurer's marker/stub path still catches the uncovered transfer).
+            if let Some(rows) = jmpp_rows(instrs, hi - 1) {
+                succs = rows.into_iter().filter(|r| off_to_idx.contains_key(r)).collect();
+            }
+        } else if is_return(n) {
+            // none
         } else if is_uncond_jump(n) {
             if let Some(t) = jump_target(last).filter(|t| off_to_idx.contains_key(t)) {
                 succs.push(t);

--- a/crates/gore-as/src/cache/decompile.rs
+++ b/crates/gore-as/src/cache/decompile.rs
@@ -47,7 +47,7 @@ pub(crate) fn build_param_off_map_rvo(
     refs: &RefResolver,
 ) -> (HashMap<i32, usize>, Option<i32>) {
     let base = param_slot_map(&f.param_types, f.is_method, false, Some(refs));
-    if !returns_struct_by_value(&f.ret) {
+    if !returns_struct_by_value(&f.ret, refs) {
         return (base, None);
     }
     let rvo = param_slot_map(&f.param_types, f.is_method, true, Some(refs));
@@ -63,24 +63,17 @@ pub(crate) fn build_param_off_map_rvo(
     // `actorToSpawnClass` -> `TSubclassOf::GetActorLocation()`, 18 in-game errors; the
     // GetSpawnPosition/Rotation family: 2 params, last unused, struct return). Credit the
     // ret-slot offset to the RVO map's score — it IS explained by that layout.
-    // ENUM returns are token 5 (so returns_struct_by_value admits them) but return in the
-    // VALUE REGISTER — no hidden RVO slot exists (batch-24a ret_via_rvo() / the switch
-    // recovery's register_based test). Crediting the ret-slot offset for them is wrong twice
-    // over: the offset it would credit (-AS_PTR_SIZE for a method) is the BASE layout's
-    // param-0 slot, so the credit flips correct base maps to RVO and shifts every param
-    // reference (TryPerformActionNow/TryPerformMovementNow regressed to argtype stubs when
-    // the credit was unconditional).
-    let ret_is_enum = {
-        let n = f.ret.base_name(refs);
-        let b = n.as_bytes();
-        b.len() >= 2 && b[0] == b'E' && b[1].is_ascii_uppercase()
-    };
+    // ENUM returns are token 5 but return in the VALUE REGISTER — no hidden RVO slot exists
+    // (batch-24a ret_via_rvo() / the switch recovery's register_based test). Since batch-29c
+    // they are excluded inside `returns_struct_by_value` itself (A4: the phantom `__return`
+    // slot swallowed a real parameter), so only genuine F/T struct returns reach this scoring
+    // and the ret-slot credit is unconditional.
     let observed = observed_neg_offsets(instrs);
     let rvo_off = if f.is_method { -AS_PTR_SIZE } else { 0 };
     let score = |m: &HashMap<i32, usize>| observed.iter().filter(|o| m.contains_key(o)).count();
     let score_rvo = observed
         .iter()
-        .filter(|o| rvo.contains_key(o) || (!ret_is_enum && **o == rvo_off))
+        .filter(|o| rvo.contains_key(o) || **o == rvo_off)
         .count();
     if score(&base) > score_rvo {
         (base, None)

--- a/crates/gore-as/src/cache/decompile.rs
+++ b/crates/gore-as/src/cache/decompile.rs
@@ -55,12 +55,36 @@ pub(crate) fn build_param_off_map_rvo(
     // A by-value struct return ALWAYS carries the RVO out-pointer per the ABI, so prefer the
     // RVO map on ties; only fall back to the no-RVO map if it strictly explains MORE observed
     // offsets (i.e. the return type was mis-classified as by-value).
+    //
+    // batch-25c (specs/batch23-nomatch.md C2): the RVO map deliberately does NOT contain the
+    // hidden ret-slot offset as a key (it is not a parameter), so a function that references
+    // the ret slot but NOT its last parameter scored base=N+1 vs rvo=N -> the (wrong) no-RVO
+    // map won and every param reference shifted one over (`owner` rendered as
+    // `actorToSpawnClass` -> `TSubclassOf::GetActorLocation()`, 18 in-game errors; the
+    // GetSpawnPosition/Rotation family: 2 params, last unused, struct return). Credit the
+    // ret-slot offset to the RVO map's score — it IS explained by that layout.
+    // ENUM returns are token 5 (so returns_struct_by_value admits them) but return in the
+    // VALUE REGISTER — no hidden RVO slot exists (batch-24a ret_via_rvo() / the switch
+    // recovery's register_based test). Crediting the ret-slot offset for them is wrong twice
+    // over: the offset it would credit (-AS_PTR_SIZE for a method) is the BASE layout's
+    // param-0 slot, so the credit flips correct base maps to RVO and shifts every param
+    // reference (TryPerformActionNow/TryPerformMovementNow regressed to argtype stubs when
+    // the credit was unconditional).
+    let ret_is_enum = {
+        let n = f.ret.base_name(refs);
+        let b = n.as_bytes();
+        b.len() >= 2 && b[0] == b'E' && b[1].is_ascii_uppercase()
+    };
     let observed = observed_neg_offsets(instrs);
+    let rvo_off = if f.is_method { -AS_PTR_SIZE } else { 0 };
     let score = |m: &HashMap<i32, usize>| observed.iter().filter(|o| m.contains_key(o)).count();
-    if score(&base) > score(&rvo) {
+    let score_rvo = observed
+        .iter()
+        .filter(|o| rvo.contains_key(o) || (!ret_is_enum && **o == rvo_off))
+        .count();
+    if score(&base) > score_rvo {
         (base, None)
     } else {
-        let rvo_off = if f.is_method { -AS_PTR_SIZE } else { 0 };
         (rvo, Some(rvo_off))
     }
 }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -251,7 +251,7 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // head (`TArrayConstIterator local_N;`) — a template-arity error that makes the local
     // `Unknown`. Derive `<T>` from the `Iterator()` call's container receiver; applied AFTER
     // the member pass so the composed type wins over the bare member-derived head.
-    let iter_overrides = infer_iterator_types(f, &fc, refs, fields, &local_types);
+    let (iter_overrides, iter_flips) = infer_iterator_types(f, &fc, refs, fields, &local_types);
     for (slot, ty) in &iter_overrides {
         local_types.insert(*slot, ty.clone());
     }
@@ -309,6 +309,21 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     for (slot, ty) in &iter_overrides {
         if used.contains(slot) && !locals.get(slot).is_some_and(|t| t.contains('<')) {
             locals.insert(*slot, ty.clone());
+        }
+    }
+    // Const->mutable DECLARATION flip for iterator out-slots whose receiver is provably
+    // non-const in the emitted source (a plain local / this-field — locals are never declared
+    // const by this emitter): the re-compiled `.Iterator()` overload then returns the MUTABLE
+    // iterator, so a Const-headed declaration fails "Can't implicitly convert from
+    // 'TArrayIterator<T>' to 'TArrayConstIterator<T>'" (100+ in-game errors; 0 reverse).
+    // DECLARATION-only: the structurer's local_types keeps the cache's Const head, which its
+    // RVO out-slot probe must match against the native's recorded return type to recover
+    // `local = recv.Iterator()` at all.
+    for slot in iter_flips.keys() {
+        if let Some(t) = locals.get_mut(slot) {
+            if t.contains("ConstIterator") {
+                *t = t.replacen("ConstIterator", "Iterator", 1);
+            }
         }
     }
     // call-result types (A3): only upgrade a width-guessed PRIMITIVE declaration — an
@@ -604,6 +619,15 @@ fn ret_is_struct(ty: &str) -> bool {
     matches!(ty.split('<').next().unwrap_or(ty).bytes().next(), Some(b'F') | Some(b'T'))
 }
 
+/// True if a call with return DataType `d` uses a hidden RVO out-slot: a struct/template head
+/// returned BY VALUE. A by-REFERENCE struct return (`FMemoryFilter& CausedBy(...)` builder
+/// chains) comes back in the register (`PshRPtr`), NOT via an out-slot — counting one there
+/// over-consumes the operand stack and mis-pairs an enclosing call's pending arg with this
+/// call's params (proven: `AfterTime`'s pending FInGameTime arg typed FName via `CausedBy`).
+fn ret_has_rvo_slot(d: &super::types::DataType, refs: &RefResolver) -> bool {
+    !d.is_reference && ret_is_struct(&d.base_name(refs))
+}
+
 fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
     let instrs = match disassemble(&f.bytecode) {
         Ok(i) => i,
@@ -636,20 +660,33 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
         // last user arg (just before the receiver); count it so it is consumed, but exclude it from
         // pairing (it is NOT params[last] — pairing it would shift every real arg one param over and
         // mis-type the slot, e.g. the TSubclassOf out param landing on an EQuestState param).
-        let rvo = (ret_struct && is_method) as usize;
-        let total = if is_method { params.len() + 1 + rvo } else { params.len() };
+        // A FREE/static struct-returning call pushes the same hidden out-slot ON TOP (no receiver
+        // follows it — proven by `FInGameTime::Now`: `PshGPtr __WorldContext ; PSF <out> ; CALLSYS`,
+        // FunctionReferences params=[const UObject], ret=FInGameTime). Not modelling it paired the
+        // PSF'd out-slot with the hidden WorldContext param -> slot mis-typed `UObject`, clobbering
+        // the correct obj_locals type (FInGameTime) and blinding build_call's free-RVO probe
+        // ("Can't implicitly convert from 'UObject' to 'FInGameTime'" ×144 in-game).
+        let rvo = ret_struct as usize;
+        let total = if is_method { params.len() + 1 + rvo } else { params.len() + rvo };
         let take = total.min(ostack.len());
         let popped = ostack.split_off(ostack.len() - take);
         // method: top popped entry is the receiver -> drop it (plus the RVO out-slot just below it);
-        // the rest are the user args.
+        // free call: top popped entry is the RVO out-slot itself. The rest are the user args.
         let args = if is_method && !popped.is_empty() {
             &popped[..popped.len().saturating_sub(1 + rvo)]
-        } else { &popped[..] };
-        // pair from the TOP: last arg <-> last param (so a leading `this` param, if the cache
-        // counts it, never shifts the user-arg pairing).
+        } else {
+            &popped[..popped.len().saturating_sub(rvo)]
+        };
+        // pair from the TOP: args are pushed in REVERSE source order for EVERY call type (see
+        // maybe_reverse_args — 7 opcode-level confirmations, 0 counterexamples), so the TOP
+        // popped entry is the FIRST param. The old top<->LAST-param mapping mis-attributed
+        // every multi-arg call (proven: `HasCharacterKnowledgeOfText(FName, const FText)` typed
+        // its FText arg slot FName); it survived only when a second consumer created a lucky
+        // conflict. Pairing top<->params[0] also stays aligned when the stack held FEWER
+        // entries than the full frame (the popped suffix = the TOP pushes = the first params).
         for (i, slot) in args.iter().rev().enumerate() {
             if let Some(s) = slot {
-                if let Some(pt) = params.len().checked_sub(1 + i).and_then(|j| params.get(j)) {
+                if let Some(pt) = params.get(i) {
                     let ty = pt.base_name(refs);
                     match cand.get(s) {
                         None => { cand.insert(*s, Some(ty)); }
@@ -681,7 +718,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
             }
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
-                let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                let rs = refs.func_ret_by_id(id).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
                 pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand);
             }
             "CALLSYS" | "Thiscall1" => {
@@ -711,7 +748,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
                     ostack.truncate(ostack.len() - drop_n);
                     continue;
                 }
-                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
                 pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand);
             }
             _ => {}
@@ -866,10 +903,10 @@ fn infer_iterator_types(
     refs: &RefResolver,
     fields: Option<&HashMap<String, String>>,
     known: &HashMap<i32, String>,
-) -> HashMap<i32, String> {
+) -> (HashMap<i32, String>, HashMap<i32, bool>) {
     let instrs = match disassemble(&fc.bytecode) {
         Ok(i) => i,
-        Err(_) => return HashMap::new(),
+        Err(_) => return (HashMap::new(), HashMap::new()),
     };
     // frame offset -> param index, for container receivers that are parameters.
     let (param_off_map, _rvo_off) = super::decompile::build_param_off_map_rvo(fc, &instrs, refs);
@@ -914,12 +951,15 @@ fn infer_iterator_types(
     }
     let mut stack: Vec<Ent> = Vec::new();
     let mut cand: HashMap<i32, Option<String>> = HashMap::new();
+    // slot -> "the DECLARED head must be the MUTABLE Iterator variant" (see recv_mutable).
+    let mut flips: HashMap<i32, bool> = HashMap::new();
     // per-call consumption, mirroring `infer_slot_types::pair`: params + receiver + RVO
-    // out-slot for methods; unknown param info -> clear (conservative: drop pending slots).
+    // out-slot (methods AND free calls — a free by-value struct return pushes it on top);
+    // unknown param info -> clear (conservative: drop pending slots).
     let consume = |stack: &mut Vec<Ent>, params: Option<usize>, is_method: bool, ret_struct: bool| {
         let Some(n) = params else { stack.clear(); return; };
-        let rvo = (ret_struct && is_method) as usize;
-        let total = if is_method { n + 1 + rvo } else { n };
+        let rvo = ret_struct as usize;
+        let total = if is_method { n + 1 + rvo } else { n + rvo };
         stack.truncate(stack.len() - total.min(stack.len()));
     };
     for ins in &instrs {
@@ -949,7 +989,7 @@ fn infer_iterator_types(
             }
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
-                let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                let rs = refs.func_ret_by_id(id).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
                 consume(&mut stack, refs.func_params_by_id(id).map(|p| p.len()), refs.is_method_by_id(id), rs);
             }
             "CALLSYS" | "Thiscall1" => {
@@ -970,17 +1010,41 @@ fn infer_iterator_types(
                         Ent::Member(c) => c.clone(),
                         Ent::Other => None,
                     };
+                    // Receiver mutability in the RE-COMPILED source: `.Iterator()` overload
+                    // resolution there follows the EMITTED receiver's constness, not the
+                    // original source's. A local slot is never declared const by this emitter,
+                    // and a this-class UPROPERTY field is non-const -> the mutable Iterator.
+                    // A const parameter keeps the Const variant; unknown receivers stay
+                    // untouched (conservative). AND-merged per slot: one non-mutable site
+                    // vetoes the flip.
+                    let recv_mutable = match recv {
+                        Ent::Slot { slot, .. } if *slot > 0 => true,
+                        Ent::Slot { slot, .. } if *slot < 0 => param_off_map
+                            .get(slot)
+                            .and_then(|idx| fc.param_types.get(*idx))
+                            .map(|d| !d.is_read_only && !d.is_object_const)
+                            .unwrap_or(false),
+                        Ent::Member(Some(_)) => true,
+                        _ => false,
+                    };
                     if let Ent::Slot { slot: out_slot, psf: true } = *out {
                         record_iterator_candidate(refs, known, &mut cand, out_slot, ptr, container);
+                        if out_slot > 0 {
+                            flips
+                                .entry(out_slot)
+                                .and_modify(|m| *m &= recv_mutable)
+                                .or_insert(recv_mutable);
+                        }
                     }
                 }
-                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
                 consume(&mut stack, refs.func_params_by_ptr(ptr).map(|p| p.len()), refs.is_method_by_ptr(ptr), rs);
             }
             _ => {}
         }
     }
-    cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect()
+    let flips = flips.into_iter().filter(|&(_, m)| m).map(|(s, _)| (s, true)).collect();
+    (cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect(), flips)
 }
 
 /// Compose + record one iterator out-slot candidate (see [`infer_iterator_types`]).
@@ -1080,8 +1144,9 @@ fn infer_call_result_types(
     // per-call operand-stack consumption, mirroring `infer_slot_types`.
     let consume = |stack: &mut Vec<Option<i32>>, params: Option<usize>, is_method: bool, ret_struct: bool| {
         let Some(n) = params else { stack.clear(); return; };
-        let rvo = (ret_struct && is_method) as usize;
-        let total = if is_method { n + 1 + rvo } else { n };
+        // hidden RVO out-slot: methods AND free calls (free: pushed on top — see infer_slot_types).
+        let rvo = ret_struct as usize;
+        let total = if is_method { n + 1 + rvo } else { n + rvo };
         stack.truncate(stack.len() - total.min(stack.len()));
     };
     // rendered return type + receiver slot of the just-completed call (None once anything
@@ -1112,8 +1177,8 @@ fn infer_call_result_types(
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let is_m = refs.is_method_by_id(id);
                 let recv = if is_m { ostack.last().copied().flatten() } else { None };
+                let rs = refs.func_ret_by_id(id).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
                 let ret = refs.func_ret_by_id(id).map(|d| d.base_name(refs));
-                let rs = ret.as_deref().map(ret_is_struct).unwrap_or(false);
                 consume(&mut ostack, refs.func_params_by_id(id).map(|p| p.len()), is_m, rs);
                 last = ret.map(|t| (t, recv));
             }
@@ -1129,8 +1194,8 @@ fn infer_call_result_types(
                 }
                 let is_m = refs.is_method_by_ptr(ptr);
                 let recv = if is_m { ostack.last().copied().flatten() } else { None };
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
                 let ret = refs.func_ret_by_ptr(ptr).map(|d| d.base_name(refs));
-                let rs = ret.as_deref().map(ret_is_struct).unwrap_or(false);
                 consume(&mut ostack, refs.func_params_by_ptr(ptr).map(|p| p.len()), is_m, rs);
                 last = ret.map(|t| (t, recv));
             }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -365,11 +365,13 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         // assignment to a declaration-with-initializer (in-place construction — the original
         // source form). Any other reference shape keeps the hoist (status quo).
         let (body, suppressed) = rewrite_ctor_only_locals(&body, &locals);
+        // Iterator locals have no default ctor either; declare them at their `Iterator()` call.
+        let (body, iter_suppressed) = rewrite_iterator_decl_init(&body, &locals);
         // hoist local declarations; primitives must be initialized (AngelScript errors on
         // "may not be initialized"), objects/structs/handles default-construct themselves.
         for (slot, ty) in &locals {
-            if suppressed.contains(slot) {
-                continue; // Class A: declared at its (rewritten) assignment site instead
+            if suppressed.contains(slot) || iter_suppressed.contains(slot) {
+                continue; // declared at its (rewritten) assignment/Iterator() site instead
             }
             if is_primitive(ty) {
                 let _ = writeln!(s, "{ind}    {ty} local_{slot} = {};", default_for(ty));
@@ -1074,6 +1076,63 @@ fn rewrite_ctor_only_locals(body: &str, locals: &BTreeMap<i32, String>) -> (Stri
         }
         out = rewritten;
         suppressed.insert(*slot);
+    }
+    (out, suppressed)
+}
+
+/// Iterator locals (`TArrayIterator<T>`, `TSetIterator<T>`, `TMapIterator<T>`, ... incl. Const
+/// variants) have NO default constructor, so a bare hoisted `TArrayIterator<T> local_N;` fails
+/// "No default constructor". The only legal form is declaration-with-initializer from the
+/// `Iterator()` call that produces it: `TArrayIterator<T> local_N = container.Iterator();`. Unlike
+/// the ctor-only (FStatID) case an iterator IS read afterwards (in its loop), so the gate is only
+/// that the local's FIRST mention in the body is a single-`ident` assignment `local_N = ...;` —
+/// then decl-init at that site is valid and nothing reads it before. Returns the rewritten body +
+/// the set of slots whose hoisted declaration must be suppressed.
+fn rewrite_iterator_decl_init(body: &str, locals: &BTreeMap<i32, String>) -> (String, HashSet<i32>) {
+    let is_iter = |ty: &str| {
+        let h = ty.split('<').next().unwrap_or(ty);
+        matches!(h, "TArrayIterator" | "TArrayConstIterator" | "TSetIterator" | "TSetConstIterator"
+            | "TMapIterator" | "TMapConstIterator")
+    };
+    let mut suppressed: HashSet<i32> = HashSet::new();
+    let mut out = body.to_string();
+    for (slot, ty) in locals {
+        if !is_iter(ty) {
+            continue;
+        }
+        let ident = format!("local_{slot}");
+        let pat = format!("{ident} = ");
+        // The FIRST line mentioning the ident must be a single-occurrence assignment `local_N = …;`.
+        let mut first_ok = false;
+        for line in out.lines() {
+            if count_ident(line, &ident) == 0 {
+                continue;
+            }
+            let t = line.trim_start();
+            first_ok = count_ident(line, &ident) == 1 && t.starts_with(&pat) && t.ends_with(';');
+            break;
+        }
+        if !first_ok {
+            continue;
+        }
+        // Rewrite ONLY that first assignment to a decl-init; leave later reads untouched.
+        let mut done = false;
+        let mut rewritten = String::with_capacity(out.len() + 32);
+        for line in out.lines() {
+            let t = line.trim_start();
+            if !done && count_ident(line, &ident) == 1 && t.starts_with(&pat) && t.ends_with(';') {
+                let indent = &line[..line.len() - t.len()];
+                let _ = writeln!(rewritten, "{indent}{ty} {t}");
+                done = true;
+            } else {
+                rewritten.push_str(line);
+                rewritten.push('\n');
+            }
+        }
+        if done {
+            out = rewritten;
+            suppressed.insert(*slot);
+        }
     }
     (out, suppressed)
 }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -368,6 +368,27 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // batch-30a (C6c): snapshot the cache's own (vanilla) object-local types before any
     // override mutates the map — the member-override gate below compares against these.
     let vanilla_obj_types = local_types.clone();
+    // batch-34: member-access-derived declaring class per slot (the field's OWNER type is a
+    // TYPE LOWER-BOUND: the slot's real type must have that member). Computed BEFORE the
+    // call-arg (`slot_overrides`) pass so that pass cannot widen a slot below a type that
+    // provably has an accessed member. `member_widen_below` below turns it into a guard.
+    let member_overrides = infer_slot_types_from_members(f, refs, fields, class_name);
+    // A candidate `cand` for `slot` widens BELOW a member lower-bound iff the slot has member
+    // evidence `lb` that the VANILLA type provably satisfies (`is_subclass(vanilla, lb)`) while
+    // `cand` does NOT provably satisfy it (`!is_subclass(cand, lb)`). Comparing against the
+    // vanilla type (which compiled every member access in the real source) sidesteps the gaps
+    // in KNOWN_NATIVE_HIERARCHY — e.g. ACharacter's native chain up to AActor is absent, so a
+    // direct `is_subclass(ACharacter, AActor)` can't see the widen, but `is_subclass(vanilla=
+    // AGothicCharacter, lb=ACharacter)` holds and `is_subclass(cand=AActor, ACharacter)` does
+    // not, correctly rejecting the AActor widen (AInvulnerableVisual::SetUpCollisions,
+    // ARagdollFallingActor::Initialize, UGA_Death_Meatbug — `.CapsuleComponent` off AActor).
+    let member_widen_below = |slot: &i32, cand: &String| {
+        let Some(lb) = member_overrides.get(slot) else { return false };
+        let Some(vanilla) = vanilla_obj_types.get(slot) else { return false };
+        cand != lb
+            && refs.is_subclass(vanilla, lb)
+            && !refs.is_subclass(cand, lb)
+    };
     // consumer-side override: never-written arg slots get the type their callee expects (fixes
     // mis-typed default/optional-arg slots — FName->UAIState_DailyRoutine, TSubclassOf<X>->X).
     // outref_overrides: PSF slots feeding float-family REFERENCE params (declaration-only, below).
@@ -422,6 +443,16 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
                 continue;
             }
         }
+        // batch-34: member-access lower-bound. A call-arg candidate (e.g. `AActor` from an
+        // `IgnoreActorWhenMoving(AActor, bool)`/`SetOwner(AActor)` param) must not widen a slot
+        // below a type that provably has a member the body reads off it — the batch-31d guard
+        // above only fires when the widen target is an is_subclass-visible ANCESTOR of vanilla,
+        // but the native chain ACharacter->..->AActor is absent from KNOWN_NATIVE_HIERARCHY, so
+        // AActor slips past it. Anchoring on the member's declaring class vs the vanilla type
+        // closes that gap (the `.CapsuleComponent`-on-AActor regressions).
+        if member_widen_below(slot, ty) {
+            continue;
+        }
         local_types.insert(*slot, ty.clone());
     }
     // batch-20 Class C: unlike the float out-refs (declaration-only), a BOOL out-ref slot must
@@ -466,9 +497,9 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     for (slot, ty) in &float_args {
         local_types.entry(*slot).or_insert_with(|| ty.clone());
     }
-    // member-access-derived types: the field's declaring class is the strongest signal for a
-    // slot used as a member-access base; apply AFTER (overriding) the call-arg guess.
-    let member_overrides = infer_slot_types_from_members(f, refs, fields, class_name);
+    // member-access-derived types (`member_overrides`, computed above as the type lower-bound):
+    // the field's declaring class is the strongest signal for a slot used as a member-access
+    // base; apply AFTER (overriding) the call-arg guess.
     // batch-30a (C6c, specs/batch29-errortail.md §6c): when a slot's ONLY object write is a
     // STOREOBJ of a single call's result AND that call's return type equals the cache's own
     // obj_locals type, the vanilla static type is authoritative — a member-derived candidate
@@ -695,6 +726,12 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
                 if vanilla != ty && refs.is_subclass(vanilla, ty) {
                     continue;
                 }
+            }
+            // batch-34: declaration-side mirror of the member-access lower-bound guard — a
+            // call-arg candidate must not widen the declaration below a member's declaring
+            // class (keeps `AGothicCharacter local_N;` where the body reads `.CapsuleComponent`).
+            if member_widen_below(slot, ty) {
+                continue;
             }
             locals.insert(*slot, ty.clone());
         }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -340,7 +340,7 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // mis-typed default/optional-arg slots — FName->UAIState_DailyRoutine, TSubclassOf<X>->X).
     // outref_overrides: PSF slots feeding float-family REFERENCE params (declaration-only, below).
     // float_args/keep_ints (batch-25g): numeric BY-VALUE arg slots — see structure::ArgSlotHints.
-    let (slot_overrides, outref_overrides, float_args, keep_ints, int_refs) = infer_slot_types(f, refs);
+    let (slot_overrides, outref_overrides, float_args, keep_ints, int_refs, small_args) = infer_slot_types(f, refs);
     // batch-28 (specs/batch27-floatwarnings.md §2): unified numeric-kind dataflow pass.
     // Anti-seed imports: slots value-pushed into int-family params (keep_ints), PSF-bound to
     // int-family reference params (int_refs), or bool&-bound (outref "bool") hold int/bool
@@ -544,6 +544,15 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // constants now render as float literals — `float32 local_1 = 0.0; ... local_1 = 1.0f;`).
     // Primitive-only upgrade, before the authoritative out-ref pass below.
     for (slot, ty) in &float_args {
+        if used.contains(slot) && locals.get(slot).map(|t| is_primitive(t)).unwrap_or(true) {
+            locals.insert(*slot, ty.clone());
+        }
+    }
+    // batch-28b (spec §5.1): small-int by-value arg slots (uint8/int8/uint16/int16 params —
+    // FColor ctor args, FindLastChar/FindChar char params, SetMovementMode's NewCustomMode).
+    // Fully gated in infer_slot_types (SetV-only op profile + constant range fit);
+    // declaration-only, primitive-upgrade-only — the C4a/C4b truncate/signedness classes.
+    for (slot, ty) in &small_args {
         if used.contains(slot) && locals.get(slot).map(|t| is_primitive(t)).unwrap_or(true) {
             locals.insert(*slot, ty.clone());
         }
@@ -946,10 +955,12 @@ fn ret_is_struct(ty: &str) -> bool {
 fn infer_slot_types(
     f: &Func,
     refs: &RefResolver,
-) -> (HashMap<i32, String>, HashMap<i32, String>, HashMap<i32, String>, HashSet<i32>, HashSet<i32>) {
+) -> (HashMap<i32, String>, HashMap<i32, String>, HashMap<i32, String>, HashSet<i32>, HashSet<i32>, HashMap<i32, String>) {
     let instrs = match disassemble(&f.bytecode) {
         Ok(i) => i,
-        Err(_) => return (HashMap::new(), HashMap::new(), HashMap::new(), HashSet::new(), HashSet::new()),
+        Err(_) => {
+            return (HashMap::new(), HashMap::new(), HashMap::new(), HashSet::new(), HashSet::new(), HashMap::new())
+        }
     };
     let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32);
     let writes = |op: &str| {
@@ -986,7 +997,42 @@ fn infer_slot_types(
     // for `infer_float_flow` (floating such a decl breaks the `int&` binding; the exact
     // batch-9-class risk named in specs/batch27-floatwarnings.md §2.6).
     let mut iref: HashSet<i32> = HashSet::new();
-    let mut pair = |ostack: &mut Vec<Option<(i32, bool)>>, params: Option<&[super::types::DataType]>, is_method: bool, ret_struct: bool, cand: &mut HashMap<i32, Option<String>>, outref: &mut HashMap<i32, Option<String>>, farg: &mut HashMap<i32, Option<String>>, ikeep: &mut HashSet<i32>, iref: &mut HashSet<i32>| {
+    // batch-28b (spec §5.1): small-int BY-VALUE arg slots (token 0x45 int8 / 0x46 int16 /
+    // 0x4C uint8 / 0x4D uint16) — declaration retype candidates for the C4a/C4b truncate/
+    // signedness classes. Conflicts (differing small kws, or ANY full-width int pairing)
+    // resolve to None; the SetV-only op-profile + range gates apply below.
+    let mut sarg: HashMap<i32, Option<String>> = HashMap::new();
+    // shared numeric BY-VALUE channel (used by both ordinary-call pairing and the $beh0
+    // ctor-arg pairing): float params -> farg, int-family params -> ikeep (+ sarg small-ints).
+    let val_arg = |s: i32, pt: &super::types::DataType, farg: &mut HashMap<i32, Option<String>>, ikeep: &mut HashSet<i32>, sarg: &mut HashMap<i32, Option<String>>| {
+        match pt.token {
+            0x50 | 0x51 | 0x5E => {
+                let kw = super::types::token_keyword(pt.token).to_string();
+                match farg.get(&s) {
+                    None => { farg.insert(s, Some(kw)); }
+                    Some(Some(prev)) if *prev != kw => { farg.insert(s, None); }
+                    _ => {}
+                }
+            }
+            0x45 | 0x46 | 0x4C | 0x4D => {
+                ikeep.insert(s);
+                let kw = super::types::token_keyword(pt.token).to_string();
+                match sarg.get(&s) {
+                    None => { sarg.insert(s, Some(kw)); }
+                    Some(Some(prev)) if *prev != kw => { sarg.insert(s, None); }
+                    _ => {}
+                }
+            }
+            0x44 | 0x47 | 0x4B | 0x4E => {
+                ikeep.insert(s);
+                // a full-width int pairing disqualifies the small-int retype (the widened
+                // push may carry values outside the small range).
+                sarg.insert(s, None);
+            }
+            _ => {}
+        }
+    };
+    let pair = |ostack: &mut Vec<Option<(i32, bool)>>, params: Option<&[super::types::DataType]>, is_method: bool, ret_struct: bool, cand: &mut HashMap<i32, Option<String>>, outref: &mut HashMap<i32, Option<String>>, farg: &mut HashMap<i32, Option<String>>, ikeep: &mut HashSet<i32>, iref: &mut HashSet<i32>, sarg: &mut HashMap<i32, Option<String>>| {
         let Some(params) = params else { ostack.clear(); return; };
         // A method returning a struct BY VALUE (F/T/E) carries a hidden RVO out-slot pushed as the
         // last user arg (just before the receiver); count it so it is consumed, but exclude it from
@@ -1049,22 +1095,11 @@ fn infer_slot_types(
                     {
                         iref.insert(*s);
                     }
-                    // batch-25g: numeric BY-VALUE args (value-pushed, non-reference params).
+                    // batch-25g: numeric BY-VALUE args (value-pushed, non-reference params);
+                    // batch-28b routes them through the shared `val_arg` channel (farg/ikeep
+                    // + the small-int sarg candidates).
                     if !*is_psf && !pt.is_reference {
-                        match pt.token {
-                            0x50 | 0x51 | 0x5E => {
-                                let kw = super::types::token_keyword(pt.token).to_string();
-                                match farg.get(s) {
-                                    None => { farg.insert(*s, Some(kw)); }
-                                    Some(Some(prev)) if *prev != kw => { farg.insert(*s, None); }
-                                    _ => {}
-                                }
-                            }
-                            0x44 | 0x45 | 0x46 | 0x47 | 0x4B | 0x4C | 0x4D | 0x4E => {
-                                ikeep.insert(*s);
-                            }
-                            _ => {}
-                        }
+                        val_arg(*s, pt, farg, ikeep, sarg);
                     }
                 }
             }
@@ -1092,7 +1127,7 @@ fn infer_slot_types(
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let rs = refs.func_ret_by_id(id).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
-                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand, &mut outref, &mut farg, &mut ikeep, &mut iref);
+                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand, &mut outref, &mut farg, &mut ikeep, &mut iref, &mut sarg);
             }
             "CALLSYS" | "Thiscall1" => {
                 let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
@@ -1115,6 +1150,23 @@ fn infer_slot_types(
                             }
                         }
                     }
+                    // batch-28b (spec §5.1): pair the nargs ctor args (the entries BELOW the
+                    // receiver) against the behaviour's params for the NUMERIC channels only
+                    // (farg/ikeep/sarg — never `cand`, preserving the arm's receiver-
+                    // mistyping guard). Args are reverse-pushed like every call type, so the
+                    // entry nearest the receiver is params[0]. Feeds the FColor uint8 /
+                    // FRotator float ctor args (C4a/C4b + infer_float_flow seed (f)).
+                    if let Some(params) = refs.func_params_by_ptr(ptr) {
+                        let args_end = ostack.len().saturating_sub(1); // receiver on top
+                        let take = params.len().min(args_end);
+                        for (i, slot) in ostack[args_end - take..args_end].iter().rev().enumerate() {
+                            if let (Some((s, is_psf)), Some(pt)) = (slot, params.get(i)) {
+                                if !*is_psf && !pt.is_reference {
+                                    val_arg(*s, pt, &mut farg, &mut ikeep, &mut sarg);
+                                }
+                            }
+                        }
+                    }
                     // pop receiver + ctor args off the operand stack so they don't leak.
                     let nargs = refs.func_params_by_ptr(ptr).map(|p| p.len()).unwrap_or(0);
                     let drop_n = (1 + nargs).min(ostack.len());
@@ -1122,7 +1174,7 @@ fn infer_slot_types(
                     continue;
                 }
                 let rs = refs.func_ret_by_ptr(ptr).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
-                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand, &mut outref, &mut farg, &mut ikeep, &mut iref);
+                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand, &mut outref, &mut farg, &mut ikeep, &mut iref, &mut sarg);
             }
             _ => {}
         }
@@ -1148,8 +1200,51 @@ fn infer_slot_types(
     for s in both {
         float_args.remove(&s);
         ikeep.remove(&s);
+        sarg.remove(&s);
     }
-    (obj, outref, float_args, ikeep, iref)
+    // batch-28b gates (spec §5.1): a small-int retype candidate must (b) have an op profile
+    // of ONLY SetV1/SetV2/SetV4 constant writes + PshV4 value pushes — any arithmetic/
+    // bitwise/conversion/compare/PSF/copy participation disqualifies (e.g. FindLastChar's
+    // `int&` out-slot does SUBi math and must NOT retype) — and (c) every tracked SetV
+    // constant must fit the target range (a mis-scoped -1 into uint8 would turn a warning
+    // into an error). (SetV2: the FindLastChar/FindChar TCHAR consts are 2-byte writes —
+    // `SetV2 w16, 0x3a` — spec §5.1 cites them as SetV4; disasm-verified SetV2.)
+    // Conservative: an unrelated word operand that numerically collides with the slot also
+    // disqualifies.
+    let mut small_args: HashMap<i32, String> = sarg
+        .into_iter()
+        .filter_map(|(slot, ty)| ty.map(|t| (slot, t)))
+        .collect();
+    if !small_args.is_empty() {
+        let fits = |kw: &str, bits: u32| -> bool {
+            let v = bits as i32;
+            match kw {
+                "int8" => (-128..=127).contains(&v),
+                "int16" => (-32768..=32767).contains(&v),
+                "uint8" => (0..=255).contains(&v),
+                "uint16" => (0..=65535).contains(&v),
+                _ => false,
+            }
+        };
+        for ins in &instrs {
+            let n = ins.op.name;
+            for (wi, &wd) in ins.words.iter().enumerate() {
+                let s = wd as i16 as i32;
+                let Some(kw) = small_args.get(&s) else { continue };
+                let ok = match n {
+                    "SetV1" | "SetV2" | "SetV4" => {
+                        wi == 0 && fits(kw, ins.dwords.first().copied().unwrap_or(0))
+                    }
+                    "PshV4" => true,
+                    _ => false,
+                };
+                if !ok {
+                    small_args.remove(&s);
+                }
+            }
+        }
+    }
+    (obj, outref, float_args, ikeep, iref, small_args)
 }
 
 /// Member-access-driven slot typing: a `LoadRObjR`/`LoadVObjR base, off, tid` reads field

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -251,7 +251,7 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // head (`TArrayConstIterator local_N;`) — a template-arity error that makes the local
     // `Unknown`. Derive `<T>` from the `Iterator()` call's container receiver; applied AFTER
     // the member pass so the composed type wins over the bare member-derived head.
-    let (iter_overrides, iter_flips) = infer_iterator_types(f, &fc, refs, fields, &local_types);
+    let iter_overrides = infer_iterator_types(f, &fc, refs, fields, &local_types);
     for (slot, ty) in &iter_overrides {
         local_types.insert(*slot, ty.clone());
     }
@@ -309,21 +309,6 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     for (slot, ty) in &iter_overrides {
         if used.contains(slot) && !locals.get(slot).is_some_and(|t| t.contains('<')) {
             locals.insert(*slot, ty.clone());
-        }
-    }
-    // Const->mutable DECLARATION flip for iterator out-slots whose receiver is provably
-    // non-const in the emitted source (a plain local / this-field — locals are never declared
-    // const by this emitter): the re-compiled `.Iterator()` overload then returns the MUTABLE
-    // iterator, so a Const-headed declaration fails "Can't implicitly convert from
-    // 'TArrayIterator<T>' to 'TArrayConstIterator<T>'" (100+ in-game errors; 0 reverse).
-    // DECLARATION-only: the structurer's local_types keeps the cache's Const head, which its
-    // RVO out-slot probe must match against the native's recorded return type to recover
-    // `local = recv.Iterator()` at all.
-    for slot in iter_flips.keys() {
-        if let Some(t) = locals.get_mut(slot) {
-            if t.contains("ConstIterator") {
-                *t = t.replacen("ConstIterator", "Iterator", 1);
-            }
         }
     }
     // call-result types (A3): only upgrade a width-guessed PRIMITIVE declaration — an
@@ -619,15 +604,6 @@ fn ret_is_struct(ty: &str) -> bool {
     matches!(ty.split('<').next().unwrap_or(ty).bytes().next(), Some(b'F') | Some(b'T'))
 }
 
-/// True if a call with return DataType `d` uses a hidden RVO out-slot: a struct/template head
-/// returned BY VALUE. A by-REFERENCE struct return (`FMemoryFilter& CausedBy(...)` builder
-/// chains) comes back in the register (`PshRPtr`), NOT via an out-slot — counting one there
-/// over-consumes the operand stack and mis-pairs an enclosing call's pending arg with this
-/// call's params (proven: `AfterTime`'s pending FInGameTime arg typed FName via `CausedBy`).
-fn ret_has_rvo_slot(d: &super::types::DataType, refs: &RefResolver) -> bool {
-    !d.is_reference && ret_is_struct(&d.base_name(refs))
-}
-
 fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
     let instrs = match disassemble(&f.bytecode) {
         Ok(i) => i,
@@ -660,33 +636,20 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
         // last user arg (just before the receiver); count it so it is consumed, but exclude it from
         // pairing (it is NOT params[last] — pairing it would shift every real arg one param over and
         // mis-type the slot, e.g. the TSubclassOf out param landing on an EQuestState param).
-        // A FREE/static struct-returning call pushes the same hidden out-slot ON TOP (no receiver
-        // follows it — proven by `FInGameTime::Now`: `PshGPtr __WorldContext ; PSF <out> ; CALLSYS`,
-        // FunctionReferences params=[const UObject], ret=FInGameTime). Not modelling it paired the
-        // PSF'd out-slot with the hidden WorldContext param -> slot mis-typed `UObject`, clobbering
-        // the correct obj_locals type (FInGameTime) and blinding build_call's free-RVO probe
-        // ("Can't implicitly convert from 'UObject' to 'FInGameTime'" ×144 in-game).
-        let rvo = ret_struct as usize;
-        let total = if is_method { params.len() + 1 + rvo } else { params.len() + rvo };
+        let rvo = (ret_struct && is_method) as usize;
+        let total = if is_method { params.len() + 1 + rvo } else { params.len() };
         let take = total.min(ostack.len());
         let popped = ostack.split_off(ostack.len() - take);
         // method: top popped entry is the receiver -> drop it (plus the RVO out-slot just below it);
-        // free call: top popped entry is the RVO out-slot itself. The rest are the user args.
+        // the rest are the user args.
         let args = if is_method && !popped.is_empty() {
             &popped[..popped.len().saturating_sub(1 + rvo)]
-        } else {
-            &popped[..popped.len().saturating_sub(rvo)]
-        };
-        // pair from the TOP: args are pushed in REVERSE source order for EVERY call type (see
-        // maybe_reverse_args — 7 opcode-level confirmations, 0 counterexamples), so the TOP
-        // popped entry is the FIRST param. The old top<->LAST-param mapping mis-attributed
-        // every multi-arg call (proven: `HasCharacterKnowledgeOfText(FName, const FText)` typed
-        // its FText arg slot FName); it survived only when a second consumer created a lucky
-        // conflict. Pairing top<->params[0] also stays aligned when the stack held FEWER
-        // entries than the full frame (the popped suffix = the TOP pushes = the first params).
+        } else { &popped[..] };
+        // pair from the TOP: last arg <-> last param (so a leading `this` param, if the cache
+        // counts it, never shifts the user-arg pairing).
         for (i, slot) in args.iter().rev().enumerate() {
             if let Some(s) = slot {
-                if let Some(pt) = params.get(i) {
+                if let Some(pt) = params.len().checked_sub(1 + i).and_then(|j| params.get(j)) {
                     let ty = pt.base_name(refs);
                     match cand.get(s) {
                         None => { cand.insert(*s, Some(ty)); }
@@ -718,7 +681,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
             }
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
-                let rs = refs.func_ret_by_id(id).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
+                let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand);
             }
             "CALLSYS" | "Thiscall1" => {
@@ -748,7 +711,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
                     ostack.truncate(ostack.len() - drop_n);
                     continue;
                 }
-                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand);
             }
             _ => {}
@@ -903,10 +866,10 @@ fn infer_iterator_types(
     refs: &RefResolver,
     fields: Option<&HashMap<String, String>>,
     known: &HashMap<i32, String>,
-) -> (HashMap<i32, String>, HashMap<i32, bool>) {
+) -> HashMap<i32, String> {
     let instrs = match disassemble(&fc.bytecode) {
         Ok(i) => i,
-        Err(_) => return (HashMap::new(), HashMap::new()),
+        Err(_) => return HashMap::new(),
     };
     // frame offset -> param index, for container receivers that are parameters.
     let (param_off_map, _rvo_off) = super::decompile::build_param_off_map_rvo(fc, &instrs, refs);
@@ -951,15 +914,12 @@ fn infer_iterator_types(
     }
     let mut stack: Vec<Ent> = Vec::new();
     let mut cand: HashMap<i32, Option<String>> = HashMap::new();
-    // slot -> "the DECLARED head must be the MUTABLE Iterator variant" (see recv_mutable).
-    let mut flips: HashMap<i32, bool> = HashMap::new();
     // per-call consumption, mirroring `infer_slot_types::pair`: params + receiver + RVO
-    // out-slot (methods AND free calls — a free by-value struct return pushes it on top);
-    // unknown param info -> clear (conservative: drop pending slots).
+    // out-slot for methods; unknown param info -> clear (conservative: drop pending slots).
     let consume = |stack: &mut Vec<Ent>, params: Option<usize>, is_method: bool, ret_struct: bool| {
         let Some(n) = params else { stack.clear(); return; };
-        let rvo = ret_struct as usize;
-        let total = if is_method { n + 1 + rvo } else { n + rvo };
+        let rvo = (ret_struct && is_method) as usize;
+        let total = if is_method { n + 1 + rvo } else { n };
         stack.truncate(stack.len() - total.min(stack.len()));
     };
     for ins in &instrs {
@@ -989,7 +949,7 @@ fn infer_iterator_types(
             }
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
-                let rs = refs.func_ret_by_id(id).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
+                let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 consume(&mut stack, refs.func_params_by_id(id).map(|p| p.len()), refs.is_method_by_id(id), rs);
             }
             "CALLSYS" | "Thiscall1" => {
@@ -1010,41 +970,17 @@ fn infer_iterator_types(
                         Ent::Member(c) => c.clone(),
                         Ent::Other => None,
                     };
-                    // Receiver mutability in the RE-COMPILED source: `.Iterator()` overload
-                    // resolution there follows the EMITTED receiver's constness, not the
-                    // original source's. A local slot is never declared const by this emitter,
-                    // and a this-class UPROPERTY field is non-const -> the mutable Iterator.
-                    // A const parameter keeps the Const variant; unknown receivers stay
-                    // untouched (conservative). AND-merged per slot: one non-mutable site
-                    // vetoes the flip.
-                    let recv_mutable = match recv {
-                        Ent::Slot { slot, .. } if *slot > 0 => true,
-                        Ent::Slot { slot, .. } if *slot < 0 => param_off_map
-                            .get(slot)
-                            .and_then(|idx| fc.param_types.get(*idx))
-                            .map(|d| !d.is_read_only && !d.is_object_const)
-                            .unwrap_or(false),
-                        Ent::Member(Some(_)) => true,
-                        _ => false,
-                    };
                     if let Ent::Slot { slot: out_slot, psf: true } = *out {
                         record_iterator_candidate(refs, known, &mut cand, out_slot, ptr, container);
-                        if out_slot > 0 {
-                            flips
-                                .entry(out_slot)
-                                .and_modify(|m| *m &= recv_mutable)
-                                .or_insert(recv_mutable);
-                        }
                     }
                 }
-                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 consume(&mut stack, refs.func_params_by_ptr(ptr).map(|p| p.len()), refs.is_method_by_ptr(ptr), rs);
             }
             _ => {}
         }
     }
-    let flips = flips.into_iter().filter(|&(_, m)| m).map(|(s, _)| (s, true)).collect();
-    (cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect(), flips)
+    cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect()
 }
 
 /// Compose + record one iterator out-slot candidate (see [`infer_iterator_types`]).
@@ -1144,9 +1080,8 @@ fn infer_call_result_types(
     // per-call operand-stack consumption, mirroring `infer_slot_types`.
     let consume = |stack: &mut Vec<Option<i32>>, params: Option<usize>, is_method: bool, ret_struct: bool| {
         let Some(n) = params else { stack.clear(); return; };
-        // hidden RVO out-slot: methods AND free calls (free: pushed on top — see infer_slot_types).
-        let rvo = ret_struct as usize;
-        let total = if is_method { n + 1 + rvo } else { n + rvo };
+        let rvo = (ret_struct && is_method) as usize;
+        let total = if is_method { n + 1 + rvo } else { n };
         stack.truncate(stack.len() - total.min(stack.len()));
     };
     // rendered return type + receiver slot of the just-completed call (None once anything
@@ -1177,8 +1112,8 @@ fn infer_call_result_types(
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let is_m = refs.is_method_by_id(id);
                 let recv = if is_m { ostack.last().copied().flatten() } else { None };
-                let rs = refs.func_ret_by_id(id).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
                 let ret = refs.func_ret_by_id(id).map(|d| d.base_name(refs));
+                let rs = ret.as_deref().map(ret_is_struct).unwrap_or(false);
                 consume(&mut ostack, refs.func_params_by_id(id).map(|p| p.len()), is_m, rs);
                 last = ret.map(|t| (t, recv));
             }
@@ -1194,8 +1129,8 @@ fn infer_call_result_types(
                 }
                 let is_m = refs.is_method_by_ptr(ptr);
                 let recv = if is_m { ostack.last().copied().flatten() } else { None };
-                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_has_rvo_slot(d, refs)).unwrap_or(false);
                 let ret = refs.func_ret_by_ptr(ptr).map(|d| d.base_name(refs));
+                let rs = ret.as_deref().map(ret_is_struct).unwrap_or(false);
                 consume(&mut ostack, refs.func_params_by_ptr(ptr).map(|p| p.len()), is_m, rs);
                 last = ret.map(|t| (t, recv));
             }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -242,7 +242,7 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     }
     // member-access-derived types: the field's declaring class is the strongest signal for a
     // slot used as a member-access base; apply AFTER (overriding) the call-arg guess.
-    let member_overrides = infer_slot_types_from_members(f, refs);
+    let member_overrides = infer_slot_types_from_members(f, refs, fields, class_name);
     for (slot, ty) in &member_overrides {
         local_types.insert(*slot, ty.clone());
     }
@@ -255,6 +255,12 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     for (slot, ty) in &iter_overrides {
         local_types.insert(*slot, ty.clone());
     }
+    // A3 (illegal-op-round2.md): a `CpyRtoV4/CpyRtoV8 wD` that copies a CALL RESULT out of the
+    // value register carries no type, so the slot declares as the write-width default (`int`)
+    // and every member use fails "Illegal operation on 'int'". Adopt the call's rendered return
+    // type for the DECLARATION only (never fed to the structurer -> body render unchanged).
+    // Consumes the iterator subtypes above for bare `TMap*` pair returns.
+    let callret_overrides = infer_call_result_types(f, refs, &local_types);
     let body = body_statements_ctor(&fc, refs, depth + 1, super_ctor, Some(&f.ret), fields, Some(&param_types), class_name, Some(&local_types));
     // hoist every referenced local; infer_locals types what it can, the rest default to `int`
     // (a wrong type just becomes a compile error the in-game loop force-stubs, rather than the
@@ -302,6 +308,14 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // container-derived instantiation; never downgrade an already-subtyped declaration.
     for (slot, ty) in &iter_overrides {
         if used.contains(slot) && !locals.get(slot).is_some_and(|t| t.contains('<')) {
+            locals.insert(*slot, ty.clone());
+        }
+    }
+    // call-result types (A3): only upgrade a width-guessed PRIMITIVE declaration — an
+    // obj_locals / member-derived / iterator-derived object type is a stronger signal
+    // (all non-primitive, so they are naturally never overridden here).
+    for (slot, ty) in &callret_overrides {
+        if used.contains(slot) && locals.get(slot).map(|t| is_primitive(t)).unwrap_or(true) {
             locals.insert(*slot, ty.clone());
         }
     }
@@ -654,6 +668,17 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
             }
             "PshC4" | "PshC8" | "PshNull" | "PGA" | "PshGPtr" | "PshG4" | "PshRPtr" | "STR"
             | "TYPEID" | "OBJTYPE" | "PshListElmnt" => ostack.push(None),
+            // P1 (is-not-a-member.md §2.3): ADDSi rewrites the pushed pointer in place into
+            // `&slotN.field` — the entry no longer identifies slot N, so a later call-arg
+            // pairing must not attribute the FIELD's param type to the BASE slot (e.g.
+            // `slot24.AllRequired` feeding `AppendTags(const FGameplayTagContainer&)` typed
+            // slot 24 as FGameplayTagContainer). The §2.2 member peephole supplies the
+            // correct owner-derived type for these bases instead.
+            "ADDSi" => {
+                if let Some(top) = ostack.last_mut() {
+                    *top = None;
+                }
+            }
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
@@ -707,32 +732,116 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
 /// or not at all (`int`), producing "<field> is not a member of <T>". Override the slot with the
 /// declaring class. Conservative: LOCAL slots only (base > 0), single consistent declaring type
 /// (conflict -> drop), non-empty non-primitive.
-fn infer_slot_types_from_members(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
+///
+/// A5 extension (illegal-op-round2.md): a `LoadRObjR/LoadVObjR` immediately followed by
+/// `CpyRtoV8 wD` copies the member REFERENCE into slot `wD` — the destination's type is the
+/// field's VALUE type. That is only recoverable from the emitting class's own fields map (T7
+/// PropertyReferences' OldTypeId is the OWNER class, not the value type — see the structure.rs
+/// ADDSi arm caveat), so it applies only when the member's owner IS the current class.
+fn infer_slot_types_from_members(
+    f: &Func,
+    refs: &RefResolver,
+    fields: Option<&HashMap<String, String>>,
+    class_name: Option<&str>,
+) -> HashMap<i32, String> {
     let instrs = match disassemble(&f.bytecode) {
         Ok(i) => i,
         Err(_) => return HashMap::new(),
     };
     let mut cand: HashMap<i32, Option<String>> = HashMap::new();
-    for ins in &instrs {
-        if matches!(ins.op.name, "LoadRObjR" | "LoadVObjR") {
-            let base = match ins.words.first() {
-                Some(w) => *w as i16 as i32,
-                None => continue,
-            };
-            if base <= 0 {
-                continue; // this / param-as-receiver: skip (only local slots here)
+    // Candidate merge, inheritance-aware (is-not-a-member.md §2.2): one slot can collect the
+    // declaring classes of members from BOTH a derived class and its script base (e.g.
+    // UAIGroup_Combat's `TargetEnemy` + base UGothicAIGroup's `JoinedCharacters`) — the more
+    // DERIVED class has ALL the accessed members, so keep it. A bare vs composed instantiation
+    // of the SAME template head keeps the composed one. Anything else (unrelated types /
+    // native-only hierarchies / differing compositions) is genuine slot reuse -> drop (None),
+    // exactly the pre-existing conservative behaviour.
+    let record = |cand: &mut HashMap<i32, Option<String>>, slot: i32, ty: String| {
+        if ty.is_empty() || is_primitive(ty.split('<').next().unwrap_or(&ty)) {
+            return;
+        }
+        match cand.get(&slot) {
+            None => {
+                cand.insert(slot, Some(ty));
             }
-            let off = ins.words.get(1).copied().unwrap_or(0) as i32;
-            let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
-            let Some(ty) = refs.member_type(tid, off) else { continue };
-            if ty.is_empty() || is_primitive(ty) {
-                continue;
+            Some(Some(prev)) if *prev != ty => {
+                let (ph, nh) = (prev.split('<').next().unwrap_or(prev), ty.split('<').next().unwrap_or(&ty));
+                let merged = if ph == nh {
+                    match (prev.contains('<'), ty.contains('<')) {
+                        (true, false) => Some(prev.clone()),
+                        (false, true) => Some(ty),
+                        _ => None, // two DIFFERENT compositions of one head: conflict
+                    }
+                } else if refs.is_subclass(&ty, prev) {
+                    Some(ty)
+                } else if refs.is_subclass(prev, &ty) {
+                    Some(prev.clone())
+                } else {
+                    None
+                };
+                cand.insert(slot, merged);
             }
-            match cand.get(&base) {
-                None => { cand.insert(base, Some(ty.to_string())); }
-                Some(Some(prev)) if prev != ty => { cand.insert(base, None); }
-                _ => {}
+            _ => {}
+        }
+    };
+    for (i, ins) in instrs.iter().enumerate() {
+        match ins.op.name {
+            "LoadRObjR" | "LoadVObjR" => {
+                let base = match ins.words.first() {
+                    Some(w) => *w as i16 as i32,
+                    None => continue,
+                };
+                let off = ins.words.get(1).copied().unwrap_or(0) as i32;
+                let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
+                if base > 0 {
+                    // base-slot typing: the field's declaring class (skip this/params).
+                    // Composed (§2.1): the bare head of a template instance is a declaration
+                    // arity error that turns the whole slot `Unknown`.
+                    if let Some(ty) = refs.member_type_composed(tid, off) {
+                        record(&mut cand, base, ty);
+                    }
+                }
+                // A5: `LoadRObjR/LoadVObjR ; CpyRtoV8 wD` — type the copy DESTINATION with the
+                // field's value type (current-class fields only; the owner check guards
+                // against cross-class field-name collisions).
+                if let Some(next) = instrs.get(i + 1) {
+                    if next.op.name == "CpyRtoV8" {
+                        let dst = next.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+                        if dst > 0
+                            && class_name.is_some()
+                            && refs.type_by_id(tid) == class_name
+                        {
+                            let vty = refs
+                                .member(tid, off)
+                                .and_then(|name| fields.and_then(|m| m.get(name)));
+                            if let Some(vty) = vty {
+                                record(&mut cand, dst, vty.clone());
+                            }
+                        }
+                    }
+                }
             }
+            // §2.2 sub-case M: Idiom-A member access — `PshVPtr wN`/`PSF wN` immediately
+            // followed by `ADDSi off, tid` reads a member off the object in slot N; these
+            // bases never appear in LoadRObjR form, so STEP 1 was blind to them. Chained
+            // walks (`PshVPtr w0; ADDSi a; RDSPtr; ADDSi b`) skip automatically: the second
+            // ADDSi's predecessor is RDSPtr, not a push.
+            "ADDSi" => {
+                let prev = match i.checked_sub(1).and_then(|j| instrs.get(j)) {
+                    Some(p) if matches!(p.op.name, "PshVPtr" | "PSF") => p,
+                    _ => continue,
+                };
+                let base = prev.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+                if base <= 0 {
+                    continue; // this / param receivers: locals only (STEP 1 scope)
+                }
+                let off = ins.words.first().copied().unwrap_or(0) as i32;
+                let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
+                if let Some(ty) = refs.member_type_composed(tid, off) {
+                    record(&mut cand, base, ty);
+                }
+            }
+            _ => {}
         }
     }
     cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect()
@@ -924,6 +1033,157 @@ fn record_iterator_candidate(
         }
         _ => {}
     }
+}
+
+/// A3 (illegal-op-round2.md): call-result register-copy typing. A reference/element-returning
+/// call (`X.Proceed()`, `pair.GetKey()`, ...) leaves its result in the VALUE register; the
+/// following `CpyRtoV4/CpyRtoV8 wD` copies it into slot `wD`, which `infer_locals` can only
+/// width-guess (`int`/`int64`) — so `local_38 = local_28.Proceed(); local_38.GetActor...()`
+/// fails "Illegal operation on 'int'". Track the last CALL/CALLINTF/CALLBND/CALLSYS/Thiscall1
+/// and its rendered return type; when the next instruction (only benign SUSPENDs between) is a
+/// `CpyRtoV*` into a local slot, adopt the return type for that slot's DECLARATION.
+/// Conservative: never for obj_locals slots, never for slots also written by non-CpyRtoV ops
+/// (int/float scratch reuse), never primitives/enums/`?`, and a BARE template head (e.g. the
+/// `TMap*` iterator pair) is only adopted after composing `<...>` from the receiver iterator's
+/// inferred instantiation (`known`, which includes the A1 pass results) — else skipped.
+/// Conflicting candidates for one slot drop (regression-free).
+fn infer_call_result_types(
+    f: &Func,
+    refs: &RefResolver,
+    known: &HashMap<i32, String>,
+) -> HashMap<i32, String> {
+    let instrs = match disassemble(&f.bytecode) {
+        Ok(i) => i,
+        Err(_) => return HashMap::new(),
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    // slots also written by a non-CpyRtoV writing op are int/float scratch (slot reuse) — never
+    // adopt an object type for them. ADDSi is excluded: its first word is a member OFFSET.
+    let writes_other = |op: &str| {
+        op != "ADDSi"
+            && (op.starts_with("SetV") || op.starts_with("CpyVtoV") || op.starts_with("RDR")
+                || op.contains("TO") || op == "PopRPtr"
+                || op.starts_with("ADD") || op.starts_with("SUB") || op.starts_with("MUL")
+                || op.starts_with("DIV") || op.starts_with("MOD") || op.starts_with("NEG")
+                || op.starts_with("Inc") || op.starts_with("Dec") || op == "NOT")
+    };
+    let mut disq: HashSet<i32> = HashSet::new();
+    for ins in &instrs {
+        if writes_other(ins.op.name) {
+            let d = w0(ins);
+            if d > 0 {
+                disq.insert(d);
+            }
+        }
+    }
+    let obj: HashSet<i32> = f.obj_locals.iter().map(|(s, _)| *s).collect();
+    // per-call operand-stack consumption, mirroring `infer_slot_types`.
+    let consume = |stack: &mut Vec<Option<i32>>, params: Option<usize>, is_method: bool, ret_struct: bool| {
+        let Some(n) = params else { stack.clear(); return; };
+        let rvo = (ret_struct && is_method) as usize;
+        let total = if is_method { n + 1 + rvo } else { n };
+        stack.truncate(stack.len() - total.min(stack.len()));
+    };
+    // rendered return type + receiver slot of the just-completed call (None once anything
+    // non-benign executes, so a later CpyRtoV can't adopt a stale type).
+    let mut last: Option<(String, Option<i32>)> = None;
+    let mut ostack: Vec<Option<i32>> = Vec::new();
+    let mut cand: HashMap<i32, Option<String>> = HashMap::new();
+    for ins in &instrs {
+        match ins.op.name {
+            "PshVPtr" | "PSF" => {
+                let s = w0(ins);
+                ostack.push((s > 0).then_some(s));
+                last = None;
+            }
+            "PshV4" | "PshV8" | "PshC4" | "PshC8" | "PshNull" | "PGA" | "PshGPtr" | "PshG4"
+            | "PshRPtr" | "STR" | "TYPEID" | "OBJTYPE" | "PshListElmnt" => {
+                ostack.push(None);
+                last = None;
+            }
+            "ADDSi" => {
+                // member access rewrites the pushed pointer: no longer the bare slot.
+                if let Some(top) = ostack.last_mut() {
+                    *top = None;
+                }
+                last = None;
+            }
+            "CALL" | "CALLINTF" | "CALLBND" => {
+                let id = ins.dwords.first().copied().unwrap_or(0) as i32;
+                let is_m = refs.is_method_by_id(id);
+                let recv = if is_m { ostack.last().copied().flatten() } else { None };
+                let ret = refs.func_ret_by_id(id).map(|d| d.base_name(refs));
+                let rs = ret.as_deref().map(ret_is_struct).unwrap_or(false);
+                consume(&mut ostack, refs.func_params_by_id(id).map(|p| p.len()), is_m, rs);
+                last = ret.map(|t| (t, recv));
+            }
+            "CALLSYS" | "Thiscall1" => {
+                let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+                if refs.func_by_ptr(ptr) == Some("$beh0") {
+                    // in-place construct: receiver + ctor args, no register result.
+                    let nargs = refs.func_params_by_ptr(ptr).map(|p| p.len()).unwrap_or(0);
+                    let drop_n = (1 + nargs).min(ostack.len());
+                    ostack.truncate(ostack.len() - drop_n);
+                    last = None;
+                    continue;
+                }
+                let is_m = refs.is_method_by_ptr(ptr);
+                let recv = if is_m { ostack.last().copied().flatten() } else { None };
+                let ret = refs.func_ret_by_ptr(ptr).map(|d| d.base_name(refs));
+                let rs = ret.as_deref().map(ret_is_struct).unwrap_or(false);
+                consume(&mut ostack, refs.func_params_by_ptr(ptr).map(|p| p.len()), is_m, rs);
+                last = ret.map(|t| (t, recv));
+            }
+            "CpyRtoV4" | "CpyRtoV8" => {
+                if let Some((ty, recv)) = last.take() {
+                    let d = w0(ins);
+                    if d > 0 && !obj.contains(&d) && !disq.contains(&d) {
+                        if let Some(ty) = usable_ret_type(ty, recv, known) {
+                            match cand.get(&d) {
+                                None => {
+                                    cand.insert(d, Some(ty));
+                                }
+                                Some(Some(prev)) if *prev != ty => {
+                                    cand.insert(d, None); // slot reused across types: drop
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+            "SUSPEND" => {} // benign: doesn't touch the value register
+            _ => {
+                last = None;
+            }
+        }
+    }
+    cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect()
+}
+
+/// Filter/compose one A3 return-type candidate (see [`infer_call_result_types`]):
+/// primitives/enums/placeholders are rejected (int declarations already work for them); a bare
+/// template head (`TMapIteratorPair` with no `<...>` in its T1 entry) is composed from the
+/// receiver iterator's inferred instantiation, or rejected when that isn't available either.
+fn usable_ret_type(ty: String, recv: Option<i32>, known: &HashMap<i32, String>) -> Option<String> {
+    if ty.is_empty() || ty == "void" || ty == "?" || ty == "auto" || is_primitive(&ty) || is_enum(&ty) {
+        return None;
+    }
+    let b = ty.as_bytes();
+    let bare_template = !ty.contains('<') && b.len() >= 2 && b[0] == b'T' && b[1].is_ascii_uppercase();
+    if !bare_template {
+        return Some(ty);
+    }
+    // compose the bare head from the receiver's iterator instantiation (A1 pass result).
+    let r = known.get(&recv?)?;
+    if !r.split('<').next().unwrap_or(r).contains("Iterator") {
+        return None;
+    }
+    let (lt, gt) = (r.find('<')?, r.rfind('>')?);
+    if gt <= lt + 1 {
+        return None;
+    }
+    Some(format!("{ty}<{}>", &r[lt + 1..gt]))
 }
 
 /// §3.3 consumer-driven typing of out-of-range `argN` slots. Scans the body for the RHS of an

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -641,6 +641,14 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
             }
         }
     }
+    // batch-41d: when the function's own return type is a CONST object handle (vanilla marked
+    // `const T GetX()`), a `return local_n;` of a const-marked slot is const->const = legal, so
+    // the return use must NOT strip the slot's const (the strip would relocate the error to the
+    // const-member-read assignment: "const T -> T", GetSelectedItem). The signature re-adds the
+    // `const` too (see `ret_sig` below). Gated to object-const returns only — a non-const-return
+    // getter still strips (the pre-batch-41d behaviour). Mirrors DataType::render's const
+    // condition (is_read_only || is_object_const) so `ret` and the kept slot stay consistent.
+    let ret_obj_const = f.ret.is_object_handle && (f.ret.is_object_const || f.ret.is_read_only);
     loop {
         let keep: HashSet<i32> = const_slots
             .iter()
@@ -659,7 +667,7 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
                         .map(|m| const_slots.contains(&m))
                         .unwrap_or(false);
                     !lhs_const
-                }) && !body.contains(&format!("return local_{n};"))
+                }) && (ret_obj_const || !body.contains(&format!("return local_{n};")))
             })
             .collect();
         // fixed point: dropping a slot can invalidate a copy INTO it that justified keeping
@@ -853,6 +861,18 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
             || (reason.is_some() && percep_stub_param.is_some()))
     {
         format!("{}&", f.ret.render(refs))
+    } else if ret_obj_const
+        && reason.is_none()
+        && const_slots
+            .iter()
+            .any(|n| body.contains(&format!("return local_{n};")))
+    {
+        // batch-41d: a getter that returns a const-marked slot (`return this.<constMember>;`)
+        // needs its return type const too, so `return local_n;` is const->const. Vanilla marked
+        // this return `const T` (f.ret.is_object_const); re-add the qualifier the generic strip
+        // at line ~349 removed. Only when a const slot is actually returned (the stub/RVODEF
+        // paths use the non-const `ret` for `T __r;`, which stays correct).
+        format!("const {ret}")
     } else {
         ret.clone()
     };

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -630,8 +630,8 @@ fn used_locals(body: &str) -> HashSet<i32> {
 /// the type that call's parameter expects (e.g. an optional/default-arg slot the cache mis-typed —
 /// FName where UAIState_DailyRoutine is wanted, or TSubclassOf<X> where X is wanted). Returns an
 /// override `slot -> type` ONLY for never-written slots with a single consistent consumer object
-/// type, so it can never clobber a real producer type. Pairs args from the stack TOP (robust to the
-/// cache counting the implicit `this` in a method's param list).
+/// type, so it can never clobber a real producer type. Pairs args from the stack TOP against
+/// params[0] onward (args are reverse-pushed, so the top entry is the FIRST source arg).
 /// True if a return type name denotes a struct/template returned BY VALUE via a hidden RVO
 /// out-slot (`F*` engine struct, `T*` template value like TSubclassOf). Enums/primitives/objects
 /// return in a register, not an out-slot, so they are excluded.
@@ -688,11 +688,20 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
         } else {
             &popped[..popped.len().saturating_sub(rvo)]
         };
-        // pair from the TOP: last arg <-> last param (so a leading `this` param, if the cache
-        // counts it, never shifts the user-arg pairing).
+        // pair from the TOP: bytecode pushes args in REVERSE source order for EVERY call type
+        // (proven — see structure.rs maybe_reverse_args), so the TOP entry is params[0], the one
+        // below params[1], ... FRONT-anchored pairing is also robust to trailing-default omission
+        // (provided args align to the FIRST params) and to a truncated model stack (missing
+        // entries are the DEEPEST = trailing args). The previous END-anchored pairing
+        // (top <-> params[last]) guarded against a phantom leading `this` in the cache's method
+        // param lists — scanning T3 shows that phantom does not exist (every params[0]==owner hit
+        // is a genuine operator overload), while end-anchoring REVERSED every multi-param pairing
+        // (LocText/HasListenedTo: the FText out-slot re-pushed as `Voiceline` paired with the
+        // AGothicCharacterState `Character` param -> wrong declaration, RVO probe miss, dropped
+        // string arg — 400+ in-game errors).
         for (i, slot) in args.iter().rev().enumerate() {
             if let Some(s) = slot {
-                if let Some(pt) = params.len().checked_sub(1 + i).and_then(|j| params.get(j)) {
+                if let Some(pt) = params.get(i) {
                     let ty = pt.base_name(refs);
                     match cand.get(s) {
                         None => { cand.insert(*s, Some(ty)); }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -472,12 +472,14 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     if is_ctor {
         let _ = writeln!(s, "{ind}{}({params})", f.name); // constructors have no return type
     } else {
-        // Batch-21 Class A: vanilla `const` methods (asTRAIT_CONST in FunctionTraits) must
-        // render their qualifier back — callers hold `const` object handles (the param
-        // DataTypes carry bIsObjectConst), so a non-const re-declaration fails every call
-        // site with "Non-const method call on read-only object reference".
-        let constq = if is_method && f.is_const_method() { " const" } else { "" };
-        let _ = writeln!(s, "{ind}{ret_sig} {}({params}){constq}", f.name);
+        // Batch-21 Class A attempted to re-emit the vanilla `const` method qualifier
+        // (asTRAIT_CONST in FunctionTraits) so const-handle callers compile — but HARNESS-
+        // REGRESSED +636 (read-only errors 150 -> 2763): a `const` qualifier makes `this`
+        // read-only inside the body, and our RECOVERED bodies are not const-faithful (recovery
+        // artifacts call non-const members/methods on `this`). Vanilla compiles because its
+        // real bodies are const-clean; ours aren't. Emission disabled — the ~150 caller-side
+        // errors are the lesser residue; a body-const-safety scan could re-enable per-function.
+        let _ = writeln!(s, "{ind}{ret_sig} {}({params})", f.name);
     }
     let _ = writeln!(s, "{ind}{{");
 

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1622,8 +1622,19 @@ fn infer_oor_arg_types(
 /// classes.md Class A): a hoisted bare declaration fails ("No default constructor") AND the
 /// later whole-object assignment fails ("No appropriate opAssign"); the only legal form is
 /// declaration-with-initializer (in-place construction).
+///
+/// batch-25h: FAngelscriptGameThreadScopeWorldContext — the compiler-inserted RAII
+/// world-context scope guard (GetPlayerRelationshipForGlossary rendered a hoisted decl +
+/// else-branch ctor-assign; the type has no default ctor/opAssign). Routed through THIS
+/// decl-init rewrite (its write-only ctor-assign shape passes the existing gate; the
+/// declaration sinks into the assigning block, which is scope-safe because the gate proves
+/// the object is never read) rather than dropping the statement: the guard's side effect IS
+/// its lifetime — it sets the game-thread world context for every native call in the scope,
+/// so deleting it would silently change runtime native-call resolution at OTHER potential
+/// sites of the same type. Any future site with reads keeps the hoist (status-quo error,
+/// never a wrong rewrite).
 fn has_no_default_ctor(ty: &str) -> bool {
-    matches!(ty, "FStatID" | "FScopeCycleCounter")
+    matches!(ty, "FStatID" | "FScopeCycleCounter" | "FAngelscriptGameThreadScopeWorldContext")
 }
 
 /// Count identifier-boundary occurrences of `ident` in `line` (so `local_3` does not match

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -353,6 +353,21 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         .collect();
     let numkinds = infer_float_flow(f, &fc, refs, fields, &float_args, &outref_overrides, &num_anti);
     for (slot, ty) in &slot_overrides {
+        // batch-29c (C2, specs/batch29-errortail.md §2): never let an ARGLESS template head
+        // (the $beh0 construct OWNER / a copy-ctor param whose DataType carries no SubTypes —
+        // bare `TSubclassOf`) downgrade an already-composed body type from the authoritative
+        // obj_locals entry (`TSubclassOf<UGameplayAbility>`). The $beh0/value-ctor renders
+        // compose their type from THIS map, and the bare head emitted
+        // `local_170 = TSubclassOf(local_106);` ("Template 'TSubclassOf' expects 1 sub
+        // type(s)" + paired ctor no-match, 52 [E] lines). Mirror of the declaration-side
+        // gate below — the DECL already kept the composed name, only the body map regressed.
+        if !ty.contains('<') {
+            if let Some(prev) = local_types.get(slot) {
+                if prev.contains('<') && prev.split('<').next() == Some(ty.as_str()) {
+                    continue;
+                }
+            }
+        }
         local_types.insert(*slot, ty.clone());
     }
     // batch-20 Class C: unlike the float out-refs (declaration-only), a BOOL out-ref slot must

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -372,7 +372,14 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         .iter()
         .chain(int_refs.iter())
         .copied()
-        .chain(outref_overrides.iter().filter(|(_, t)| t.as_str() == "bool").map(|(s, _)| *s))
+        // non-float out-ref bindings hold non-float data at the call — bool (batch-28) and
+        // the batch-31c enum/struct out-slots alike; float evidence on them is slot reuse.
+        .chain(
+            outref_overrides
+                .iter()
+                .filter(|(_, t)| !matches!(t.as_str(), "float" | "float32" | "double"))
+                .map(|(s, _)| *s),
+        )
         .collect();
     let numkinds = infer_float_flow(f, &fc, refs, fields, &float_args, &outref_overrides, &num_anti);
     for (slot, ty) in &slot_overrides {
@@ -399,6 +406,12 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     for (slot, ty) in &outref_overrides {
         if ty == "bool" {
             local_types.insert(*slot, ty.clone());
+        } else if !matches!(ty.as_str(), "float" | "float32" | "double") {
+            // batch-31c (N3 Fix 2 / N8): enum/struct out-slots reach the body renderer too —
+            // the SetV/CpyVtoV enum wraps and the typed pushes need the slot's type
+            // (`EInventoryTypes local_7 = local_8;` must wrap the int copy). or_insert:
+            // an obj_locals/consumer entry stays authoritative.
+            local_types.entry(*slot).or_insert_with(|| ty.clone());
         }
     }
     // batch-28 (spec §2.4.2): the dataflow pass's float slots feed the body renderer FIRST —
@@ -1151,6 +1164,16 @@ fn infer_slot_types(
                 // push may carry values outside the small range).
                 sarg.insert(s, None);
             }
+            // batch-31c (N1, spec batch31-nomatch-illegalop §1.4): a slot VALUE-pushed into a
+            // known ENUM by-value param is a REAL argument, not a stranded SetV temporary —
+            // it earns the retain keep flag exactly like the int-family pairs (enum slots are
+            // not in the typed-locals map, so their pushes are Arg::int and died in the
+            // nested-call split: TargetCharacterOfInterest lost its FocusPriority to an
+            // intervening GetCharacterOfInterest()). Keep-only — the render-side wrap is the
+            // EXISTING cast_arg enum wrap, which fires once the arg survives.
+            5 if super::structure::is_enum_name(&pt.base_name(refs)) => {
+                ikeep.insert(s);
+            }
             _ => {}
         }
     };
@@ -1191,6 +1214,28 @@ fn infer_slot_types(
         for (i, slot) in args.iter().rev().enumerate() {
             if let Some((s, is_psf)) = slot {
                 if let Some(pt) = params.get(i) {
+                    // batch-31c (N1): PARAM slots (negative frame offsets) join the model, but
+                    // ONLY for the keep channel — their declarations are fixed by the
+                    // signature (never retyped; farg/sarg/cand/outref stay locals-only), and
+                    // enum-typed params pushed by value are exactly the Proof-A/B purge
+                    // victims (FocusPriority w65534). Float-family params are excluded: the
+                    // signature already types them (typed pushes survive the retain), and
+                    // routing them into ikeep would anti-seed a float slot. PSF pushes of the
+                    // same slot are naturally NEUTRAL here (the gate is value-push-only).
+                    if *s < 0 {
+                        if !*is_psf && !pt.is_reference {
+                            match pt.token {
+                                0x44 | 0x45 | 0x46 | 0x47 | 0x4B | 0x4C | 0x4D | 0x4E => {
+                                    ikeep.insert(*s);
+                                }
+                                5 if super::structure::is_enum_name(&pt.base_name(refs)) => {
+                                    ikeep.insert(*s);
+                                }
+                                _ => {}
+                            }
+                        }
+                        continue;
+                    }
                     let ty = pt.base_name(refs);
                     match cand.get(s) {
                         None => { cand.insert(*s, Some(ty)); }
@@ -1208,6 +1253,33 @@ fn infer_slot_types(
                             None => { outref.insert(*s, Some(kw)); }
                             Some(Some(prev)) if *prev != kw => { outref.insert(*s, None); }
                             _ => {}
+                        }
+                    }
+                    // batch-31c (N3 Fix 2 + N8, spec batch31-nomatch-illegalop §1.5/§1.9):
+                    // out-param slot typing — a PSF'd slot feeding a NON-const identifier-
+                    // typed reference param (`EInventoryTypes&out`, `FVector2D&out`) adopts
+                    // the callee's param type; the call cannot compile otherwise, and the
+                    // slot is an untyped scratch today (declared `int`, poisoning every
+                    // downstream use: GetFirstItemWithType / GetCameraShotMode /
+                    // PointCorrection's 9-line FVector2D cascade). Enum + F-struct heads
+                    // only; const refs are READS (&in) and prove nothing about the slot.
+                    // Same conflict-drop map as the float/bool out-refs.
+                    if *is_psf
+                        && pt.is_reference
+                        && pt.token == 5
+                        && !pt.is_object_const
+                        && !pt.is_read_only
+                        && !pt.is_object_handle
+                    {
+                        let ty = pt.base_name(refs);
+                        let f_struct = ty.starts_with('F')
+                            && ty.as_bytes().get(1).is_some_and(|c| c.is_ascii_uppercase());
+                        if super::structure::is_enum_name(&ty) || f_struct {
+                            match outref.get(s) {
+                                None => { outref.insert(*s, Some(ty)); }
+                                Some(Some(prev)) if *prev != ty => { outref.insert(*s, None); }
+                                _ => {}
+                            }
                         }
                     }
                     // batch-28: int-family reference binding — see `iref` above.
@@ -1231,7 +1303,10 @@ fn infer_slot_types(
         match ins.op.name {
             "PshVPtr" | "PshV4" | "PshV8" | "PSF" => {
                 let s = w0(ins).unwrap_or(0);
-                ostack.push(if s > 0 { Some((s, ins.op.name == "PSF")) } else { None });
+                // batch-31c (N1): param slots (negative offsets) enter the model too — the
+                // pair() body routes them into the keep-only channel. Slot 0 (`this`) stays
+                // opaque.
+                ostack.push(if s != 0 { Some((s, ins.op.name == "PSF")) } else { None });
             }
             "PshC4" | "PshC8" | "PshNull" | "PGA" | "PshGPtr" | "PshG4" | "PshRPtr" | "STR"
             | "TYPEID" | "OBJTYPE" | "PshListElmnt" => ostack.push(None),
@@ -1262,7 +1337,9 @@ fn infer_slot_types(
                     let owner = refs.func_owner_by_ptr(ptr).map(|s| s.to_string());
                     // receiver = top operand; ctor args = the params below it.
                     if let Some(Some((rslot, _))) = ostack.last().copied() {
-                        if let Some(ty) = owner {
+                        // batch-31c: param slots (negative) never enter `cand` — their
+                        // declarations are fixed by the signature.
+                        if let Some(ty) = owner.filter(|_| rslot > 0) {
                             if !ty.is_empty() {
                                 match cand.get(&rslot) {
                                     None => { cand.insert(rslot, Some(ty)); }
@@ -1283,7 +1360,9 @@ fn infer_slot_types(
                         let take = params.len().min(args_end);
                         for (i, slot) in ostack[args_end - take..args_end].iter().rev().enumerate() {
                             if let (Some((s, is_psf)), Some(pt)) = (slot, params.get(i)) {
-                                if !*is_psf && !pt.is_reference {
+                                // batch-31c: locals only — negative (param) slots must not
+                                // reach the farg/sarg retype maps.
+                                if *s > 0 && !*is_psf && !pt.is_reference {
                                     val_arg(*s, pt, &mut farg, &mut ikeep, &mut sarg);
                                 }
                             }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -339,7 +339,8 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // consumer-side override: never-written arg slots get the type their callee expects (fixes
     // mis-typed default/optional-arg slots — FName->UAIState_DailyRoutine, TSubclassOf<X>->X).
     // outref_overrides: PSF slots feeding float-family REFERENCE params (declaration-only, below).
-    let (slot_overrides, outref_overrides) = infer_slot_types(f, refs);
+    // float_args/keep_ints (batch-25g): numeric BY-VALUE arg slots — see structure::ArgSlotHints.
+    let (slot_overrides, outref_overrides, float_args, keep_ints) = infer_slot_types(f, refs);
     for (slot, ty) in &slot_overrides {
         local_types.insert(*slot, ty.clone());
     }
@@ -360,6 +361,13 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         if matches!(ty.as_str(), "float" | "float32" | "double") {
             local_types.entry(slot).or_insert(ty);
         }
+    }
+    // batch-25g: slots value-pushed into a float-family BY-VALUE parameter are float-typed
+    // in the VM (the compiler converts before the push) — same body-typing treatment as the
+    // width-op floats above: bare typed pushes that survive the nested-call retain
+    // (SaveWorldFloatData's payload was purged as a stranded int under a nested GetWorld()).
+    for (slot, ty) in &float_args {
+        local_types.entry(*slot).or_insert_with(|| ty.clone());
     }
     // member-access-derived types: the field's declaring class is the strongest signal for a
     // slot used as a member-access base; apply AFTER (overriding) the call-arg guess.
@@ -382,7 +390,13 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // type for the DECLARATION only (never fed to the structurer -> body render unchanged).
     // Consumes the iterator subtypes above for bare `TMap*` pair returns.
     let callret_overrides = infer_call_result_types(f, refs, &local_types);
-    let body = body_statements_ctor(&fc, refs, depth + 1, super_ctor, Some(&f.ret), fields, Some(&param_types), class_name, Some(&local_types));
+    // batch-25g: hand the numeric value-arg slot sets to the body renderer (float-literal
+    // SetV* rendering + the int retain keep flag).
+    let hints = super::structure::ArgSlotHints {
+        float_slots: float_args.keys().copied().collect(),
+        keep_ints,
+    };
+    let body = body_statements_ctor(&fc, refs, depth + 1, super_ctor, Some(&f.ret), fields, Some(&param_types), class_name, Some(&local_types), Some(&hints));
     // Batch-21 Class C: CONSTSTORE-marked stores carry a const object handle of the local's
     // EXACT type (a same-type Cast<T> does NOT strip const in-game — every batch-20 exact-type
     // Cast site failed "No conversion from 'const X' to 'X'"). Vanilla declared these locals
@@ -477,6 +491,14 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // obj_locals / member-derived / iterator-derived object type is a stronger signal
     // (all non-primitive, so they are naturally never overridden here).
     for (slot, ty) in &callret_overrides {
+        if used.contains(slot) && locals.get(slot).map(|t| is_primitive(t)).unwrap_or(true) {
+            locals.insert(*slot, ty.clone());
+        }
+    }
+    // batch-25g: float value-arg slots declare with the callee's float keyword (their SetV*
+    // constants now render as float literals — `float32 local_1 = 0.0; ... local_1 = 1.0f;`).
+    // Primitive-only upgrade, before the authoritative out-ref pass below.
+    for (slot, ty) in &float_args {
         if used.contains(slot) && locals.get(slot).map(|t| is_primitive(t)).unwrap_or(true) {
             locals.insert(*slot, ty.clone());
         }
@@ -876,10 +898,13 @@ fn ret_is_struct(ty: &str) -> bool {
 /// float literals via the cbits/float-operand path. `bool&` out-params are NOT retyped: every
 /// int-slot render (SetV consts, `(x != 0)` wraps, NOT-patterns) would need a bool form —
 /// renderer-wide surgery documented as skipped in specs/batch19-classes.md.
-fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, HashMap<i32, String>) {
+fn infer_slot_types(
+    f: &Func,
+    refs: &RefResolver,
+) -> (HashMap<i32, String>, HashMap<i32, String>, HashMap<i32, String>, HashSet<i32>) {
     let instrs = match disassemble(&f.bytecode) {
         Ok(i) => i,
-        Err(_) => return (HashMap::new(), HashMap::new()),
+        Err(_) => return (HashMap::new(), HashMap::new(), HashMap::new(), HashSet::new()),
     };
     let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32);
     let writes = |op: &str| {
@@ -905,7 +930,14 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, Hash
     let mut ostack: Vec<Option<(i32, bool)>> = Vec::new();
     let mut cand: HashMap<i32, Option<String>> = HashMap::new(); // slot -> Some(type) | None(conflict)
     let mut outref: HashMap<i32, Option<String>> = HashMap::new(); // PSF slot -> float-ref param type
-    let mut pair = |ostack: &mut Vec<Option<(i32, bool)>>, params: Option<&[super::types::DataType]>, is_method: bool, ret_struct: bool, cand: &mut HashMap<i32, Option<String>>, outref: &mut HashMap<i32, Option<String>>| {
+    // batch-25g: numeric BY-VALUE argument slots (see structure::ArgSlotHints). A slot
+    // VALUE-pushed (never PSF) into a float-family param is float-typed in the VM — the
+    // compiler inserts the int->float conversion BEFORE the push, so any direct PshV4 into a
+    // float param proves the slot holds float bits. Int-family pairs only earn the retain
+    // keep flag (no retype). Conflicts (differing float kws, or float+int for one slot) drop.
+    let mut farg: HashMap<i32, Option<String>> = HashMap::new();
+    let mut ikeep: HashSet<i32> = HashSet::new();
+    let mut pair = |ostack: &mut Vec<Option<(i32, bool)>>, params: Option<&[super::types::DataType]>, is_method: bool, ret_struct: bool, cand: &mut HashMap<i32, Option<String>>, outref: &mut HashMap<i32, Option<String>>, farg: &mut HashMap<i32, Option<String>>, ikeep: &mut HashSet<i32>| {
         let Some(params) = params else { ostack.clear(); return; };
         // A method returning a struct BY VALUE (F/T/E) carries a hidden RVO out-slot pushed as the
         // last user arg (just before the receiver); count it so it is consumed, but exclude it from
@@ -961,6 +993,23 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, Hash
                             _ => {}
                         }
                     }
+                    // batch-25g: numeric BY-VALUE args (value-pushed, non-reference params).
+                    if !*is_psf && !pt.is_reference {
+                        match pt.token {
+                            0x50 | 0x51 | 0x5E => {
+                                let kw = super::types::token_keyword(pt.token).to_string();
+                                match farg.get(s) {
+                                    None => { farg.insert(*s, Some(kw)); }
+                                    Some(Some(prev)) if *prev != kw => { farg.insert(*s, None); }
+                                    _ => {}
+                                }
+                            }
+                            0x44 | 0x45 | 0x46 | 0x47 | 0x4B | 0x4C | 0x4D | 0x4E => {
+                                ikeep.insert(*s);
+                            }
+                            _ => {}
+                        }
+                    }
                 }
             }
         }
@@ -987,7 +1036,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, Hash
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let rs = refs.func_ret_by_id(id).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
-                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand, &mut outref);
+                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand, &mut outref, &mut farg, &mut ikeep);
             }
             "CALLSYS" | "Thiscall1" => {
                 let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
@@ -1017,7 +1066,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, Hash
                     continue;
                 }
                 let rs = refs.func_ret_by_ptr(ptr).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
-                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand, &mut outref);
+                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand, &mut outref, &mut farg, &mut ikeep);
             }
             _ => {}
         }
@@ -1033,7 +1082,18 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, Hash
     let outref = outref.into_iter()
         .filter_map(|(slot, ty)| ty.map(|t| (slot, t)))
         .collect();
-    (obj, outref)
+    // batch-25g: resolve the numeric value-arg candidates. A slot paired with BOTH an
+    // int-family and a float-family param is ambiguous slot reuse — drop it from both sets.
+    let mut float_args: HashMap<i32, String> = farg
+        .into_iter()
+        .filter_map(|(slot, ty)| ty.map(|t| (slot, t)))
+        .collect();
+    let both: Vec<i32> = float_args.keys().copied().filter(|s| ikeep.contains(s)).collect();
+    for s in both {
+        float_args.remove(&s);
+        ikeep.remove(&s);
+    }
+    (obj, outref, float_args, ikeep)
 }
 
 /// Member-access-driven slot typing: a `LoadRObjR`/`LoadVObjR base, off, tid` reads field

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -140,6 +140,12 @@ pub fn emit_module(m: &Module, refs: &RefResolver) -> String {
         .collect();
 
     for c in &m.classes {
+        // batch-24c: a compiler-generated delegate/event wrapper class re-emits as its ORIGINAL
+        // one-line declaration (the verbatim class can never compile — see the detector's doc).
+        if let Some(decl) = delegate_wrapper_decl(c, refs) {
+            s.push_str(&decl);
+            continue;
+        }
         emit_class(&mut s, c, refs);
     }
 
@@ -184,6 +190,56 @@ fn is_generated_spawn(f: &Func, refs: &RefResolver) -> bool {
         return true;
     }
     false
+}
+
+/// Batch-24c (specs/batch23-waitseconds.md Class 2 Shape A): the Hazelight compiler
+/// AUTO-GENERATES a wrapper class for every `delegate` / `event` declaration — an `_Inner`
+/// field typed `_FScriptDelegate` (single-cast) / `_FMulticastScriptDelegate` (multicast)
+/// plus Execute*/Broadcast/Bind/Add methods built on the compiler intrinsics
+/// (`__DelegateSignature`, `__Evt_PushArgument*`, `__Evt_ExecuteDelegate`). The cache stores
+/// the GENERATED class; re-emitting it verbatim can never compile (the intrinsics and the
+/// generated copy/assign forms have no source form: 17 cannot-pass + 12 cant-convert errors
+/// + 12 copyctor raw stubs across 12 wrapper classes). Detect the wrapper structurally and
+/// return the original one-line declaration — the byte-faithful form, from which the
+/// compiler regenerates the identical wrapper:
+///
+/// ```angelscript
+/// event void FPlayerBeginOverlapFireGolemArenaEvent(AActor Actor);
+/// delegate void FSoulHarvestVisualDelegate(ASoulHarvestCharacter_Visual CurrentInstance);
+/// ```
+///
+/// (decl syntax per the vendored fork docs, hazelight-docs/page_scripting_delegates_.html).
+/// Gates (belt-and-braces against a hand-written lookalike): no super class, EXACTLY one
+/// field named `_Inner` of the internal delegate type, and the signature-carrier method
+/// present — `Broadcast` (event) / `Execute` or `ExecuteIfBound` (delegate), whose params
+/// (names cache-preserved) and return type form the declared signature.
+fn delegate_wrapper_decl(c: &Class, refs: &RefResolver) -> Option<String> {
+    if c.super_class.as_deref().is_some_and(|s| !s.is_empty()) {
+        return None;
+    }
+    let [field] = c.fields.as_slice() else {
+        return None;
+    };
+    if field.name != "_Inner" {
+        return None;
+    }
+    let (kw, carrier) = match field.ty.base_name(refs).as_str() {
+        "_FMulticastScriptDelegate" => {
+            ("event", c.methods.iter().find(|f| f.name == "Broadcast")?)
+        }
+        "_FScriptDelegate" => (
+            "delegate",
+            // prefer `Execute` (carries a RetVal delegate's return type); `ExecuteIfBound`
+            // as the fallback carrier (void-returning delegates always have it).
+            c.methods
+                .iter()
+                .find(|f| f.name == "Execute")
+                .or_else(|| c.methods.iter().find(|f| f.name == "ExecuteIfBound"))?,
+        ),
+        _ => return None,
+    };
+    let ret = carrier.ret.render(refs).trim_start_matches("const ").to_string();
+    Some(format!("{kw} {ret} {}({});\n\n", c.name, render_params(carrier, refs)))
 }
 
 fn emit_class(s: &mut String, c: &Class, refs: &RefResolver) {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -236,7 +236,8 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     }).collect();
     // consumer-side override: never-written arg slots get the type their callee expects (fixes
     // mis-typed default/optional-arg slots — FName->UAIState_DailyRoutine, TSubclassOf<X>->X).
-    let slot_overrides = infer_slot_types(f, refs);
+    // outref_overrides: PSF slots feeding float-family REFERENCE params (declaration-only, below).
+    let (slot_overrides, outref_overrides) = infer_slot_types(f, refs);
     for (slot, ty) in &slot_overrides {
         local_types.insert(*slot, ty.clone());
     }
@@ -315,6 +316,16 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // obj_locals / member-derived / iterator-derived object type is a stronger signal
     // (all non-primitive, so they are naturally never overridden here).
     for (slot, ty) in &callret_overrides {
+        if used.contains(slot) && locals.get(slot).map(|t| is_primitive(t)).unwrap_or(true) {
+            locals.insert(*slot, ty.clone());
+        }
+    }
+    // out-ref float params (batch19 class 3): the callee's `float32&`/`float&`/`double&`
+    // signature is authoritative for a PSF'd out-slot — the call cannot compile otherwise
+    // ("expected float32&, but got int"). DECLARATION-only (body renders the slot name
+    // unchanged), applied LAST over the width-guessed primitive; never clobbers an
+    // object/struct declaration (a mis-paired entry would be non-primitive-declared).
+    for (slot, ty) in &outref_overrides {
         if used.contains(slot) && locals.get(slot).map(|t| is_primitive(t)).unwrap_or(true) {
             locals.insert(*slot, ty.clone());
         }
@@ -639,10 +650,21 @@ fn ret_is_struct(ty: &str) -> bool {
     matches!(ty.split('<').next().unwrap_or(ty).bytes().next(), Some(b'F') | Some(b'T'))
 }
 
-fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
+/// Returns (consumer-typed object-slot overrides, out-ref primitive DECLARATION overrides).
+///
+/// The second map (batch19 class 3): a slot whose ADDRESS (`PSF`) feeds a `float32&`/`float&`/
+/// `double&` reference parameter MUST be declared with exactly that float type — an
+/// `&out`/`&inout` primitive reference needs an lvalue of the exact type, and the width-guessed
+/// `int` declaration fails "Parameter 'data' expected float32&, but got int" (86 in-game errors,
+/// e.g. `AG1RGameState::GetWorldFloatData(world, name, data)`). Declaration-side only: the body
+/// already renders the slot NAME at the call site, and float-bits constants already render as
+/// float literals via the cbits/float-operand path. `bool&` out-params are NOT retyped: every
+/// int-slot render (SetV consts, `(x != 0)` wraps, NOT-patterns) would need a bool form —
+/// renderer-wide surgery documented as skipped in specs/batch19-classes.md.
+fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, HashMap<i32, String>) {
     let instrs = match disassemble(&f.bytecode) {
         Ok(i) => i,
-        Err(_) => return HashMap::new(),
+        Err(_) => return (HashMap::new(), HashMap::new()),
     };
     let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32);
     let writes = |op: &str| {
@@ -663,9 +685,12 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
             }
         }
     }
-    let mut ostack: Vec<Option<i32>> = Vec::new();
+    // operand-stack entries: (slot, pushed_via_PSF) — PSF-ness gates the out-ref pass (only an
+    // address push can be a primitive-reference arg; a PshV4 value push never is).
+    let mut ostack: Vec<Option<(i32, bool)>> = Vec::new();
     let mut cand: HashMap<i32, Option<String>> = HashMap::new(); // slot -> Some(type) | None(conflict)
-    let mut pair = |ostack: &mut Vec<Option<i32>>, params: Option<&[super::types::DataType]>, is_method: bool, ret_struct: bool, cand: &mut HashMap<i32, Option<String>>| {
+    let mut outref: HashMap<i32, Option<String>> = HashMap::new(); // PSF slot -> float-ref param type
+    let mut pair = |ostack: &mut Vec<Option<(i32, bool)>>, params: Option<&[super::types::DataType]>, is_method: bool, ret_struct: bool, cand: &mut HashMap<i32, Option<String>>, outref: &mut HashMap<i32, Option<String>>| {
         let Some(params) = params else { ostack.clear(); return; };
         // A method returning a struct BY VALUE (F/T/E) carries a hidden RVO out-slot pushed as the
         // last user arg (just before the receiver); count it so it is consumed, but exclude it from
@@ -700,13 +725,23 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
         // AGothicCharacterState `Character` param -> wrong declaration, RVO probe miss, dropped
         // string arg — 400+ in-game errors).
         for (i, slot) in args.iter().rev().enumerate() {
-            if let Some(s) = slot {
+            if let Some((s, is_psf)) = slot {
                 if let Some(pt) = params.get(i) {
                     let ty = pt.base_name(refs);
                     match cand.get(s) {
                         None => { cand.insert(*s, Some(ty)); }
                         Some(Some(prev)) if *prev != ty => { cand.insert(*s, None); }
                         _ => {}
+                    }
+                    // out-ref float pass: a PSF'd (address-pushed) slot feeding a float-family
+                    // REFERENCE param must be declared with exactly that type (see fn doc).
+                    if *is_psf && pt.is_reference && matches!(pt.token, 0x50 | 0x51 | 0x5E) {
+                        let kw = super::types::token_keyword(pt.token).to_string();
+                        match outref.get(s) {
+                            None => { outref.insert(*s, Some(kw)); }
+                            Some(Some(prev)) if *prev != kw => { outref.insert(*s, None); }
+                            _ => {}
+                        }
                     }
                 }
             }
@@ -716,7 +751,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
         match ins.op.name {
             "PshVPtr" | "PshV4" | "PshV8" | "PSF" => {
                 let s = w0(ins).unwrap_or(0);
-                ostack.push(if s > 0 { Some(s) } else { None });
+                ostack.push(if s > 0 { Some((s, ins.op.name == "PSF")) } else { None });
             }
             "PshC4" | "PshC8" | "PshNull" | "PGA" | "PshGPtr" | "PshG4" | "PshRPtr" | "STR"
             | "TYPEID" | "OBJTYPE" | "PshListElmnt" => ostack.push(None),
@@ -734,7 +769,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
-                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand);
+                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand, &mut outref);
             }
             "CALLSYS" | "Thiscall1" => {
                 let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
@@ -746,7 +781,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
                 if refs.func_by_ptr(ptr) == Some("$beh0") {
                     let owner = refs.func_owner_by_ptr(ptr).map(|s| s.to_string());
                     // receiver = top operand; ctor args = the params below it.
-                    if let Some(Some(rslot)) = ostack.last().copied() {
+                    if let Some(Some((rslot, _))) = ostack.last().copied() {
                         if let Some(ty) = owner {
                             if !ty.is_empty() {
                                 match cand.get(&rslot) {
@@ -764,17 +799,23 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
                     continue;
                 }
                 let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
-                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand);
+                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand, &mut outref);
             }
             _ => {}
         }
     }
-    cand.into_iter()
+    let obj = cand.into_iter()
         .filter_map(|(slot, ty)| match ty {
             Some(t) if !written.contains(&slot) && !is_primitive(t.trim_end_matches('@')) && t != "void" && !t.is_empty() => Some((slot, t)),
             _ => None,
         })
-        .collect()
+        .collect();
+    // out-ref float slots ARE written (the callee's whole point is to write them; typically a
+    // `SetV4 slot, 0` init precedes) — no never-written filter. Conflicts already dropped.
+    let outref = outref.into_iter()
+        .filter_map(|(slot, ty)| ty.map(|t| (slot, t)))
+        .collect();
+    (obj, outref)
 }
 
 /// Member-access-driven slot typing: a `LoadRObjR`/`LoadVObjR base, off, tid` reads field

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -241,6 +241,24 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     for (slot, ty) in &slot_overrides {
         local_types.insert(*slot, ty.clone());
     }
+    // batch-20 Class C: unlike the float out-refs (declaration-only), a BOOL out-ref slot must
+    // also be known to the BODY renderer — its `local_N = local_M;` int-copy needs the
+    // `(... != 0)` wrap (no implicit int->bool in AS) and its pushes must render bare.
+    for (slot, ty) in &outref_overrides {
+        if ty == "bool" {
+            local_types.insert(*slot, ty.clone());
+        }
+    }
+    // batch-20 Class C (SetByCallerMagnitude): float-family slots (from the width-typed ops,
+    // e.g. `dTOf w35`) must survive the nested-call stack-split retain (`!is_int` keeps them)
+    // and render bare — an untyped `PshV4` push is dropped as a stranded int temporary, which
+    // ate the float Magnitude arg pushed before a chained `GetSpec()` call (17 in-game errors).
+    // Never overrides an object/consumer-derived type (entry API).
+    for (slot, ty) in infer_locals(f, refs) {
+        if matches!(ty.as_str(), "float" | "float32" | "double") {
+            local_types.entry(slot).or_insert(ty);
+        }
+    }
     // member-access-derived types: the field's declaring class is the strongest signal for a
     // slot used as a member-access base; apply AFTER (overriding) the call-arg guess.
     let member_overrides = infer_slot_types_from_members(f, refs, fields, class_name);
@@ -417,6 +435,13 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         // legal form is declaration-with-initializer (copy-construction). Rewrite qualifying
         // executor locals to decl-init at their assignment sites.
         let (body, na_suppressed) = rewrite_no_assign_locals(&body, &locals);
+        // Batch-20 Class A residue: executor locals whose reference shape failed the decl-init
+        // gates above (multi-assign with reads, read-before-assign, cross-block reads) still
+        // carry `local_N = <call>;` assignments — temporary into non-const opAssign. Split each
+        // into `TY __na_tK = <call>; local_N = __na_tK;` — the lvalue assign compiles (proven
+        // in-game: `__return = local_16;` never errored in the batch-19 capture) and the temp
+        // lives/dies on adjacent lines of the same block, so it is scope-safe by construction.
+        let body = rewrite_no_assign_residual_assigns(&body, &locals, &ret);
         // Iterator locals have no default ctor either; declare them at their `Iterator()` call.
         let (body, iter_suppressed) = rewrite_iterator_decl_init(&body, &locals);
         // hoist local declarations; primitives must be initialized (AngelScript errors on
@@ -735,7 +760,10 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, Hash
                     }
                     // out-ref float pass: a PSF'd (address-pushed) slot feeding a float-family
                     // REFERENCE param must be declared with exactly that type (see fn doc).
-                    if *is_psf && pt.is_reference && matches!(pt.token, 0x50 | 0x51 | 0x5E) {
+                    // batch-20 Class C: bool& out params too (GetFloatAttributeFromAbility-
+                    // SystemComponent's `bool& bSuccessfullyFoundAttribute` — the slot was
+                    // declared int, and an int lvalue can't bind to bool&; 34 in-game errors).
+                    if *is_psf && pt.is_reference && matches!(pt.token, 0x41 | 0x50 | 0x51 | 0x5E) {
                         let kw = super::types::token_keyword(pt.token).to_string();
                         match outref.get(s) {
                             None => { outref.insert(*s, Some(kw)); }
@@ -768,7 +796,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, Hash
             }
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
-                let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                let rs = refs.func_ret_by_id(id).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand, &mut outref);
             }
             "CALLSYS" | "Thiscall1" => {
@@ -798,7 +826,7 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> (HashMap<i32, String>, Hash
                     ostack.truncate(ostack.len() - drop_n);
                     continue;
                 }
-                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand, &mut outref);
             }
             _ => {}
@@ -1042,7 +1070,7 @@ fn infer_iterator_types(
             }
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
-                let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                let rs = refs.func_ret_by_id(id).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 consume(&mut stack, refs.func_params_by_id(id).map(|p| p.len()), refs.is_method_by_id(id), rs);
             }
             "CALLSYS" | "Thiscall1" => {
@@ -1067,7 +1095,7 @@ fn infer_iterator_types(
                         record_iterator_candidate(refs, known, &mut cand, out_slot, ptr, container);
                     }
                 }
-                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 consume(&mut stack, refs.func_params_by_ptr(ptr).map(|p| p.len()), refs.is_method_by_ptr(ptr), rs);
             }
             _ => {}
@@ -1206,7 +1234,7 @@ fn infer_call_result_types(
                 let is_m = refs.is_method_by_id(id);
                 let recv = if is_m { ostack.last().copied().flatten() } else { None };
                 let ret = refs.func_ret_by_id(id).map(|d| d.base_name(refs));
-                let rs = ret.as_deref().map(ret_is_struct).unwrap_or(false);
+                let rs = refs.func_ret_by_id(id).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 consume(&mut ostack, refs.func_params_by_id(id).map(|p| p.len()), is_m, rs);
                 last = ret.map(|t| (t, recv));
             }
@@ -1223,7 +1251,7 @@ fn infer_call_result_types(
                 let is_m = refs.is_method_by_ptr(ptr);
                 let recv = if is_m { ostack.last().copied().flatten() } else { None };
                 let ret = refs.func_ret_by_ptr(ptr).map(|d| d.base_name(refs));
-                let rs = ret.as_deref().map(ret_is_struct).unwrap_or(false);
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
                 consume(&mut ostack, refs.func_params_by_ptr(ptr).map(|p| p.len()), is_m, rs);
                 last = ret.map(|t| (t, recv));
             }
@@ -1518,6 +1546,59 @@ fn rewrite_no_assign_locals(body: &str, locals: &BTreeMap<i32, String>) -> (Stri
         suppressed.insert(*slot);
     }
     (out, suppressed)
+}
+
+/// Residual pass behind [`rewrite_no_assign_locals`]: any REMAINING `local_N = <call>;` (or
+/// `__return = <call>;`) statement whose LHS is a no-assign type still assigns a temporary into
+/// the non-const `opAssign(TY&)` and fails in-game. Split the statement in place:
+///
+/// ```text
+/// FAbilityTaskExecutor __na_tK = <call>;   // copy-construction from the temporary — legal
+/// local_N = __na_tK;                       // opAssign from an LVALUE — legal (capture-proven)
+/// ```
+///
+/// The temp is declared and consumed on adjacent lines of the same block, so no scope/dominance
+/// analysis is needed (unlike the decl-init rewrites above, which rename or sink declarations).
+/// Only call-like RHS (ends in `)`) is split; a bare lvalue RHS (`__return = local_16;`) already
+/// compiles. Lines rewritten by the decl-init passes start with the type name, not `local_N =`,
+/// so the two passes never overlap.
+fn rewrite_no_assign_residual_assigns(
+    body: &str,
+    locals: &BTreeMap<i32, String>,
+    ret_ty: &str,
+) -> String {
+    // LHS ident → its declared type, for every no-assign-typed assignable name in this body.
+    let is_candidate = |ident: &str| -> Option<&str> {
+        if ident == "__return" {
+            return no_assign_type(ret_ty).then_some(ret_ty);
+        }
+        let slot: i32 = ident.strip_prefix("local_")?.parse().ok()?;
+        let ty = locals.get(&slot)?;
+        no_assign_type(ty).then_some(ty.as_str())
+    };
+    let mut k = 0usize;
+    let mut out = String::with_capacity(body.len() + 64);
+    for line in body.lines() {
+        let t = line.trim_start();
+        let split = t
+            .split_once(" = ")
+            .and_then(|(lhs, rhs)| Some((is_candidate(lhs)?, lhs, rhs)))
+            .filter(|(_, _, rhs)| rhs.ends_with(");"));
+        match split {
+            Some((ty, lhs, rhs)) => {
+                k += 1;
+                let indent = &line[..line.len() - t.len()];
+                let rhs = &rhs[..rhs.len() - 1]; // strip trailing `;`
+                let _ = writeln!(out, "{indent}{ty} __na_t{k} = {rhs};");
+                let _ = writeln!(out, "{indent}{lhs} = __na_t{k};");
+            }
+            None => {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+    }
+    out
 }
 
 /// Iterator locals (`TArrayIterator<T>`, `TSetIterator<T>`, `TMapIterator<T>`, ... incl. Const

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -398,6 +398,21 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
                 }
             }
         }
+        // batch-31d (N7, spec batch31-nomatch-illegalop §1.7): most-derived merge — a
+        // param-derived candidate that is a PROVABLE ANCESTOR of the cache's own obj_locals
+        // type must not widen it. The vanilla static type compiled every use in the vanilla
+        // source (member access on the ancestor stays legal on the derived type), while the
+        // widened type loses derived-only natives: the OldCamp `GetAllNPCStates()` loop
+        // element (obj_locals AGothicNPCState) paired with a guard CALL's
+        // AGothicCharacterState param -> `local_24.RemoveFromWorld()` on the BASE type,
+        // 5× "No matching signatures" (the FreeMine twins, guard-free, kept NPCState and
+        // compile). Hierarchy comparability via is_subclass (script-super walk +
+        // KNOWN_NATIVE_HIERARCHY).
+        if let Some(vanilla) = vanilla_obj_types.get(slot) {
+            if vanilla != ty && refs.is_subclass(vanilla, ty) {
+                continue;
+            }
+        }
         local_types.insert(*slot, ty.clone());
     }
     // batch-20 Class C: unlike the float out-refs (declaration-only), a BOOL out-ref slot must
@@ -647,6 +662,13 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
                             continue;
                         }
                     }
+                }
+            }
+            // batch-31d (N7): declaration-side mirror of the most-derived merge above — the
+            // vanilla obj_locals type wins over a param-derived ANCESTOR candidate.
+            if let Some(vanilla) = vanilla_obj_types.get(slot) {
+                if vanilla != ty && refs.is_subclass(vanilla, ty) {
+                    continue;
                 }
             }
             locals.insert(*slot, ty.clone());
@@ -1859,9 +1881,34 @@ fn infer_call_result_types(
     // rendered return type + receiver slot of the just-completed call (None once anything
     // non-benign executes, so a later CpyRtoV can't adopt a stale type).
     let mut last: Option<(String, Option<i32>)> = None;
+    // batch-31d (N8, spec batch31-nomatch-illegalop §1.9): value type of the LAST ADDSi
+    // member access, surviving a following PopRPtr — the `PshVPtr base ; ADDSi off,tid ;
+    // [ADDSi ...] ; PopRPtr ; CpyRtoV8 dst` idiom is a MEMBER READ into the register, and
+    // the dst slot (PointCorrection's w24 = `CalculatedPosition.Position`, FVector2D) was
+    // width-declared `int`, poisoning 9 error lines (5 no-match + 2 no-conversion-to-math
+    // + 2 implconv). The ADDSi tid resolves the field's value type independent of the base
+    // slot (script owners only — field_type_by_class; native owners yield None). NOTE: the
+    // spec's §1.9 "&out scratch" premise is disasm-REFUTED (w24 is never PSF'd; it feeds
+    // BY-VALUE FVector2D params) — this tracker is the corrected lever, same declaration-
+    // only, primitive-upgrade-only safety posture as the A3 call-result case.
+    let mut member_ty: Option<String> = None; // last ADDSi's field value type
+    let mut member_reg: Option<String> = None; // ... after PopRPtr loaded the register
     let mut ostack: Vec<Option<i32>> = Vec::new();
     let mut cand: HashMap<i32, Option<String>> = HashMap::new();
     for ins in &instrs {
+        // PopRPtr moves the member pointer into the register (member_ty -> member_reg, the
+        // form a following CpyRtoV may consume); everything except ADDSi/PopRPtr/SUSPEND/
+        // CpyRtoV kills both trackers.
+        match ins.op.name {
+            "ADDSi" | "SUSPEND" | "CpyRtoV4" | "CpyRtoV8" => {}
+            "PopRPtr" => {
+                member_reg = member_ty.take();
+            }
+            _ => {
+                member_ty = None;
+                member_reg = None;
+            }
+        }
         match ins.op.name {
             "PshVPtr" | "PSF" => {
                 let s = w0(ins);
@@ -1878,6 +1925,13 @@ fn infer_call_result_types(
                 if let Some(top) = ostack.last_mut() {
                     *top = None;
                 }
+                let off = w0(ins);
+                let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
+                member_ty = refs.member(tid, off).and_then(|field| {
+                    refs.type_by_id(tid)
+                        .and_then(|cls| refs.field_type_by_class(cls, field))
+                        .map(|s| s.to_string())
+                });
                 last = None;
             }
             "CALL" | "CALLINTF" | "CALLBND" => {
@@ -1907,7 +1961,11 @@ fn infer_call_result_types(
                 last = ret.map(|t| (t, recv));
             }
             "CpyRtoV4" | "CpyRtoV8" => {
-                if let Some((ty, recv)) = last.take() {
+                // A3 call-result case first; else the batch-31d member-read case (the
+                // PopRPtr'd ADDSi chain) — identical candidate/conflict discipline, and
+                // usable_ret_type keeps primitives/enums/bare templates out either way.
+                let src_ty = last.take().or_else(|| member_reg.take().map(|t| (t, None)));
+                if let Some((ty, recv)) = src_ty {
                     let d = w0(ins);
                     if d > 0 && !obj.contains(&d) && !disq.contains(&d) {
                         if let Some(ty) = usable_ret_type(ty, recv, known) {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -32,7 +32,7 @@ fn force_stub_set() -> &'static HashSet<String> {
 use super::disasm::disassemble;
 use super::model::{Class, Func, Module};
 use super::refs::RefResolver;
-use super::structure::{body_statements_ctor, RVODEF};
+use super::structure::{body_statements_ctor, CONSTSTORE, RVODEF};
 use super::types::token_keyword;
 use super::walk_modules::FuncCode;
 
@@ -179,8 +179,22 @@ fn emit_class(s: &mut String, c: &Class, refs: &RefResolver) {
     }
     let super_name = c.super_class.as_deref().filter(|s| !s.is_empty());
     // field name -> base type name, so the decompiler can cast `this.field = <int>` assignments.
-    let field_types: HashMap<String, String> =
+    let mut field_types: HashMap<String, String> =
         c.fields.iter().map(|f| (f.name.clone(), f.ty.base_name(refs))).collect();
+    // Batch-21 Class B residue: fold in INHERITED fields by walking the script hierarchy —
+    // the own-fields map left e.g. `this.RoleCategoryContainers.opIndex(<int>)` (field declared
+    // on the super class) untyped, so the container-subtype enum-key wrap never fired. Own
+    // fields win on a name collision (shadowing is illegal in AS anyway). Walk is cycle-bounded.
+    let mut cur = super_name.map(|s| s.to_string());
+    for _ in 0..64 {
+        let Some(sup) = cur else { break };
+        if let Some(fs) = refs.class_field_types(&sup) {
+            for (k, v) in fs {
+                field_types.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+        cur = refs.class_super_of(&sup).map(|s| s.to_string());
+    }
     for ctor in &c.ctors {
         emit_function_ctor(s, ctor, refs, true, true, 1, super_name, Some(&field_types), Some(&c.name));
     }
@@ -281,6 +295,47 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // Consumes the iterator subtypes above for bare `TMap*` pair returns.
     let callret_overrides = infer_call_result_types(f, refs, &local_types);
     let body = body_statements_ctor(&fc, refs, depth + 1, super_ctor, Some(&f.ret), fields, Some(&param_types), class_name, Some(&local_types));
+    // Batch-21 Class C: CONSTSTORE-marked stores carry a const object handle of the local's
+    // EXACT type (a same-type Cast<T> does NOT strip const in-game — every batch-20 exact-type
+    // Cast site failed "No conversion from 'const X' to 'X'"). Vanilla declared these locals
+    // `const`; strip the marker and const-qualify the declaration below.
+    let (body, const_slots) = strip_const_store_markers(&body);
+    // CASCADE GATE: a const handle can't be COPIED into a non-const local / `__return` /
+    // member (handle assignment preserves const), so any slot consumed as a bare copy-RHS
+    // keeps its non-const declaration (the store keeps the status-quo error) unless the copy
+    // target is itself const-marked. Method calls / call args / `!= nullptr` / Cast<Derived>
+    // uses are const-safe: vanilla used the same value through a const local, and Class A
+    // restored the faithful const method qualifiers + const param renders.
+    let mut const_slots = const_slots;
+    loop {
+        let keep: HashSet<i32> = const_slots
+            .iter()
+            .copied()
+            .filter(|n| {
+                let needle = format!("= local_{n};");
+                !body.lines().any(|l| {
+                    let t = l.trim();
+                    if !t.ends_with(needle.as_str()) {
+                        return false;
+                    }
+                    let lhs = t[..t.len() - needle.len()].trim_end();
+                    let lhs_const = lhs
+                        .strip_prefix("local_")
+                        .and_then(|d| d.parse::<i32>().ok())
+                        .map(|m| const_slots.contains(&m))
+                        .unwrap_or(false);
+                    !lhs_const
+                }) && !body.contains(&format!("return local_{n};"))
+            })
+            .collect();
+        // fixed point: dropping a slot can invalidate a copy INTO it that justified keeping
+        // its source, so iterate until stable (bounded: the set only shrinks).
+        if keep.len() == const_slots.len() {
+            break;
+        }
+        const_slots = keep;
+    }
+    let const_slots = const_slots;
     // hoist every referenced local; infer_locals types what it can, the rest default to `int`
     // (a wrong type just becomes a compile error the in-game loop force-stubs, rather than the
     // whole function stubbing on an undeclared identifier).
@@ -417,7 +472,12 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     if is_ctor {
         let _ = writeln!(s, "{ind}{}({params})", f.name); // constructors have no return type
     } else {
-        let _ = writeln!(s, "{ind}{ret_sig} {}({params})", f.name);
+        // Batch-21 Class A: vanilla `const` methods (asTRAIT_CONST in FunctionTraits) must
+        // render their qualifier back — callers hold `const` object handles (the param
+        // DataTypes carry bIsObjectConst), so a non-const re-declaration fails every call
+        // site with "Non-const method call on read-only object reference".
+        let constq = if is_method && f.is_const_method() { " const" } else { "" };
+        let _ = writeln!(s, "{ind}{ret_sig} {}({params}){constq}", f.name);
     }
     let _ = writeln!(s, "{ind}{{");
 
@@ -452,6 +512,11 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
             }
             if is_primitive(ty) {
                 let _ = writeln!(s, "{ind}    {ty} local_{slot} = {};", default_for(ty));
+            } else if const_slots.contains(slot) {
+                // batch-21 Class C: at least one store is a const handle of this exact type;
+                // `const` on the declaration matches the vanilla form (non-const stores into a
+                // const handle remain legal, so mixed-source slots are safe).
+                let _ = writeln!(s, "{ind}    const {ty} local_{slot};");
             } else {
                 let _ = writeln!(s, "{ind}    {ty} local_{slot};");
             }
@@ -567,6 +632,35 @@ fn render_params(f: &Func, refs: &RefResolver) -> String {
         })
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// Strip [`CONSTSTORE`] markers from a rendered body, returning the cleaned body plus the
+/// set of `local_N` slots whose store RHS was a const handle of the local's exact type —
+/// those declarations get a `const` qualifier (batch-21 Class C). A marked store whose LHS
+/// is not a plain `local_N` (e.g. `__return`) just loses the marker (status-quo behavior).
+fn strip_const_store_markers(body: &str) -> (String, HashSet<i32>) {
+    let mut slots = HashSet::new();
+    if !body.contains(CONSTSTORE) {
+        return (body.to_string(), slots);
+    }
+    let mut out = String::with_capacity(body.len());
+    for line in body.lines() {
+        if let Some(pos) = line.find(CONSTSTORE) {
+            let lhs = line[..pos].trim_start();
+            if let Some(n) = lhs
+                .strip_prefix("local_")
+                .and_then(|r| r.strip_suffix(" = "))
+                .and_then(|d| d.parse::<i32>().ok())
+            {
+                slots.insert(n);
+            }
+            out.extend(line.chars().filter(|c| *c != CONSTSTORE));
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    (out, slots)
 }
 
 /// A body is "recoverable" only if it has NO recovery gaps: the decompiler emits a

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -379,12 +379,18 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         // assignment to a declaration-with-initializer (in-place construction — the original
         // source form). Any other reference shape keeps the hoist (status quo).
         let (body, suppressed) = rewrite_ctor_only_locals(&body, &locals);
+        // FAbilityTaskExecutor's opAssign takes a NON-const reference, so assigning a by-value
+        // call result to a declared local ('local = DrawMeleeWeapon(AI);') fails "Cannot pass a
+        // temporary value into non-const reference parameter" (2841 in-game errors). The only
+        // legal form is declaration-with-initializer (copy-construction). Rewrite qualifying
+        // executor locals to decl-init at their assignment sites.
+        let (body, na_suppressed) = rewrite_no_assign_locals(&body, &locals);
         // Iterator locals have no default ctor either; declare them at their `Iterator()` call.
         let (body, iter_suppressed) = rewrite_iterator_decl_init(&body, &locals);
         // hoist local declarations; primitives must be initialized (AngelScript errors on
         // "may not be initialized"), objects/structs/handles default-construct themselves.
         for (slot, ty) in &locals {
-            if suppressed.contains(slot) || iter_suppressed.contains(slot) {
+            if suppressed.contains(slot) || na_suppressed.contains(slot) || iter_suppressed.contains(slot) {
                 continue; // declared at its (rewritten) assignment/Iterator() site instead
             }
             if is_primitive(ty) {
@@ -1332,6 +1338,93 @@ fn rewrite_ctor_only_locals(body: &str, locals: &BTreeMap<i32, String>) -> (Stri
                 k += 1;
                 let indent = &line[..line.len() - t.len()];
                 let rest = &t[ident.len()..]; // ` = TY(...);`
+                if k == 1 {
+                    let _ = writeln!(rewritten, "{indent}{ty} {ident}{rest}");
+                } else {
+                    let _ = writeln!(rewritten, "{indent}{ty} {ident}_{k}{rest}");
+                }
+            } else {
+                rewritten.push_str(line);
+                rewritten.push('\n');
+            }
+        }
+        out = rewritten;
+        suppressed.insert(*slot);
+    }
+    (out, suppressed)
+}
+
+/// Value types whose `opAssign` takes a NON-const reference: assigning a by-value call result
+/// (`local = DrawMeleeWeapon(AI);`) fails "Cannot pass a temporary value ... into non-const
+/// reference parameter"; only declaration-with-initializer (copy-construction) compiles.
+fn no_assign_type(ty: &str) -> bool {
+    matches!(ty, "FAbilityTaskExecutor")
+}
+
+/// Rewrite locals of a no-assign type (see [`no_assign_type`]) to declaration-with-initializer.
+/// The bytecode reuses one slot for several source-level locals, so each assignment gets a fresh
+/// declaration. Two safe shapes:
+/// - WRITE-ONLY (any number of assignments, no reads): every assignment becomes
+///   `TY local_N[_k] = ...;` with fresh names — nothing else references the slot, so sinking the
+///   declarations into blocks is scope-safe (mirrors the FStatID rewrite).
+/// - SINGLE assignment + reads, ALL references at the same indentation (one block): decl-init in
+///   place, name kept — later reads are lvalue uses (a non-const ref binds to an lvalue; only
+///   temporaries fail), and same-indent means the declaration dominates every read.
+/// Anything else (read before assign, cross-block reads, self-referential RHS) keeps the hoisted
+/// declaration — the status-quo compile error, never a new one.
+fn rewrite_no_assign_locals(body: &str, locals: &BTreeMap<i32, String>) -> (String, HashSet<i32>) {
+    let mut suppressed: HashSet<i32> = HashSet::new();
+    let mut out = body.to_string();
+    for (slot, ty) in locals {
+        if !no_assign_type(ty) {
+            continue;
+        }
+        let ident = format!("local_{slot}");
+        let assign_pat = format!("{ident} = ");
+        let mut assigns = 0usize;
+        let mut reads = 0usize;
+        let mut first_is_assign = false;
+        let mut first = true;
+        let mut indents: Vec<&str> = Vec::new();
+        let mut ok = true;
+        for line in out.lines() {
+            let c = count_ident(line, &ident);
+            if c == 0 {
+                continue;
+            }
+            let t = line.trim_start();
+            let is_assign = c == 1 && t.starts_with(&assign_pat) && t.ends_with(';');
+            if first {
+                first_is_assign = is_assign;
+                first = false;
+            }
+            if is_assign {
+                assigns += 1;
+            } else {
+                reads += c;
+                if c > 1 {
+                    ok = false; // multi-occurrence non-assign line (self-referential etc.) — bail
+                    break;
+                }
+            }
+            indents.push(&line[..line.len() - t.len()]);
+        }
+        if !ok || assigns == 0 || !first_is_assign {
+            continue;
+        }
+        let write_only = reads == 0;
+        let uniform_indent = indents.windows(2).all(|w| w[0] == w[1]);
+        if !write_only && !(assigns == 1 && uniform_indent) {
+            continue;
+        }
+        let mut k = 0usize;
+        let mut rewritten = String::with_capacity(out.len() + 64);
+        for line in out.lines() {
+            let t = line.trim_start();
+            if count_ident(line, &ident) == 1 && t.starts_with(&assign_pat) && t.ends_with(';') {
+                k += 1;
+                let indent = &line[..line.len() - t.len()];
+                let rest = &t[ident.len()..]; // ` = <expr>;`
                 if k == 1 {
                     let _ = writeln!(rewritten, "{indent}{ty} {ident}{rest}");
                 } else {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -217,15 +217,8 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // override -> "must have the same return type as in the base class". Stripping makes them match.
     let ret = f.ret.render(refs).trim_start_matches("const ").to_string();
     let params = render_params(f, refs);
-    if f.is_ufunction {
-        let _ = writeln!(s, "{ind}UFUNCTION()");
-    }
-    if is_ctor {
-        let _ = writeln!(s, "{ind}{}({params})", f.name); // constructors have no return type
-    } else {
-        let _ = writeln!(s, "{ind}{ret} {}({params})", f.name);
-    }
-    let _ = writeln!(s, "{ind}{{");
+    // NOTE: the signature is written AFTER the body is computed (below) — the ref-return `&`
+    // rendering must know whether the body falls back to a stub / RVODEF default return.
 
     let fc = FuncCode {
         func: f.name.clone(),
@@ -251,6 +244,15 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // slot used as a member-access base; apply AFTER (overriding) the call-arg guess.
     let member_overrides = infer_slot_types_from_members(f, refs);
     for (slot, ty) in &member_overrides {
+        local_types.insert(*slot, ty.clone());
+    }
+    // iterator-instance subtypes (illegal-op-round2.md A1): the T1 entry for a `T*Iterator`
+    // template INSTANCE carries no SubTypes, so every slot typed from it declares as a bare
+    // head (`TArrayConstIterator local_N;`) — a template-arity error that makes the local
+    // `Unknown`. Derive `<T>` from the `Iterator()` call's container receiver; applied AFTER
+    // the member pass so the composed type wins over the bare member-derived head.
+    let iter_overrides = infer_iterator_types(f, &fc, refs, fields, &local_types);
+    for (slot, ty) in &iter_overrides {
         local_types.insert(*slot, ty.clone());
     }
     let body = body_statements_ctor(&fc, refs, depth + 1, super_ctor, Some(&f.ret), fields, Some(&param_types), class_name, Some(&local_types));
@@ -296,6 +298,13 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
             locals.insert(*slot, ty.clone());
         }
     }
+    // iterator-subtype overrides (A1) replace the bare `T*Iterator` declaration with the
+    // container-derived instantiation; never downgrade an already-subtyped declaration.
+    for (slot, ty) in &iter_overrides {
+        if used.contains(slot) && !locals.get(slot).is_some_and(|t| t.contains('<')) {
+            locals.insert(*slot, ty.clone());
+        }
+    }
     // Drop locals never referenced in the body: `obj_locals` includes profiling temporaries like
     // FScopeCycleCounter / FStatID that the body never uses, and they have no default constructor,
     // so declaring an unused one fails ("No default constructor"). An unused declaration is dead.
@@ -323,10 +332,45 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         stub_reason(&body, &locals, f.params.len(), ret == "void")
     };
 
+    // Class B1 (emission-classes.md): the cache flags 266 script functions with a REFERENCE
+    // return (`FPerceptionHandler& OnSensedSelf(...)` — chainable builders); rendering them
+    // by value makes every call site a temporary, which the game compiler rejects ("Cannot
+    // call non-const method on a temporary object" / temp into non-const `&` param). Emit
+    // `{ty}&` (keeping a leading `const` — meaningful on a ref return) for object-token
+    // by-ref value returns. A ref return never has an RVO slot, so `__return` can't occur;
+    // the only exposures are the RVODEF default-return and the stub fallback, which declare
+    // `{ret} __r;` — invalid for a reference type — so those keep the by-value signature
+    // (status quo).
+    let ref_ret = f.ret.is_reference && f.ret.token == 5 && !f.ret.is_object_handle;
+    let ret_sig = if ref_ret && reason.is_none() && !body.contains(RVODEF) && !body.contains("__return") {
+        format!("{}&", f.ret.render(refs))
+    } else {
+        ret.clone()
+    };
+    if f.is_ufunction {
+        let _ = writeln!(s, "{ind}UFUNCTION()");
+    }
+    if is_ctor {
+        let _ = writeln!(s, "{ind}{}({params})", f.name); // constructors have no return type
+    } else {
+        let _ = writeln!(s, "{ind}{ret_sig} {}({params})", f.name);
+    }
+    let _ = writeln!(s, "{ind}{{");
+
     if reason.is_none() {
+        // Class A (emission-classes.md): FStatID/FScopeCycleCounter have neither a default
+        // constructor nor an opAssign, so BOTH the bare hoisted declaration and the later
+        // whole-object ctor-assign fail. When every reference to such a local is the
+        // write-only `local_N = TY(...);` shape, suppress the hoist and rewrite each
+        // assignment to a declaration-with-initializer (in-place construction — the original
+        // source form). Any other reference shape keeps the hoist (status quo).
+        let (body, suppressed) = rewrite_ctor_only_locals(&body, &locals);
         // hoist local declarations; primitives must be initialized (AngelScript errors on
         // "may not be initialized"), objects/structs/handles default-construct themselves.
         for (slot, ty) in &locals {
+            if suppressed.contains(slot) {
+                continue; // Class A: declared at its (rewritten) assignment site instead
+            }
             if is_primitive(ty) {
                 let _ = writeln!(s, "{ind}    {ty} local_{slot} = {};", default_for(ty));
             } else {
@@ -692,6 +736,194 @@ fn infer_slot_types_from_members(f: &Func, refs: &RefResolver) -> HashMap<i32, S
     cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect()
 }
 
+/// A1 (illegal-op-round2.md): subtype inference for iterator locals. An `Iterator()` call
+/// lowers as `PSF <out> ; ... ; <receiver push> ; CALLSYS <ptr>` — the hidden RVO out-slot
+/// is pushed before the container receiver (a PSF/PshVPtr slot, or `PshVPtr w0 ; ADDSi` for
+/// a `this.<field>` container), possibly with a whole interleaved call in between. The
+/// iterator INSTANCE's T1 entry usually carries no SubTypes, so the out-slot would declare
+/// bare (`TArrayConstIterator local_N;` — template-arity error, every use `Unknown`).
+/// Compose the type as: head from `func_ret_by_ptr` (TArrayIterator vs TArrayConstIterator
+/// vs TMap/TSetIterator) + the container's `<...>` subtype list. Uses the same light
+/// operand-stack model as `infer_slot_types` (pushes + per-call consumption) so interleaved
+/// calls don't break the out-slot/receiver association. Conservative: unknown-arity calls
+/// clear the stack, un-subtyped containers are skipped, an out-slot whose existing bare
+/// head disagrees is skipped, already-subtyped slots are never overridden, and conflicting
+/// candidates drop (regression-free).
+fn infer_iterator_types(
+    f: &Func,
+    fc: &FuncCode,
+    refs: &RefResolver,
+    fields: Option<&HashMap<String, String>>,
+    known: &HashMap<i32, String>,
+) -> HashMap<i32, String> {
+    let instrs = match disassemble(&fc.bytecode) {
+        Ok(i) => i,
+        Err(_) => return HashMap::new(),
+    };
+    // frame offset -> param index, for container receivers that are parameters.
+    let (param_off_map, _rvo_off) = super::decompile::build_param_off_map_rvo(fc, &instrs, refs);
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    // authoritative composed obj-local types: a `$beh0`/call-arg override may have CLOBBERED a
+    // slot's entry in `known` down to a bare template head (`TMap`), while the cache's own
+    // obj_locals entry composes fully (`TMap<A, B>`). Prefer whichever is subtyped.
+    let obj_composed: HashMap<i32, String> = f
+        .obj_locals
+        .iter()
+        .map(|(slot, tinfo)| {
+            let ty = super::types::DataType { token: 5, type_info: *tinfo, is_object_handle: true, ..Default::default() }.base_name(refs);
+            (*slot, ty)
+        })
+        .collect();
+    // composed container type (e.g. `TArray<AGothicCharacter>`) for a receiver slot.
+    let container_of = |slot: i32| -> Option<String> {
+        if slot > 0 {
+            // local: prefer the subtyped candidate (override map first, then obj_locals).
+            return match (known.get(&slot), obj_composed.get(&slot)) {
+                (Some(k), _) if k.contains('<') => Some(k.clone()),
+                (_, Some(o)) if o.contains('<') => Some(o.clone()),
+                (k, o) => k.or(o).cloned(),
+            };
+        }
+        if slot == 0 && fc.is_method {
+            return None; // `this` is not a container
+        }
+        let idx = *param_off_map.get(&slot)?;
+        fc.param_types.get(idx).map(|d| d.base_name(refs))
+    };
+    /// Operand-stack entry: enough to identify a receiver's container and a PSF'd out-slot.
+    #[derive(Clone)]
+    enum Ent {
+        /// `PSF wN` / `PshVPtr wN`.
+        Slot { slot: i32, psf: bool },
+        /// After `ADDSi` (member access rewrites the top in place): the composed container
+        /// type when resolvable (`this.<field>` via the class fields map), else None.
+        Member(Option<String>),
+        /// Any other push (constants, globals, register re-pushes, value slots).
+        Other,
+    }
+    let mut stack: Vec<Ent> = Vec::new();
+    let mut cand: HashMap<i32, Option<String>> = HashMap::new();
+    // per-call consumption, mirroring `infer_slot_types::pair`: params + receiver + RVO
+    // out-slot for methods; unknown param info -> clear (conservative: drop pending slots).
+    let consume = |stack: &mut Vec<Ent>, params: Option<usize>, is_method: bool, ret_struct: bool| {
+        let Some(n) = params else { stack.clear(); return; };
+        let rvo = (ret_struct && is_method) as usize;
+        let total = if is_method { n + 1 + rvo } else { n };
+        stack.truncate(stack.len() - total.min(stack.len()));
+    };
+    for ins in &instrs {
+        match ins.op.name {
+            "PshVPtr" | "PSF" => {
+                stack.push(Ent::Slot { slot: w0(ins), psf: ins.op.name == "PSF" });
+            }
+            "PshV4" | "PshV8" | "PshC4" | "PshC8" | "PshNull" | "PGA" | "PshGPtr" | "PshG4"
+            | "PshRPtr" | "STR" | "TYPEID" | "OBJTYPE" | "PshListElmnt" => stack.push(Ent::Other),
+            "ADDSi" => {
+                // member access rewrites the pushed pointer in place: `this.<field>` resolves
+                // its container type via the class fields map; anything else is unresolvable
+                // here (a foreign class's field value type isn't in the tail tables).
+                let c = match stack.last() {
+                    Some(Ent::Slot { slot: 0, .. }) if fc.is_method => {
+                        let off = ins.words.first().copied().unwrap_or(0) as i32;
+                        let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
+                        refs.member(tid, off)
+                            .and_then(|name| fields.and_then(|m| m.get(name)))
+                            .cloned()
+                    }
+                    _ => None,
+                };
+                if let Some(top) = stack.last_mut() {
+                    *top = Ent::Member(c);
+                }
+            }
+            "CALL" | "CALLINTF" | "CALLBND" => {
+                let id = ins.dwords.first().copied().unwrap_or(0) as i32;
+                let rs = refs.func_ret_by_id(id).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                consume(&mut stack, refs.func_params_by_id(id).map(|p| p.len()), refs.is_method_by_id(id), rs);
+            }
+            "CALLSYS" | "Thiscall1" => {
+                let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+                if refs.func_by_ptr(ptr) == Some("$beh0") {
+                    // in-place construct: receiver + ctor args (mirror infer_slot_types).
+                    let nargs = refs.func_params_by_ptr(ptr).map(|p| p.len()).unwrap_or(0);
+                    let drop_n = (1 + nargs).min(stack.len());
+                    stack.truncate(stack.len() - drop_n);
+                    continue;
+                }
+                if refs.func_by_ptr(ptr) == Some("Iterator") && stack.len() >= 2 {
+                    // receiver = top; hidden RVO out-slot = the PSF entry directly below.
+                    let recv = &stack[stack.len() - 1];
+                    let out = &stack[stack.len() - 2];
+                    let container = match recv {
+                        Ent::Slot { slot, .. } => container_of(*slot),
+                        Ent::Member(c) => c.clone(),
+                        Ent::Other => None,
+                    };
+                    if let Ent::Slot { slot: out_slot, psf: true } = *out {
+                        record_iterator_candidate(refs, known, &mut cand, out_slot, ptr, container);
+                    }
+                }
+                let rs = refs.func_ret_by_ptr(ptr).map(|d| ret_is_struct(&d.base_name(refs))).unwrap_or(false);
+                consume(&mut stack, refs.func_params_by_ptr(ptr).map(|p| p.len()), refs.is_method_by_ptr(ptr), rs);
+            }
+            _ => {}
+        }
+    }
+    cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect()
+}
+
+/// Compose + record one iterator out-slot candidate (see [`infer_iterator_types`]).
+fn record_iterator_candidate(
+    refs: &RefResolver,
+    known: &HashMap<i32, String>,
+    cand: &mut HashMap<i32, Option<String>>,
+    out_slot: i32,
+    ptr: i64,
+    container: Option<String>,
+) {
+    if out_slot <= 0 {
+        return; // only local out-slots get declarations
+    }
+    // never override a slot that already has a subtyped (template-complete) type.
+    if known.get(&out_slot).is_some_and(|t| t.contains('<')) {
+        return;
+    }
+    // head = the Iterator() return type. Iterator INSTANCES usually serialize BARE (then the
+    // container's `<...>` subtype list is appended), but some (TMap) compose fully — use
+    // those directly, no container needed.
+    let Some(head) = refs.func_ret_by_ptr(ptr).map(|d| d.base_name(refs)) else { return };
+    if !head.starts_with('T') || !head.contains("Iterator") {
+        return;
+    }
+    let ty = if head.contains('<') {
+        head
+    } else {
+        // the container must itself be a subtyped template (`TArray<AGothicCharacter>`).
+        let Some(c) = container else { return };
+        let (Some(lt), Some(gt)) = (c.find('<'), c.rfind('>')) else { return };
+        if gt <= lt + 1 {
+            return;
+        }
+        format!("{head}<{}>", &c[lt + 1..gt])
+    };
+    // stack-model safety: if the slot already has a BARE type (member-pass derived), its head
+    // must agree with ours — a mismatch means a mis-associated out-slot, so skip.
+    if let Some(prev) = known.get(&out_slot) {
+        if !prev.is_empty() && ty.split('<').next() != Some(prev.as_str()) {
+            return;
+        }
+    }
+    match cand.get(&out_slot) {
+        None => {
+            cand.insert(out_slot, Some(ty));
+        }
+        Some(Some(prev)) if *prev != ty => {
+            cand.insert(out_slot, None); // slot reused across containers: drop
+        }
+        _ => {}
+    }
+}
+
 /// §3.3 consumer-driven typing of out-of-range `argN` slots. Scans the body for the RHS of an
 /// `argN = <expr>` assignment (including `return argN = <expr>;`) and resolves `<expr>`'s type
 /// from the maps we already have: `this.<field>` -> field type, `local_M` -> local type,
@@ -751,6 +983,99 @@ fn infer_oor_arg_types(
         let _ = param_types;
     }
     out
+}
+
+/// Types with NEITHER a default constructor NOR an opAssign in this AS binding (emission-
+/// classes.md Class A): a hoisted bare declaration fails ("No default constructor") AND the
+/// later whole-object assignment fails ("No appropriate opAssign"); the only legal form is
+/// declaration-with-initializer (in-place construction).
+fn has_no_default_ctor(ty: &str) -> bool {
+    matches!(ty, "FStatID" | "FScopeCycleCounter")
+}
+
+/// Count identifier-boundary occurrences of `ident` in `line` (so `local_3` does not match
+/// inside `local_32` or `local_3_2`).
+fn count_ident(line: &str, ident: &str) -> usize {
+    let (b, ib) = (line.as_bytes(), ident.as_bytes());
+    let is_id = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+    let (mut n, mut i) = (0usize, 0usize);
+    while i + ib.len() <= b.len() {
+        if &b[i..i + ib.len()] == ib
+            && (i == 0 || !is_id(b[i - 1]))
+            && (i + ib.len() == b.len() || !is_id(b[i + ib.len()]))
+        {
+            n += 1;
+            i += ib.len();
+        } else {
+            i += 1;
+        }
+    }
+    n
+}
+
+/// Class A (emission-classes.md): for a hoisted local whose type has no default ctor AND no
+/// opAssign (`FStatID`/`FScopeCycleCounter`), when EVERY body reference is the write-only
+/// whole-object ctor-assign `local_N = TY(...);`, suppress the hoisted declaration and
+/// rewrite each assignment to a declaration-with-initializer `TY local_N = TY(...);`. A
+/// 2nd..nth assignment to the same (compiler-reused) slot gets a fresh name (`local_N_2`) so
+/// sibling-scope re-declarations of one name are avoided. If any reference does NOT match
+/// the pattern (a read), the local keeps its hoist (status-quo error, never force-stub).
+/// Returns the rewritten body + the slots whose hoisted declaration must be suppressed.
+fn rewrite_ctor_only_locals(body: &str, locals: &BTreeMap<i32, String>) -> (String, HashSet<i32>) {
+    let mut suppressed: HashSet<i32> = HashSet::new();
+    let mut out = body.to_string();
+    for (slot, ty) in locals {
+        if !has_no_default_ctor(ty) {
+            continue;
+        }
+        let ident = format!("local_{slot}");
+        let pat = format!("{ident} = {ty}(");
+        // gate: every referencing line is exactly `local_N = TY(...);` with a single occurrence.
+        let mut assigns = 0usize;
+        let mut ok = true;
+        for line in out.lines() {
+            match count_ident(line, &ident) {
+                0 => continue,
+                1 => {
+                    let t = line.trim_start();
+                    if t.starts_with(&pat) && t.ends_with(");") {
+                        assigns += 1;
+                    } else {
+                        ok = false;
+                        break;
+                    }
+                }
+                _ => {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if !ok || assigns == 0 {
+            continue;
+        }
+        let mut k = 0usize;
+        let mut rewritten = String::with_capacity(out.len() + 32);
+        for line in out.lines() {
+            let t = line.trim_start();
+            if count_ident(line, &ident) == 1 && t.starts_with(&pat) && t.ends_with(");") {
+                k += 1;
+                let indent = &line[..line.len() - t.len()];
+                let rest = &t[ident.len()..]; // ` = TY(...);`
+                if k == 1 {
+                    let _ = writeln!(rewritten, "{indent}{ty} {ident}{rest}");
+                } else {
+                    let _ = writeln!(rewritten, "{indent}{ty} {ident}_{k}{rest}");
+                }
+            } else {
+                rewritten.push_str(line);
+                rewritten.push('\n');
+            }
+        }
+        out = rewritten;
+        suppressed.insert(*slot);
+    }
+    (out, suppressed)
 }
 
 /// Infer (slot, type) for primitive + object locals to hoist as declarations.

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1218,6 +1218,16 @@ fn infer_slot_types(
                 // push may carry values outside the small range).
                 sarg.insert(s, None);
             }
+            // batch-33b (N1 residue): a slot VALUE-pushed into a BOOL by-value param is a
+            // real argument exactly like the int-family/enum cases above — bool slots are
+            // untyped ints in the model, so the push died in the nested-call split
+            // (UCM_RollToSide lost Math::RandBool()'s bFlipSide to five intervening
+            // GetNavAgentLocation/opSub/GetUnsafeNormal calls -> RollToEvade 2-arg
+            // no-match). Keep-only: the render-side `(local_N != 0)` wrap is the existing
+            // bool-param cast_arg path, which fires once the arg survives.
+            0x41 => {
+                ikeep.insert(s);
+            }
             // batch-31c (N1, spec batch31-nomatch-illegalop §1.4): a slot VALUE-pushed into a
             // known ENUM by-value param is a REAL argument, not a stranded SetV temporary —
             // it earns the retain keep flag exactly like the int-family pairs (enum slots are
@@ -1279,7 +1289,8 @@ fn infer_slot_types(
                     if *s < 0 {
                         if !*is_psf && !pt.is_reference {
                             match pt.token {
-                                0x44 | 0x45 | 0x46 | 0x47 | 0x4B | 0x4C | 0x4D | 0x4E => {
+                                // 0x41: batch-33b — bool params join the keep set (see val_arg).
+                                0x41 | 0x44 | 0x45 | 0x46 | 0x47 | 0x4B | 0x4C | 0x4D | 0x4E => {
                                     ikeep.insert(*s);
                                 }
                                 5 if super::structure::is_enum_name(&pt.base_name(refs)) => {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1857,6 +1857,40 @@ fn infer_locals(f: &Func, refs: &RefResolver) -> BTreeMap<i32, String> {
             }
         }
     }
+    // Float return-payload retype: a slot copied into the value register (`CpyVtoR8`/
+    // `CpyVtoR4`) in a function returning the matching-width float family IS the float
+    // return value, so its `SetV*`-guessed int/int64 declaration must become the return
+    // type keyword (structure.rs `float_operand_slots` renders those constants as float
+    // literals — `local_4 = -55.0;` needs `float local_4;`, not `int64`). Never overrides
+    // object-typed slots (rank 0).
+    {
+        let copy_op = match f.ret.token {
+            0x51 | 0x5E => Some("CpyVtoR8"),
+            0x50 => Some("CpyVtoR4"),
+            _ => None,
+        };
+        if let Some(op) = copy_op {
+            let kw = token_keyword(f.ret.token).to_string();
+            for ins in &instrs {
+                if ins.op.name != op {
+                    continue;
+                }
+                let Some(dst) = ins.words.first().map(|w| *w as i16 as i32) else { continue };
+                if dst <= 0 {
+                    continue;
+                }
+                match locals.get(&dst) {
+                    None => {
+                        locals.insert(dst, kw.clone());
+                    }
+                    Some(prev) if matches!(prev.as_str(), "int" | "int64" | "float" | "double") => {
+                        locals.insert(dst, kw.clone());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
     let _ = token_keyword; // keep import used if obj path elided
     locals
 }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -340,7 +340,18 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // mis-typed default/optional-arg slots — FName->UAIState_DailyRoutine, TSubclassOf<X>->X).
     // outref_overrides: PSF slots feeding float-family REFERENCE params (declaration-only, below).
     // float_args/keep_ints (batch-25g): numeric BY-VALUE arg slots — see structure::ArgSlotHints.
-    let (slot_overrides, outref_overrides, float_args, keep_ints) = infer_slot_types(f, refs);
+    let (slot_overrides, outref_overrides, float_args, keep_ints, int_refs) = infer_slot_types(f, refs);
+    // batch-28 (specs/batch27-floatwarnings.md §2): unified numeric-kind dataflow pass.
+    // Anti-seed imports: slots value-pushed into int-family params (keep_ints), PSF-bound to
+    // int-family reference params (int_refs), or bool&-bound (outref "bool") hold int/bool
+    // bits at that point — float evidence on the same slot is slot reuse -> poison.
+    let num_anti: HashSet<i32> = keep_ints
+        .iter()
+        .chain(int_refs.iter())
+        .copied()
+        .chain(outref_overrides.iter().filter(|(_, t)| t.as_str() == "bool").map(|(s, _)| *s))
+        .collect();
+    let numkinds = infer_float_flow(f, &fc, refs, fields, &float_args, &outref_overrides, &num_anti);
     for (slot, ty) in &slot_overrides {
         local_types.insert(*slot, ty.clone());
     }
@@ -351,6 +362,17 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         if ty == "bool" {
             local_types.insert(*slot, ty.clone());
         }
+    }
+    // batch-28 (spec §2.4.2): the dataflow pass's float slots feed the body renderer FIRST —
+    // the pass beats infer_locals' width guesses below, while or_insert keeps the
+    // obj_locals/consumer/bool entries above authoritative. I64 entries are declaration-only.
+    for (slot, kd) in &numkinds {
+        let kw = match kd {
+            NumKind::F32 => "float32",
+            NumKind::F64 => "float",
+            NumKind::I64 => continue,
+        };
+        local_types.entry(*slot).or_insert_with(|| kw.to_string());
     }
     // batch-20 Class C (SetByCallerMagnitude): float-family slots (from the width-typed ops,
     // e.g. `dTOf w35`) must survive the nested-call stack-split retain (`!is_int` keeps them)
@@ -393,7 +415,13 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // batch-25g: hand the numeric value-arg slot sets to the body renderer (float-literal
     // SetV* rendering + the int retain keep flag).
     let hints = super::structure::ArgSlotHints {
-        float_slots: float_args.keys().copied().collect(),
+        // batch-28: the pass's float slots extend the SetV*-literal render set (C3 — the
+        // `int64 local = 0; local = 0.33;` asymmetry) and the S4 outref-literal bonus.
+        float_slots: float_args
+            .keys()
+            .copied()
+            .chain(numkinds.iter().filter(|(_, k)| !matches!(k, NumKind::I64)).map(|(s, _)| *s))
+            .collect(),
         keep_ints,
     };
     let body = body_statements_ctor(&fc, refs, depth + 1, super_ctor, Some(&f.ret), fields, Some(&param_types), class_name, Some(&local_types), Some(&hints));
@@ -443,6 +471,23 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // whole function stubbing on an undeclared identifier).
     let used = used_locals(&body);
     let mut locals = infer_locals(f, refs);
+    // batch-28: unified numeric-kind dataflow (C1/C2/C3/C4c/C4d) — overrides ONLY the
+    // width-guessed primitive keywords; farg/outref/member/callret overrides still apply
+    // after and keep their precedence. `Some("float")` IS overridable: that is exactly the
+    // dTOf/f-op dst mis-keyword (a 4-byte slot declared with the 8-byte keyword) -> float32.
+    for (slot, kd) in &numkinds {
+        let kw = match kd {
+            NumKind::F32 => "float32",
+            NumKind::F64 => "float",
+            NumKind::I64 => "int64",
+        };
+        match locals.get(slot).map(String::as_str) {
+            None | Some("int" | "int64" | "float" | "double") => {
+                locals.insert(*slot, kw.to_string());
+            }
+            _ => {} // opCast/object/ret-retype float32 entries win
+        }
+    }
     for &n in &used {
         locals.entry(n).or_insert_with(|| "int".to_string());
     }
@@ -901,10 +946,10 @@ fn ret_is_struct(ty: &str) -> bool {
 fn infer_slot_types(
     f: &Func,
     refs: &RefResolver,
-) -> (HashMap<i32, String>, HashMap<i32, String>, HashMap<i32, String>, HashSet<i32>) {
+) -> (HashMap<i32, String>, HashMap<i32, String>, HashMap<i32, String>, HashSet<i32>, HashSet<i32>) {
     let instrs = match disassemble(&f.bytecode) {
         Ok(i) => i,
-        Err(_) => return (HashMap::new(), HashMap::new(), HashMap::new(), HashSet::new()),
+        Err(_) => return (HashMap::new(), HashMap::new(), HashMap::new(), HashSet::new(), HashSet::new()),
     };
     let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32);
     let writes = |op: &str| {
@@ -937,7 +982,11 @@ fn infer_slot_types(
     // keep flag (no retype). Conflicts (differing float kws, or float+int for one slot) drop.
     let mut farg: HashMap<i32, Option<String>> = HashMap::new();
     let mut ikeep: HashSet<i32> = HashSet::new();
-    let mut pair = |ostack: &mut Vec<Option<(i32, bool)>>, params: Option<&[super::types::DataType]>, is_method: bool, ret_struct: bool, cand: &mut HashMap<i32, Option<String>>, outref: &mut HashMap<i32, Option<String>>, farg: &mut HashMap<i32, Option<String>>, ikeep: &mut HashSet<i32>| {
+    // batch-28: PSF slots bound to an INT-family reference param — int lvalues; anti-seeds
+    // for `infer_float_flow` (floating such a decl breaks the `int&` binding; the exact
+    // batch-9-class risk named in specs/batch27-floatwarnings.md §2.6).
+    let mut iref: HashSet<i32> = HashSet::new();
+    let mut pair = |ostack: &mut Vec<Option<(i32, bool)>>, params: Option<&[super::types::DataType]>, is_method: bool, ret_struct: bool, cand: &mut HashMap<i32, Option<String>>, outref: &mut HashMap<i32, Option<String>>, farg: &mut HashMap<i32, Option<String>>, ikeep: &mut HashSet<i32>, iref: &mut HashSet<i32>| {
         let Some(params) = params else { ostack.clear(); return; };
         // A method returning a struct BY VALUE (F/T/E) carries a hidden RVO out-slot pushed as the
         // last user arg (just before the receiver); count it so it is consumed, but exclude it from
@@ -993,6 +1042,13 @@ fn infer_slot_types(
                             _ => {}
                         }
                     }
+                    // batch-28: int-family reference binding — see `iref` above.
+                    if *is_psf
+                        && pt.is_reference
+                        && matches!(pt.token, 0x44 | 0x45 | 0x46 | 0x47 | 0x4B | 0x4C | 0x4D | 0x4E)
+                    {
+                        iref.insert(*s);
+                    }
                     // batch-25g: numeric BY-VALUE args (value-pushed, non-reference params).
                     if !*is_psf && !pt.is_reference {
                         match pt.token {
@@ -1036,7 +1092,7 @@ fn infer_slot_types(
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let rs = refs.func_ret_by_id(id).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
-                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand, &mut outref, &mut farg, &mut ikeep);
+                pair(&mut ostack, refs.func_params_by_id(id), refs.is_method_by_id(id), rs, &mut cand, &mut outref, &mut farg, &mut ikeep, &mut iref);
             }
             "CALLSYS" | "Thiscall1" => {
                 let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
@@ -1066,7 +1122,7 @@ fn infer_slot_types(
                     continue;
                 }
                 let rs = refs.func_ret_by_ptr(ptr).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
-                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand, &mut outref, &mut farg, &mut ikeep);
+                pair(&mut ostack, refs.func_params_by_ptr(ptr), refs.is_method_by_ptr(ptr), rs, &mut cand, &mut outref, &mut farg, &mut ikeep, &mut iref);
             }
             _ => {}
         }
@@ -1093,7 +1149,7 @@ fn infer_slot_types(
         float_args.remove(&s);
         ikeep.remove(&s);
     }
-    (obj, outref, float_args, ikeep)
+    (obj, outref, float_args, ikeep, iref)
 }
 
 /// Member-access-driven slot typing: a `LoadRObjR`/`LoadVObjR base, off, tid` reads field
@@ -1555,6 +1611,356 @@ fn usable_ret_type(ty: String, recv: Option<i32>, known: &HashMap<i32, String>) 
         return None;
     }
     Some(format!("{ty}<{}>", &r[lt + 1..gt]))
+}
+
+/// batch-28 (specs/batch27-floatwarnings.md §2.3): numeric kind of a slot, as proven by the
+/// unified dataflow pass. Keyword mapping: `F32 -> "float32"`, `F64 -> "float"` (the faithful
+/// vanilla keyword in this `floatIsFloat64` build), `I64 -> "int64"`. Conflict = removal
+/// (status-quo declaration).
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum NumKind {
+    F32,
+    F64,
+    I64,
+}
+
+/// Merge one piece of kind evidence into `slot` (returns true when anything changed).
+/// Float evidence REPLACES an I64 guess (SetV8 raw bits are float64 bits whenever the slot
+/// has float evidence); F32-vs-F64 is a REAL width conflict -> poison; float evidence landing
+/// on an anti-seeded (proven-int) slot -> poison.
+fn nk_apply(
+    kind: &mut HashMap<i32, NumKind>,
+    poison: &mut HashSet<i32>,
+    anti: &HashSet<i32>,
+    slot: i32,
+    k: NumKind,
+) -> bool {
+    if poison.contains(&slot) {
+        return false;
+    }
+    if !matches!(k, NumKind::I64) && anti.contains(&slot) {
+        kind.remove(&slot);
+        poison.insert(slot);
+        return true;
+    }
+    match kind.get(&slot).copied() {
+        None => {
+            kind.insert(slot, k);
+            true
+        }
+        Some(prev) if prev == k => false,
+        Some(NumKind::I64) => {
+            kind.insert(slot, k);
+            true
+        }
+        Some(_) if matches!(k, NumKind::I64) => false, // float evidence wins, I64 seed dropped
+        Some(_) => {
+            kind.remove(&slot);
+            poison.insert(slot);
+            true
+        }
+    }
+}
+
+/// batch-28: unified numeric-kind dataflow (spec §2.3). The VM never converts implicitly —
+/// every numeric conversion is an explicit `*TO*` opcode and `SetV*`/`CpyVtoV*`/`CpyRtoV*`/
+/// `RDR*`/`WRTV*` are TYPELESS width copies — so a slot's numeric kind is statically
+/// decidable from its op profile and float-ness propagates deterministically across the
+/// typeless copies. Root cause of the C1/C2/C3/C4c/C4d warning classes: the declaration side
+/// was blind to float evidence on op OPERANDS, float call returns through `CpyRtoV*`, float
+/// member reads through `RDR8`, and kind propagation across `CpyVtoV*`.
+///
+/// Seeds:
+///  (a) float-op OPERANDS: every word of f-ops -> F32, of d-ops -> F64 (same op lists as
+///      `structure::float_operand_slots`);
+///  (b) width-changing conversions, BOTH sides (fTOd/dTOf/iTOd/…/dTOi/…); the same-width
+///      float<->int casts fTOi/fTOu poison their slots (one offset changing kind
+///      mid-lifetime is undecidable — bail to status quo);
+///  (c) call results: CpyRtoV4 with last-call by-value ret token 0x50 -> F32, CpyRtoV8 with
+///      0x51|0x5E -> F64 (same `last`-tracking discipline as `infer_call_result_types`);
+///  (d) member reads/writes: Load*R + RDR4/8 (dst) / WRTV4/8 (src) when the field's VALUE
+///      type resolves via the own-class `fields` map or `field_type_by_class` — width-matched
+///      (native-struct fields stay unresolved; propagation may still type the slot);
+///  (e) by-value float param slots (via `build_param_off_map_rvo`; int-family by-value param
+///      offsets are anti-seeds);
+///  (f) imports: `float_args`/`outrefs` float keywords, CpyVtoR4/8 float-return payloads
+///      (mirrors the infer_locals ret-retype so propagation sees it);
+///  (g) I64 seeds (LOWEST priority — any float evidence wins): SetV8 dsts + int64-op operands.
+///
+/// Anti-seeds (poison on float contact): int arith/bitwise/inc/dec operands, the int sides of
+/// conversions, CMPi/CMPu(64)/CMPIi/CMPIu operands, NOT slots, TZ/TNZ-tested register
+/// payloads, plus the imported `anti` set (int-family value args / `int&` / `bool&` bindings).
+///
+/// Propagation to fixed point over CpyVtoV edges: 8-byte edges carry {F64, I64} (an F32
+/// endpoint is a width conflict -> poison both); 4-byte edges carry {F32} (an F64 endpoint ->
+/// poison both). A poisoned endpoint poisons its copy partner — the copy pair must agree, or
+/// the retype would CREATE a new float->int warning on the copy line (batch-9 class).
+///
+/// Output: POSITIVE, non-object slots only, conflicts removed. Decompile mode never calls
+/// this (emit-only context).
+fn infer_float_flow(
+    f: &Func,
+    fc: &FuncCode,
+    refs: &RefResolver,
+    fields: Option<&HashMap<String, String>>,
+    float_args: &HashMap<i32, String>,
+    outrefs: &HashMap<i32, String>,
+    anti_imports: &HashSet<i32>,
+) -> HashMap<i32, NumKind> {
+    let instrs = match disassemble(&f.bytecode) {
+        Ok(i) => i,
+        Err(_) => return HashMap::new(),
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let w1 = |ins: &super::disasm::Instr| ins.words.get(1).map(|w| *w as i16 as i32).unwrap_or(0);
+    let mut anti: HashSet<i32> = anti_imports.clone();
+    let mut poison: HashSet<i32> = HashSet::new();
+    let mut seeds: Vec<(i32, NumKind)> = Vec::new();
+    let mut edges: Vec<(i32, i32, bool)> = Vec::new(); // (dst, src, is_8_byte)
+
+    // (e) by-value param slots: float tokens seed, int-family tokens anti-seed (params are
+    // never declared by us — they matter as propagation sources across CpyVtoV copies).
+    let (param_offs, _rvo) = super::decompile::build_param_off_map_rvo(fc, &instrs, refs);
+    for (off, idx) in &param_offs {
+        let Some(pt) = fc.param_types.get(*idx) else { continue };
+        if pt.is_reference {
+            continue; // the frame offset holds a pointer, not the value
+        }
+        match pt.token {
+            0x50 => seeds.push((*off, NumKind::F32)),
+            0x51 | 0x5E => seeds.push((*off, NumKind::F64)),
+            0x44 | 0x45 | 0x46 | 0x47 | 0x4B | 0x4C | 0x4D | 0x4E => {
+                anti.insert(*off);
+            }
+            _ => {}
+        }
+    }
+    // (f) imported float evidence from the arg-pairing walk (by-value float args + float
+    // out-refs; bool out-refs arrive through `anti_imports`).
+    for m in [float_args, outrefs] {
+        for (slot, kw) in m {
+            match kw.as_str() {
+                "float32" => seeds.push((*slot, NumKind::F32)),
+                "float" | "double" => seeds.push((*slot, NumKind::F64)),
+                _ => {}
+            }
+        }
+    }
+    // trackers: just-completed call's by-value return token (survives only SUSPEND, consumed
+    // by CpyRtoV*), pending member ref (tid, member-off, base-is-slot0; survives CHKREF-family
+    // checks), and the slot behind a CpyVtoR4 for the TZ/TNZ anti-seed.
+    let mut last_ret: Option<i32> = None;
+    let mut ref_field: Option<(i32, i32, bool)> = None;
+    let mut last_vreg4: Option<i32> = None;
+    for ins in &instrs {
+        let n = ins.op.name;
+        // ---- tracker consumers ----
+        match n {
+            "CpyRtoV4" => {
+                if last_ret == Some(0x50) {
+                    seeds.push((w0(ins), NumKind::F32));
+                }
+            }
+            "CpyRtoV8" => {
+                if matches!(last_ret, Some(0x51) | Some(0x5E)) {
+                    seeds.push((w0(ins), NumKind::F64));
+                }
+            }
+            "RDR4" | "RDR8" | "WRTV4" | "WRTV8" => {
+                if let Some((tid, moff, own)) = ref_field {
+                    let fty = refs.member(tid, moff).and_then(|name| {
+                        let own_ty = if own { fields.and_then(|m| m.get(name)) } else { None };
+                        own_ty.map(String::as_str).or_else(|| {
+                            refs.type_by_id(tid).and_then(|cls| refs.field_type_by_class(cls, name))
+                        })
+                    });
+                    let is8 = n.ends_with('8');
+                    match fty.map(|t| t.trim_start_matches("const ")) {
+                        Some("float" | "double") if is8 => seeds.push((w0(ins), NumKind::F64)),
+                        Some("float32") if !is8 => seeds.push((w0(ins), NumKind::F32)),
+                        _ => {} // unknown / width-mismatched field: no seed
+                    }
+                }
+            }
+            "TZ" | "TNZ" => {
+                if let Some(s) = last_vreg4 {
+                    anti.insert(s);
+                }
+            }
+            _ => {}
+        }
+        // ---- per-op seeds / anti-seeds / copy edges ----
+        match n {
+            // (a) float-op operand seeds — same op lists as structure::float_operand_slots.
+            "ADDf" | "SUBf" | "MULf" | "DIVf" | "MODf" | "NEGf" | "IncVf" | "DecVf" | "ADDIf"
+            | "SUBIf" | "MULIf" | "CMPf" | "CMPIf" => {
+                for &wd in &ins.words {
+                    seeds.push((wd as i16 as i32, NumKind::F32));
+                }
+            }
+            "ADDd" | "SUBd" | "MULd" | "DIVd" | "MODd" | "NEGd" | "CMPd" => {
+                for &wd in &ins.words {
+                    seeds.push((wd as i16 as i32, NumKind::F64));
+                }
+            }
+            // (b) width-changing conversions, both sides.
+            "fTOd" => {
+                seeds.push((w0(ins), NumKind::F64));
+                seeds.push((w1(ins), NumKind::F32));
+            }
+            "dTOf" => {
+                seeds.push((w0(ins), NumKind::F32));
+                seeds.push((w1(ins), NumKind::F64));
+            }
+            "iTOd" | "uTOd" | "i64TOd" | "u64TOd" => {
+                seeds.push((w0(ins), NumKind::F64));
+                anti.insert(w1(ins));
+            }
+            "iTOf" | "uTOf" | "i64TOf" | "u64TOf" => {
+                seeds.push((w0(ins), NumKind::F32));
+                anti.insert(w1(ins));
+            }
+            "dTOi" | "dTOu" | "dTOi64" | "dTOu64" => {
+                seeds.push((w1(ins), NumKind::F64));
+                anti.insert(w0(ins));
+            }
+            "fTOi64" | "fTOu64" => {
+                seeds.push((w1(ins), NumKind::F32));
+                anti.insert(w0(ins));
+            }
+            // same-width float<->int casts: one offset holds both kinds mid-lifetime — bail.
+            "fTOi" | "fTOu" => {
+                poison.insert(w0(ins));
+                poison.insert(w1(ins));
+            }
+            // int<->int conversions: both sides proven int.
+            "sbTOi" | "swTOi" | "ubTOi" | "uwTOi" | "iTOb" | "iTOw" | "i64TOi" | "iTOi64"
+            | "uTOi64" => {
+                anti.insert(w0(ins));
+                anti.insert(w1(ins));
+            }
+            // anti-seeds: genuine int arithmetic/bitwise/compare evidence.
+            "ADDi" | "SUBi" | "MULi" | "DIVi" | "MODi" | "IncVi" | "DecVi" | "NEGi" | "BAND"
+            | "BOR" | "BXOR" | "BSLL" | "BSRA" | "BSRL" | "BNOT" | "ADDIi" | "SUBIi" | "MULIi"
+            | "CMPi" | "CMPu" | "CMPIi" | "CMPIu" | "NOT" => {
+                for &wd in &ins.words {
+                    anti.insert(wd as i16 as i32);
+                }
+            }
+            // (g) int64 ops: I64 seeds (lowest priority) AND anti (poison on float contact).
+            "ADDi64" | "SUBi64" | "MULi64" | "DIVi64" | "MODi64" | "CMPi64" | "CMPu64" => {
+                for &wd in &ins.words {
+                    anti.insert(wd as i16 as i32);
+                    seeds.push((wd as i16 as i32, NumKind::I64));
+                }
+            }
+            "SetV8" => seeds.push((w0(ins), NumKind::I64)),
+            // (f) float return payloads (mirror of the infer_locals ret-retype).
+            "CpyVtoR4" => {
+                if f.ret.token == 0x50 {
+                    seeds.push((w0(ins), NumKind::F32));
+                }
+            }
+            "CpyVtoR8" => {
+                if matches!(f.ret.token, 0x51 | 0x5E) {
+                    seeds.push((w0(ins), NumKind::F64));
+                }
+            }
+            // typeless slot-to-slot copies: propagation edges.
+            "CpyVtoV4" => edges.push((w0(ins), w1(ins), false)),
+            "CpyVtoV8" => edges.push((w0(ins), w1(ins), true)),
+            _ => {}
+        }
+        // ---- tracker updates ----
+        last_ret = match n {
+            "CALL" | "CALLINTF" | "CALLBND" => {
+                let id = ins.dwords.first().copied().unwrap_or(0) as i32;
+                refs.func_ret_by_id(id).filter(|d| !d.is_reference).map(|d| d.token)
+            }
+            "CALLSYS" | "Thiscall1" => {
+                let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+                if refs.func_by_ptr(ptr) == Some("$beh0") {
+                    None
+                } else {
+                    refs.func_ret_by_ptr(ptr).filter(|d| !d.is_reference).map(|d| d.token)
+                }
+            }
+            "SUSPEND" => last_ret,
+            _ => None,
+        };
+        ref_field = match n {
+            "LoadThisR" => Some((ins.dwords.first().copied().unwrap_or(0) as i32, w0(ins), true)),
+            "LoadRObjR" | "LoadVObjR" => {
+                Some((ins.dwords.first().copied().unwrap_or(0) as i32, w1(ins), false))
+            }
+            "CHKREF" | "ChkRefS" | "ChkNullV" | "SUSPEND" => ref_field,
+            _ => None,
+        };
+        last_vreg4 = match n {
+            "CpyVtoR4" => Some(w0(ins)),
+            "SUSPEND" => last_vreg4,
+            _ => None,
+        };
+    }
+    // ---- apply seeds (anti set complete), then propagate to fixed point ----
+    let mut kind: HashMap<i32, NumKind> = HashMap::new();
+    for (s, k) in seeds {
+        if poison.contains(&s) {
+            continue;
+        }
+        nk_apply(&mut kind, &mut poison, &anti, s, k);
+    }
+    for s in &poison {
+        kind.remove(s);
+    }
+    loop {
+        let mut changed = false;
+        for &(a, b, is8) in &edges {
+            let pa = poison.contains(&a);
+            let pb = poison.contains(&b);
+            if pa || pb {
+                if !(pa && pb) {
+                    kind.remove(&a);
+                    kind.remove(&b);
+                    poison.insert(a);
+                    poison.insert(b);
+                    changed = true;
+                }
+                continue;
+            }
+            let ka = kind.get(&a).copied();
+            let kb = kind.get(&b).copied();
+            // a kind whose width contradicts the copy width: conflict, poison both ends.
+            let bad = if is8 { NumKind::F32 } else { NumKind::F64 };
+            if ka == Some(bad) || kb == Some(bad) {
+                kind.remove(&a);
+                kind.remove(&b);
+                poison.insert(a);
+                poison.insert(b);
+                changed = true;
+                continue;
+            }
+            // domain per edge width: 8-byte edges carry {F64, I64}, 4-byte edges {F32}.
+            let dom = |k: Option<NumKind>| match (k, is8) {
+                (Some(NumKind::F64) | Some(NumKind::I64), true) => k,
+                (Some(NumKind::F32), false) => k,
+                _ => None,
+            };
+            if let Some(k) = dom(ka) {
+                changed |= nk_apply(&mut kind, &mut poison, &anti, b, k);
+            }
+            if let Some(k) = dom(kb) {
+                changed |= nk_apply(&mut kind, &mut poison, &anti, a, k);
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    // POSITIVE local slots only; obj_locals-typed slots are outside the numeric domain.
+    let obj: HashSet<i32> = f.obj_locals.iter().map(|(s, _)| *s).collect();
+    kind.retain(|s, _| *s > 0 && !obj.contains(s) && !poison.contains(s));
+    kind
 }
 
 /// §3.3 consumer-driven typing of out-of-range `argN` slots. Scans the body for the RHS of an
@@ -2218,7 +2624,10 @@ fn is_primitive(ty: &str) -> bool {
 /// A default initializer literal for a base type.
 fn default_for(ty: &str) -> String {
     match ty {
-        "float" | "double" | "float32" => "0.0".into(),
+        "float" | "double" => "0.0".into(),
+        // batch-28 rider: constant-exactness is silent for 0.0 either way, but the
+        // f-suffix is the faithful vanilla form for the 4-byte float.
+        "float32" => "0.0f".into(),
         "bool" => "false".into(),
         _ => "0".into(),
     }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -636,23 +636,15 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
         // last user arg (just before the receiver); count it so it is consumed, but exclude it from
         // pairing (it is NOT params[last] — pairing it would shift every real arg one param over and
         // mis-type the slot, e.g. the TSubclassOf out param landing on an EQuestState param).
-        // A FREE/static struct-returning call pushes the same hidden out-slot ON TOP (no receiver
-        // follows it — proven by FInGameTime::Now: `PshGPtr __WorldContext ; PSF <out> ; CALLSYS`,
-        // params=[const UObject], ret=FInGameTime). Not counting it paired the PSF'd out-slot with
-        // the hidden WorldContext param -> slot mis-typed UObject, clobbering the correct
-        // obj_locals type (FInGameTime) and blinding build_call's free-RVO probe ("Can't
-        // implicitly convert from 'UObject' to 'FInGameTime'" x144 in-game).
-        let rvo = ret_struct as usize;
-        let total = if is_method { params.len() + 1 + rvo } else { params.len() + rvo };
+        let rvo = (ret_struct && is_method) as usize;
+        let total = if is_method { params.len() + 1 + rvo } else { params.len() };
         let take = total.min(ostack.len());
         let popped = ostack.split_off(ostack.len() - take);
-        // method: top popped entry is the receiver -> drop it (plus the RVO out-slot just below);
-        // free call: top popped entry is the RVO out-slot itself. The rest are the user args.
+        // method: top popped entry is the receiver -> drop it (plus the RVO out-slot just below it);
+        // the rest are the user args.
         let args = if is_method && !popped.is_empty() {
             &popped[..popped.len().saturating_sub(1 + rvo)]
-        } else {
-            &popped[..popped.len().saturating_sub(rvo)]
-        };
+        } else { &popped[..] };
         // pair from the TOP: last arg <-> last param (so a leading `this` param, if the cache
         // counts it, never shifts the user-arg pairing).
         for (i, slot) in args.iter().rev().enumerate() {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1637,6 +1637,66 @@ fn has_no_default_ctor(ty: &str) -> bool {
     matches!(ty, "FStatID" | "FScopeCycleCounter" | "FAngelscriptGameThreadScopeWorldContext")
 }
 
+/// batch-25i: net brace delta of an emitted body line. The structurer/emitter only produce
+/// STRUCTURAL braces as standalone lines (`{ind}{{` / `{ind}}}`), so counting is keyed on the
+/// trimmed content being exactly `{`/`}` — statement lines whose string literals contain
+/// braces (`"Value {0}"`) trim to longer text and never miscount.
+fn brace_net(line: &str) -> i32 {
+    match line.trim() {
+        "{" => 1,
+        "}" => -1,
+        _ => 0,
+    }
+}
+
+/// batch-25i: the innermost brace-block span containing line `i`: returns `(start, end)` line
+/// indices of the opening/closing brace lines (exclusive bounds for content). When `i` sits at
+/// function top level, returns `(0, lines.len())` — the whole body.
+fn block_span(lines: &[&str], i: usize) -> (usize, usize) {
+    let mut start = 0usize;
+    let mut bal = 0i32;
+    for j in (0..i).rev() {
+        bal += brace_net(lines[j]);
+        if bal > 0 {
+            start = j;
+            break;
+        }
+    }
+    let mut end = lines.len();
+    bal = 0;
+    for (j, l) in lines.iter().enumerate().skip(i + 1) {
+        bal += brace_net(l);
+        if bal < 0 {
+            end = j;
+            break;
+        }
+    }
+    (start, end)
+}
+
+/// batch-25i: identifier-boundary rename of `ident` -> `new` in one line (same boundary rule
+/// as [`count_ident`]; byte-copies non-matches so UTF-8 string literals survive intact).
+fn rename_ident(line: &str, ident: &str, new: &str) -> String {
+    let (b, ib) = (line.as_bytes(), ident.as_bytes());
+    let is_id = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+    let mut out: Vec<u8> = Vec::with_capacity(b.len() + 8);
+    let mut i = 0usize;
+    while i < b.len() {
+        if i + ib.len() <= b.len()
+            && &b[i..i + ib.len()] == ib
+            && (i == 0 || !is_id(b[i - 1]))
+            && (i + ib.len() == b.len() || !is_id(b[i + ib.len()]))
+        {
+            out.extend_from_slice(new.as_bytes());
+            i += ib.len();
+        } else {
+            out.push(b[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| line.to_string())
+}
+
 /// Count identifier-boundary occurrences of `ident` in `line` (so `local_3` does not match
 /// inside `local_32` or `local_3_2`).
 fn count_ident(line: &str, ident: &str) -> usize {
@@ -1735,9 +1795,12 @@ fn no_assign_type(ty: &str) -> bool {
 /// - WRITE-ONLY (any number of assignments, no reads): every assignment becomes
 ///   `TY local_N[_k] = ...;` with fresh names — nothing else references the slot, so sinking the
 ///   declarations into blocks is scope-safe (mirrors the FStatID rewrite).
-/// - SINGLE assignment + reads, ALL references at the same indentation (one block): decl-init in
-///   place, name kept — later reads are lvalue uses (a non-const ref binds to an lvalue; only
-///   temporaries fail), and same-indent means the declaration dominates every read.
+/// - SINGLE assignment + reads, ALL reads inside the assignment's innermost brace block and
+///   after it (batch-25i: was "same indentation", which wrongly accepted equal-depth lines in
+///   DIFFERENT blocks — e.g. two braced switch cases — leaving later references undeclared
+///   once the decl-init became block-scoped): decl-init in place, name kept — later reads are
+///   lvalue uses (a non-const ref binds to an lvalue; only temporaries fail), and block-span
+///   containment means the declaration dominates every read.
 /// Anything else (read before assign, cross-block reads, self-referential RHS) keeps the hoisted
 /// declaration — the status-quo compile error, never a new one.
 fn rewrite_no_assign_locals(body: &str, locals: &BTreeMap<i32, String>) -> (String, HashSet<i32>) {
@@ -1749,13 +1812,15 @@ fn rewrite_no_assign_locals(body: &str, locals: &BTreeMap<i32, String>) -> (Stri
         }
         let ident = format!("local_{slot}");
         let assign_pat = format!("{ident} = ");
+        let lines: Vec<&str> = out.lines().collect();
         let mut assigns = 0usize;
         let mut reads = 0usize;
         let mut first_is_assign = false;
         let mut first = true;
-        let mut indents: Vec<&str> = Vec::new();
+        let mut assign_line: Option<usize> = None; // line index of the (first) assignment
+        let mut read_lines: Vec<usize> = Vec::new();
         let mut ok = true;
-        for line in out.lines() {
+        for (i, line) in lines.iter().enumerate() {
             let c = count_ident(line, &ident);
             if c == 0 {
                 continue;
@@ -1768,21 +1833,29 @@ fn rewrite_no_assign_locals(body: &str, locals: &BTreeMap<i32, String>) -> (Stri
             }
             if is_assign {
                 assigns += 1;
+                assign_line.get_or_insert(i);
             } else {
                 reads += c;
+                read_lines.push(i);
                 if c > 1 {
                     ok = false; // multi-occurrence non-assign line (self-referential etc.) — bail
                     break;
                 }
             }
-            indents.push(&line[..line.len() - t.len()]);
         }
         if !ok || assigns == 0 || !first_is_assign {
             continue;
         }
         let write_only = reads == 0;
-        let uniform_indent = indents.windows(2).all(|w| w[0] == w[1]);
-        if !write_only && !(assigns == 1 && uniform_indent) {
+        // batch-25i scope gate for the single-assign+reads shape: every read must sit INSIDE
+        // the assignment's innermost brace block (and after it — guaranteed by first_is_assign
+        // plus line order), so the block-scoped decl-init dominates every read.
+        let in_block = || {
+            let Some(a) = assign_line else { return false };
+            let (_, end) = block_span(&lines, a);
+            read_lines.iter().all(|&r| r > a && r < end)
+        };
+        if !write_only && !(assigns == 1 && in_block()) {
             continue;
         }
         let mut k = 0usize;
@@ -1865,11 +1938,21 @@ fn rewrite_no_assign_residual_assigns(
 /// Iterator locals (`TArrayIterator<T>`, `TSetIterator<T>`, `TMapIterator<T>`, ... incl. Const
 /// variants) have NO default constructor, so a bare hoisted `TArrayIterator<T> local_N;` fails
 /// "No default constructor". The only legal form is declaration-with-initializer from the
-/// `Iterator()` call that produces it: `TArrayIterator<T> local_N = container.Iterator();`. Unlike
-/// the ctor-only (FStatID) case an iterator IS read afterwards (in its loop), so the gate is only
-/// that the local's FIRST mention in the body is a single-`ident` assignment `local_N = ...;` —
-/// then decl-init at that site is valid and nothing reads it before. Returns the rewritten body +
-/// the set of slots whose hoisted declaration must be suppressed.
+/// `Iterator()` call that produces it: `auto local_N = container.Iterator();`. Unlike the
+/// ctor-only (FStatID) case an iterator IS read afterwards (in its loop).
+///
+/// batch-25i (scope-aware rework): batch-24d braces every switch case body, so an in-place
+/// decl-init inside a braced case is BLOCK-SCOPED — the old first-mention-only rewrite left
+/// any reference in a LATER case/block undeclared (APuzzleStoneTorch_Manager::InitPuzzleState:
+/// case 0/1 declared `auto local_8`, case 3 still referenced `local_8` -> "'local_8' is not
+/// declared", the single batch-24 regression). References are now grouped by the innermost
+/// brace block of each assignment: every group must START with a `local_N = ...;` assignment
+/// and contain only references inside that assignment's block span. Group 1 keeps the name;
+/// each later group decl-inits a FRESH name (`local_N_2`, ...) and renames its in-block
+/// references — the compiler-reused slot becomes one source-level local per block, all
+/// initialized (the original per-case iterators). ANY reference that doesn't fit this shape
+/// (read before assign, a bare read outside every assign's block) keeps the hoisted
+/// declaration — the status-quo error, never a broken reference.
 fn rewrite_iterator_decl_init(body: &str, locals: &BTreeMap<i32, String>) -> (String, HashSet<i32>) {
     let is_iter = |ty: &str| {
         let h = ty.split('<').next().unwrap_or(ty);
@@ -1884,43 +1967,77 @@ fn rewrite_iterator_decl_init(body: &str, locals: &BTreeMap<i32, String>) -> (St
         }
         let ident = format!("local_{slot}");
         let pat = format!("{ident} = ");
-        // The FIRST line mentioning the ident must be a single-occurrence assignment `local_N = …;`.
-        let mut first_ok = false;
-        for line in out.lines() {
-            if count_ident(line, &ident) == 0 {
-                continue;
-            }
-            let t = line.trim_start();
-            first_ok = count_ident(line, &ident) == 1 && t.starts_with(&pat) && t.ends_with(';');
-            break;
-        }
-        if !first_ok {
+        let lines: Vec<&str> = out.lines().collect();
+        let refs: Vec<usize> = lines
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| count_ident(l, &ident) > 0)
+            .map(|(i, _)| i)
+            .collect();
+        if refs.is_empty() {
             continue;
         }
-        // Rewrite ONLY that first assignment to a decl-init; leave later reads untouched.
-        let mut done = false;
-        let mut rewritten = String::with_capacity(out.len() + 32);
-        for line in out.lines() {
-            let t = line.trim_start();
-            if !done && count_ident(line, &ident) == 1 && t.starts_with(&pat) && t.ends_with(';') {
+        // Group references: each group starts at an assignment line and swallows every
+        // following reference inside that assignment's innermost block span.
+        let mut groups: Vec<(usize, Vec<usize>)> = Vec::new(); // (assign line, later refs)
+        let mut ok = true;
+        let mut k = 0usize;
+        while k < refs.len() {
+            let i = refs[k];
+            let t = lines[i].trim_start();
+            let is_assign =
+                count_ident(lines[i], &ident) == 1 && t.starts_with(&pat) && t.ends_with(';');
+            if !is_assign {
+                ok = false; // read before any in-block assignment — keep the hoist
+                break;
+            }
+            let (_, end) = block_span(&lines, i);
+            let mut members: Vec<usize> = Vec::new();
+            k += 1;
+            while k < refs.len() && refs[k] < end {
+                members.push(refs[k]);
+                k += 1;
+            }
+            groups.push((i, members));
+        }
+        if !ok || groups.is_empty() {
+            continue;
+        }
+        // Render. `auto`, not the inferred iterator type: the cache's recorded return type
+        // does not reliably distinguish Const vs mutable Iterator overloads (the receiver's
+        // constness decides in-source), so a spelled-out head fails "Can't implicitly convert
+        // TXIterator<T> <-> TXConstIterator<T>" whenever we guess wrong (72 in-game errors;
+        // the batch-9 const-flip regression was the same coin's other face). AngelScript's
+        // auto infers the exact overload the compiler resolves.
+        let mut new_names: HashMap<usize, String> = HashMap::new(); // line -> name for renames
+        let mut decl_lines: HashSet<usize> = HashSet::new();
+        for (g, (assign, members)) in groups.iter().enumerate() {
+            decl_lines.insert(*assign);
+            if g > 0 {
+                let fresh = format!("{ident}_{}", g + 1);
+                new_names.insert(*assign, fresh.clone());
+                for m in members {
+                    new_names.insert(*m, fresh.clone());
+                }
+            }
+        }
+        let mut rewritten = String::with_capacity(out.len() + 64);
+        for (i, line) in lines.iter().enumerate() {
+            let line: String = match new_names.get(&i) {
+                Some(new) => rename_ident(line, &ident, new),
+                None => (*line).to_string(),
+            };
+            if decl_lines.contains(&i) {
+                let t = line.trim_start();
                 let indent = &line[..line.len() - t.len()];
-                // `auto`, not the inferred iterator type: the cache's recorded return type does
-                // not reliably distinguish Const vs mutable Iterator overloads (the receiver's
-                // constness decides in-source), so a spelled-out head fails "Can't implicitly
-                // convert TXIterator<T> <-> TXConstIterator<T>" whenever we guess wrong (72
-                // in-game errors; the batch-9 const-flip regression was the same coin's other
-                // face). AngelScript's auto infers the exact overload the compiler resolves.
                 let _ = writeln!(rewritten, "{indent}auto {t}");
-                done = true;
             } else {
-                rewritten.push_str(line);
+                rewritten.push_str(&line);
                 rewritten.push('\n');
             }
         }
-        if done {
-            out = rewritten;
-            suppressed.insert(*slot);
-        }
+        out = rewritten;
+        suppressed.insert(*slot);
     }
     (out, suppressed)
 }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -29,6 +29,38 @@ fn force_stub_set() -> &'static HashSet<String> {
     })
 }
 
+/// Batch-23b (specs/const-safety.md §5): the minimal body-const-safe set — the only methods
+/// whose vanilla `const` qualifier (asTRAIT_CONST) is re-emitted. Each entry is individually
+/// in-game-verified (batch-21 all-const capture as the per-method oracle: its RECOVERED body
+/// produces no new diagnostics under a read-only `this`), and the set is closed under
+/// own-class `this`-callees and script overrides. Keys are exact `Class::Method` — never
+/// bare names (GetCrimeProcessingSubsystem/GetSortLayer exist on unrelated classes that must
+/// stay non-const). Do NOT const-qualify anything outside this set even if is_const_method()
+/// is true — that was batch-21 (+636 regression, JOURNAL LESSON #4).
+static CONST_SAFE: &[&str] = &[
+    "UGameplayAbility_CharacterAI_Gothic::GetCrimeProcessingSubsystem",
+    "UGameplayAbility_CharacterAI_Gothic::GetSensedLivingHostiles",
+    "UGameplayAbility_CharacterAI_Gothic::GetSensedLivingEnemies",
+    "UGameplayAbility_CharacterAI_Gothic::IsCharacterConsideredAThreat",
+    "UGameplayAbility_CharacterAI_Gothic::IsInSameTerritoryOrCombatRadiusAsOtherCharacter",
+    "UGameplayAbility_CharacterAI_Gothic::IsWeaponConsideredAThreat",
+    "UGameplayAbility_CharacterAI_Gothic::IsCharacterInCombatRadius",
+    "UGameplayAbility_CreatureAI::IsCharacterConsideredAThreat",
+    "UGameplayAbility_CreatureAI::IsWeaponConsideredAThreat",
+    "FAttackMoveData::GetCombatMove",
+    "FAttackMoveData::GetWeight",
+    "FItemPickupHandle::GetDroppedBy",
+    "FItemPickupHandle::GetReason",
+    "UCBT_Node::GetSortLayer",
+    "UCBT_Tree::GetSortLayer",
+    "UCBT_Decorator::GetSortLayer",
+];
+
+fn const_safe_set() -> &'static HashSet<&'static str> {
+    static S: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    S.get_or_init(|| CONST_SAFE.iter().copied().collect())
+}
+
 use super::disasm::disassemble;
 use super::model::{Class, Func, Module};
 use super::refs::RefResolver;
@@ -472,14 +504,20 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     if is_ctor {
         let _ = writeln!(s, "{ind}{}({params})", f.name); // constructors have no return type
     } else {
-        // Batch-21 Class A attempted to re-emit the vanilla `const` method qualifier
-        // (asTRAIT_CONST in FunctionTraits) so const-handle callers compile — but HARNESS-
-        // REGRESSED +636 (read-only errors 150 -> 2763): a `const` qualifier makes `this`
-        // read-only inside the body, and our RECOVERED bodies are not const-faithful (recovery
-        // artifacts call non-const members/methods on `this`). Vanilla compiles because its
-        // real bodies are const-clean; ours aren't. Emission disabled — the ~150 caller-side
-        // errors are the lesser residue; a body-const-safety scan could re-enable per-function.
-        let _ = writeln!(s, "{ind}{ret_sig} {}({params})", f.name);
+        // Vanilla `const` methods (asTRAIT_CONST in FunctionTraits) need their qualifier back
+        // so const-handle callers compile ("Non-const method call on read-only object
+        // reference") — but a blanket re-emit makes `this` read-only inside every RECOVERED
+        // body, which is not const-faithful (batch-21 HARNESS-REGRESSED +636, read-only errors
+        // 150 -> 2763). Batch-23b: emit the qualifier ONLY for the per-method body-const-
+        // safety-verified set (specs/const-safety.md); everything else stays non-const and
+        // keeps its caller-side residue.
+        let constq = if is_method && f.is_const_method() && const_safe_set().contains(qid.as_str())
+        {
+            " const"
+        } else {
+            ""
+        };
+        let _ = writeln!(s, "{ind}{ret_sig} {}({params}){constq}", f.name);
     }
     let _ = writeln!(s, "{ind}{{");
 

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1521,7 +1521,13 @@ fn rewrite_iterator_decl_init(body: &str, locals: &BTreeMap<i32, String>) -> (St
             let t = line.trim_start();
             if !done && count_ident(line, &ident) == 1 && t.starts_with(&pat) && t.ends_with(';') {
                 let indent = &line[..line.len() - t.len()];
-                let _ = writeln!(rewritten, "{indent}{ty} {t}");
+                // `auto`, not the inferred iterator type: the cache's recorded return type does
+                // not reliably distinguish Const vs mutable Iterator overloads (the receiver's
+                // constness decides in-source), so a spelled-out head fails "Can't implicitly
+                // convert TXIterator<T> <-> TXConstIterator<T>" whenever we guess wrong (72
+                // in-game errors; the batch-9 const-flip regression was the same coin's other
+                // face). AngelScript's auto infers the exact overload the compiler resolves.
+                let _ = writeln!(rewritten, "{indent}auto {t}");
                 done = true;
             } else {
                 rewritten.push_str(line);

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -54,6 +54,12 @@ static CONST_SAFE: &[&str] = &[
     "UCBT_Node::GetSortLayer",
     "UCBT_Tree::GetSortLayer",
     "UCBT_Decorator::GetSortLayer",
+    // batch-30a (C7, specs/batch29-errortail.md §7): the documented const-safety.md §5
+    // UNSAFE residue. Its body artifact `local_38 = this;` (const `this` copied into a
+    // non-const local) is const-LEGAL now that FAttackInfo is emitted as a `struct`
+    // (asOBJ_VALUE): the copy is a value read through the generated const&in opAssign,
+    // not a const-handle escape. Un-stubs the two AddAttack callers' read-only errors.
+    "FAttackInfo::GetAttackMoveData",
 ];
 
 fn const_safe_set() -> &'static HashSet<&'static str> {
@@ -243,12 +249,26 @@ fn delegate_wrapper_decl(c: &Class, refs: &RefResolver) -> Option<String> {
 }
 
 fn emit_class(s: &mut String, c: &Class, refs: &RefResolver) {
+    // batch-30a (C6b, specs/batch29-errortail.md §6): the cache Class record's asOBJ_*
+    // Flags discriminate script VALUE types (asOBJ_VALUE, 0x2 — vanilla `struct`) from
+    // reference types (asOBJ_REF, 0x1 — vanilla `class`). Emitting the 46 value types as
+    // `class` gave them Hazelight REFERENCE semantics: `const T` params became const
+    // HANDLES, so ctor bodies value-assigning from them failed ("Can't implicitly convert
+    // from 'const FVoiceReactionData' to 'FVoiceReactionData'") and const& arguments could
+    // not bind ("Cannot pass a reference of type 'FCrimeSeverityStackValues const&' into
+    // non-const reference parameter"). The corpus proves the discriminator: every compiling
+    // `ctor(const F* &inout P) { this.X = P; }` site uses a NATIVE struct; the only failing
+    // ones use script types flagged asOBJ_VALUE. `struct` restores value semantics (the
+    // compiler generates the const&in opAssign, matching the native-struct behaviour) and
+    // is the byte-faithful vanilla keyword. Value types here never carry a super class,
+    // and delegate/event wrappers (also VALUE-flagged) take the one-liner path above.
+    let kw = if c.flags & 0x2 != 0 { "struct" } else { "class" };
     match &c.super_class {
         Some(sup) if !sup.is_empty() => {
-            let _ = writeln!(s, "class {} : {}", c.name, sup);
+            let _ = writeln!(s, "{kw} {} : {}", c.name, sup);
         }
         _ => {
-            let _ = writeln!(s, "class {}", c.name);
+            let _ = writeln!(s, "{kw} {}", c.name);
         }
     }
     let _ = writeln!(s, "{{");
@@ -336,6 +356,9 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         let ty = super::types::DataType { token: 5, type_info: *tinfo, is_object_handle: true, ..Default::default() }.base_name(refs);
         (*slot, ty)
     }).collect();
+    // batch-30a (C6c): snapshot the cache's own (vanilla) object-local types before any
+    // override mutates the map — the member-override gate below compares against these.
+    let vanilla_obj_types = local_types.clone();
     // consumer-side override: never-written arg slots get the type their callee expects (fixes
     // mis-typed default/optional-arg slots — FName->UAIState_DailyRoutine, TSubclassOf<X>->X).
     // outref_overrides: PSF slots feeding float-family REFERENCE params (declaration-only, below).
@@ -409,7 +432,24 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // member-access-derived types: the field's declaring class is the strongest signal for a
     // slot used as a member-access base; apply AFTER (overriding) the call-arg guess.
     let member_overrides = infer_slot_types_from_members(f, refs, fields, class_name);
+    // batch-30a (C6c, specs/batch29-errortail.md §6c): when a slot's ONLY object write is a
+    // STOREOBJ of a single call's result AND that call's return type equals the cache's own
+    // obj_locals type, the vanilla static type is authoritative — a member-derived candidate
+    // (the field's DECLARING class, e.g. StateTag's UAbilityTask_StateBasedAction) must not
+    // widen it. The member access stays legal (the declaring class is an ancestor of the
+    // vanilla type in the real hierarchy — the bytecode proves it compiled), and the exact
+    // type keeps `return local;` exact and kills the bogus `Cast<DeclaringClass>` render
+    // (3× `UAbilityTask_StateBasedAction& -> UAbilityTask_InteractWith`, NativeAICommands).
+    let sole_call_store = infer_sole_call_store_types(f, refs);
+    let member_widen_blocked = |slot: &i32, ty: &String| {
+        sole_call_store
+            .get(slot)
+            .is_some_and(|ct| vanilla_obj_types.get(slot) == Some(ct) && ct != ty)
+    };
     for (slot, ty) in &member_overrides {
+        if member_widen_blocked(slot, ty) {
+            continue;
+        }
         local_types.insert(*slot, ty.clone());
     }
     // iterator-instance subtypes (illegal-op-round2.md A1): the T1 entry for a `T*Iterator`
@@ -452,6 +492,48 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // uses are const-safe: vanilla used the same value through a const local, and Class A
     // restored the faithful const method qualifiers + const param renders.
     let mut const_slots = const_slots;
+    // batch-30a (C6a, specs/batch29-errortail.md §6a): propagate const FORWARD through
+    // same-type handle copies BEFORE the shrink loop. `local_M = local_N;` with N
+    // const-marked previously DROPPED N (copy into a non-const local), keeping the
+    // status-quo error at the const-returning call store (`const UComboAttackConfig ->
+    // UComboAttackConfig`, GetNextAttackConfig chains). Vanilla-faithfulness argument: the
+    // bytecode stores a const handle into N and RefCpyV-copies N into M with no cast, so
+    // vanilla's declarations for BOTH slots were const — const-marking M reproduces the
+    // vanilla dataflow exactly. Gated to OBJECT handles of the identical recorded type
+    // (a const VALUE-type declaration would reject the assignment itself); the shrink loop
+    // below still drops the whole chain if any link leaks into `__return`/members.
+    if !const_slots.is_empty() {
+        let obj_ty = |n: &i32| {
+            local_types
+                .get(n)
+                .filter(|t| t.starts_with('U') || t.starts_with('A'))
+        };
+        loop {
+            let mut grew = false;
+            for l in body.lines() {
+                let t = l.trim();
+                let Some(rest) = t.strip_suffix(';') else { continue };
+                let Some((lhs, rhs)) = rest.split_once(" = ") else { continue };
+                let (Some(m), Some(n)) = (
+                    lhs.strip_prefix("local_").and_then(|d| d.parse::<i32>().ok()),
+                    rhs.strip_prefix("local_").and_then(|d| d.parse::<i32>().ok()),
+                ) else {
+                    continue;
+                };
+                if const_slots.contains(&n)
+                    && !const_slots.contains(&m)
+                    && obj_ty(&m).is_some()
+                    && obj_ty(&m) == obj_ty(&n)
+                {
+                    const_slots.insert(m);
+                    grew = true;
+                }
+            }
+            if !grew {
+                break;
+            }
+        }
+    }
     loop {
         let keep: HashSet<i32> = const_slots
             .iter()
@@ -536,7 +618,9 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     }
     // member-derived declaring-class types override the cache's wrong/general slot type
     for (slot, ty) in &member_overrides {
-        if used.contains(slot) {
+        // batch-30a (C6c): same gate as the body map — a sole-call-written slot whose call
+        // return type matches the vanilla obj_locals entry keeps the exact vanilla type.
+        if used.contains(slot) && !member_widen_blocked(slot, ty) {
             locals.insert(*slot, ty.clone());
         }
     }
@@ -1584,6 +1668,55 @@ fn record_iterator_candidate(
 /// `TMap*` iterator pair) is only adopted after composing `<...>` from the receiver iterator's
 /// inferred instantiation (`known`, which includes the A1 pass results) — else skipped.
 /// Conflicting candidates for one slot drop (regression-free).
+/// batch-30a (C6c): slots whose ONLY object write is a `STOREOBJ` DIRECTLY following a
+/// call, mapped to that call's returned object base type. Conservative: any second
+/// object write to the slot (another STOREOBJ, or a `RefCpyV` copy) disqualifies it,
+/// as does a STOREOBJ whose producing call/return type is unknown. Consumed by the
+/// member-override gate in `emit_function` (vanilla obj_locals type wins over a
+/// member-derived WIDENING when the cache and the sole producing call agree).
+fn infer_sole_call_store_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
+    let instrs = match disassemble(&f.bytecode) {
+        Ok(i) => i,
+        Err(_) => return HashMap::new(),
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let mut cand: HashMap<i32, Option<String>> = HashMap::new();
+    for (i, ins) in instrs.iter().enumerate() {
+        let dst = match ins.op.name {
+            "STOREOBJ" | "RefCpyV" => w0(ins),
+            _ => continue,
+        };
+        if dst <= 0 {
+            continue;
+        }
+        // the producing call's object return type — only for a STOREOBJ right after it.
+        let ret = (ins.op.name == "STOREOBJ")
+            .then(|| i.checked_sub(1).and_then(|j| instrs.get(j)))
+            .flatten()
+            .and_then(|prev| match prev.op.name {
+                "CALL" | "CALLINTF" | "CALLBND" => {
+                    let id = prev.dwords.first().copied().unwrap_or(0) as i32;
+                    refs.func_ret_by_id(id).filter(|d| d.token == 5).map(|d| d.base_name(refs))
+                }
+                "CALLSYS" | "Thiscall1" => {
+                    let ptr = prev.qwords.first().copied().unwrap_or(0) as i64;
+                    refs.func_ret_by_ptr(ptr).filter(|d| d.token == 5).map(|d| d.base_name(refs))
+                }
+                _ => None,
+            });
+        match (cand.get(&dst), ret) {
+            (None, Some(t)) => {
+                cand.insert(dst, Some(t));
+            }
+            // second write / unknown producer -> disqualify (keep a tombstone).
+            _ => {
+                cand.insert(dst, None);
+            }
+        }
+    }
+    cand.into_iter().filter_map(|(s, t)| t.map(|t| (s, t))).collect()
+}
+
 fn infer_call_result_types(
     f: &Func,
     refs: &RefResolver,

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1556,20 +1556,31 @@ fn infer_slot_types_from_members(
                     }
                 }
                 // A5: `LoadRObjR/LoadVObjR ; CpyRtoV8 wD` — type the copy DESTINATION with the
-                // field's value type (current-class fields only; the owner check guards
-                // against cross-class field-name collisions).
+                // field's value type. batch-32a: resolved through the cross-module class-fields
+                // index (batch-30c `field_type_by_class`, keyed by the tid's OWNER class — no
+                // cross-class field-name collision is possible), because every proven A5 owner
+                // is a FOREIGN class the old this-class-only gate could never match (T7
+                // OldTypeId names the owner; batch-29 §1.2). Own-class sites resolve through
+                // the same index; the `fields` param stays as fallback for a driver without
+                // the injected index. The body renderer emits the matching `dst = obj.field;`
+                // assignment ONLY when this typing landed (slot_type == value type) — see the
+                // structure.rs CpyRtoV8 arm.
                 if let Some(next) = instrs.get(i + 1) {
                     if next.op.name == "CpyRtoV8" {
                         let dst = next.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
-                        if dst > 0
-                            && class_name.is_some()
-                            && refs.type_by_id(tid) == class_name
-                        {
-                            let vty = refs
-                                .member(tid, off)
-                                .and_then(|name| fields.and_then(|m| m.get(name)));
+                        if dst > 0 {
+                            let vty = refs.member(tid, off).and_then(|fname| {
+                                refs.type_by_id(tid)
+                                    .and_then(|cls| refs.field_type_by_class(cls, fname))
+                                    .map(|s| s.to_string())
+                                    .or_else(|| {
+                                        (refs.type_by_id(tid) == class_name)
+                                            .then(|| fields.and_then(|m| m.get(fname)).cloned())
+                                            .flatten()
+                                    })
+                            });
                             if let Some(vty) = vty {
-                                record(&mut cand, dst, vty.clone());
+                                record(&mut cand, dst, vty);
                             }
                         }
                     }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -60,6 +60,15 @@ static CONST_SAFE: &[&str] = &[
     // (asOBJ_VALUE): the copy is a value read through the generated const&in opAssign,
     // not a const-handle escape. Un-stubs the two AddAttack callers' read-only errors.
     "FAttackInfo::GetAttackMoveData",
+    // batch-31e: the capture.batch30-0705 OnItemPickedUp regression (3907:40 "Non-const
+    // method call on read-only object reference") is `ItemPickupHandle.GetClass()` on the
+    // `const FItemPickupHandle&inout` PARAM — surfaced by 30a's struct emission of
+    // FItemPickupHandle (value semantics enforce receiver constness), NOT by C6a const
+    // propagation (the module emits zero const locals; the receiver's constness is the
+    // vanilla signature's). Vanilla compiled this exact call on the const param, so
+    // vanilla's GetClass was const; the recovered body (`return this._Class;`, a pure
+    // field read) is trivially body-const-safe, satisfying the §5 oracle discipline.
+    "FItemPickupHandle::GetClass",
 ];
 
 fn const_safe_set() -> &'static HashSet<&'static str> {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -480,6 +480,29 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         keep_ints,
     };
     let body = body_statements_ctor(&fc, refs, depth + 1, super_ctor, Some(&f.ret), fields, Some(&param_types), class_name, Some(&local_types), Some(&hints));
+    // batch-30c (C9 accessor-ambiguity, specs/batch29-errortail.md §9): the recovered ctor
+    // default-writes `this.WalkSpeed = ...;` collide with the class's inherited SetWalkSpeed
+    // property accessor ("Assigned property also has a SetWalkSpeed accessor declared. Write
+    // is ambiguous." — a module-killer under warnings-as-errors). Vanilla's ctor bytecode is
+    // GENERATED from UPROPERTY defaults (no source statement to warn on), so no property-
+    // write spelling can reproduce it warning-free; the accessor-call spelling is the
+    // corpus-proven compiling form (`this.SetWalkSpeed(...)` call sites). Exact-keyed to the
+    // two captured ctors — a per-site fix, not a mechanism.
+    let body = if is_ctor
+        && matches!(class_name, Some("UAIState_Warning" | "UAIState_Warning_Crime"))
+        && body.contains("this.WalkSpeed = ")
+    {
+        body.lines()
+            .map(|l| match l.split_once("this.WalkSpeed = ") {
+                Some((ind2, rhs)) if ind2.trim().is_empty() && rhs.ends_with(';') => {
+                    format!("{ind2}this.SetWalkSpeed({});\n", &rhs[..rhs.len() - 1])
+                }
+                _ => format!("{l}\n"),
+            })
+            .collect()
+    } else {
+        body
+    };
     // Batch-21 Class C: CONSTSTORE-marked stores carry a const object handle of the local's
     // EXACT type (a same-type Cast<T> does NOT strip const in-game — every batch-20 exact-type
     // Cast site failed "No conversion from 'const X' to 'X'"). Vanilla declared these locals

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -487,6 +487,22 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         if member_widen_blocked(slot, ty) {
             continue;
         }
+        // batch-33a: 31d most-derived merge, mirrored onto the MEMBER pass — a field's
+        // DECLARING class that is a PROVABLE ANCESTOR of the cache's own obj_locals type
+        // must not widen it. The member access stays legal on the derived vanilla type
+        // (the bytecode proves it compiled), while widening loses derived-only methods:
+        // `Cast<ABallLightningVisual>` result copied into the vanilla-typed slot, then
+        // `local_2.m_CollisionComp` (declared on native AProjectileVisual) re-typed the
+        // slot to the base -> `AProjectileVisual::SetSpellLevel(int)` no-match (9 fns:
+        // BallLightning/Orc/FireBall_Orc/Heal spells, Explode/StormOfFire visuals,
+        // Xardas Initialize, both CreatureTeleport DoTeleport* via ACharacter's
+        // CapsuleComponent/Mesh). C6c (sole-call gate above) covered only call-stored
+        // slots; this covers the RefCpyV/copy-written rest.
+        if let Some(vanilla) = vanilla_obj_types.get(slot) {
+            if vanilla != ty && refs.is_subclass(vanilla, ty) {
+                continue;
+            }
+        }
         local_types.insert(*slot, ty.clone());
     }
     // iterator-instance subtypes (illegal-op-round2.md A1): the T1 entry for a `T*Iterator`
@@ -688,6 +704,13 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         // batch-30a (C6c): same gate as the body map — a sole-call-written slot whose call
         // return type matches the vanilla obj_locals entry keeps the exact vanilla type.
         if used.contains(slot) && !member_widen_blocked(slot, ty) {
+            // batch-33a: declaration-side mirror of the most-derived member merge above —
+            // the vanilla obj_locals type wins over a field-declaring-class ANCESTOR.
+            if let Some(vanilla) = vanilla_obj_types.get(slot) {
+                if vanilla != ty && refs.is_subclass(vanilla, ty) {
+                    continue;
+                }
+            }
             locals.insert(*slot, ty.clone());
         }
     }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -636,15 +636,23 @@ fn infer_slot_types(f: &Func, refs: &RefResolver) -> HashMap<i32, String> {
         // last user arg (just before the receiver); count it so it is consumed, but exclude it from
         // pairing (it is NOT params[last] — pairing it would shift every real arg one param over and
         // mis-type the slot, e.g. the TSubclassOf out param landing on an EQuestState param).
-        let rvo = (ret_struct && is_method) as usize;
-        let total = if is_method { params.len() + 1 + rvo } else { params.len() };
+        // A FREE/static struct-returning call pushes the same hidden out-slot ON TOP (no receiver
+        // follows it — proven by FInGameTime::Now: `PshGPtr __WorldContext ; PSF <out> ; CALLSYS`,
+        // params=[const UObject], ret=FInGameTime). Not counting it paired the PSF'd out-slot with
+        // the hidden WorldContext param -> slot mis-typed UObject, clobbering the correct
+        // obj_locals type (FInGameTime) and blinding build_call's free-RVO probe ("Can't
+        // implicitly convert from 'UObject' to 'FInGameTime'" x144 in-game).
+        let rvo = ret_struct as usize;
+        let total = if is_method { params.len() + 1 + rvo } else { params.len() + rvo };
         let take = total.min(ostack.len());
         let popped = ostack.split_off(ostack.len() - take);
-        // method: top popped entry is the receiver -> drop it (plus the RVO out-slot just below it);
-        // the rest are the user args.
+        // method: top popped entry is the receiver -> drop it (plus the RVO out-slot just below);
+        // free call: top popped entry is the RVO out-slot itself. The rest are the user args.
         let args = if is_method && !popped.is_empty() {
             &popped[..popped.len().saturating_sub(1 + rvo)]
-        } else { &popped[..] };
+        } else {
+            &popped[..popped.len().saturating_sub(rvo)]
+        };
         // pair from the TOP: last arg <-> last param (so a leading `this` param, if the cache
         // counts it, never shifts the user-arg pairing).
         for (i, slot) in args.iter().rev().enumerate() {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -356,7 +356,28 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
     // `{ret} __r;` — invalid for a reference type — so those keep the by-value signature
     // (status quo).
     let ref_ret = f.ret.is_reference && f.ret.token == 5 && !f.ret.is_object_handle;
-    let ret_sig = if ref_ret && reason.is_none() && !body.contains(RVODEF) && !body.contains("__return") {
+    // A STUBBED ref-return FPerceptionHandler mixin must NOT degrade to a by-value signature:
+    // that poisons every CALLER ("Cannot pass a temporary value ... into non-const reference
+    // parameter" at each BindAssessmentToPerception site — one stubbed mixin cascades into
+    // dozens of caller stubs). Keep the `&` signature and return a typed non-temporary:
+    // `return OnSensedOther(<PerceptionParam>);` — semantically degenerate (like every stub)
+    // but signature-faithful, so callers compile.
+    let percep_stub_param = (ref_ret
+        && f.ret.base_name(refs) == "FPerceptionHandler")
+        .then(|| {
+            f.params.iter().enumerate().find_map(|(i, p)| {
+                (p.ty.base_name(refs) == "UCharacterPerceptionComponent").then(|| {
+                    if p.name.is_empty() { format!("arg{i}") } else { p.name.clone() }
+                })
+            })
+        })
+        .flatten();
+    let ret_sig = if ref_ret
+        && ((reason.is_none()
+            && !body.contains("__return")
+            && (!body.contains(RVODEF) || percep_stub_param.is_some()))
+            || (reason.is_some() && percep_stub_param.is_some()))
+    {
         format!("{}&", f.ret.render(refs))
     } else {
         ret.clone()
@@ -430,7 +451,12 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
             // default. Object/AActor handles have no default constructor, so `{ret} __r;` fails to
             // compile — return `nullptr` directly (this build's null-handle literal, matching
             // PshNull/CmpPtrNull). `render` strips `@`, so detect handles via the DataType flag.
-            if f.ret.is_object_handle {
+            if let Some(p) = &percep_stub_param {
+                // ref-return FPerceptionHandler mixin with an unrecovered return: a by-value `__r`
+                // default would force a by-value SIGNATURE and poison every caller (temporary into
+                // non-const ref). Return a typed non-temporary instead; ret_sig keeps the `&`.
+                s.push_str(&body.replace(RVODEF, &format!("OnSensedOther({p})")));
+            } else if f.ret.is_object_handle {
                 s.push_str(&body.replace(RVODEF, "nullptr"));
             } else {
                 let _ = writeln!(s, "{ind}    {ret} __r;");
@@ -446,7 +472,10 @@ fn emit_function_ctor(s: &mut String, f: &Func, refs: &RefResolver, is_method: b
         // handle return defaults to `nullptr` (no default-constructor for engine object types;
         // `nullptr` is this build's null-handle literal — `null` parses as undeclared).
         if !is_ctor && ret != "void" {
-            if f.ret.is_object_handle {
+            if let Some(p) = &percep_stub_param {
+                // ref-return FPerceptionHandler mixin: signature-faithful stub (see ret_sig).
+                let _ = writeln!(s, "{ind}    return OnSensedOther({p});");
+            } else if f.ret.is_object_handle {
                 let _ = writeln!(s, "{ind}    return nullptr;");
             } else {
                 let _ = writeln!(s, "{ind}    {ret} __r; return __r;");

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1352,6 +1352,16 @@ fn infer_slot_types(
                     *top = None;
                 }
             }
+            // batch-32c (spec batch31 §1.8 site-2 root cause, corrected by disasm): PopRPtr
+            // POPS the top stack entry into the reference register (the member-read idiom
+            // `PshVPtr w0 ; ADDSi ; RDSPtr ; ADDSi ; PopRPtr ; RDR4`). Unmodeled, it left a
+            // ghost entry that shifted every later pairing one param deeper —
+            // SetTimerDelegate's bool bMaxOncePerFrame slot paired against the float32
+            // InitialStartDelay -> `float32 local_8` decl -> bare render where the bool wrap
+            // `(local_8 != 0)` was needed (2 in-game no-match).
+            "PopRPtr" => {
+                ostack.pop();
+            }
             "CALL" | "CALLINTF" | "CALLBND" => {
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let rs = refs.func_ret_by_id(id).map(|d| !d.is_reference && ret_is_struct(&d.base_name(refs))).unwrap_or(false);
@@ -1402,6 +1412,19 @@ fn infer_slot_types(
                     // pop receiver + ctor args off the operand stack so they don't leak.
                     let nargs = refs.func_params_by_ptr(ptr).map(|p| p.len()).unwrap_or(0);
                     let drop_n = (1 + nargs).min(ostack.len());
+                    ostack.truncate(ostack.len() - drop_n);
+                    continue;
+                }
+                // batch-32c (site-3b root cause): the `opCast` behaviour consumes exactly
+                // THREE pushes (`TYPEID ; PSF <dst> ; PshVPtr <src> ; CALLSYS opCast`) and
+                // pushes nothing. Routing it through pair() desynced the model at every Cast
+                // diamond (unknown params -> ostack.clear() wiped the enclosing call's
+                // pending args; known params mis-popped) — the bool&-out pairing for
+                // GetFloatAttributeFromAbilitySystemComponent's `local_33` never happened
+                // (declared int, "expected bool&, but got int"). Mirror of the $beh0
+                // special-case above; structure.rs has its own dedicated opCast arm.
+                if refs.func_by_ptr(ptr) == Some("opCast") {
+                    let drop_n = 3.min(ostack.len());
                     ostack.truncate(ostack.len() - drop_n);
                     continue;
                 }

--- a/crates/gore-as/src/cache/mod.rs
+++ b/crates/gore-as/src/cache/mod.rs
@@ -1,6 +1,7 @@
 //! Parsing of `PrecompiledScript_Shipping.Cache`.
 
 pub mod binds;
+pub mod bytediff;
 pub mod cfg;
 pub mod decompile;
 pub mod disasm;

--- a/crates/gore-as/src/cache/model.rs
+++ b/crates/gore-as/src/cache/model.rs
@@ -115,6 +115,17 @@ pub struct Func {
     /// (slot offset, type-ptr) for object-typed locals.
     pub obj_locals: Vec<(i32, i64)>,
     pub is_ufunction: bool,
+    /// asSFunctionTraits bitfield (asTRAIT_CONST=4, asTRAIT_FINAL=32, generated=0x40000, ...).
+    pub traits: i32,
+}
+
+impl Func {
+    /// The vanilla method was declared `const` (asTRAIT_CONST). Dropping it on re-emit makes
+    /// every call through a `const` object handle fail with "Non-const method call on
+    /// read-only object reference", so the emitter must render it back.
+    pub fn is_const_method(&self) -> bool {
+        self.traits & 4 != 0
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -190,7 +201,7 @@ fn read_function(c: &mut Cursor) -> Result<Func, WireError> {
         pflags.push(c.read_i32()?);
     }
     c.skip_tarray_sia("ParameterDefaultArgs")?;
-    c.skip(4)?; // FunctionTraits
+    let traits = c.read_i32()?; // FunctionTraits (asSFunctionTraits bitfield)
     let bytecode = c.read_tarray_i32("ByteCode")?;
     c.skip_tarray_fixed(4, "ByteCodeReferences")?;
     c.skip(4)?; // VariableSpace
@@ -230,7 +241,7 @@ fn read_function(c: &mut Cursor) -> Result<Func, WireError> {
         });
     }
     let obj_locals = obj_pos.into_iter().zip(obj_types).collect();
-    Ok(Func { name, namespace, ret, params, bytecode, obj_locals, is_ufunction })
+    Ok(Func { name, namespace, ret, params, bytecode, obj_locals, is_ufunction, traits })
 }
 
 fn read_property(c: &mut Cursor) -> Result<Field, WireError> {

--- a/crates/gore-as/src/cache/model.rs
+++ b/crates/gore-as/src/cache/model.rs
@@ -152,6 +152,8 @@ pub struct Class {
     pub fields: Vec<Field>,
     pub methods: Vec<Func>,
     pub ctors: Vec<Func>,
+    /// asCObjectType flags (asOBJ_* bitfield) from the cache Class record.
+    pub flags: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -282,7 +284,7 @@ fn read_property(c: &mut Cursor) -> Result<Field, WireError> {
 fn read_class(c: &mut Cursor) -> Result<Class, WireError> {
     let name = c.read_sia()?;
     c.read_sia()?; // Namespace
-    c.skip(4)?; // Flags
+    let flags = c.read_i32()? as u32; // asCObjectType Flags (asOBJ_* bitfield)
     let nprops = c.read_count("Class.Properties")?;
     let mut fields = Vec::with_capacity(nprops);
     for _ in 0..nprops {
@@ -319,7 +321,7 @@ fn read_class(c: &mut Cursor) -> Result<Class, WireError> {
         c.skip_tarray_sia("Class.MetaValues")?;
         c.read_sia()?; // ComposeOntoClassName
     }
-    Ok(Class { name, super_class, fields, methods, ctors })
+    Ok(Class { name, super_class, fields, methods, ctors, flags })
 }
 
 fn read_enum(c: &mut Cursor) -> Result<EnumDef, WireError> {

--- a/crates/gore-as/src/cache/model.rs
+++ b/crates/gore-as/src/cache/model.rs
@@ -69,8 +69,18 @@ fn is_enum_name(name: &str) -> bool {
 /// out-pointer slot (one `AS_PTR_SIZE`) between `this` and the first real parameter.
 /// UObject/AActor handles (`is_object_handle`) return in the value register, NOT via an RVO
 /// slot, so they are excluded.
-pub fn returns_struct_by_value(ret: &DataType) -> bool {
-    ret.token == 5 && !ret.is_object_handle && !ret.is_reference
+///
+/// batch-29c (A4, specs/batch29-errortail.md §1.1): ENUMS are also token 5 but return in the
+/// VALUE REGISTER — no hidden RVO slot exists (the callee-side probes in structure.rs/emit.rs
+/// already exclude `E*` heads; this predicate was the last admitter). Counting an enum return
+/// as by-value-struct mapped a REAL param onto the phantom RVO slot (`ERelationship __return;
+/// ... UpdateCrimeSeverityTowardsPlayer(__return, AI);` — 11 [E] lines, 6 fns), so enum-named
+/// returns are excluded here, at the map-building choke point.
+pub fn returns_struct_by_value(ret: &DataType, refs: &RefResolver) -> bool {
+    ret.token == 5
+        && !ret.is_object_handle
+        && !ret.is_reference
+        && !is_enum_name(&ret.base_name(refs))
 }
 
 /// Build the AS_PTR_SIZE-aware map from a frame offset (signed dword slot, negative below the

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -71,6 +71,14 @@ pub struct RefResolver {
     /// global sharing such a name is SHADOWED by member lookup inside classes and must be
     /// `::`-qualified.
     method_names: std::collections::HashSet<String>,
+    /// T3 FunctionReferences declaring-module name per NON-method function ptr (batch-25f):
+    /// keys the cross-module free-fn rename map, matching the parsed `Module::name` exactly.
+    func_module: HashMap<i64, String>,
+    /// batch-25f: per-function-ptr rename for cross-module free-fn collisions — the emit-side
+    /// collision scan renames each colliding declaration `Name -> Name_g<mi>` with a TEXT pass
+    /// over the DECLARING module only; this id-keyed map lets CALL/CALLINTF sites in EVERY
+    /// module resolve the renamed symbol.
+    free_fn_renames: HashMap<i64, String>,
 }
 
 impl RefResolver {
@@ -107,7 +115,7 @@ impl RefResolver {
         for _ in 0..c.read_count("FunctionReferences")? {
             let key = c.read_i64()?;
             let name = c.read_sia()?;
-            c.read_sia()?; // Module
+            let module = c.read_sia()?; // Module (declaring module name, batch-25f)
             let ns = c.read_sia()?; // Namespace
             c.skip(4)?; // bIsConst
             c.skip(4)?; // bIsImportedDecl
@@ -134,6 +142,11 @@ impl RefResolver {
             // rendered via its receiver. Record the namespace so the call site can prefix it.
             if !is_method && !ns.is_empty() {
                 r.func_ns.insert(key, ns);
+            }
+            // Declaring module of a free function (batch-25f rename-map key; methods are
+            // rendered via their receiver and never rename).
+            if !is_method && !module.is_empty() {
+                r.func_module.insert(key, module);
             }
             r.func_by_ptr.insert(key, name);
         }
@@ -396,6 +409,40 @@ impl RefResolver {
     /// `CastSpell(AI, int)` even if the method itself is never called).
     pub fn add_method_names<I: IntoIterator<Item = String>>(&mut self, names: I) {
         self.method_names.extend(names);
+    }
+    /// batch-25f: install the cross-module free-fn rename map. `by_module` is
+    /// `module name -> (original fn name -> renamed name)` — exactly the collision set the
+    /// emit-side scan feeds the per-module `rename_free_fn` TEXT pass, so declarations and
+    /// call sites can never disagree. Keyed here per FUNCTION PTR (id-based), never by bare
+    /// name — the mixed-overload hazard the text pass documents is inherited from its gate
+    /// (a module's name only enters the collision set when EVERY emittable same-name overload
+    /// collides).
+    pub fn set_free_fn_renames(&mut self, by_module: &HashMap<String, HashMap<String, String>>) {
+        let mut m: HashMap<i64, String> = HashMap::new();
+        if !by_module.is_empty() {
+            for (ptr, name) in &self.func_by_ptr {
+                if self.func_is_method.contains(ptr) {
+                    continue;
+                }
+                let renamed = self
+                    .func_module
+                    .get(ptr)
+                    .and_then(|module| by_module.get(module))
+                    .and_then(|names| names.get(name));
+                if let Some(new) = renamed {
+                    m.insert(*ptr, new.clone());
+                }
+            }
+        }
+        self.free_fn_renames = m;
+    }
+    /// Renamed leaf for a free function by CALL id, when its declaration was collision-renamed
+    /// (batch-25f). None = not renamed (the overwhelmingly common case).
+    pub fn renamed_free_fn_by_id(&self, id: i32) -> Option<&str> {
+        self.funcid_to_ptr
+            .get(&id)
+            .and_then(|p| self.free_fn_renames.get(p))
+            .map(|s| s.as_str())
     }
     /// True if `name` exists as a MEMBER anywhere: T3 method names (native or script, referenced
     /// by bytecode), injected script-class method declarations, or any Binds native signature

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -496,8 +496,18 @@ impl RefResolver {
     /// by bytecode), injected script-class method declarations, or any Binds native signature
     /// name. The production emit runs WITHOUT Binds (JOURNAL: binds-arity emit regressed), so the
     /// cache-derived sets are the load-bearing sources; Binds adds coverage when loaded.
+    /// batch-32b (N6, spec batch31-nomatch-illegalop §1.10): universal UObject members shadow a
+    /// same-named free script global inside EVERY class body (all script classes derive UObject),
+    /// but are invisible to the cache-derived sets unless some bytecode call references them as a
+    /// T3 method — `GetName(EPerceptionCharacterType)` resolved against the inherited
+    /// `FName UObject::GetName() const` instead of the free script fn (EventResponses ×2).
+    /// Static list; `::`-over-qualification of a non-shadowed global stays harmless.
     pub fn member_name_exists(&self, name: &str) -> bool {
-        self.method_names.contains(name) || self.native_name_exists(name)
+        const UNIVERSAL_UOBJECT_MEMBERS: [&str; 5] =
+            ["GetName", "GetClass", "GetOuter", "GetWorld", "GetFName"];
+        self.method_names.contains(name)
+            || UNIVERSAL_UOBJECT_MEMBERS.contains(&name)
+            || self.native_name_exists(name)
     }
     pub fn global_by_ptr(&self, ptr: i64) -> Option<&str> {
         self.global_by_ptr.get(&ptr).map(|s| s.as_str())

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -301,11 +301,19 @@ impl RefResolver {
         // vanilla-compiled => the chain passes through AProjectileVisual; single
         // inheritance makes the link row sound (intermediates stay transparent to the
         // walk — precedent: the UAIGroup_Combat_Base row).
+        // batch-41d: UAbilityTask_AI derives UAbilityTaskGeneric — evidence: the vanilla-compiled
+        // TryPerformActionNow body upcasts `local_36 (UAbilityTaskGeneric) = local_34
+        // (UAITask_CombatMove : UGothicCharacterAITask : UAbilityTask_AI)` (a legal derived->base
+        // handle copy), proving UAITask_CombatMove's chain passes through UAbilityTaskGeneric; the
+        // script walk dead-ends at the native super UAbilityTask_AI, so this link lets the
+        // reciprocal member store `this.ActiveActionTask (UAITask_CombatMove) = local_36` recover
+        // the required `Cast<UAITask_CombatMove>`. Single inheritance keeps the row sound.
         const KNOWN_NATIVE_HIERARCHY: &[(&str, &str)] = &[
             ("UAIGroup_Combat_Base", "UGothicAIGroup"),
             ("AGothicNPCState", "AGothicCharacterState"),
             ("AGothicCharacter", "ACharacter"),
             ("ASpellProjectileVisual", "AProjectileVisual"),
+            ("UAbilityTask_AI", "UAbilityTaskGeneric"),
         ];
         if sub == sup {
             return true;
@@ -548,8 +556,21 @@ impl RefResolver {
     /// from KNOWN_NATIVE_FIELD_TYPES: those rows mirror the Binds field DECLS (validated by
     /// the binds.rs test) and feed enum/float-filtered consumers.
     pub fn native_field_const_object(&self, class: &str, field: &str) -> Option<&'static str> {
-        const KNOWN_NATIVE_CONST_OBJECT_FIELDS: &[(&str, &str, &str)] =
-            &[("FItemActionHandler", "ItemDefinition", "UItemDefinition")];
+        // batch-41d: FGameplayEventData's object-handle fields are declared const in the engine
+        // (`TObjectPtr<const AActor> Instigator/Target`, `TWeakObjectPtr<const UObject>
+        // OptionalObject`). A member read of a `const FGameplayEventData &inout` PARAM yields a
+        // const handle, so batch-41a's `local_N = EventData.Target;` recovery into a same-typed
+        // non-const local failed "Can't implicitly convert from 'const AActor' to 'AActor'" in
+        // generate-mode (18 sites: GA_Defeated/MCQueen/Xardas/Summon* etc.). Same production
+        // source + exact-type-match consumer discipline as the FItemActionHandler row; the read
+        // slots are only ever used const-safely (null-check / method receiver / Cast<Derived>
+        // source), so const-declaring them is regression-free.
+        const KNOWN_NATIVE_CONST_OBJECT_FIELDS: &[(&str, &str, &str)] = &[
+            ("FItemActionHandler", "ItemDefinition", "UItemDefinition"),
+            ("FGameplayEventData", "Instigator", "AActor"),
+            ("FGameplayEventData", "Target", "AActor"),
+            ("FGameplayEventData", "OptionalObject", "UObject"),
+        ];
         KNOWN_NATIVE_CONST_OBJECT_FIELDS
             .iter()
             .find(|(c, f, _)| *c == class && *f == field)

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -421,6 +421,20 @@ impl RefResolver {
             // their EVerticalAlignment(...) casts.
             ("FLetterboxLayoutSettings", "VerticalLoadingWidgetPosition", "EVerticalAlignment"),
             ("FLetterboxLayoutSettings", "VerticalTipWidgetPosition", "EVerticalAlignment"),
+            // batch-30c: core-math FLOAT fields — NOT in the Binds field tables (math types
+            // are special-registered; probed None), so these rows are excluded from the
+            // binds.rs mirror test. Evidence is the in-game diagnostic itself: reads of
+            // these fields into int slots emit "Implicit conversion from float to integer
+            // loses precision" (the compiler names the source float), UE5 core math is
+            // double ('float' in Hazelight AS). Consumed by the member-load float-source
+            // typing (structure.rs) for the RDR8 int(...) wraps; the enum-filtered nfty
+            // consumers ignore non-enum rows by construction.
+            ("FVector", "X", "float"),
+            ("FVector", "Y", "float"),
+            ("FVector", "Z", "float"),
+            ("FRotator", "Pitch", "float"),
+            ("FRotator", "Yaw", "float"),
+            ("FRotator", "Roll", "float"),
         ];
         if let Some((_, _, t)) =
             KNOWN_NATIVE_FIELD_TYPES.iter().find(|(c, f, _)| *c == class && *f == field)

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -65,6 +65,12 @@ pub struct RefResolver {
     /// `FAngelscriptManager::StaticNames[Id]`, which PrepareToFinalizePrecompiledModules
     /// populates from THIS table — so the bytecode's int operand indexes it directly.
     static_names: Vec<String>,
+    /// Names that exist as a METHOD somewhere: T3 FunctionReferences flagged bIsMethod
+    /// (native or script methods actually referenced by bytecode) plus script-class method
+    /// declarations injected from the parsed modules. Batch-24b shadow gate: a free script
+    /// global sharing such a name is SHADOWED by member lookup inside classes and must be
+    /// `::`-qualified.
+    method_names: std::collections::HashSet<String>,
 }
 
 impl RefResolver {
@@ -115,6 +121,7 @@ impl RefResolver {
             let ret = DataType::read(&mut c)?; // ReturnType
             if is_method {
                 r.func_is_method.insert(key);
+                r.method_names.insert(name.clone());
             }
             // Always record params — even an empty list — so the call-site arg-count check
             // can stub a zero-param method that was decompiled with phantom args.
@@ -343,6 +350,27 @@ impl RefResolver {
             Some(&ptr) => self.native_arity_by_ptr(ptr, name),
             None => self.native.as_ref()?.arity_by_name(name),
         }
+    }
+    /// True if `name` exists ANYWHERE in the Binds.Cache native API (any class' member or any
+    /// global; ambiguous-arity overloads count). Binds absent -> false, so callers degrade to
+    /// the status quo. Batch-24b: over-approximates "some class in the (native) ancestry has a
+    /// same-named member that would SHADOW a script global" — safe, because `::`-qualifying a
+    /// non-shadowed global resolves identically.
+    pub fn native_name_exists(&self, name: &str) -> bool {
+        self.native.as_ref().is_some_and(|n| n.has_name(name))
+    }
+    /// Inject script-class METHOD names from the parsed modules (a shadowing member need not be
+    /// referenced by any bytecode — e.g. `UCM_CastSpell_Base::CastSpell()` shadows the free
+    /// `CastSpell(AI, int)` even if the method itself is never called).
+    pub fn add_method_names<I: IntoIterator<Item = String>>(&mut self, names: I) {
+        self.method_names.extend(names);
+    }
+    /// True if `name` exists as a MEMBER anywhere: T3 method names (native or script, referenced
+    /// by bytecode), injected script-class method declarations, or any Binds native signature
+    /// name. The production emit runs WITHOUT Binds (JOURNAL: binds-arity emit regressed), so the
+    /// cache-derived sets are the load-bearing sources; Binds adds coverage when loaded.
+    pub fn member_name_exists(&self, name: &str) -> bool {
+        self.method_names.contains(name) || self.native_name_exists(name)
     }
     pub fn global_by_ptr(&self, ptr: i64) -> Option<&str> {
         self.global_by_ptr.get(&ptr).map(|s| s.as_str())

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -271,15 +271,31 @@ impl RefResolver {
     pub fn is_script_class(&self, name: &str) -> bool {
         self.class_super.contains_key(name)
     }
-    /// True if `sub` is `sup` or transitively derives from it (within the script hierarchy).
+    /// True if `sub` is `sup` or transitively derives from it (within the script hierarchy,
+    /// extended by the known-native links below).
     pub fn is_subclass(&self, sub: &str, sup: &str) -> bool {
+        // batch-30b (C4, specs/batch29-errortail.md §4): known NATIVE ancestor links the
+        // script hierarchy cannot see — the walk dead-ends at the first native super
+        // (UAIGroup_Combat : UAIGroup_Combat_Base [native] : ... : UGothicAIGroup), so the
+        // inheritance-aware member-candidate merge dropped the slot to UObject (8×
+        // "'X' is not a member of 'UObject'" in CalculateScore_Implementation). Precedent:
+        // KNOWN_NATIVE_ARITY. Evidence for the entry: the same function passes
+        // `UAIGroup_Combat::StaticClass()` into a `TSubclassOf<UGothicAIGroup>` (vanilla-
+        // compiled => UAIGroup_Combat derives UGothicAIGroup), and single inheritance places
+        // UGothicAIGroup at or above the direct super UAIGroup_Combat_Base.
+        const KNOWN_NATIVE_HIERARCHY: &[(&str, &str)] =
+            &[("UAIGroup_Combat_Base", "UGothicAIGroup")];
         if sub == sup {
             return true;
         }
         let mut cur = sub;
         for _ in 0..64 {
-            // bound the walk against cycles
-            match self.class_super.get(cur) {
+            // bound the walk against cycles; on a script-map dead end, follow a known
+            // native link before giving up.
+            let next = self.class_super.get(cur).map(String::as_str).or_else(|| {
+                KNOWN_NATIVE_HIERARCHY.iter().find(|(c, _)| *c == cur).map(|(_, p)| *p)
+            });
+            match next {
                 Some(s) if s == sup => return true,
                 Some(s) => cur = s,
                 None => return false,
@@ -396,6 +412,15 @@ impl RefResolver {
             ("FTextAppearance", "Justification", "ETextJustify"),
             ("FInteractionAnimTransition", "TransitionKind", "EInteractionInputKind"),
             ("FWeatherSaveGame", "CurrentWeather", "EWeather"),
+            // batch-30b (C9 G2 rows, specs/batch29-errortail.md §9): the two Letterbox
+            // enum fields rendered as bool stores (`= (local_80 != 0)`) — 5×
+            // "Can't implicitly convert from 'bool' to 'EVerticalAlignment&'" in the
+            // LoadingScreen SetupGeneralLoadingScreen family. Owner derived from the
+            // ADDSi tid at the WRTV1 sites (0x4002a20 -> FLetterboxLayoutSettings,
+            // offsets 0/1); the sibling FWidgetAlignment rows above already render
+            // their EVerticalAlignment(...) casts.
+            ("FLetterboxLayoutSettings", "VerticalLoadingWidgetPosition", "EVerticalAlignment"),
+            ("FLetterboxLayoutSettings", "VerticalTipWidgetPosition", "EVerticalAlignment"),
         ];
         if let Some((_, _, t)) =
             KNOWN_NATIVE_FIELD_TYPES.iter().find(|(c, f, _)| *c == class && *f == field)

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -56,6 +56,11 @@ pub struct RefResolver {
     /// Native AngelScript API arities parsed from Binds.Cache (fallback arity for native calls
     /// whose param count isn't carried in the script FunctionReferences).
     native: Option<super::binds::NativeApi>,
+    /// StaticNames tail table (table 5): the `n"..."` FName-literal pool. The synthesized
+    /// accessor `const FName& __STATIC_NAME(int Id)` (decl string in the shipping exe) returns
+    /// `FAngelscriptManager::StaticNames[Id]`, which PrepareToFinalizePrecompiledModules
+    /// populates from THIS table — so the bytecode's int operand indexes it directly.
+    static_names: Vec<String>,
 }
 
 impl RefResolver {
@@ -142,9 +147,11 @@ impl RefResolver {
             }
             r.global_by_ptr.insert(key, name);
         }
-        // T6 StaticNames: TArray<SIA>
-        for _ in 0..c.read_count("StaticNames")? {
-            c.read_sia()?;
+        // T6 StaticNames: TArray<SIA> — the FName-literal pool `__STATIC_NAME(Id)` indexes.
+        let n_static = c.read_count("StaticNames")?;
+        r.static_names.reserve_exact(n_static);
+        for _ in 0..n_static {
+            r.static_names.push(c.read_sia()?);
         }
         // T7 PropertyReferences: int64 key + (Name, int32 OldTypeId)
         for _ in 0..c.read_count("PropertyReferences")? {
@@ -295,6 +302,15 @@ impl RefResolver {
             .get(&id)
             .map(|p| self.func_is_method.contains(p))
             .unwrap_or(false)
+    }
+    /// FName-literal text for a `__STATIC_NAME(Id)` index into the StaticNames tail table.
+    /// None if out of range (e.g. a mini-cache with empty tail tables).
+    pub fn static_name(&self, id: i64) -> Option<&str> {
+        usize::try_from(id).ok().and_then(|i| self.static_names.get(i)).map(|s| s.as_str())
+    }
+    /// Number of StaticNames entries (debug aid).
+    pub fn static_name_count(&self) -> usize {
+        self.static_names.len()
     }
     /// Member name from a containing type-id + byte offset.
     pub fn member(&self, type_id: i32, offset: i32) -> Option<&str> {

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -290,9 +290,22 @@ impl RefResolver {
         // GASCharacterStateMixins free fn `ExchangeDailyRoutineToClass(AGothicCharacterState
         // Character, ...)` wraps exactly `Cast<AGothicNPCState>(Character)` — both directions
         // of the single-inheritance proof.
+        // batch-33a: AGothicCharacter derives ACharacter — evidence: vanilla-compiled
+        // bytecode reads ACharacter fields (CapsuleComponent/Mesh, ADDSi on the native
+        // tid) off Cast<AGothicCharacter> results corpus-wide (XardasSleeper Initialize,
+        // CreatureTeleport DoTeleport*), and the 30a-C6d GA_FallingRagdoll axiom in
+        // provably_derived encodes the same edge. ASpellProjectileVisual derives
+        // AProjectileVisual — evidence: ASpellBallVisual_AS (: ASpellProjectileVisual)
+        // method bodies access `this.m_CollisionComp` declared on native
+        // AProjectileVisual (ADDSi tid 0x400199b, GA_Spell_BallLightning family),
+        // vanilla-compiled => the chain passes through AProjectileVisual; single
+        // inheritance makes the link row sound (intermediates stay transparent to the
+        // walk — precedent: the UAIGroup_Combat_Base row).
         const KNOWN_NATIVE_HIERARCHY: &[(&str, &str)] = &[
             ("UAIGroup_Combat_Base", "UGothicAIGroup"),
             ("AGothicNPCState", "AGothicCharacterState"),
+            ("AGothicCharacter", "ACharacter"),
+            ("ASpellProjectileVisual", "AProjectileVisual"),
         ];
         if sub == sup {
             return true;

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -42,6 +42,10 @@ pub struct RefResolver {
     /// Script class -> its super class name (injected from the parsed modules after build).
     /// Lets call sites distinguish a legal upcast from an unrelated-object arg.
     class_super: HashMap<String, String>,
+    /// Script class -> (field name -> COMPOSED field type name), injected from the parsed
+    /// modules after build. Lets the emitter fold INHERITED fields into a class's field-type
+    /// map (batch-21 Class B: `this.<inherited TMap>.opIndex(int)` needed the enum key wrap).
+    class_fields: HashMap<String, HashMap<String, String>>,
     /// FunctionReferences parameter DataTypes (for arg-type-driven casts at call sites).
     func_params: HashMap<i64, Vec<DataType>>,
     /// FunctionReferences return DataType.
@@ -212,6 +216,36 @@ impl RefResolver {
     /// Inject the script-class hierarchy (class name -> super name) from parsed modules.
     pub fn set_class_hierarchy(&mut self, supers: HashMap<String, String>) {
         self.class_super = supers;
+    }
+    /// Inject per-class field-type maps (class -> field -> composed type) from parsed modules.
+    pub fn set_class_fields(&mut self, fields: HashMap<String, HashMap<String, String>>) {
+        self.class_fields = fields;
+    }
+    /// Field-type map of a single script class (own fields only; walk supers via
+    /// [`Self::class_super_of`] for the inherited view).
+    pub fn class_field_types(&self, class: &str) -> Option<&HashMap<String, String>> {
+        self.class_fields.get(class)
+    }
+    /// Direct super-class name of a script class (None for engine types / roots).
+    pub fn class_super_of(&self, class: &str) -> Option<&str> {
+        self.class_super.get(class).map(|s| s.as_str()).filter(|s| !s.is_empty())
+    }
+    /// Field VALUE type by containing class name + field name, resolved through the injected
+    /// per-class field maps (walking script supers, cycle-bounded). Correct for FOREIGN script
+    /// classes/structs — where `member_type` (PropertyReferences.OldTypeId) only names the
+    /// OWNER type, not the field's own type.
+    pub fn field_type_by_class(&self, class: &str, field: &str) -> Option<&str> {
+        let mut cur = class;
+        for _ in 0..64 {
+            if let Some(t) = self.class_fields.get(cur).and_then(|m| m.get(field)) {
+                return Some(t);
+            }
+            match self.class_super.get(cur) {
+                Some(s) if !s.is_empty() => cur = s,
+                _ => return None,
+            }
+        }
+        None
     }
     /// True if `name` is a class DEFINED in a script module (vs an engine/native type).
     pub fn is_script_class(&self, name: &str) -> bool {

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -171,6 +171,21 @@ impl RefResolver {
             .and_then(|p| self.type_by_ptr.get(p))
             .map(|s| s.as_str())
     }
+    /// Type name by id WITH template subtypes composed
+    /// (`TArrayConstIterator<AGothicCharacter>`), mirroring `DataType::render` — `type_by_id`
+    /// returns the bare head, which is a template-arity error when used as a declaration.
+    /// Falls back to the bare name when the T1 entry records no subtypes.
+    pub fn type_by_id_composed(&self, id: i32) -> Option<String> {
+        let ptr = self.typeid_to_ptr.get(&id)?;
+        let base = self.type_by_ptr.get(ptr)?;
+        match self.type_subtypes.get(ptr) {
+            Some(subs) if !subs.is_empty() => {
+                let inner: Vec<String> = subs.iter().map(|s| s.base_name(self)).collect();
+                Some(format!("{base}<{}>", inner.join(", ")))
+            }
+            _ => Some(base.clone()),
+        }
+    }
     pub fn func_by_id(&self, id: i32) -> Option<&str> {
         self.funcid_to_ptr
             .get(&id)
@@ -322,5 +337,13 @@ impl RefResolver {
     pub fn member_type(&self, type_id: i32, offset: i32) -> Option<&str> {
         let key = ((type_id as i64) << 1) | ((offset as i64) << 33) | 1;
         self.prop_type_id.get(&key).and_then(|id| self.type_by_id(*id))
+    }
+    /// [`Self::member_type`], composed variant (declaring class INCLUDING template subtypes,
+    /// e.g. `TArrayConstIterator<AGothicCharacter>` instead of the bare head). Used where the
+    /// name becomes a slot DECLARATION (is-not-a-member.md §2.1/§2.2); the bare variant stays
+    /// for the head-comparing cast paths in structure.rs.
+    pub fn member_type_composed(&self, type_id: i32, offset: i32) -> Option<String> {
+        let key = ((type_id as i64) << 1) | ((offset as i64) << 33) | 1;
+        self.prop_type_id.get(&key).and_then(|id| self.type_by_id_composed(*id))
     }
 }

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -452,6 +452,26 @@ impl RefResolver {
         }
         self.native.as_ref().and_then(|n| n.field_type(class, field))
     }
+    /// batch-32d: CONST object-handle fields of NATIVE structs — the live compiler treats a
+    /// read of these as `const U*`, so a plain store into a same-typed local fails "Can't
+    /// implicitly convert from 'const UItemDefinition' to 'UItemDefinition'" (and a same-type
+    /// `Cast<>` provably does NOT strip const in-game, batch-21 Class C). The script cache
+    /// carries no constness for foreign fields (PropertyReferences = Name + OWNER OldTypeId),
+    /// so this in-crate row is the production source, keyed by the ADDSi (owner, member) pair
+    /// observed at the failing RefCpyV site (CharacterAI_Gothic
+    /// SelectBestItemActionFromInventory :3002). Returns the field's BASE value type; the
+    /// consumer (RefCpyV arm) compares it against the destination's declared type and emits
+    /// the CONSTSTORE marker so the decl gains the `const` qualifier. Deliberately separate
+    /// from KNOWN_NATIVE_FIELD_TYPES: those rows mirror the Binds field DECLS (validated by
+    /// the binds.rs test) and feed enum/float-filtered consumers.
+    pub fn native_field_const_object(&self, class: &str, field: &str) -> Option<&'static str> {
+        const KNOWN_NATIVE_CONST_OBJECT_FIELDS: &[(&str, &str, &str)] =
+            &[("FItemActionHandler", "ItemDefinition", "UItemDefinition")];
+        KNOWN_NATIVE_CONST_OBJECT_FIELDS
+            .iter()
+            .find(|(c, f, _)| *c == class && *f == field)
+            .map(|(_, _, t)| *t)
+    }
     /// Inject script-class METHOD names from the parsed modules (a shadowing member need not be
     /// referenced by any bytecode — e.g. `UCM_CastSpell_Base::CastSpell()` shadows the free
     /// `CastSpell(AI, int)` even if the method itself is never called).

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -281,6 +281,20 @@ impl RefResolver {
     /// Best-known native arity for a call by function ptr: prefer the exact (owning class,
     /// name) match, else the unambiguous by-name arity. None if no native data / ambiguous.
     pub fn native_arity_by_ptr(&self, ptr: i64, name: &str) -> Option<usize> {
+        // batch-20 Class C: natives whose tail-table FunctionReferences param list UNDERCOUNTS
+        // the live game API (proven by the in-game error candidates). Keyed (owner, name); the
+        // live-compiler signature is authoritative, so this overrides even a Binds arity.
+        // FGameplayEffectSpec::SetByCallerMagnitude(FGameplayTag DataTag, float32 Magnitude):
+        // the cache lists only DataTag, so the float Magnitude was dropped (17 in-game errors).
+        const KNOWN_NATIVE_ARITY: &[(&str, &str, usize)] =
+            &[("FGameplayEffectSpec", "SetByCallerMagnitude", 2)];
+        if let Some(cls) = self.func_owner.get(&ptr) {
+            if let Some((_, _, a)) =
+                KNOWN_NATIVE_ARITY.iter().find(|(c, n, _)| c == cls && n == &name)
+            {
+                return Some(*a);
+            }
+        }
         let n = self.native.as_ref()?;
         if let Some(cls) = self.func_owner.get(&ptr) {
             if let Some(a) = n.arity(cls, name) {

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -283,8 +283,17 @@ impl RefResolver {
         // `UAIGroup_Combat::StaticClass()` into a `TSubclassOf<UGothicAIGroup>` (vanilla-
         // compiled => UAIGroup_Combat derives UGothicAIGroup), and single inheritance places
         // UGothicAIGroup at or above the direct super UAIGroup_Combat_Base.
-        const KNOWN_NATIVE_HIERARCHY: &[(&str, &str)] =
-            &[("UAIGroup_Combat_Base", "UGothicAIGroup")];
+        // batch-31d (N7, spec batch31-nomatch-illegalop §1.7): AGothicNPCState derives
+        // AGothicCharacterState — evidence: the vanilla-compiled corpus passes
+        // `GetAllNPCStates()` elements (TArray<AGothicNPCState>) into script params typed
+        // AGothicCharacterState (the OldCamp guard CALL 0x2436d), and the
+        // GASCharacterStateMixins free fn `ExchangeDailyRoutineToClass(AGothicCharacterState
+        // Character, ...)` wraps exactly `Cast<AGothicNPCState>(Character)` — both directions
+        // of the single-inheritance proof.
+        const KNOWN_NATIVE_HIERARCHY: &[(&str, &str)] = &[
+            ("UAIGroup_Combat_Base", "UGothicAIGroup"),
+            ("AGothicNPCState", "AGothicCharacterState"),
+        ];
         if sub == sup {
             return true;
         }

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -435,6 +435,47 @@ impl RefResolver {
     pub fn static_name_count(&self) -> usize {
         self.static_names.len()
     }
+    /// Composed CONTAINER type of a NATIVE class's field (batch-25e,
+    /// specs/batch23-nomatch.md E; precedent: KNOWN_NATIVE_ARITY). The script cache stores no
+    /// value types for native-class fields, so `cast_container_args` could never derive the
+    /// key/value enums for e.g. `this.m_CollisionComp.m_CustomCollisionResponse.Add(1, 1)`
+    /// (25 in-game errors: TMap::Add/FindOrAdd/Find with bare int keys). Every entry's
+    /// subtypes are taken VERBATIM from the live compiler's `Candidates are:` lines in
+    /// capture.batch24-0705 (authoritative), keyed by the exact ADDSi-tid owners probed at
+    /// the failing sites (all three UHit*CollisionComponent variants carry their own
+    /// property-reference key). FWeatherSaveGame.DailyWeathers (named by the spec) is
+    /// deliberately ABSENT: batch-24 shows zero errors for it, so no candidate lines exist
+    /// to seed it from — never guess subtypes.
+    pub fn known_native_field_subtype(&self, class: &str, field: &str) -> Option<&'static str> {
+        const KNOWN_NATIVE_FIELD_SUBTYPES: &[(&str, &str, &str)] = &[
+            (
+                "UHitBoxCollisionComponent",
+                "m_CustomCollisionResponse",
+                "TMap<ECollisionChannel, ECollisionResponse>",
+            ),
+            (
+                "UHitCapsuleCollisionComponent",
+                "m_CustomCollisionResponse",
+                "TMap<ECollisionChannel, ECollisionResponse>",
+            ),
+            (
+                "UHitConeCollisionComponent",
+                "m_CustomCollisionResponse",
+                "TMap<ECollisionChannel, ECollisionResponse>",
+            ),
+            (
+                "FFXParticleSystem",
+                "NiagaraSystemPathBySurfaceType",
+                "TMap<EPhysicalSurface, TSoftObjectPtr<UNiagaraSystem>>",
+            ),
+            ("FWeatherSaveGame", "WeatherModifiers", "TMap<EWeather, float32>"),
+        ];
+        KNOWN_NATIVE_FIELD_SUBTYPES
+            .iter()
+            .find(|(c, f, _)| *c == class && *f == field)
+            .map(|(_, _, t)| *t)
+    }
+
     /// Member name from a containing type-id + byte offset.
     pub fn member(&self, type_id: i32, offset: i32) -> Option<&str> {
         let key = ((type_id as i64) << 1) | ((offset as i64) << 33) | 1;

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -458,8 +458,78 @@ impl RefResolver {
             ("FRotator", "Yaw", "float"),
             ("FRotator", "Roll", "float"),
         ];
+        // batch-40b (specs/rgt-and-methods-triage.md PART 1): NATIVE-struct FLOAT-family fields
+        // the script cache cannot type. The production emit runs WITHOUT Binds.Cache, so the
+        // batch-40 float-const-store fix (float literal instead of raw int bit-pattern) was inert
+        // for these NATIVE structs: `float_field_type` reaches `native_field_type`, which — absent
+        // binds — returned None, leaving `top.ty = None` so the WRTV `float_lit` reinterpret never
+        // fired (e.g. `FLightValues.SourceWidth = local_1101;` = the int bits of 250.0f, which the
+        // AS compiler then iTOf-coerces to the garbage float 1.13e9). These rows are the CACHE-FREE
+        // production source. The owner CLASS is still resolved cache-only (via the ADDSi type-id ->
+        // `type_by_id`, always present); this table only supplies the (class, field) -> float TYPE
+        // that used to require binds. Every entry is `float32` (verified). Enumerated by diffing the
+        // with-binds vs no-binds emit (the ADDSi member-store idiom sites) and confirmed against the
+        // shipped Binds.Cache field decls by `binds.rs::validate_float_field_types_against_real_binds_cache`.
+        const KNOWN_NATIVE_FLOAT_FIELDS: &[(&str, &str, &str)] = &[
+            ("FALoadingScreenSettings", "MinimumLoadingScreenDisplayTime", "float32"),
+            ("FAlphaBlendArgs", "BlendTime", "float32"),
+            ("FCameraBehaviour", "m_ArmLength", "float32"),
+            ("FCameraBehaviour", "m_LagSpeed", "float32"),
+            ("FCameraBehaviour", "m_SpellPitchLimit", "float32"),
+            ("FCameraBehaviour", "m_SpellYawLimit", "float32"),
+            ("FDodgeData", "m_SuperArmorResistanceMultiplier", "float32"),
+            ("FFreezeParams", "m_BlendOutDuration", "float32"),
+            ("FFreezeParams", "m_CustomTimeDilation", "float32"),
+            ("FFreezeParams", "m_FreezeDuration", "float32"),
+            ("FGameplayCueParameters", "NormalizedMagnitude", "float32"),
+            ("FGameplayCueParameters", "RawMagnitude", "float32"),
+            ("FGameplayEffectContext_HitResponse", "BowStretch", "float32"),
+            ("FGameplayEffectContext_HitResponse", "MultiplierSuperArmor", "float32"),
+            ("FGothicFlyDiveSettings", "AdaptToCollisionSampleZDistance", "float32"),
+            ("FGothicFlyDiveSettings", "CharacterZDivergeOffset", "float32"),
+            ("FGothicFlyDiveSettings", "GroundedMoveBeforeGoalDistance", "float32"),
+            ("FGothicFlyDiveSettings", "UseFlyDiveMinDistance", "float32"),
+            ("FGothicPathfollowSettings", "AgentRadiusMultiplier", "float32"),
+            ("FGothicPathfollowSettings", "CrowdAgentRadiusMultiplier", "float32"),
+            ("FGothicPathfollowSettings", "CrowdAgentSeparationWeight", "float32"),
+            ("FInteractionAnimTransition", "BlockOtherTransitionsForSeconds", "float32"),
+            ("FInteractionAnimTransition", "CooldownSeconds", "float32"),
+            ("FInteractionAnimTransition", "Probability", "float32"),
+            ("FInteractionAnimTransition", "Weight", "float32"),
+            ("FLightSet", "BarnDoorAngle", "float32"),
+            ("FLightSet", "BarnDoorLength", "float32"),
+            ("FLightSet", "IndirectLightingIntensity", "float32"),
+            ("FLightSet", "VolumetricScatteringIntensity", "float32"),
+            ("FLightValues", "AttenuationRadius", "float32"),
+            ("FLightValues", "SourceHeight", "float32"),
+            ("FLightValues", "SourceWidth", "float32"),
+            ("FMemorizedEvent", "Magnitude", "float32"),
+            ("FPathfollowModifyAvoidVelocitySettings", "FastSpeedVelocityMultiplier", "float32"),
+            ("FPathfollowModifyAvoidVelocitySettings", "MediumRangeVelocityMultiplier", "float32"),
+            ("FPathfollowModifyAvoidVelocitySettings", "ShortRangeVelocityMultiplier", "float32"),
+            ("FPathfollowMoveFocusSettings", "FocalPointHeightMultiplier", "float32"),
+            ("FPerceptionHandler", "DelaySeconds", "float32"),
+            ("FRelativeCrimeDataEntry", "BaseSeverity", "float32"),
+            ("FRememberedPerception", "Magnitude", "float32"),
+            ("FRememberedPerception", "TimeUpdated", "float32"),
+            ("FScalableFloat", "Value", "float32"),
+            ("FScoredItemAction", "Score", "float32"),
+            ("FSlateFontInfo", "Size", "float32"),
+            ("FTipSettings", "TipSwapTime", "float32"),
+            ("FTipSettings", "TipWrapAt", "float32"),
+        ];
         if let Some((_, _, t)) =
             KNOWN_NATIVE_FIELD_TYPES.iter().find(|(c, f, _)| *c == class && *f == field)
+        {
+            return Some(t);
+        }
+        // batch-40b: NATIVE-struct FLOAT-family field types the script cache cannot resolve.
+        // Kept in a SEPARATE table from the enum rows above because these are consumed only by
+        // the float-family-gated `float_field_type` (WRTV float-const store + RDR8 read wraps),
+        // never the enum/int cast gates. Every row is verified against the shipped Binds.Cache
+        // by `binds.rs::validate_float_field_types_against_real_binds_cache`.
+        if let Some((_, _, t)) =
+            KNOWN_NATIVE_FLOAT_FIELDS.iter().find(|(c, f, _)| *c == class && *f == field)
         {
             return Some(t);
         }

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -359,6 +359,38 @@ impl RefResolver {
     pub fn native_name_exists(&self, name: &str) -> bool {
         self.native.as_ref().is_some_and(|n| n.has_name(name))
     }
+    /// Enum VALUE type of a NATIVE struct's field, for the WRTV1 1-byte-write guard
+    /// (batch-25a, specs/batch23-cantconvert.md G2). The script cache cannot resolve these:
+    /// PropertyReferences.OldTypeId is the OWNER struct (verified: FWidgetAlignment.
+    /// VerticalAlignment -> "FWidgetAlignment"), and several of the enums are not even in the
+    /// T1 type table. The PRODUCTION source is this in-crate table — the emit runs without
+    /// Binds.Cache (no `GORE_AS_BINDS`, no sibling next to the input cache; the Binds-loaded
+    /// arity trim is a proven regression, batch-24b report), so a Binds-side parse alone would
+    /// never fire. Every entry is verified against the shipped Binds.Cache field decls
+    /// (`binds.rs` test `validate_field_types_against_real_binds_cache`) and keyed by the
+    /// exact (ADDSi type-id -> owner, member) pair observed at the failing WRTV1 sites.
+    /// The Binds field-type table (when loaded, dev runs) extends coverage as a fallback.
+    pub fn native_field_type(&self, class: &str, field: &str) -> Option<&str> {
+        const KNOWN_NATIVE_FIELD_TYPES: &[(&str, &str, &str)] = &[
+            ("FWidgetAlignment", "VerticalAlignment", "EVerticalAlignment"),
+            ("FWidgetAlignment", "HorizontalAlignment", "EHorizontalAlignment"),
+            ("FPerceivedAgent", "Relationship", "ERelationship"),
+            ("FPerceivedAgent", "Hostility", "ERelationshipHostility"),
+            ("FPerceivedAgent", "RelativeRank", "ERelationshipRelativeRank"),
+            ("FFXPerceptionSoundArea", "PerceptionLoudness", "EPerceptionNoiseLoudness"),
+            ("FALoadingScreenSettings", "Layout", "EAsyncLoadingScreenLayout"),
+            ("FALoadingScreenSettings", "PlaybackType", "EMoviePlaybackType"),
+            ("FTextAppearance", "Justification", "ETextJustify"),
+            ("FInteractionAnimTransition", "TransitionKind", "EInteractionInputKind"),
+            ("FWeatherSaveGame", "CurrentWeather", "EWeather"),
+        ];
+        if let Some((_, _, t)) =
+            KNOWN_NATIVE_FIELD_TYPES.iter().find(|(c, f, _)| *c == class && *f == field)
+        {
+            return Some(t);
+        }
+        self.native.as_ref().and_then(|n| n.field_type(class, field))
+    }
     /// Inject script-class METHOD names from the parsed modules (a shadowing member need not be
     /// referenced by any bytecode — e.g. `UCM_CastSpell_Base::CastSpell()` shadows the free
     /// `CastSpell(AI, int)` even if the method itself is never called).

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -529,9 +529,9 @@ impl RefResolver {
     /// subtypes are taken VERBATIM from the live compiler's `Candidates are:` lines in
     /// capture.batch24-0705 (authoritative), keyed by the exact ADDSi-tid owners probed at
     /// the failing sites (all three UHit*CollisionComponent variants carry their own
-    /// property-reference key). FWeatherSaveGame.DailyWeathers (named by the spec) is
-    /// deliberately ABSENT: batch-24 shows zero errors for it, so no candidate lines exist
-    /// to seed it from — never guess subtypes.
+    /// property-reference key). FWeatherSaveGame.DailyWeathers joined in batch-31c (N3
+    /// Fix 3): capture.batch30-0705 OnDayElapsed(413:48) provides the candidate line
+    /// `bool TArray::Contains(const EWeather&in Value) const` — same never-guess rule.
     pub fn known_native_field_subtype(&self, class: &str, field: &str) -> Option<&'static str> {
         const KNOWN_NATIVE_FIELD_SUBTYPES: &[(&str, &str, &str)] = &[
             (
@@ -555,6 +555,7 @@ impl RefResolver {
                 "TMap<EPhysicalSurface, TSoftObjectPtr<UNiagaraSystem>>",
             ),
             ("FWeatherSaveGame", "WeatherModifiers", "TMap<EWeather, float32>"),
+            ("FWeatherSaveGame", "DailyWeathers", "TArray<EWeather>"),
         ];
         KNOWN_NATIVE_FIELD_SUBTYPES
             .iter()

--- a/crates/gore-as/src/cache/remap.rs
+++ b/crates/gore-as/src/cache/remap.rs
@@ -351,8 +351,8 @@ fn scan_surviving_regen_keys(
 }
 
 /// Where a ref operand lives within an instruction + which table it keys.
-#[derive(Clone, Copy)]
-enum RefKind {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefKind {
     GlobalPtr,
     FuncPtr,
     TypePtr,
@@ -361,16 +361,19 @@ enum RefKind {
 }
 
 /// One ref operand site: the dword index within the instruction + its kind.
-struct RefSite {
+pub struct RefSite {
     /// First operand dword index within the instruction (the low dword for a qword).
-    dw_index: usize,
-    is_qword: bool,
-    kind: RefKind,
+    pub dw_index: usize,
+    pub is_qword: bool,
+    pub kind: RefKind,
 }
 
 /// Operand sites per opcode. Empty for non-ref ops. The authoritative classification from
 /// `findings/decompile-refs.md §3`. ALLOC carries TWO ref operands (type ptr + ctor func id).
-fn ref_sites(op: &str) -> Vec<RefSite> {
+/// Shared by the ref-remapper (key->key rewrite) and the bytediff oracle (key->identity N1
+/// canonicalization) so both use the SAME op->table map — the make-or-break for a build-portable
+/// bytecode compare (`specs/semantic-oracle.md §3.1`).
+pub fn ref_sites(op: &str) -> Vec<RefSite> {
     use RefKind::*;
     match op {
         // global ptr (QW @ dword 1)
@@ -902,4 +905,130 @@ pub fn remap_module_to_base(extracted_mini: &[u8], base: &[u8]) -> Result<(Vec<u
     out.extend_from_slice(&module_bytes);
     out.extend_from_slice(&[0u8; 28]); // 7 tables × int32 count 0
     Ok((out, total))
+}
+
+// ---------------------------------------------------------------------------------------------
+// PUBLIC N1 API for the bytediff oracle (`specs/semantic-oracle.md §3.1`): resolve a raw
+// bytecode ref operand to a build-PORTABLE identity string, reusing the exact `SymTables`
+// classification the remapper uses. Where `remap.rs` maps key->key (size-preserving splice),
+// bytediff needs key->identity (a strict subset: `SymTables` already builds the forward
+// `*_id_of_ptr` identity maps). No new RE.
+// ---------------------------------------------------------------------------------------------
+
+/// One cache's tail-table identity resolver for bytecode ref operands. Build once per cache;
+/// call [`Self::resolve_operand`] on each ref operand of each disassembled instruction.
+pub struct RefIdentity {
+    syms: SymTables,
+}
+
+/// A resolved ref operand: either a portable identity (name+module+ns+signature — comparable
+/// across builds) or, when the operand keys nothing in the tables (a primitive type-id, or a
+/// key genuinely absent from the tail tables), a raw fallback that still compares equal to an
+/// identical raw operand on the other side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperandId {
+    /// Portable identity resolved via the tail tables (the normal cross-referencing case).
+    Named { kind: RefKind, identity: String },
+    /// Primitive type-id (<= LAST_PRIMITIVE, not in T2) — resolves to itself. Compared by value.
+    Primitive(i32),
+    /// A key/id present as an operand but absent from this cache's tables (defensive: a null
+    /// sentinel, or a table gap). Compared by raw value so two identical raws still match.
+    RawPtr(i64),
+    RawId(i32),
+}
+
+impl OperandId {
+    /// Human-readable form for the SEMANTIC-DIFF report (e.g. `CALLSYS Story::GiveXP`).
+    /// The identity string embeds unit-separator chars; render them as `::`-ish for readability.
+    pub fn display(&self) -> String {
+        match self {
+            OperandId::Named { identity, .. } => identity.replace(SEP, " » "),
+            OperandId::Primitive(id) => format!("prim#{id}"),
+            OperandId::RawPtr(p) => format!("<unresolved-ptr {p:#x}>"),
+            OperandId::RawId(i) => format!("<unresolved-id {i}>"),
+        }
+    }
+}
+
+impl RefIdentity {
+    /// Build the identity resolver from a full cache's tail tables.
+    pub fn build(bytes: &[u8]) -> Result<Self, WireError> {
+        Ok(RefIdentity { syms: SymTables::build(bytes)? })
+    }
+
+    /// Resolve a QWORD ptr operand (global/func/type ptr) to a portable identity.
+    pub fn resolve_ptr(&self, kind: RefKind, key: i64) -> OperandId {
+        let map = match kind {
+            RefKind::GlobalPtr => &self.syms.global_id_of_ptr,
+            RefKind::FuncPtr => &self.syms.func_id_of_ptr,
+            RefKind::TypePtr => &self.syms.type_id_of_ptr,
+            // FuncId/TypeId are DW operands, not ptr — never routed here.
+            RefKind::FuncId | RefKind::TypeId => return OperandId::RawPtr(key),
+        };
+        match map.get(&key) {
+            Some(id) => OperandId::Named { kind, identity: id.clone() },
+            None => OperandId::RawPtr(key),
+        }
+    }
+
+    /// Resolve a DWORD id operand (func-id via T4->T3, type-id via T2->T1) to a portable
+    /// identity. A type-id absent from T2 is a PRIMITIVE (int/bool/float32/...) that resolves to
+    /// itself (verbatim copy of the remapper's primitive-passthrough rule, `ref-remap.md §2.5`).
+    pub fn resolve_id(&self, kind: RefKind, id: i32) -> OperandId {
+        match kind {
+            RefKind::FuncId => match self.syms.funcid_to_ptr.get(&id) {
+                Some(ptr) => match self.syms.func_id_of_ptr.get(ptr) {
+                    Some(ident) => OperandId::Named { kind, identity: ident.clone() },
+                    None => OperandId::RawPtr(*ptr),
+                },
+                // Not a real func-id in this cache: defensive, compare raw.
+                None => OperandId::RawId(id),
+            },
+            RefKind::TypeId => match self.syms.typeid_to_ptr.get(&id) {
+                Some(ptr) => match self.syms.type_id_of_ptr.get(ptr) {
+                    Some(ident) => OperandId::Named { kind, identity: ident.clone() },
+                    None => OperandId::RawPtr(*ptr),
+                },
+                // Absent from T2 => primitive type-id, resolves to itself.
+                None => OperandId::Primitive(id),
+            },
+            RefKind::GlobalPtr | RefKind::FuncPtr | RefKind::TypePtr => OperandId::RawId(id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod bytediff_n1_tests {
+    use super::*;
+
+    /// N1: a CALLSYS func-ptr operand resolves to a portable identity string that embeds the
+    /// function name — the exact make-or-break for the bytediff oracle. Uses the richtest sample.
+    #[test]
+    fn n1_resolves_callsys_ptr_to_named_identity() {
+        let bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../work/reversing/gore-as/samples/PrecompiledScript.richtest.Cache"
+        ))
+        .expect("read richtest sample");
+        let ident = RefIdentity::build(&bytes).expect("build RefIdentity");
+        // Find any T3 func ptr key and confirm resolve_ptr yields a Named identity containing
+        // the function's Name (the identity is module|ns|owner|name|is_method|params|ret).
+        let (&ptr, name) =
+            ident.syms.func_name_of_ptr.iter().next().expect("at least one func ref");
+        let resolved = ident.resolve_ptr(RefKind::FuncPtr, ptr);
+        match &resolved {
+            OperandId::Named { kind, identity } => {
+                assert_eq!(*kind, RefKind::FuncPtr);
+                assert!(
+                    identity.contains(name.as_str()),
+                    "identity {identity:?} should contain func name {name:?}"
+                );
+            }
+            other => panic!("expected Named identity, got {other:?}"),
+        }
+        // An unknown ptr resolves to a RawPtr (defensive), NOT a panic.
+        assert!(matches!(ident.resolve_ptr(RefKind::FuncPtr, 0x7fff_dead_beef), OperandId::RawPtr(_)));
+        // A primitive type-id (bool == not-in-T2, small id) resolves to itself.
+        assert!(matches!(ident.resolve_id(RefKind::TypeId, 0x41), OperandId::Primitive(0x41)));
+    }
 }

--- a/crates/gore-as/src/cache/remap.rs
+++ b/crates/gore-as/src/cache/remap.rs
@@ -1090,6 +1090,44 @@ impl OperandId {
         }
     }
 
+    /// For a resolved FUNCTION identity (a `CALLSYS`/`CALL` callee), return the callee's
+    /// (owner-type-name, method-name) as borrowed slices of the composed `Ident.full`.
+    ///
+    /// A T3 FunctionReference identity is composed (see `SymTables::build`) as the SEP-joined
+    /// fields `module | namespace | <owner.full> | name | is_method | params | ret`, where
+    /// `<owner.full>` is itself a TYPE identity of EXACTLY 4 SEP-fields
+    /// (`owner_module | owner_ns | owner_name | Nsub:subs`). So on a raw `split(SEP)` the layout is
+    /// positionally fixed regardless of field CONTENT:
+    ///   [0]=module [1]=ns [2]=owner_module [3]=owner_ns [4]=owner_name [5]=owner_subs
+    ///   [6]=name(the method) [7]=is_method [8..]=params/ret.
+    /// This is the cache-INDEPENDENT keying the scope-strip needs (the raw CALLSYS func-PTR drifts
+    /// across builds, but the resolved owner+method identity does not). Returns `None` for a
+    /// non-`Named` operand or a malformed identity with too few fields (defensive).
+    pub fn func_owner_method(&self) -> Option<(&str, &str)> {
+        match self {
+            OperandId::Named { kind: RefKind::FuncPtr | RefKind::FuncId, ident } => {
+                let mut it = ident.full.split(SEP);
+                let owner = it.nth(4)?; // fields 0..=4, leaving cursor after field 4
+                let method = it.nth(1)?; // field 6 (skip field 5 = owner_subs)
+                Some((owner, method))
+            }
+            _ => None,
+        }
+    }
+
+    /// TEST-ONLY constructor: build a `Named` FUNC-ptr identity from an owner-type name + method
+    /// name, composing the exact SEP layout `SEP SEP SEP SEP owner SEP 0: SEP method SEP 1` so
+    /// [`func_owner_method`](Self::func_owner_method) round-trips. Used by the bytediff N5 unit
+    /// tests (which construct synthetic `NormInstr` CALLSYS callees).
+    #[doc(hidden)]
+    pub fn named_func_for_test(owner: &str, method: &str) -> OperandId {
+        let full = format!("{SEP}{SEP}{SEP}{SEP}{owner}{SEP}0:{SEP}{method}{SEP}1");
+        OperandId::Named {
+            kind: RefKind::FuncPtr,
+            ident: Ident { full: full.clone(), ns_stripped: full, namespaces: vec![] },
+        }
+    }
+
     /// True if this is a large runtime object type-id resolved as [`OperandId::Primitive`] (an
     /// `asCTypeInfo` id NOT in T2 that has the AngelScript object-mask bits set). Such an id is
     /// build-specific and drifts across recompiles; GAP-C (batch-38) treats a lone diff of one as
@@ -1313,5 +1351,51 @@ mod bytediff_n1_tests {
         assert!(!OperandId::Primitive(10).is_runtime_object_typeid());
         // Non-primitive variants are never runtime type-ids.
         assert!(!OperandId::RawId(1207972964).is_runtime_object_typeid());
+    }
+
+    /// `func_owner_method` extracts owner-type-name (field 4) + method-name (field 6) from a
+    /// composed T3 function identity, positionally fixed because the embedded owner is EXACTLY 4
+    /// SEP-fields. This is the cache-independent key the n5 scope-strip uses.
+    #[test]
+    fn func_owner_method_splits_composed_identity() {
+        let sep = SEP;
+        // Mirror the exact composition for a RAII scope-counter ctor `FScopeCycleCounter::$beh0`:
+        // module="" ns="" owner=(""|""|"FScopeCycleCounter"|"0:") name="$beh0" is_method="1" ...
+        let full = format!(
+            "{sep}{sep}{sep}{sep}FScopeCycleCounter{sep}0:{sep}$beh0{sep}1{sep}110100:5:{sep}{sep}FStatID{sep}0:,{sep}000000:82:"
+        );
+        let stripped = full.clone(); // ns fields already empty here
+        let id = OperandId::Named {
+            kind: RefKind::FuncPtr,
+            ident: Ident { full, ns_stripped: stripped, namespaces: vec![] },
+        };
+        assert_eq!(id.func_owner_method(), Some(("FScopeCycleCounter", "$beh0")));
+
+        // FStatID temp dtor `FStatID::$beh2`.
+        let full2 = format!("{sep}{sep}{sep}{sep}FStatID{sep}0:{sep}$beh2{sep}1{sep}{sep}000000:82:");
+        let id2 = OperandId::Named {
+            kind: RefKind::FuncPtr,
+            ident: Ident { full: full2.clone(), ns_stripped: full2, namespaces: vec![] },
+        };
+        assert_eq!(id2.func_owner_method(), Some(("FStatID", "$beh2")));
+
+        // A callee WITH non-empty module/namespace/owner-namespace still indexes correctly (the
+        // owner is still exactly 4 fields).
+        let full3 = format!(
+            "GAS.Mixins{sep}NS{sep}OMod{sep}ONs{sep}AGothicCharacterState{sep}0:{sep}IsTrulyPartOfGuild{sep}1{sep}p{sep}r"
+        );
+        let id3 = OperandId::Named {
+            kind: RefKind::FuncPtr,
+            ident: Ident { full: full3.clone(), ns_stripped: full3, namespaces: vec![] },
+        };
+        assert_eq!(id3.func_owner_method(), Some(("AGothicCharacterState", "IsTrulyPartOfGuild")));
+
+        // Non-function operands / malformed identities return None.
+        assert_eq!(OperandId::Primitive(3).func_owner_method(), None);
+        let short = OperandId::Named {
+            kind: RefKind::FuncPtr,
+            ident: Ident { full: format!("a{sep}b"), ns_stripped: String::new(), namespaces: vec![] },
+        };
+        assert_eq!(short.func_owner_method(), None);
     }
 }

--- a/crates/gore-as/src/cache/remap.rs
+++ b/crates/gore-as/src/cache/remap.rs
@@ -69,12 +69,77 @@ pub enum RemapError {
 /// Field separator for composing a stable symbol identity string (unlikely in any name).
 const SEP: char = '\u{1f}';
 
+/// Field separator INSIDE a namespace field's `::`-qualified segments (regen drops leading
+/// `Ns::` segments — see [`ns_drift_ok`]).
+const NS_SEP: &str = "::";
+
+/// A symbol identity in three parallel forms. `full` is the display/exact-match string
+/// (namespaces embedded); `ns_stripped` is the same string with every namespace field replaced
+/// by empty (the structural skeleton — module/name/subtypes/signature only); `namespaces` lists
+/// the namespace-field values in traversal order. GAP-A (batch-38): our emitter never writes
+/// `namespace X { }` blocks, so a vanilla symbol carries a namespace where the regen has none (or
+/// a `::`-suffix of it); the binding is unchanged (module+name+subtypes+signature pin the symbol).
+/// Two identities match (see [`Ident::oracle_eq`]) when their skeletons are equal AND every
+/// namespace-field pair is a benign drift (equal / one-empty / one a `::`-suffix of the other),
+/// which collapses the ~26.8k drift diffs while KEEPING the ~39 real `Foo::Bar` vs `Baz::Bar`
+/// namespace-collisions SEMANTIC (both-nonempty-non-suffix → not a match).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Ident {
+    full: String,
+    ns_stripped: String,
+    namespaces: Vec<String>,
+}
+
+impl Ident {
+    /// Oracle equality with benign namespace-drift tolerance (GAP-A). Exact-string-equal always
+    /// matches (self-identity, and the common no-drift case). Otherwise require identical
+    /// structural skeletons AND every namespace-field pair to be a benign drift.
+    fn oracle_eq(&self, other: &Ident) -> bool {
+        if self.full == other.full {
+            return true;
+        }
+        if self.ns_stripped != other.ns_stripped
+            || self.namespaces.len() != other.namespaces.len()
+        {
+            return false;
+        }
+        self.namespaces
+            .iter()
+            .zip(&other.namespaces)
+            .all(|(a, b)| ns_drift_ok(a, b))
+    }
+}
+
+/// True if two namespace-field values differ only by the benign drift our emitter introduces:
+/// they are equal, one is empty (the pure-global drop), or one is a `::`-suffix of the other
+/// (the enclosing `namespace G1R { }` block dropped, e.g. `G1R::UStoryG1R` vs `UStoryG1R`).
+/// A `Foo::Bar` vs `Baz::Bar` pair (both non-empty, neither a `::`-suffix of the other) is a
+/// REAL namespace-collision and returns false → stays SEMANTIC (the 39-collision guard, spec §1.1).
+fn ns_drift_ok(a: &str, b: &str) -> bool {
+    if a == b || a.is_empty() || b.is_empty() {
+        return true;
+    }
+    is_ns_suffix(a, b) || is_ns_suffix(b, a)
+}
+
+/// True if `short` equals `long` with ≥1 leading `Seg::` namespace segment removed (i.e. `short`
+/// is a proper `::`-delimited suffix of `long`). `"UStoryG1R"` is a suffix of `"G1R::UStoryG1R"`;
+/// `"Bar"` is NOT a suffix of `"BazBar"` (segment-boundary required, not a raw substring).
+fn is_ns_suffix(long: &str, short: &str) -> bool {
+    long.len() > short.len()
+        && long.ends_with(short)
+        && long[..long.len() - short.len()].ends_with(NS_SEP)
+}
+
 /// Symbol identity → key inverse maps for one cache's tail tables, plus the forward key→name
 /// maps needed to compose function/global identities and to report unresolved refs.
 struct SymTables {
     /// T1: type ptr key -> identity ; identity -> ptr key.
     type_id_of_ptr: HashMap<i64, String>,
     type_ptr_of_id: HashMap<String, Vec<i64>>,
+    /// T1: type ptr key -> the oracle [`Ident`] (full + ns-stripped skeleton + namespace list).
+    /// PARALLEL to `type_id_of_ptr` (whose full string the remapper's key→key splice keeps).
+    type_ident_of_ptr: HashMap<i64, Ident>,
     /// T2: type-id (i32, raw operand) -> type ptr.
     typeid_to_ptr: HashMap<i32, i64>,
     /// inverse of T2: type ptr -> type-id (raw i32 operand).
@@ -82,6 +147,8 @@ struct SymTables {
     /// T3: func ptr key -> identity ; identity -> ptr key.
     func_id_of_ptr: HashMap<i64, String>,
     func_ptr_of_id: HashMap<String, Vec<i64>>,
+    /// T3: func ptr key -> the oracle [`Ident`] (parallel to `func_id_of_ptr`).
+    func_ident_of_ptr: HashMap<i64, Ident>,
     /// forward Name (for error messages) per func ptr.
     func_name_of_ptr: HashMap<i64, String>,
     type_name_of_ptr: HashMap<i64, String>,
@@ -92,6 +159,8 @@ struct SymTables {
     /// T5: global ptr key -> identity ; identity -> ptr key.
     global_id_of_ptr: HashMap<i64, String>,
     global_ptr_of_id: HashMap<String, Vec<i64>>,
+    /// T5: global ptr key -> the oracle [`Ident`] (parallel to `global_id_of_ptr`).
+    global_ident_of_ptr: HashMap<i64, Ident>,
     /// EVERY int64 ptr-key that appears as a key in this cache's tail tables: T1 type ptrs,
     /// T3 func ptrs, T5 global ptrs, and the ptr values in T2/T4 (id->ptr). Used by the
     /// post-condition scan to assert no regen ptr-key survives in a remapped module's bytes.
@@ -104,7 +173,11 @@ struct SymTables {
 /// resolved TYPE IDENTITY of its `type_info` ptr (the build-specific ptr resolved to a portable
 /// identity that includes the type's name + template subtypes — so `TSubclassOf<AFoo>` and
 /// `TSubclassOf<ABar>` are distinguished, which matters for conversion-operator overloads).
-fn datatype_identity(c: &mut Cursor, type_id_of_ptr: &HashMap<i64, String>) -> Result<String, WireError> {
+///
+/// Returns the oracle [`Ident`] triple: the nested type's namespace fields (which drift, GAP-A)
+/// are carried through into both the stripped skeleton and the namespace list, so a func/global
+/// identity that embeds this DataType composes correctly for [`Ident::oracle_eq`].
+fn datatype_identity(c: &mut Cursor, type_ident_of_ptr: &HashMap<i64, Ident>) -> Result<Ident, WireError> {
     // 6 bools, i64 type_info, i32 token (mirror DataType::read order).
     let b0 = c.read_bool4()?;
     let b1 = c.read_bool4()?;
@@ -115,14 +188,19 @@ fn datatype_identity(c: &mut Cursor, type_id_of_ptr: &HashMap<i64, String>) -> R
     let type_info = c.read_i64()?;
     let token = c.read_i32()?;
     let tident = if token == 5 {
-        type_id_of_ptr.get(&type_info).cloned().unwrap_or_default()
+        type_ident_of_ptr.get(&type_info).cloned().unwrap_or_default()
     } else {
-        String::new()
+        Ident::default()
     };
-    Ok(format!(
-        "{}{}{}{}{}{}:{token}:{tident}",
+    let prefix = format!(
+        "{}{}{}{}{}{}:{token}:",
         b0 as u8, b1 as u8, b2 as u8, b3 as u8, b4 as u8, b5 as u8
-    ))
+    );
+    Ok(Ident {
+        full: format!("{prefix}{}", tident.full),
+        ns_stripped: format!("{prefix}{}", tident.ns_stripped),
+        namespaces: tident.namespaces,
+    })
 }
 
 impl SymTables {
@@ -135,6 +213,7 @@ impl SymTables {
         let mut all_ptr_keys: HashSet<i64> = HashSet::new();
         let mut type_id_of_ptr = HashMap::new();
         let mut type_ptr_of_id: HashMap<String, Vec<i64>> = HashMap::new();
+        let mut type_ident_of_ptr: HashMap<i64, Ident> = HashMap::new();
         let mut type_name_of_ptr = HashMap::new();
 
         // T1 TypeReferences: i64 key + (Name, Module, Namespace, TArray<DataType> SubTypes).
@@ -171,7 +250,10 @@ impl SymTables {
             type_name_of_ptr.insert(key, name.clone());
             raw_types.push(RawType { key, name, module, namespace, subs });
         }
-        // PASS 2: compose identities using resolved subtype names.
+        // PASS 2: compose identities using resolved subtype names. Subtype names are the bare
+        // T1 Name (no module/namespace), so a subtype contributes NO namespace field — the only
+        // namespace in a type identity is the type's OWN (field index 1). The oracle skeleton
+        // drops it; the namespace list carries it (GAP-A).
         for rt in &raw_types {
             let mut sub_ident = String::new();
             for (token, sub_ptr) in &rt.subs {
@@ -185,6 +267,15 @@ impl SymTables {
             let identity = format!(
                 "{}{SEP}{}{SEP}{}{SEP}{}:{sub_ident}",
                 rt.module, rt.namespace, rt.name, rt.subs.len()
+            );
+            // ns-stripped skeleton: identical but with the namespace field blanked.
+            let ns_stripped = format!(
+                "{}{SEP}{SEP}{}{SEP}{}:{sub_ident}",
+                rt.module, rt.name, rt.subs.len()
+            );
+            type_ident_of_ptr.insert(
+                rt.key,
+                Ident { full: identity.clone(), ns_stripped, namespaces: vec![rt.namespace.clone()] },
             );
             type_id_of_ptr.insert(rt.key, identity.clone());
             type_ptr_of_id.entry(identity).or_default().push(rt.key);
@@ -205,6 +296,7 @@ impl SymTables {
         // TArray<DataType> params, DataType ret).
         let mut func_id_of_ptr = HashMap::new();
         let mut func_ptr_of_id: HashMap<String, Vec<i64>> = HashMap::new();
+        let mut func_ident_of_ptr: HashMap<i64, Ident> = HashMap::new();
         let mut func_name_of_ptr = HashMap::new();
         for _ in 0..c.read_count("FunctionReferences")? {
             let key = c.read_i64()?;
@@ -218,19 +310,38 @@ impl SymTables {
             let objtype = c.read_i64()?;
             // Use the owner's FULL type identity (name + template subtypes), not just its name,
             // so e.g. `TSubclassOf<AFoo>::opImplConv` and `TSubclassOf<ABar>::opImplConv` (which
-            // share the bare owner name `TSubclassOf`) are distinguished.
-            let owner = type_id_of_ptr.get(&objtype).cloned().unwrap_or_default();
+            // share the bare owner name `TSubclassOf`) are distinguished. The owner + each param +
+            // ret are type identities that carry their OWN (drifting) namespace fields, so compose
+            // all three oracle forms in lockstep (GAP-A: a func's own ns is field index 1, then the
+            // owner's ns, then each param's, then ret's — traversal order preserved in the list).
+            let owner = type_ident_of_ptr.get(&objtype).cloned().unwrap_or_default();
             let nparams = c.read_count("FuncRef.Params")?;
-            let mut params = String::new();
+            let mut params_full = String::new();
+            let mut params_stripped = String::new();
+            let mut param_ns: Vec<String> = Vec::new();
             for _ in 0..nparams {
-                params.push_str(&datatype_identity(&mut c, &type_id_of_ptr)?);
-                params.push(',');
+                let p = datatype_identity(&mut c, &type_ident_of_ptr)?;
+                params_full.push_str(&p.full);
+                params_full.push(',');
+                params_stripped.push_str(&p.ns_stripped);
+                params_stripped.push(',');
+                param_ns.extend(p.namespaces);
             }
-            let ret = datatype_identity(&mut c, &type_id_of_ptr)?;
+            let ret = datatype_identity(&mut c, &type_ident_of_ptr)?;
             let identity = format!(
-                "{module}{SEP}{namespace}{SEP}{owner}{SEP}{name}{SEP}{}{SEP}{params}{SEP}{ret}",
-                is_method as u8
+                "{module}{SEP}{namespace}{SEP}{}{SEP}{name}{SEP}{}{SEP}{params_full}{SEP}{}",
+                owner.full, is_method as u8, ret.full
             );
+            let ns_stripped = format!(
+                "{module}{SEP}{SEP}{}{SEP}{name}{SEP}{}{SEP}{params_stripped}{SEP}{}",
+                owner.ns_stripped, is_method as u8, ret.ns_stripped
+            );
+            let mut namespaces = Vec::with_capacity(2 + param_ns.len() + ret.namespaces.len());
+            namespaces.push(namespace.clone()); // the func's own namespace (field index 1)
+            namespaces.extend(owner.namespaces.iter().cloned());
+            namespaces.extend(param_ns);
+            namespaces.extend(ret.namespaces.iter().cloned());
+            func_ident_of_ptr.insert(key, Ident { full: identity.clone(), ns_stripped, namespaces });
             func_id_of_ptr.insert(key, identity.clone());
             func_ptr_of_id.entry(identity).or_default().push(key);
             func_name_of_ptr.insert(key, name);
@@ -250,6 +361,7 @@ impl SymTables {
         // T5 GlobalReferences: i64 key + (Name, Module, Namespace, i32 bIsString).
         let mut global_id_of_ptr = HashMap::new();
         let mut global_ptr_of_id: HashMap<String, Vec<i64>> = HashMap::new();
+        let mut global_ident_of_ptr: HashMap<i64, Ident> = HashMap::new();
         let mut global_name_of_ptr = HashMap::new();
         for _ in 0..c.read_count("GlobalReferences")? {
             let key = c.read_i64()?;
@@ -259,6 +371,12 @@ impl SymTables {
             let namespace = c.read_sia()?;
             let is_string = c.read_bool4()?;
             let identity = format!("{module}{SEP}{namespace}{SEP}{name}{SEP}{}", is_string as u8);
+            // ns-stripped skeleton: namespace field (index 1) blanked (GAP-A).
+            let ns_stripped = format!("{module}{SEP}{SEP}{name}{SEP}{}", is_string as u8);
+            global_ident_of_ptr.insert(
+                key,
+                Ident { full: identity.clone(), ns_stripped, namespaces: vec![namespace.clone()] },
+            );
             global_id_of_ptr.insert(key, identity.clone());
             global_ptr_of_id.entry(identity).or_default().push(key);
             global_name_of_ptr.insert(key, name);
@@ -269,10 +387,12 @@ impl SymTables {
         Ok(SymTables {
             type_id_of_ptr,
             type_ptr_of_id,
+            type_ident_of_ptr,
             typeid_to_ptr,
             ptr_to_typeid,
             func_id_of_ptr,
             func_ptr_of_id,
+            func_ident_of_ptr,
             func_name_of_ptr,
             type_name_of_ptr,
             global_name_of_ptr,
@@ -280,6 +400,7 @@ impl SymTables {
             ptr_to_funcid,
             global_id_of_ptr,
             global_ptr_of_id,
+            global_ident_of_ptr,
             all_ptr_keys,
         })
     }
@@ -925,10 +1046,16 @@ pub struct RefIdentity {
 /// across builds) or, when the operand keys nothing in the tables (a primitive type-id, or a
 /// key genuinely absent from the tail tables), a raw fallback that still compares equal to an
 /// identical raw operand on the other side.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Equality is CUSTOM ([`PartialEq`] below): two `Named` operands compare via
+/// [`Ident::oracle_eq`], which tolerates benign namespace-drift (GAP-A). This relation is NOT
+/// transitive (`Foo::X` ~ `X` ~ `Baz::X`, yet `Foo::X` ≁ `Baz::X`), so `OperandId` is
+/// deliberately NOT `Eq`; the oracle only ever compares operand PAIRS, never keys a map/set by
+/// one, so a full equivalence relation is not required.
+#[derive(Debug, Clone)]
 pub enum OperandId {
     /// Portable identity resolved via the tail tables (the normal cross-referencing case).
-    Named { kind: RefKind, identity: String },
+    Named { kind: RefKind, ident: Ident },
     /// Primitive type-id (<= LAST_PRIMITIVE, not in T2) — resolves to itself. Compared by value.
     Primitive(i32),
     /// A key/id present as an operand but absent from this cache's tables (defensive: a null
@@ -937,15 +1064,44 @@ pub enum OperandId {
     RawId(i32),
 }
 
+impl PartialEq for OperandId {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (OperandId::Named { kind: ka, ident: ia }, OperandId::Named { kind: kb, ident: ib }) => {
+                ka == kb && ia.oracle_eq(ib)
+            }
+            (OperandId::Primitive(a), OperandId::Primitive(b)) => a == b,
+            (OperandId::RawPtr(a), OperandId::RawPtr(b)) => a == b,
+            (OperandId::RawId(a), OperandId::RawId(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
 impl OperandId {
     /// Human-readable form for the SEMANTIC-DIFF report (e.g. `CALLSYS Story::GiveXP`).
     /// The identity string embeds unit-separator chars; render them as `::`-ish for readability.
     pub fn display(&self) -> String {
         match self {
-            OperandId::Named { identity, .. } => identity.replace(SEP, " » "),
+            OperandId::Named { ident, .. } => ident.full.replace(SEP, " » "),
             OperandId::Primitive(id) => format!("prim#{id}"),
             OperandId::RawPtr(p) => format!("<unresolved-ptr {p:#x}>"),
             OperandId::RawId(i) => format!("<unresolved-id {i}>"),
+        }
+    }
+
+    /// True if this is a large runtime object type-id resolved as [`OperandId::Primitive`] (an
+    /// `asCTypeInfo` id NOT in T2 that has the AngelScript object-mask bits set). Such an id is
+    /// build-specific and drifts across recompiles; GAP-C (batch-38) treats a lone diff of one as
+    /// benign when it feeds an `opCast`/`Cast` whose callee identity matches on both sides.
+    /// Genuine primitive type-ids (bool/int/float — fixed engine constants, mask bits clear)
+    /// return false and keep comparing by raw value.
+    pub fn is_runtime_object_typeid(&self) -> bool {
+        match self {
+            // asTYPEID_MASK_OBJECT = 0x1C00_0000 (APPOBJECT|SCRIPTOBJECT|TEMPLATE). A primitive
+            // (void/bool/int*/float/double) has none of these set; a runtime class type-id does.
+            OperandId::Primitive(id) => (*id as u32) & 0x1C00_0000 != 0,
+            _ => false,
         }
     }
 }
@@ -959,14 +1115,14 @@ impl RefIdentity {
     /// Resolve a QWORD ptr operand (global/func/type ptr) to a portable identity.
     pub fn resolve_ptr(&self, kind: RefKind, key: i64) -> OperandId {
         let map = match kind {
-            RefKind::GlobalPtr => &self.syms.global_id_of_ptr,
-            RefKind::FuncPtr => &self.syms.func_id_of_ptr,
-            RefKind::TypePtr => &self.syms.type_id_of_ptr,
+            RefKind::GlobalPtr => &self.syms.global_ident_of_ptr,
+            RefKind::FuncPtr => &self.syms.func_ident_of_ptr,
+            RefKind::TypePtr => &self.syms.type_ident_of_ptr,
             // FuncId/TypeId are DW operands, not ptr — never routed here.
             RefKind::FuncId | RefKind::TypeId => return OperandId::RawPtr(key),
         };
         match map.get(&key) {
-            Some(id) => OperandId::Named { kind, identity: id.clone() },
+            Some(ident) => OperandId::Named { kind, ident: ident.clone() },
             None => OperandId::RawPtr(key),
         }
     }
@@ -977,16 +1133,16 @@ impl RefIdentity {
     pub fn resolve_id(&self, kind: RefKind, id: i32) -> OperandId {
         match kind {
             RefKind::FuncId => match self.syms.funcid_to_ptr.get(&id) {
-                Some(ptr) => match self.syms.func_id_of_ptr.get(ptr) {
-                    Some(ident) => OperandId::Named { kind, identity: ident.clone() },
+                Some(ptr) => match self.syms.func_ident_of_ptr.get(ptr) {
+                    Some(ident) => OperandId::Named { kind, ident: ident.clone() },
                     None => OperandId::RawPtr(*ptr),
                 },
                 // Not a real func-id in this cache: defensive, compare raw.
                 None => OperandId::RawId(id),
             },
             RefKind::TypeId => match self.syms.typeid_to_ptr.get(&id) {
-                Some(ptr) => match self.syms.type_id_of_ptr.get(ptr) {
-                    Some(ident) => OperandId::Named { kind, identity: ident.clone() },
+                Some(ptr) => match self.syms.type_ident_of_ptr.get(ptr) {
+                    Some(ident) => OperandId::Named { kind, ident: ident.clone() },
                     None => OperandId::RawPtr(*ptr),
                 },
                 // Absent from T2 => primitive type-id, resolves to itself.
@@ -1017,11 +1173,19 @@ mod bytediff_n1_tests {
             ident.syms.func_name_of_ptr.iter().next().expect("at least one func ref");
         let resolved = ident.resolve_ptr(RefKind::FuncPtr, ptr);
         match &resolved {
-            OperandId::Named { kind, identity } => {
+            OperandId::Named { kind, ident } => {
                 assert_eq!(*kind, RefKind::FuncPtr);
                 assert!(
-                    identity.contains(name.as_str()),
-                    "identity {identity:?} should contain func name {name:?}"
+                    ident.full.contains(name.as_str()),
+                    "identity {:?} should contain func name {name:?}",
+                    ident.full
+                );
+                // The ns-stripped skeleton must have the SAME structure (same SEP-field count)
+                // as the full identity — it only blanks namespace fields, never adds/drops SEPs.
+                assert_eq!(
+                    ident.full.matches(SEP).count(),
+                    ident.ns_stripped.matches(SEP).count(),
+                    "ns-stripped skeleton must preserve SEP structure"
                 );
             }
             other => panic!("expected Named identity, got {other:?}"),
@@ -1030,5 +1194,124 @@ mod bytediff_n1_tests {
         assert!(matches!(ident.resolve_ptr(RefKind::FuncPtr, 0x7fff_dead_beef), OperandId::RawPtr(_)));
         // A primitive type-id (bool == not-in-T2, small id) resolves to itself.
         assert!(matches!(ident.resolve_id(RefKind::TypeId, 0x41), OperandId::Primitive(0x41)));
+    }
+
+    // ---- GAP-A namespace-drift unit tests (batch-38) ----
+
+    fn ident(full: &str, ns_stripped: &str, namespaces: &[&str]) -> Ident {
+        Ident {
+            full: full.to_string(),
+            ns_stripped: ns_stripped.to_string(),
+            namespaces: namespaces.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// GAP-A: a vanilla symbol WITH a namespace and a regen symbol with an EMPTY namespace but
+    /// otherwise identical module/name/subtypes = MATCH (benign drift). Direction-symmetric.
+    #[test]
+    fn gap_a_empty_namespace_matches() {
+        let sep = SEP;
+        // T5 global `__StaticType_X`: vanilla ns=`G1R::GenericVoiceline`, regen ns=``.
+        let van = ident(
+            &format!("Story.G1R{sep}G1R::GenericVoiceline{sep}__StaticType_X{sep}0"),
+            &format!("Story.G1R{sep}{sep}__StaticType_X{sep}0"),
+            &["G1R::GenericVoiceline"],
+        );
+        let reg = ident(
+            &format!("Story.G1R{sep}{sep}__StaticType_X{sep}0"),
+            &format!("Story.G1R{sep}{sep}__StaticType_X{sep}0"),
+            &[""],
+        );
+        assert!(van.oracle_eq(&reg), "empty-vs-nonempty namespace must match");
+        assert!(reg.oracle_eq(&van), "match is symmetric");
+        // As full OperandId operands (same kind) they compare equal too.
+        let a = OperandId::Named { kind: RefKind::GlobalPtr, ident: van };
+        let b = OperandId::Named { kind: RefKind::GlobalPtr, ident: reg };
+        assert_eq!(a, b);
+    }
+
+    /// GAP-A drift: the enclosing `namespace G1R { }` block is dropped, leaving a `::`-suffix
+    /// (`G1R::UStoryG1R` vs `UStoryG1R`) — benign.
+    #[test]
+    fn gap_a_namespace_suffix_matches() {
+        let sep = SEP;
+        let van = ident(
+            &format!("Story.G1R{sep}G1R::UStoryG1R{sep}{sep}Get{sep}0"),
+            &format!("Story.G1R{sep}{sep}{sep}Get{sep}0"),
+            &["G1R::UStoryG1R"],
+        );
+        let reg = ident(
+            &format!("Story.G1R{sep}UStoryG1R{sep}{sep}Get{sep}0"),
+            &format!("Story.G1R{sep}{sep}{sep}Get{sep}0"),
+            &["UStoryG1R"],
+        );
+        assert!(van.oracle_eq(&reg), "namespace `::`-suffix drift must match");
+    }
+
+    /// GAP-A GUARD: two genuinely different symbols distinguished ONLY by namespace
+    /// (`Foo::Bar` vs `Baz::Bar`, both non-empty, neither a `::`-suffix of the other) must STAY
+    /// distinct (SEMANTIC) — a real collision the fix must not collapse.
+    #[test]
+    fn gap_a_real_collision_kept_semantic() {
+        let sep = SEP;
+        let foo = ident(
+            &format!("M{sep}Foo{sep}Bar{sep}0"),
+            &format!("M{sep}{sep}Bar{sep}0"),
+            &["Foo"],
+        );
+        let baz = ident(
+            &format!("M{sep}Baz{sep}Bar{sep}0"),
+            &format!("M{sep}{sep}Bar{sep}0"),
+            &["Baz"],
+        );
+        assert!(!foo.oracle_eq(&baz), "Foo::Bar vs Baz::Bar is a real collision, must NOT match");
+        assert!(!baz.oracle_eq(&foo));
+        let a = OperandId::Named { kind: RefKind::GlobalPtr, ident: foo };
+        let b = OperandId::Named { kind: RefKind::GlobalPtr, ident: baz };
+        assert_ne!(a, b);
+    }
+
+    /// GAP-A GUARD: a difference in a NON-namespace field (the name itself) is never collapsed,
+    /// even when the namespace fields would match — the skeleton differs.
+    #[test]
+    fn gap_a_different_name_kept_semantic() {
+        let sep = SEP;
+        let a = ident(
+            &format!("M{sep}G1R{sep}Alpha{sep}0"),
+            &format!("M{sep}{sep}Alpha{sep}0"),
+            &["G1R"],
+        );
+        let b = ident(
+            &format!("M{sep}{sep}Beta{sep}0"),
+            &format!("M{sep}{sep}Beta{sep}0"),
+            &[""],
+        );
+        assert!(!a.oracle_eq(&b), "different name (skeleton differs) must not match");
+    }
+
+    /// `is_ns_suffix` requires a `::` segment boundary, not a raw substring.
+    #[test]
+    fn ns_suffix_requires_segment_boundary() {
+        assert!(is_ns_suffix("G1R::UStoryG1R", "UStoryG1R"));
+        assert!(is_ns_suffix("A::B::C", "C"));
+        assert!(is_ns_suffix("A::B::C", "B::C"));
+        assert!(!is_ns_suffix("BazBar", "Bar")); // no `::` boundary
+        assert!(!is_ns_suffix("Bar", "Bar")); // not proper (equal length)
+        assert!(!is_ns_suffix("Foo::Bar", "Baz")); // not a suffix
+    }
+
+    /// GAP-C: the object-mask discriminator separates genuine primitive type-ids (mask clear,
+    /// compared by raw value) from large runtime `asCTypeInfo` ids (mask set, opCast-gated).
+    #[test]
+    fn gap_c_runtime_object_typeid_discriminator() {
+        // 0x48003464 (1207972964) has asTYPEID_SCRIPTOBJECT (0x08000000) set → runtime.
+        assert!(OperandId::Primitive(1207972964).is_runtime_object_typeid());
+        assert!(OperandId::Primitive(1207972931).is_runtime_object_typeid());
+        // Genuine primitives: mask bits clear.
+        assert!(!OperandId::Primitive(0x41).is_runtime_object_typeid());
+        assert!(!OperandId::Primitive(0).is_runtime_object_typeid());
+        assert!(!OperandId::Primitive(10).is_runtime_object_typeid());
+        // Non-primitive variants are never runtime type-ids.
+        assert!(!OperandId::RawId(1207972964).is_runtime_object_typeid());
     }
 }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1432,6 +1432,15 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
     // producer (false for non-call producers: ALLOC/CallPtr), so a stale flag can never pair
     // with a live `pending`; cleared by the flush macros with the rest of the pending state.
     let mut pending_is_ref: bool = false;
+    // batch-31b (N2b, spec batch31-nomatch-illegalop §1.2): `pending` holds the rendered
+    // `n"..."` FName literal of the `PshC4 <id> ; CALLSYS __STATIC_NAME ; PshRPtr` idiom —
+    // a PURE literal (no side effect can be reordered), so the PshRPtr push may be tagged
+    // `.carry()` and survive the D9 cast-diamond carryability gate (SendGlobalEvent /
+    // SpawnRay lost their pre-diamond FName args to the D9 bail). Set ONLY by the CALLSYS
+    // arm's __STATIC_NAME resolution; every other pending producer resets it, so a stale
+    // flag can never pair with a live non-literal `pending`. Deliberately NOT widened to
+    // other pendings (opIndex results etc. are side-effect-bearing — N4 territory).
+    let mut pending_is_static_name: bool = false;
     let mut ret_val: Option<String> = None;
     // Target type of the most recent TYPEID push — the implicit type operand of the following
     // `opCast` behaviour call (the lowered form of `Cast<T>(x)`). Resolved to a typename so the
@@ -1595,6 +1604,12 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                         let lhs = lhs.to_string();
                         out.push(format!("{p};"));
                         stack.push(Arg::typed(lhs, pending_ty.take()));
+                    } else if pending_is_static_name {
+                        // batch-31b (N2b): the pending is the PURE `n"..."`/`FName(...)`
+                        // literal of the __STATIC_NAME idiom — no side effect can be
+                        // reordered by carrying it across a cast diamond, so it may pass
+                        // the D9 carryability gate like any plain const push.
+                        stack.push(Arg::typed(p, pending_ty.take()).carry());
                     } else {
                         stack.push(Arg::typed(p, pending_ty.take()));
                     }
@@ -2083,6 +2098,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                         && ctx.refs.member_name_exists(&f);
                     build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, owner, ctx.class_name, n == "CALL", pending_ty.as_deref(), ret_is_ref, global_shadowed, ctx.refs)
                 };
+                pending_is_static_name = false;
             }
             "CALLSYS" | "Thiscall1" => {
                 test_after_call = false;
@@ -2246,12 +2262,17 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     }
                     build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, ctx.refs.func_owner_by_ptr(ptr), ctx.class_name, false, pending_ty.as_deref(), ret_is_ref, false, ctx.refs)
                 };
+                // batch-31b: tag a resolved static-name FName literal (see the flag's doc).
+                // build_call returns the literal only for the accessor name; a failed gate
+                // (non-constant Id operand) falls to the `$`-drop and returns None.
+                pending_is_static_name = f == "__STATIC_NAME" && pending.is_some();
             }
             "CallPtr" => {
                 let f = name(w(ins, 0));
                 pending_ty = None;
                 pending_const = false;
                 pending_is_ref = false;
+                pending_is_static_name = false;
                 pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, None, ctx.class_name, false, None, false, false, ctx.refs);
             }
             // ---- object construction ----
@@ -2262,6 +2283,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 pending_ty = Some(ty.clone());
                 pending_const = false;
                 pending_is_ref = false;
+                pending_is_static_name = false;
                 pending = Some(format!("{ty}({})", args.join(", ")));
             }
             // ---- result capture ----

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2986,10 +2986,40 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                     }
                 }
             }
-            // REFCPY (NO_ARG): a pure stack handle-copy with no destination slot operand — just
-            // balance the operand stack (the dominant phantom-arg cause); the value is re-read
-            // where it is actually used.
-            "REFCPY" => { stack.pop(); }
+            // REFCPY (NO_ARG): object-handle STORE — `dst.member = src` (the object analogue of
+            // WRTV*; there is no WRTV for handles). Stack top = the member lvalue built by
+            // `PshVPtr obj; ADDSi member` (optionally RDSPtr); second = the source handle. Recover
+            // it as a statement; BAIL (drop, exactly as before — pop both, emit nothing) on any
+            // un-provable operand. A WRONG store silently corrupts an object graph (worse than a
+            // dropped store), so the source-provenance gate is strict (batch-41b, Fix 1, S1/S3).
+            "REFCPY" => {
+                let dst = stack.pop(); // member lvalue (top)
+                let src = stack.pop(); // source handle (second)
+                if let (Some(dst), Some(src)) = (&dst, &src) {
+                    // GATE:
+                    //  dst is a MEMBER lvalue: contains '.', not empty/UNRESOLVED/sentinel, and NOT
+                    //  a bare slot (a bare local_N dst would be a RefCpyV, not a REFCPY member store).
+                    //  src is a PROVEN handle: `local_N` (a STOREOBJ/allocated slot), a `Cast<…>`, or
+                    //  `nullptr` (the S3 clear via PshNull). NEVER a member/param/temp whose const-ness
+                    //  or aliasing we can't prove (mirrors the RefCpyV arm's original caution — copying
+                    //  a const param/member handle into a non-const dest fails "Can't implicitly
+                    //  convert"), so those bail to the drop.
+                    let dst_ok = dst.s.contains('.')
+                        && !dst.s.is_empty()
+                        && dst.s != UNRESOLVED
+                        && !dst.s.contains('\u{2}')
+                        && !dst.s.starts_with("local_");
+                    let src_ok = !src.s.is_empty()
+                        && src.s != UNRESOLVED
+                        && !src.s.contains('\u{2}')
+                        && (src.s.starts_with("local_") || src.s.starts_with("Cast<") || src.s == "nullptr");
+                    if dst_ok && src_ok {
+                        flush!();
+                        out.push(format!("{} = {};", dst.s, src.s));
+                    }
+                    // else: both popped, nothing emitted = the status-quo drop.
+                }
+            }
             // The TYPEID push is the implicit type operand of the following opCast/cast syscall
             // (NOT counted in the cache param list) — it is not a real stack arg, so don't push
             // it. Capture its resolved typename as the target T of the upcoming `opCast` so the

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3573,6 +3573,60 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                         }
                         consumed
                     };
+                    // batch-50a (opIndex-swap read-into-temp, specs/final-tail-triage.md §3.11
+                    // ShuffleItemArray): a Fisher-Yates swap `temp = arr[i]; arr[i] = arr[j];
+                    // arr[j] = temp;` lowers the SAVE-TO-TEMP as
+                    // `PshV4 i; PshVPtr arr; Thiscall1 opIndex; PshRPtr; RDSPtr; RefCpyV wTemp`
+                    // — the opIndex getter result copied into a plain local. Today the call-expr
+                    // source drops (the `ok` whitelist accepts a `(`-bearing source ONLY into the
+                    // return out-slot, batch-43 `call_src_to_out`), leaving `local_Temp` UNDECLARED;
+                    // the later `arr[j] = local_Temp;` REFCPY store then reads an uninitialised slot
+                    // and the whole swap corrupts. FIX-7's `getter_into_cmp`/batch-49c's
+                    // `getter_into_null_cmp` only fire when the dest feeds a CmpPtr/CmpPtrNull; this
+                    // adds the case where the dest is later consumed as the SOURCE HANDLE of a
+                    // REFCPY store (`PshVPtr <dst>` whose enclosing statement stores it back). Gate
+                    // HARD: source is a RESOLVED opIndex element read (`.opIndex(` … ends ')', no
+                    // sentinel/unresolved), and a bounded forward scan finds the FIRST consumer of
+                    // this slot to be a `PshVPtr <dst>` that is NOT a member-access base (next op is
+                    // NOT ADDSi — that would be the param-alias shape) and NOT re-defined before —
+                    // i.e. the slot is pushed as a bare handle (a REFCPY store source or call arg),
+                    // never compared or member-dotted. Safe: the opIndex read is a pure element read
+                    // (batch-32c `is_pure_elem_read` purity class) whose SOLE later use is the
+                    // store-back; materialising `local_Temp = arr[i];` cannot reorder a side effect
+                    // past a use it did not have before (the copy was DROPPED). Additive — recovers
+                    // the vanilla store only when the swap-temp shape is proven.
+                    let src_is_opindex_read = top.s.contains(".opIndex(")
+                        && top.s.ends_with(')')
+                        && !top.s.contains('\u{2}')
+                        && !top.s.contains('\u{1}')
+                        && top.s != UNRESOLVED
+                        && !top.s.starts_with('~');
+                    let getter_into_store_rhs = src_is_opindex_read && {
+                        let mut consumed = false;
+                        for j in (k + 1)..insns.len() {
+                            let nx = &insns[j];
+                            // first consumer is a bare-handle push of this slot (NOT a member base:
+                            // next op must not be ADDSi) -> the swap-back store source. Materialise.
+                            if nx.op.name == "PshVPtr"
+                                && w(nx, 0) == dst_slot0
+                                && !insns.get(j + 1).is_some_and(|a| a.op.name == "ADDSi")
+                            {
+                                consumed = true;
+                                break;
+                            }
+                            // re-defined before any consumer -> alias-shadow, not this copy; bail.
+                            if matches!(
+                                nx.op.name,
+                                "RefCpyV" | "CpyRtoV4" | "CpyRtoV8" | "RDR4" | "RDR8"
+                                    | "SetV4" | "SetV8" | "SetV1" | "STOREOBJ" | "FreeNullV8"
+                                    | "ClrVPtr"
+                            ) && w(nx, 0) == dst_slot0
+                            {
+                                break;
+                            }
+                        }
+                        consumed
+                    };
                     let ok = !top.s.is_empty()
                         && top.s != dst
                         && !const_ret_getter
@@ -3583,7 +3637,8 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                             || getter_into_cmp
                             || getter_into_null_cmp
                             || param_into_cmp
-                            || param_into_later_use);
+                            || param_into_later_use
+                            || getter_into_store_rhs);
                     if ok {
                         flush!();
                         // batch-25b (G4 assign shape): a slot-to-slot handle copy whose DEST
@@ -3675,6 +3730,23 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                     let member_src = src.s.contains('.')
                         && !src.s.contains('(')
                         && src.nf_const.is_none();
+                    // batch-50a (opIndex-swap middle store, specs/final-tail-triage.md §3.11
+                    // ShuffleItemArray): the Fisher-Yates `arr[i] = arr[j];` store has a getter
+                    // call-expr SOURCE `arr[j]` (an opIndex element READ) and a member-lvalue DEST
+                    // `arr[i]` (an opIndex element WRITE). Today the source drops (`member_src`
+                    // rejects `(`-bearing exprs; it is neither `local_`/`Cast<`/nullptr/param), so
+                    // the middle swap store vanishes and only `arr[j] = temp;` survives — a broken
+                    // half-swap. Accept a RESOLVED opIndex element read as the source (a pure
+                    // element read, `is_pure_elem_read` purity class): `arr[i] = arr[j];` is a legal
+                    // handle assignment and the read has no side effect that dropping/keeping it
+                    // reorders. Gate HARD: `.opIndex(` present, ends ')', no sentinel/unresolved —
+                    // so the RHS is a proven element read, never a mutating call.
+                    let src_is_opindex_elem = src.s.contains(".opIndex(")
+                        && src.s.ends_with(')')
+                        && !src.s.contains('\u{2}')
+                        && !src.s.contains('\u{1}')
+                        && src.s != UNRESOLVED
+                        && !src.s.starts_with('~');
                     let src_ok = !src.s.is_empty()
                         && src.s != UNRESOLVED
                         && !src.s.contains('\u{2}')
@@ -3682,6 +3754,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                             || src.s.starts_with("Cast<")
                             || src.s == "nullptr"
                             || member_src
+                            || src_is_opindex_elem
                             || ctx.param_src_ok(&src.s));
                     // batch-41d (CLASS 1b): the source slot holds a CONST object handle (a
                     // const-returning call result / const member read). Storing it into a

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -680,8 +680,15 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         let is_operator = assign_op(f).is_some() || binop_method(f).is_some();
         if let Some(rh) = ret_ty.map(head).filter(|_| !is_operator && !ret_is_ref) {
             if matches!(rh.bytes().next(), Some(b'F') | Some(b'T') | Some(b'E')) {
-                // the RVO out-slot = a PSF arg whose type head equals the return-type head
-                if let Some(pos) = a.iter().position(|x| x.is_psf
+                // the RVO out-slot = a PSF arg whose type head equals the return-type head.
+                // batch-29c (3a, specs/batch29-errortail.md): the ABI pushes
+                // [args..., dest, recv], so after the recv pop the dest is the LAST entry —
+                // probe with rposition. The bottom-up probe stole a same-headed struct ARG
+                // (FVector::RotateAngleAxis's Axis) and slid the real dest into the arg list
+                // (`local_54 = local_6.RotateAngleAxis(local_48, local_62);` with w48 the
+                // true dest). Single-PSF cases (the 495-site Iterator/GetActorLocation
+                // population) pick the same entry — no regression surface.
+                if let Some(pos) = a.iter().rposition(|x| x.is_psf
                     && x.ty.as_deref().map(head) == Some(rh)) {
                     let out = a.remove(pos).s;
                     if let Some(w) = arity {
@@ -2052,6 +2059,11 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                             // "No matching signatures to 'FTimerDynamicDelegate(const FName,
                             // <obj> const)'"). Same reverse-by-default scoring as every call arm.
                             maybe_reverse_args(&mut args, params, ctx.refs);
+                            // (batch-29c note: the spec's §2.1 suggestion to drop a lone
+                            // `nullptr` ctor arg is deliberately NOT taken — the corpus has
+                            // thousands of clean `TSubclassOf<T>(nullptr)` sites outside the
+                            // error tail, so the null-handle ctor provably compiles and the
+                            // composed render below joins that population byte-faithfully.)
                             // Gate (b): no arg is itself a PSF slot — that is a copy/convert ctor
                             // whose true source is an unrecovered pending call result; rendering it
                             // as `T(&slot)` would be wrong, so drop (prior behaviour).

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3425,6 +3425,66 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                                         .any(|g| matches!(g.op.name, "Thiscall1" | "CALLSYS"))
                             })
                         });
+                    // batch-47a (FIX-8, specs/final-tail-triage.md §3.3): materialise a NON-const
+                    // object/ref PARAM copy `local_N = <param>;` when the copy's dest slot is later
+                    // CONSUMED by a `CmpPtr` (binary pointer compare, either operand) or by a
+                    // MEMBER-ACCESS base (`PshVPtr <dst>; ADDSi …` — the param-alias store idiom)
+                    // several ops later, and is NOT immediately null-guarded (that adjacent-guard
+                    // case is FIX-4's fold). Today FIX-4 only folds when insns[k+1] is CmpPtrNull;
+                    // FIX-7's `param_into_cmp` only fires when the compare PARTNER is a getter-
+                    // produced RefCpyV slot. Neither covers `if (OtherActor == GetAvatar())`
+                    // (partner produced by STOREOBJ, not RefCpyV), the pure param-vs-param
+                    // `if (PreviousTarget == NewTarget)` (CheckTargetChanged), nor the param-alias
+                    // `local_2 = Data; local_2.SourceActor = SourceActor;` (InitializeValidatorData)
+                    // — so the copy drops and the comparison/member-access reads an UNINITIALISED
+                    // slot: a real behavioural bug (verified vanilla+regen on
+                    // UGA_FireDemon_FireExplosion::OnTargetReceived — regen compares garbage vs
+                    // GetAvatar()). Bounded forward scan for the FIRST consumer within the block;
+                    // BAIL if the slot is re-defined (alias-shadowed) before any consumer, so a
+                    // reused slot can never be mis-materialised. Const-safe: `param_src_ok` excludes
+                    // read-only/object-const params (the b41d/45c const-cascade class) and `this`,
+                    // exactly like FIX-4/FIX-7 — a materialised copy of a non-const object PARAM into
+                    // a plain local is a legal handle assign. Additive: a copy that is neither a
+                    // getter-compare nor an immediate null-guard was DROPPED before, so recovering
+                    // it can only ADD the vanilla store back.
+                    let param_into_later_use = ctx.param_src_ok(&top.s) && {
+                        let mut consumed = false;
+                        for j in (k + 1)..insns.len() {
+                            let nx = &insns[j];
+                            // first consumer is a binary pointer compare on this slot -> materialise.
+                            if nx.op.name == "CmpPtr"
+                                && (w(nx, 0) == dst_slot0 || w(nx, 1) == dst_slot0)
+                            {
+                                consumed = true;
+                                break;
+                            }
+                            // first consumer is a member-access base: `PshVPtr <dst>; ADDSi …`
+                            // (the param-alias `local_N.field = …` store) -> materialise. The very
+                            // next op after the PshVPtr must be an ADDSi (member offset) so a bare
+                            // PshVPtr that merely re-pushes the handle as a call arg does NOT trip
+                            // this (that use reads the SAME undefined slot but is covered by the
+                            // param name flowing through the push, not a slot alias).
+                            if nx.op.name == "PshVPtr"
+                                && w(nx, 0) == dst_slot0
+                                && insns.get(j + 1).is_some_and(|a| a.op.name == "ADDSi")
+                            {
+                                consumed = true;
+                                break;
+                            }
+                            // the slot is RE-DEFINED (output word 0) by another value producer
+                            // before any consumer -> alias-shadow, this copy is not the one read; bail.
+                            if matches!(
+                                nx.op.name,
+                                "RefCpyV" | "CpyRtoV4" | "CpyRtoV8" | "RDR4" | "RDR8"
+                                    | "SetV4" | "SetV8" | "SetV1" | "STOREOBJ" | "FreeNullV8"
+                                    | "ClrVPtr"
+                            ) && w(nx, 0) == dst_slot0
+                            {
+                                break;
+                            }
+                        }
+                        consumed
+                    };
                     let ok = !top.s.is_empty()
                         && top.s != dst
                         && !const_ret_getter
@@ -3433,7 +3493,8 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                             || member_src
                             || call_src_to_out
                             || getter_into_cmp
-                            || param_into_cmp);
+                            || param_into_cmp
+                            || param_into_later_use);
                     if ok {
                         flush!();
                         // batch-25b (G4 assign shape): a slot-to-slot handle copy whose DEST

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -600,6 +600,30 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         if matches!(f, "opImplConv" | "opConv") {
             return None;
         }
+        // GENERATED per-component static accessors (`UMyComponent::Get(Actor[, FName])`,
+        // GetOrCreate, Create): their DECLARATIONS are intentionally skipped from the emit
+        // (signature collisions), so a bare call `Get(local_2, NAME_None)` never resolves
+        // ("No matching signatures ... Did you mean 'Sit'?", 362 in-game errors). The real
+        // UE-AngelScript form is the class-qualified static: `UMyComponent::Get(local_2)`.
+        // Gate: exact generated-getter name, an owning class on the callee (the generated fns
+        // carry their component class as ObjectType), and >= 1 collected arg (the actor) —
+        // 0-param statics like UQuestSubsystem::Get are native CALLSYS, not this path.
+        // (0-arg form = the generated per-subsystem `Get()` accessor — same skip class, same
+        // qualified-static fix: `UMySubsystem::Get()` is the native Hazelight subsystem idiom.)
+        if matches!(f, "Get" | "GetOrCreate" | "Create") {
+            // Owner: the callee's ObjectType when recorded; else the RETURN type — a generated
+            // accessor returns exactly the component class it is generated on, so the return
+            // head is the qualifying class (`UPyrolaserOriginPointComponent Get(AActor, FName)`).
+            let owner = target_owner
+                .filter(|o| o.starts_with('U'))
+                .or_else(|| ret_ty
+                    .map(|t| t.split('<').next().unwrap_or(t))
+                    .filter(|t| t.starts_with('U') && refs.is_type_name(t)));
+            if let Some(owner) = owner {
+                maybe_reverse_args(&mut a, params, refs);
+                return Some(format!("{owner}::{f}({})", render_args(&a, params, refs)));
+            }
+        }
         // Free-call RVO struct-return (mirror of the method Fix-b3 arm): a free/static function
         // returning a struct BY VALUE pushes a hidden PSF out-slot. Recover `out = f(args)`
         // instead of leaking the out-slot as a leading arg (GotoPosition/Say/GiveItemTo/

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -161,11 +161,11 @@ pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, supe
     // self-correcting on observed offsets. Built once per function; consulted by slot_name/slot_type.
     let (param_off_map, rvo_off) = super::decompile::build_param_off_map_rvo(f, &instrs, refs);
     let keep_ints = hints.map(|h| &h.keep_ints);
-    let ctx = Ctx { f, refs, instrs: &instrs, super_ctor, ret_ty, fields, param_types, class_name, local_types, float_slots, param_off_map, rvo_off, keep_ints };
+    let ctx = Ctx { f, refs, instrs: &instrs, super_ctor, ret_ty, fields, param_types, class_name, local_types, float_slots, param_off_map, rvo_off, keep_ints, rvo_switch_region: std::cell::Cell::new(false) };
     let idx_of: HashMap<usize, usize> =
         g.blocks.iter().enumerate().map(|(i, b)| (b.start_dw, i)).collect();
     let mut body = String::new();
-    let mut st = Structurer { ctx: &ctx, g: &g, idx_of: &idx_of, exit_join: None, exit_join_is_ret: false, exit_ret_rows_ok: false, exit_scan_floor: 0, carry: None, loop_scope: None };
+    let mut st = Structurer { ctx: &ctx, g: &g, idx_of: &idx_of, exit_join: None, exit_join_is_ret: false, exit_ret_rows_ok: false, exit_rvo_return: false, exit_scan_floor: 0, carry: None, loop_scope: None };
     st.emit_range(0, g.blocks.len(), depth, &mut body);
     body
 }
@@ -186,6 +186,46 @@ fn strip_return_assign(v: &str) -> &str {
         i += 1;
     }
     v
+}
+
+/// batch-43 (Fix 2, switch-rvo-return.md §4.2): fold a struct-RVO case region's trailing
+/// out-slot store + synthetic return into a single per-case value return. The region text was
+/// emitted with `exit_rvo_return` set, so its last two meaningful lines are
+/// `<ws>__return = <val>;` then `<ws>return __return;`. Replace both with `<ws>return <val>;`.
+///
+/// Returns `Some(folded_text)` when the fold applied — which DOUBLES as gate G-RVO's per-region
+/// out-slot-write proof: a `return __return;` with NO immediately-preceding `__return = <val>;`
+/// store (and no resolved `<val>`) means the region does NOT provably write the out-slot on this
+/// path, so the caller MUST bail the whole switch (never emit a case that silently returns a
+/// default struct). `None` = proof failed / no fold site → bail.
+fn fold_rvo_return(region: &str) -> Option<String> {
+    let lines: Vec<&str> = region.lines().collect();
+    // locate the synthetic `return __return;` (there must be exactly the tail exit)
+    let ret_idx = lines.iter().rposition(|l| l.trim_end() == "return __return;" || l.trim() == "return __return;")?;
+    if ret_idx == 0 {
+        return None; // no preceding store line at all
+    }
+    let store = lines[ret_idx - 1];
+    let ws: String = store.chars().take_while(|c| c.is_whitespace()).collect();
+    let body = store.trim();
+    // the preceding line MUST be `__return = <val>;` with a resolved, non-empty, non-sentinel val
+    let val = body.strip_prefix("__return = ")?.strip_suffix(';')?;
+    if val.is_empty()
+        || val.contains('\u{1}')
+        || val.contains('\u{2}')
+        || val == UNRESOLVED
+        || val.contains("__return")
+        || val.contains(RVODEF)
+    {
+        return None;
+    }
+    let mut out: Vec<String> = lines[..ret_idx - 1].iter().map(|s| s.to_string()).collect();
+    out.push(format!("{ws}return {val};"));
+    for l in &lines[ret_idx + 1..] {
+        out.push(l.to_string());
+    }
+    // preserve a trailing newline (writeln! always leaves one)
+    Some(format!("{}\n", out.join("\n")))
 }
 
 /// batch-27b: if `v` is a top-level assignment expression `lhs = rhs` with a PLAIN slot /
@@ -300,6 +340,14 @@ struct Ctx<'a> {
     /// [`ArgSlotHints::keep_ints`]) — pushed with `keep` so the nested-call stack-split
     /// retain spares them.
     keep_ints: Option<&'a std::collections::HashSet<i32>>,
+    /// batch-43 (Fix 2): set ONLY while emitting a struct-RVO switch's per-case region (the
+    /// bare-RET-join shape, GetDebugColor). While set, a `$beh0(__return, src)` in a JMP-
+    /// terminated block emits `__return = src;` as a STATEMENT (so the switch's per-case
+    /// `return <val>;` fold recovers it), instead of stashing it in the block-local `ret_val`
+    /// that a JMP-terminated block would drop. OUTSIDE a switch RVO region it stays the byte-
+    /// identical `ret_val` path — this keeps batch-43 strictly switch-scoped (the general
+    /// branch/loop RVO-return recovery is the deferred Fix 3 / loop-body-cfg lever).
+    rvo_switch_region: std::cell::Cell<bool>,
 }
 
 /// Collect slots used as an operand of a float/double arithmetic or compare op. Every word
@@ -455,6 +503,45 @@ impl Ctx<'_> {
     /// `return <chain>;` (the cross-block reference carry).
     fn ret_is_ref(&self) -> bool {
         self.ret_ty.map(|t| t.token != 0x52 && t.is_reference).unwrap_or(false)
+    }
+
+    /// The frame slot that carries this function's RETURN value OUT (batch-43, Fix 1):
+    /// - struct-by-value RVO: the hidden `__return` out-slot (`self.rvo_off`);
+    /// - object/scalar/enum: the slot loaded into the return register by the terminal
+    ///   `LOADOBJ`/`CpyVtoR*` IMMEDIATELY before the function's final `RET` (e.g.
+    ///   `PopBucketFront`'s `LOADOBJ w2; RET` → slot 2). `None` when the terminal return has
+    ///   no such single-slot fill (a plain `RET`, or a computed/expression return).
+    ///
+    /// Used only to widen a copy-INTO-the-return-value (`RefCpyV`) — a phantom copy into a
+    /// normal local stays dropped; a copy into THIS slot IS the return-value write and must
+    /// survive. Conservative: matches at most one slot, from the function's own tail.
+    fn return_out_slot(&self) -> Option<i32> {
+        if let Some(off) = self.rvo_off {
+            if self.ret_via_rvo() {
+                return Some(off);
+            }
+        }
+        // scan for the function's final RET; the instr before it must be a single-slot
+        // return-register fill whose operand names the out-slot.
+        let n = self.instrs.len();
+        if n < 2 {
+            return None;
+        }
+        let last = &self.instrs[n - 1];
+        if last.op.name != "RET" {
+            return None;
+        }
+        let prev = &self.instrs[n - 2];
+        if matches!(prev.op.name, "LOADOBJ" | "CpyVtoR4" | "CpyVtoR8" | "CpyVtoR1") {
+            if let Some(&wd) = prev.words.first() {
+                return Some(wd as i16 as i32);
+            }
+        }
+        None
+    }
+
+    fn is_return_out_slot(&self, slot: i32) -> bool {
+        self.return_out_slot() == Some(slot)
     }
 
     /// Name for parameter slot `idx`: the stored name, else `arg{idx}` — which MUST match
@@ -2555,7 +2642,26 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                             let src = stack[stack.len() - 2].clone();
                             if !src.s.is_empty() && src.s != UNRESOLVED && !src.s.starts_with('\u{2}') {
                                 stack.truncate(stack.len() - 2);
-                                ret_val = Some(src.s);
+                                // batch-43 (Fix 2): a `$beh0(__return, src)` inside a struct-RVO
+                                // SWITCH CASE region (JMP-terminated, `ctx.rvo_switch_region` set)
+                                // has NO RET here to consume `ret_val` — the JMP goes to the shared
+                                // bare RET, and `ret_val` is block-local, so the value would be
+                                // LOST. Emit `__return = src;` as a STATEMENT so the switch's per-
+                                // case `return <val>;` fold (region_exit_stmt + fold_rvo_return)
+                                // recovers it. EVERYWHERE ELSE (the normal single-region struct
+                                // return, and — deliberately out of batch-43 scope — branch/loop
+                                // early returns) keep the byte-identical `ret_val` path: its RET arm
+                                // folds `ret_val`/pending to `return src;` with no duplicate stmt.
+                                // Scoping to switch regions keeps the general branch/loop RVO-return
+                                // recovery to the deferred Fix 3 / loop-body-cfg lever.
+                                if ctx.rvo_switch_region.get()
+                                    && ctx.instrs[hi - 1].op.name != "RET"
+                                {
+                                    flush!();
+                                    out.push(format!("__return = {};", src.s));
+                                } else {
+                                    ret_val = Some(src.s);
+                                }
                                 continue;
                             }
                         }
@@ -3033,10 +3139,29 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                                 && d.is_object_const
                                 && d.base_name(ctx.refs) == *top.nf_const.as_deref().unwrap_or("")
                         });
+                    // batch-43 (Fix 1, switch-rvo-return.md §4.1): accept a CALL-EXPRESSION
+                    // source ONLY when the destination is the function's return out-slot — the
+                    // object/struct being popped INTO the return value (`<out> = arr.opIndex(0)`
+                    // in `PopBucketFront`, an opIndex result RefCpyV'd into the returned slot).
+                    // A call-expr source is normally dropped (a phantom copy could reorder side
+                    // effects into a non-return local), but into the out-slot the copy IS the
+                    // return-value write and must survive so the terminal `LOADOBJ <out>; RET`
+                    // renders `return <out>;` (else the popped element is silently lost). Gate
+                    // hard: a resolved call expression (`…)`), never a sentinel/unresolved/
+                    // destructor, and the destination is exactly the proven out-slot.
+                    let call_src_to_out = ctx.is_return_out_slot(w(ins, 0))
+                        && top.s.ends_with(')')
+                        && !top.s.contains('\u{2}')
+                        && !top.s.contains('\u{1}')
+                        && top.s != UNRESOLVED
+                        && !top.s.starts_with('~');
                     let ok = !top.s.is_empty()
                         && top.s != dst
                         && !const_ret_getter
-                        && (top.s.starts_with("local_") || top.s.starts_with("Cast<") || member_src);
+                        && (top.s.starts_with("local_")
+                            || top.s.starts_with("Cast<")
+                            || member_src
+                            || call_src_to_out);
                     if ok {
                         flush!();
                         // batch-25b (G4 assign shape): a slot-to-slot handle copy whose DEST
@@ -3390,6 +3515,14 @@ struct Structurer<'a> {
     exit_join: Option<usize>,
     exit_join_is_ret: bool,
     exit_ret_rows_ok: bool,
+    /// batch-43 (Fix 2, switch-rvo-return.md §4.2): RVO-struct-return switch mode. When set, a
+    /// case region's exit `JMP` to the shared bare-RET join renders `return <val>;` folded from
+    /// the region's trailing `__return = <val>;` out-slot store (a struct-by-value return travels
+    /// through the hidden RVO slot, never the value register, so the register scan-back is empty
+    /// and would otherwise emit `return <default-struct>;` — silently wrong). Fires ONLY under the
+    /// heavily-gated G-RVO proof (`ret_via_rvo` + bare-RET join + EVERY region proves an `__return`
+    /// write); any gap bails the whole switch to the stub.
+    exit_rvo_return: bool,
     /// Instruction-index floor for the synthesized-return value scan (the current case
     /// region's first instruction — a value must not leak in from a preceding region).
     exit_scan_floor: usize,
@@ -3677,7 +3810,13 @@ impl Structurer<'_> {
         }
         let t = *b.succs.first()?;
         if t == join {
-            return Some(if self.exit_join_is_ret {
+            return Some(if self.exit_rvo_return && self.exit_join_is_ret {
+                // batch-43 (Fix 2): struct-RVO return — the payload is in the `__return` out-slot
+                // (a register scan-back is empty). Emit `return __return;`; the emission-site fold
+                // (try_emit_switch) collapses the region's trailing `__return = <val>;` store +
+                // this line into `return <val>;` to match vanilla's per-case value return.
+                "return __return;".into()
+            } else if self.exit_join_is_ret {
                 self.ctx.return_stmt(scan_back_retval_floor(self.ctx, b.instr_hi - 1, self.exit_scan_floor))
             } else {
                 "break;".into()
@@ -4129,6 +4268,15 @@ impl Structurer<'_> {
                     || is_enum_name(&t.base_name(ctx.refs))
             }
         };
+        // batch-43 (Fix 2, switch-rvo-return.md §4.2): a struct-by-value RVO return switch
+        // (`!register_based` AND a genuine RVO out-slot, NOT enum). Its per-case returns travel
+        // through the `__return` out-slot, so `JMP -> bare RET` cannot be synthesized from the
+        // register — the status quo bails the whole switch (leaving the function stubbed).
+        // Under this mode we RELAX the two `!register_based` bare-RET bails, but ONLY after a
+        // per-region `__return`-write proof (gate G-RVO, below) confirms EVERY region writes the
+        // out-slot before its exit; any unproven region bails the whole switch. Never emit a
+        // switch that silently returns a DEFAULT struct.
+        let rvo_return_mode = !register_based && ctx.ret_via_rvo() && ctx.rvo_off.is_some();
         let non_void = ctx.ret_ty.map(|t| t.token != 0x52).unwrap_or(false);
         let mut join_cands: Vec<usize> = Vec::new();
         let mut ret_rows: Vec<usize> = Vec::new();
@@ -4147,7 +4295,12 @@ impl Structurer<'_> {
                         // `break;`/`continue;` out of the switch to the enclosing loop
                         join_cands.push(x);
                     } else if self.is_bare_ret_off(x) {
-                        if !register_based {
+                        // batch-43 (Fix 2): a struct-RVO switch's per-case exit ALSO jumps to a
+                        // bare RET (GetDebugColor: every case writes `__return = FColor::X` then
+                        // `JMP -> RET`). Allow it under `rvo_return_mode` — the per-region
+                        // out-slot-write proof (G-RVO) gates the actual recovery below; here we
+                        // only let the join be recognized so validation can proceed.
+                        if !register_based && !rvo_return_mode {
                             return None;
                         }
                         ret_rows.push(x);
@@ -4196,7 +4349,15 @@ impl Structurer<'_> {
             return None;
         }
         let join_is_ret = self.is_bare_ret_off(join_off);
-        if join_is_ret && !register_based {
+        // batch-43 (Fix 2): the RVO-return recovery fires ONLY for the true out-slot shape — a
+        // struct-by-value switch whose per-case regions write `__return` and JMP to the shared
+        // BARE RET row (GetDebugColor). A struct-RVO switch whose join is a REAL block (cases
+        // write a normal local `local_N` then `break;`, and the function returns `local_N` AFTER
+        // the switch — GetSFXTagByLevel) recovers through the NORMAL `break;`-to-join path and
+        // must NOT enter RVO-return mode (its cases write no `__return`, so the G-RVO proof would
+        // wrongly bail the whole switch to a stub). Gate the proof + fold on `join_is_ret`.
+        let rvo_ret_switch = rvo_return_mode && join_is_ret;
+        if join_is_ret && !register_based && !rvo_ret_switch {
             return None; // per-case RVO-struct returns are not recoverable from the register
         }
         let join_idx = self.idx_of.get(&join_off).copied()?;
@@ -4263,13 +4424,17 @@ impl Structurer<'_> {
                             continue;
                         }
                     }
-                    if uncond && register_based && self.is_bare_ret_off(s) {
-                        continue; // per-case `return` exit
+                    if uncond && (register_based || rvo_ret_switch) && self.is_bare_ret_off(s) {
+                        continue; // per-case `return` exit (register value or RVO out-slot)
                     }
                     return None; // escapes the region (incl. cond jumps to an exit)
                 }
-                // a return-exit must have a recoverable value INSIDE this region
-                if uncond && non_void {
+                // a return-exit must have a recoverable value INSIDE this region. For a
+                // register-based return that value is a `CpyVtoR*`/`LOADOBJ` scan-back; for a
+                // struct-RVO return (rvo_ret_switch) the value travels through `__return` and is
+                // proven separately by G-RVO (the scratch-emit proof below), so the register
+                // scan-back is DELIBERATELY not required here (it is always empty for an RVO struct).
+                if uncond && non_void && !rvo_ret_switch {
                     if let Some(&s) = bb.succs.first() {
                         let ret_exit = (s == join_off && join_is_ret)
                             || (s != join_off && !(s >= b && s < end_off) && self.is_bare_ret_off(s));
@@ -4326,6 +4491,57 @@ impl Structurer<'_> {
                 }
             }
         }
+        // batch-43 (Fix 2, gate G-RVO): a struct-RVO-return switch may recover ONLY when EVERY
+        // non-trap region PROVABLY writes the `__return` out-slot before its exit. Prove it by a
+        // non-emitting scratch pass: emit each region with `exit_rvo_return` set, then require
+        // `fold_rvo_return` to succeed (its `__return = <val>;` + `return __return;` fold IS the
+        // proof — a resolved out-slot store). ANY region without such a store bails the WHOLE
+        // switch to the stub (never emit a case that silently returns a default struct). This is
+        // the LAST bail point; the real emission below is byte-for-byte identical, so the proof
+        // and the emit agree. Runs only for the bare-RET-join RVO shape (`rvo_ret_switch`).
+        if rvo_ret_switch {
+            let saved = (self.exit_join, self.exit_join_is_ret, self.exit_ret_rows_ok, self.exit_rvo_return, self.exit_scan_floor);
+            let mut all_ok = true;
+            ctx.rvo_switch_region.set(true); // scope the `$beh0(__return,src)` statement-emit
+            for r in &regions {
+                if r.trap {
+                    continue;
+                }
+                let mut scratch = String::new();
+                self.exit_join = Some(join_off);
+                self.exit_join_is_ret = join_is_ret;
+                self.exit_ret_rows_ok = register_based;
+                self.exit_rvo_return = true;
+                self.exit_scan_floor = blocks[r.start].instr_lo;
+                self.emit_range(r.start, r.end, depth + 1, &mut scratch);
+                (self.exit_join, self.exit_join_is_ret, self.exit_ret_rows_ok, self.exit_rvo_return, self.exit_scan_floor) = saved;
+                // a region that FALLS THROUGH into the join (the default, whose destructor +
+                // shared RET follow) still writes `__return` inside its body but ends without the
+                // synthetic `return __return;` — accept it iff its body carries a resolved
+                // `__return = <val>;` store; the emission handles its fallthrough return normally.
+                let has_synth_return = scratch.lines().any(|l| l.trim() == "return __return;");
+                let ok = if has_synth_return {
+                    fold_rvo_return(&scratch).is_some()
+                } else {
+                    // fallthrough region (last, into the epilogue): require a resolved out-slot store
+                    scratch.lines().rev().find_map(|l| {
+                        let t = l.trim();
+                        t.strip_prefix("__return = ").and_then(|s| s.strip_suffix(';'))
+                    }).is_some_and(|val| {
+                        !val.is_empty() && !val.contains('\u{1}') && !val.contains('\u{2}')
+                            && val != UNRESOLVED && !val.contains(RVODEF)
+                    })
+                };
+                if !ok {
+                    all_ok = false;
+                    break;
+                }
+            }
+            ctx.rvo_switch_region.set(false);
+            if !all_ok {
+                return None;
+            }
+        }
         // ---- emission (validated: no bail past this point) ----
         let ind = "    ".repeat(depth);
         let (stmts, _) = block_stmts(ctx, b0.instr_lo, b0.instr_hi);
@@ -4342,7 +4558,7 @@ impl Structurer<'_> {
         };
         let _ = writeln!(out, "{ind}switch ({sel})");
         let _ = writeln!(out, "{ind}{{");
-        let saved = (self.exit_join, self.exit_join_is_ret, self.exit_ret_rows_ok, self.exit_scan_floor);
+        let saved = (self.exit_join, self.exit_join_is_ret, self.exit_ret_rows_ok, self.exit_rvo_return, self.exit_scan_floor);
         for r in &regions {
             if r.trap {
                 continue; // trap DEF = source had NO default; recompiling regenerates it
@@ -4367,9 +4583,26 @@ impl Structurer<'_> {
             self.exit_join = Some(join_off);
             self.exit_join_is_ret = join_is_ret;
             self.exit_ret_rows_ok = register_based;
+            self.exit_rvo_return = rvo_ret_switch;
             self.exit_scan_floor = blocks[r.start].instr_lo;
-            self.emit_range(r.start, r.end, depth + 1, out);
-            (self.exit_join, self.exit_join_is_ret, self.exit_ret_rows_ok, self.exit_scan_floor) = saved;
+            if rvo_ret_switch {
+                // batch-43 (Fix 2): emit to scratch, then fold the region's trailing
+                // `__return = <val>;` + `return __return;` into `return <val>;` (G-RVO already
+                // proved every region has such a store, so the fold cannot silently drop a
+                // value). A fallthrough region (default, whose body writes `__return` but exits
+                // by falling into the shared epilogue) has no synthetic `return __return;` — its
+                // scratch has no fold site, so it is written verbatim and the trailing epilogue's
+                // shared `return __return;` (see below) covers it.
+                let mut scratch = String::new();
+                ctx.rvo_switch_region.set(true); // scope the `$beh0(__return,src)` statement-emit
+                self.emit_range(r.start, r.end, depth + 1, &mut scratch);
+                ctx.rvo_switch_region.set(false);
+                let folded = fold_rvo_return(&scratch).unwrap_or(scratch);
+                out.push_str(&folded);
+            } else {
+                self.emit_range(r.start, r.end, depth + 1, out);
+            }
+            (self.exit_join, self.exit_join_is_ret, self.exit_ret_rows_ok, self.exit_rvo_return, self.exit_scan_floor) = saved;
             if r.append_break {
                 let _ = writeln!(out, "{ind}    break;");
             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1263,6 +1263,14 @@ fn provably_derived(dst: &str, src: &str, refs: &RefResolver) -> bool {
     if src == "AActor" && dst.starts_with('A') {
         return true;
     }
+    // batch-30a (C6d, specs/batch29-errortail.md §6d): same convention one level down — a
+    // dataflow that assigns an ACharacter-typed value into an `A*`-typed slot only exists
+    // in the bytecode because vanilla compiled it, i.e. the destination class IS
+    // ACharacter-derived; the wrap direction (Cast<Derived>) is the safe one.
+    // (GA_FallingRagdoll RefCpyV residue: `ACharacter& -> AGothicCharacter`.)
+    if src == "ACharacter" && dst.starts_with('A') {
+        return true;
+    }
     false
 }
 

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -417,13 +417,14 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     let mut a: Vec<Arg> = match need {
         Some(k) if stack.len() > k => {
             // Split off this call's own operands (top `k`); the deeper entries belong to an
-            // ENCLOSING call. BUT only PRESERVE deeper entries that are plausibly real enclosing
-            // args (typed locals/globals/PSF slots) — a stranded plain int/const literal left over
-            // from an unmodeled push is dead and, if preserved, pollutes the enclosing call's arg
-            // list and force-stubs it (regression). Drop such dead leading constants here, which is
-            // exactly what the old whole-stack `mem::take` did for them.
+            // ENCLOSING call. Drop STRANDED slot-sourced ints (SetV*+PshV4 temporaries) left over
+            // from an unmodeled push — preserving them pollutes the enclosing call's arg list and
+            // force-stubs it (regression). BUT keep PshC4/PshC8 LITERAL consts (cbits set): those
+            // are almost always real pending args of the enclosing/chained call — a float Distance,
+            // an int MinCount, a builder-chain weight/cooldown — that the enclosing call needs
+            // (proven: IsCloseToCharacter(a, b, 699.0) lost its 699.0 to this drop).
             let own = stack.split_off(stack.len() - k);
-            stack.retain(|x| !x.is_int);
+            stack.retain(|x| !x.is_int || x.cbits.is_some());
             own
         }
         _ => std::mem::take(stack),
@@ -485,6 +486,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         // super-class constructor on `this` -> `super(args)` (before is_type_name, since the
         // super name is itself a type name).
         if super_ctor == Some(f) && recv.s == "this" {
+            maybe_reverse_args(&mut a, params, refs); // super calls are reverse-pushed too
             return Some(format!("super({})", render_args(&a, params, refs)));
         }
         // BUG (a) — SUPER-CALL: a NON-VIRTUAL (`CALL`) dispatch on `this` to a method owned by a
@@ -493,6 +495,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         if non_virtual && recv.s == "this" {
             if let (Some(owner), Some(cur)) = (target_owner, cur_class) {
                 if owner != cur && refs.is_subclass(cur, owner) {
+                    maybe_reverse_args(&mut a, params, refs); // super calls are reverse-pushed too
                     return Some(format!("Super::{f}({})", render_args(&a, params, refs)));
                 }
             }
@@ -501,6 +504,14 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         // implicit in AS source, emit nothing.
         if refs.is_type_name(f) {
             return None;
+        }
+        // implicit-conversion behaviours (opImplConv/opConv) have NO source form: the conversion
+        // re-fires implicitly from the assignment/argument target type. An explicit `.opImplConv()`
+        // makes AS enumerate all overloads with no target type -> "Multiple matching signatures".
+        // Render the receiver itself so it flows into the store and the compiler re-derives the
+        // conversion from the destination's declared type.
+        if matches!(f, "opImplConv" | "opConv") {
+            return Some(recv.s.clone());
         }
         // operator-overload methods -> source operators (cast the RHS to the operand type).
         if let Some(op) = assign_op(f) {
@@ -545,6 +556,11 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         // register, e.g. a member opAssign) can't render as a free call — skip it rather than
         // emit `opAssign(...)`, which never resolves.
         if assign_op(f).is_some() || binop_method(f).is_some() {
+            return None;
+        }
+        // implicit-conversion behaviour with its receiver in the reference register (no stack
+        // receiver) — never a free call; drop it (the conversion re-fires from the target type).
+        if matches!(f, "opImplConv" | "opConv") {
             return None;
         }
         // trim leading phantom extras for a known free arity too.
@@ -957,9 +973,12 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 let off = ins.words.first().copied().unwrap_or(0) as i32;
                 let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let field = ctx.refs.member(tid, off).map(|s| s.to_string()).unwrap_or_else(|| format!("field_0x{off:x}"));
-                // field VALUE type from the class map (member_type gives the owner class).
-                let fty = ctx.fields.and_then(|m| m.get(&field)).cloned()
-                    .or_else(|| ctx.refs.member_type(tid, off).map(|s| s.to_string()));
+                // field VALUE type — ONLY from the enclosing class map. `member_type(tid,off)`
+                // returns the OWNER struct (PropertyReferences.OldTypeId = the CONTAINING type),
+                // NOT the field's value type; using it poisons foreign member reads (e.g.
+                // `HitResult.BoneName` typed as `FHitResult` instead of `FName`) -> false
+                // value-head mismatch -> spurious argtype stub. None = unknown = conservative match.
+                let fty = ctx.fields.and_then(|m| m.get(&field)).cloned();
                 if let Some(top) = stack.last_mut() {
                     top.s = format!("{}.{field}", top.s);
                     top.is_int = false; // now a member access, not a bare int slot

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1590,6 +1590,13 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
     // Slots whose current value came from a MEMBER READ (RDR* after a member-ref load) — real
     // data values, kept by the nested-call retain (see Arg.keep). Invalidated on overwrite.
     let mut member_read_slots: std::collections::HashSet<i32> = std::collections::HashSet::new();
+    // batch-41d: slots currently holding a CONST object handle (a const-returning CALL result,
+    // batch-20/21 `downcast` CONSTSTORE, or a const-member-read RefCpyV, batch-32d). A REFCPY
+    // member STORE (Fix 1) of such a slot into a non-const member is a "Can't implicitly convert
+    // from 'const T' to 'T'" error in generate-mode — so Fix 1 BAILS on a const source (the
+    // store is dropped, exactly as pre-batch-41, keeping the slot's const decl intact). Cleared
+    // when the slot is re-written with a non-const value.
+    let mut const_obj_slots: std::collections::HashSet<i32> = std::collections::HashSet::new();
     let mut pending: Option<String> = None; // unconsumed call/ctor result
     let mut pending_ty: Option<String> = None; // recovered type of `pending` (call return type)
     // batch-20 Class B: the call returns a CONST object handle (`const UCharacterAIState`).
@@ -2728,6 +2735,15 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                     Some(p) => Some(downcast(p, pending_ty.take(), std::mem::take(&mut pending_const), ctx.local_types.and_then(|m| m.get(&slot)), ctx.refs)),
                     None => obj_reg.take(),
                 };
+                // batch-41d: track whether this slot now holds a CONST object handle (the
+                // downcast() CONSTSTORE marker means a const-returning call result stored
+                // same-type). A later REFCPY member store of this slot must bail (const->non-const
+                // field). Cleared for a non-const write so a slot reused later is not stale.
+                if rhs.as_deref().is_some_and(|r| r.contains(CONSTSTORE)) {
+                    const_obj_slots.insert(slot);
+                } else {
+                    const_obj_slots.remove(&slot);
+                }
                 flush_store(&mut out, name(slot), rhs);
             }
             "CpyRtoV4" | "CpyRtoV8" => {
@@ -2980,8 +2996,17 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                                 == (dst_slot > 0).then(|| ctx.slot_type(dst_slot)).flatten().as_deref()
                         {
                             out.push(format!("{dst} = {CONSTSTORE}{rhs};"));
+                            // batch-41d: the dest slot now holds a const object handle; a later
+                            // REFCPY member store of it must bail (const->non-const field).
+                            if dst_slot > 0 {
+                                const_obj_slots.insert(dst_slot);
+                            }
                         } else {
                             out.push(format!("{dst} = {rhs};"));
+                            // non-const write clears any stale const provenance for the slot.
+                            if dst_slot > 0 {
+                                const_obj_slots.remove(&dst_slot);
+                            }
                         }
                     }
                 }
@@ -3013,9 +3038,35 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                         && src.s != UNRESOLVED
                         && !src.s.contains('\u{2}')
                         && (src.s.starts_with("local_") || src.s.starts_with("Cast<") || src.s == "nullptr");
-                    if dst_ok && src_ok {
+                    // batch-41d (CLASS 1b): the source slot holds a CONST object handle (a
+                    // const-returning call result / const member read). Storing it into a
+                    // (non-const) member is a "Can't implicitly convert from 'const T' to 'T'"
+                    // error in generate-mode. BAIL to the drop — the slot keeps its const decl
+                    // and the store is dropped exactly as pre-batch-41 (safe: it was dropped
+                    // before batch-41b and those functions compiled).
+                    let src_slot = src
+                        .s
+                        .strip_prefix("local_")
+                        .and_then(|d| d.parse::<i32>().ok());
+                    let src_is_const = src_slot.is_some_and(|n| const_obj_slots.contains(&n));
+                    if dst_ok && src_ok && !src_is_const {
                         flush!();
-                        out.push(format!("{} = {};", dst.s, src.s));
+                        // batch-41d (CLASS 2): the member field type PROVABLY derives from the
+                        // source's type (`this.ActiveActionTask (UAITask_CombatMove) =
+                        // local_36 (UAbilityTaskGeneric&)` — a base-typed call result into a
+                        // derived member). AS rejects the implicit downcast; wrap Cast<field>(src).
+                        // Same provably_derived gate as the RefCpyV read path; never wrap when the
+                        // pair is unprovable (renders bare = status quo).
+                        let rhs = match (dst.ty.as_deref(), src.ty.as_deref()) {
+                            (Some(fty), Some(sty))
+                                if provably_derived(fty, sty, ctx.refs) =>
+                            {
+                                let head = fty.split('<').next().unwrap_or(fty).trim_start_matches("const ");
+                                format!("Cast<{head}>({})", src.s)
+                            }
+                            _ => src.s.clone(),
+                        };
+                        out.push(format!("{} = {};", dst.s, rhs));
                     }
                     // else: both popped, nothing emitted = the status-quo drop.
                 }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1266,6 +1266,20 @@ fn is_enum_name(tyname: &str) -> bool {
     b.len() >= 2 && b[0] == b'E' && b[1].is_ascii_uppercase()
 }
 
+/// Coarse type family for the batch-29b `CpyVtoR4/R8` fold gate: the value register can only
+/// carry the function's return payload when the pending call's return family matches the
+/// function's. `bool` / int-family / float-family buckets; everything else keys on its
+/// template-stripped head name (`TMap<A,B>` == `TMap`), so same-head folds keep the status quo.
+fn ty_family(t: &str) -> &str {
+    let t = t.trim_start_matches("const ");
+    match t {
+        "bool" => "bool",
+        "int" | "int8" | "int16" | "int64" | "uint" | "uint8" | "uint16" | "uint64" => "int",
+        "float" | "float32" | "double" => "float",
+        _ => t.split('<').next().unwrap_or(t),
+    }
+}
+
 /// Wrap an enum-typed RHS being stored into an INT slot as `int(expr)`. AngelScript has no
 /// implicit enum->int conversion, so an enum field-read / enum-returning call stored into an
 /// `int` local fails to compile. Only fires when the value is a known enum AND the dest is an
@@ -2153,7 +2167,24 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 // register content comes from the SLOT operand (e.g. a bool& out-param the call
                 // just wrote: `CalculateDistanceToTarget(.., local_3); return local_3;`).
                 // Flush the call as its own statement and use the slot.
-                if pending.is_some() && pending_ty.as_deref() == Some("void") {
+                //
+                // batch-29b (C6e, specs/batch29-errortail.md §5): the same slot-over-pending
+                // discipline for two more provably-wrong folds. (1) An ASSIGNMENT-shaped
+                // pending (batch-26 operator/RVO-dest fold) is a STATEMENT — the register
+                // holds the SLOT operand's value, not the assignment expression. (2) A call
+                // whose return-type FAMILY mismatches the enclosing function's return type
+                // can't be the return payload either — the proven class is a BOOL
+                // `TMap::Find(key, out)` folded into a FLOAT return whose true payload is
+                // the out-param slot (`return this.Severities.Find(ERelationship(local_5),
+                // local_2);` — 3 "No conversion from 'bool' to 'float'" errors). Flush and
+                // use the slot; unknown types on either side keep the status-quo fold.
+                let foldable = pending.as_deref().map(|p| assign_lhs(p).is_none()).unwrap_or(true)
+                    && match (pending_ty.as_deref(), ctx.ret_ty.map(|t| t.base_name(ctx.refs))) {
+                        (Some("void"), _) => false,
+                        (Some(pt), Some(rt)) => ty_family(pt) == ty_family(&rt),
+                        _ => true, // either side unknown -> status quo (fold)
+                    };
+                if pending.is_some() && !foldable {
                     flush!();
                 }
                 // batch-24a (G1): in an RVO function the 4/8-byte value register NEVER carries
@@ -2179,7 +2210,20 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 // return local_3;`). Folding it in rendered `return VoidCall(...)` / `if
                 // (VoidCall(...) == 0)` ("No conversion from 'void' to ..."). Flush the call as
                 // its own statement and use the slot.
-                if pending.is_some() && pending_ty.as_deref() == Some("void") {
+                //
+                // batch-29b (C5, specs/batch29-errortail.md §5): folding `pending` is only
+                // valid when the pending expression IS the tested bool (a bool-returning call
+                // immediately consumed — the `if (X.IsValid())` population). An ASSIGNMENT-
+                // shaped pending (batch-26 operator/RVO-dest fold: `local_4 =
+                // this.GetSensedLivingEnemies(...)`) is a STATEMENT whose value the register
+                // does NOT hold — CpyVtoR1 copies the NAMED SLOT operand (bytecode proof:
+                // CheckAnyHostilesOrEnemiesSensed tests w65532, a bool param), and the folded
+                // render `if (x = call() == 0)` is unparseable (18 parse [E]s, 4 module
+                // killers) AND tests the wrong value. A non-bool pending can't be the 1-byte
+                // test value either. Flush both as their own statement and test the slot.
+                let foldable = pending_ty.as_deref() == Some("bool")
+                    && pending.as_deref().map(|p| assign_lhs(p).is_none()).unwrap_or(false);
+                if pending.is_some() && !foldable {
                     flush!();
                 }
                 let is_bool = (pending.is_some() && pending_ty.as_deref() == Some("bool"))

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2229,6 +2229,39 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                         Some(t) if looks_int(&raw) => field_assign_rhs(&raw, t),
                         _ => raw.clone(),
                     };
+                    // batch-45b (FIX-3): a member-write on a FOREIGN object (a call-result /
+                    // this-member via LoadRObjR/LoadThisR) where `ref_reg_ty` resolved to the
+                    // field's OWNER class (member_type's OldTypeId is the owner, not the value
+                    // type — see the LoadThisR comment) makes `field_assign_rhs` bail to
+                    // UNRESOLVED for a `local_N` RHS, so the whole store dropped and the
+                    // quest/document/routine flag was NEVER set (`UStoryG1R::Get().<flag> = ...;`
+                    // — a REAL behavioural bug: 18 RegionTrait + 2 Document + Crime writers).
+                    // Retry with `ref_reg_vty` (the precise VALUE type from field_type_by_class /
+                    // the this-class field map) — a real PRIMITIVE value type. Bail-safe: only
+                    // rescues an already-DROPPED store (rhs still UNRESOLVED) and only when vty is
+                    // a real primitive value type (never an object/owner name that would re-bail),
+                    // so no working store changes.
+                    if rhs == UNRESOLVED {
+                        if let Some(vty) = ref_reg_vty.as_deref() {
+                            let v = vty.trim_start_matches("const ");
+                            let is_primitive = matches!(
+                                v,
+                                "int" | "uint" | "int8" | "int16" | "int64" | "uint8" | "uint16"
+                                | "uint64" | "float" | "float32" | "double" | "bool"
+                            ) || is_enum_name(v);
+                            if is_primitive {
+                                let cand = match v {
+                                    "float32" => float_lit(&set_consts, slot, false).unwrap_or_else(|| raw.clone()),
+                                    "float" | "double" => float_lit(&set_consts, slot, true).unwrap_or_else(|| raw.clone()),
+                                    _ if looks_int(&raw) => field_assign_rhs(&raw, v),
+                                    _ => raw.clone(),
+                                };
+                                if cand != UNRESOLVED {
+                                    rhs = cand;
+                                }
+                            }
+                        }
+                    }
                     // batch-25a (G2, specs/batch23-cantconvert.md): a 1-byte write to a NATIVE
                     // struct's field whose value type the in-crate native-field table resolves
                     // to an ENUM is the enum ORDINAL store (`SetV1 w80, 0x2 ... WRTV1 w80`), not

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -307,7 +307,12 @@ pub fn decompile(f: &FuncCode, refs: &RefResolver) -> String {
         .enumerate()
         .map(|(i, n)| if n.is_empty() { format!("arg{i}") } else { n.clone() })
         .collect();
-    let body = body_statements(f, refs, 1)
+    // Pass the return type so RVO / value-return functions decompile faithfully in the CLI
+    // (the ret_ty-less `body_statements` path renders `return;` for a struct-by-value return,
+    // masking the emitter's real `return <rvo_local>;`). Diagnostic-only: the authoritative
+    // emitter is emit.rs (which already threads `Some(&f.ret)`); this only aligns the readable
+    // `as decompile` view with it. Other context (fields/class/hints) stays None as before.
+    let body = body_statements_ctor(f, refs, 1, None, Some(&f.ret), None, None, None, None, None)
         .replace(RVODEF, "/* unrecovered */ {}")
         .replace(CONSTSTORE, "");
     format!(

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3124,6 +3124,22 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                     cmp = None;
                 }
             }
+            // FreeNullV8 vN: the compiler's `return null` prologue — free slot N and set it to a
+            // null object handle. Model as `local_N = nullptr;` so the following `LOADOBJ vN; RET`
+            // renders `return nullptr;` (previously it was ignored -> the null-return branch
+            // rendered empty). Additive and always correct — nulling its own slot IS the opcode's
+            // VM semantics; a rare non-return slot-reuse also legitimately nulls the slot
+            // (a redundant null-init of an already-null-defaulted object local, value-preserving).
+            // Depends on Fix 2 (the member-load must be recovered first so the null-check tests the
+            // right operand). batch-41c, Fix 3, S4.
+            "FreeNullV8" => {
+                flush!();
+                let slot = w(ins, 0);
+                out.push(format!("{} = nullptr;", name(slot)));
+                // clear any stale const / member-read provenance for this slot
+                set_consts.remove(&slot);
+                member_read_slots.remove(&slot);
+            }
             // ---- pure VM housekeeping / flow: ignore ----
             // NOTE: `ThrowException` (throw) and `JMPP` (jump-table/switch) are NOT housekeeping
             // — they're unmodeled control transfers, and `cfg.rs` leaves JMPP successors unknown.
@@ -3131,7 +3147,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
             // rather than emitting recompilable source with the throw/switch silently dropped.
             "SUSPEND" | "JitEntry" | "PopPtr" | "SwapPtr" | "ClrHi" | "ClrVPtr"
             | "FREE" | "FinConstruct" | "CHKREF" | "ChkRefS" | "ChkNullV" | "ChkNullS"
-            | "DestructScript" | "SaveReturnValue" | "ResolveObjectPtr" | "FreeNullV8" | "GETOBJ"
+            | "DestructScript" | "SaveReturnValue" | "ResolveObjectPtr" | "GETOBJ"
             | "GETOBJREF" | "GETREF"
             | "JMP" => {}
             // CopyScript performs a script-value copy (an assignment), not housekeeping — it's

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -440,7 +440,7 @@ struct Cmp {
 /// methods (opAssign/opAdd/opEquals/...) render as the source operator. Returns None for
 /// compiler-generated behaviors ($behN construct/destruct) that have no source form.
 #[allow(clippy::too_many_arguments)]
-fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option<&str>, params: Option<&[DataType]>, native_arity: Option<usize>, trusted_arity: Option<usize>, target_owner: Option<&str>, cur_class: Option<&str>, non_virtual: bool, ret_ty: Option<&str>, ret_is_ref: bool, refs: &RefResolver) -> Option<String> {
+fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option<&str>, params: Option<&[DataType]>, native_arity: Option<usize>, trusted_arity: Option<usize>, target_owner: Option<&str>, cur_class: Option<&str>, non_virtual: bool, ret_ty: Option<&str>, ret_is_ref: bool, global_shadowed: bool, refs: &RefResolver) -> Option<String> {
     if f.starts_with('$') || f.starts_with('~') || f == "__STATIC_NAME" {
         // EDIT C (the dominant FName form): `__STATIC_NAME` is the synthesized name-table accessor
         // (`const FName& __STATIC_NAME(int Id)` per the exe's registered decl) that fetches
@@ -715,6 +715,16 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
                 return Some(format!("{owner}::{f}({})", render_args(&a, params, refs)));
             }
         }
+        // batch-24b: AngelScript member lookup SHADOWS globals — an unqualified call to a free
+        // SCRIPT global from inside a class whose (native) ancestry has a same-named member
+        // resolves to the member and fails (`WaitSeconds(this.AI, 2.0)` diagnosed against
+        // `UAbilityTaskCoroutine::WaitSeconds(float32)`, 33 sites; CastSpell/IsMoving/IsDead/
+        // CanMoveIntoDirection likewise). The global-scope qualifier `::f(...)` always legally
+        // names a genuine global (over-qualification is harmless), so gated call sites render
+        // qualified. Computed AFTER the early-returns above so name-based matches (behaviours,
+        // is_type_name ctors, owner-qualified Get/GetOrCreate/Create, operators) are untouched.
+        let f: std::borrow::Cow<str> =
+            if global_shadowed { format!("::{f}").into() } else { f.into() };
         // Free-call RVO struct-return (mirror of the method Fix-b3 arm): a free/static function
         // returning a struct BY VALUE pushes a hidden PSF out-slot. Recover `out = f(args)`
         // instead of leaking the out-slot as a leading arg (GotoPosition/Say/GiveItemTo/
@@ -1574,7 +1584,19 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     let trusted = ctx.refs.func_params_by_id(id).map(|p| p.len());
                     let owner = ctx.refs.func_owner_by_id(id);
                     let ret_is_ref = ctx.refs.func_ret_by_id(id).map(|d| d.is_reference).unwrap_or(false);
-                    build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, owner, ctx.class_name, n == "CALL", pending_ty.as_deref(), ret_is_ref, ctx.refs)
+                    // batch-24b shadow gate: a free SCRIPT global (no owner, global namespace)
+                    // rendered inside a class method is shadowed by any same-named member in
+                    // the class's (native or script) ancestry. Member-name existence (T3
+                    // method names, script method decls, Binds when loaded) over-approximates
+                    // "such a member exists somewhere" — `::`-qualifying a non-shadowed global
+                    // resolves identically, so false positives are harmless; no name sources
+                    // -> false (status quo).
+                    let global_shadowed = !ctx.refs.is_method_by_id(id)
+                        && owner.is_none()
+                        && ctx.class_name.is_some()
+                        && ctx.refs.func_ns_by_id(id).map_or(true, |ns| ns.is_empty())
+                        && ctx.refs.member_name_exists(&f);
+                    build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, owner, ctx.class_name, n == "CALL", pending_ty.as_deref(), ret_is_ref, global_shadowed, ctx.refs)
                 };
             }
             "CALLSYS" | "Thiscall1" => {
@@ -1705,14 +1727,14 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // native calls too so the UObject-receiver Cast wrap (batch19 class 1) and the
                     // generated-accessor qualification see the owning class of CALLSYS methods.
                     let ret_is_ref = ctx.refs.func_ret_by_ptr(ptr).map(|d| d.is_reference).unwrap_or(false);
-                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, ctx.refs.func_owner_by_ptr(ptr), ctx.class_name, false, pending_ty.as_deref(), ret_is_ref, ctx.refs)
+                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, ctx.refs.func_owner_by_ptr(ptr), ctx.class_name, false, pending_ty.as_deref(), ret_is_ref, false, ctx.refs)
                 };
             }
             "CallPtr" => {
                 let f = name(w(ins, 0));
                 pending_ty = None;
                 pending_const = false;
-                pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, None, ctx.class_name, false, None, false, ctx.refs);
+                pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, None, ctx.class_name, false, None, false, false, ctx.refs);
             }
             // ---- object construction ----
             "ALLOC" => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -652,6 +652,47 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
                 }
             }
         }
+        // G1c (batch-26): CALLSYS value-operator with an RVO destination slot. The fork's
+        // Binds register FVector-family operators as returning the struct BY VALUE, so the
+        // caller pushes a hidden PSF dest directly BELOW the receiver: [args..., dest, recv].
+        // The is_operator exclusion above (protecting ref-returning opAssign) let the generic
+        // arity trim eat the REAL rhs and substitute the dest -> discarded `(a / dest);`
+        // statements (458 in-game "Result of expression is unused") and silently-wrong
+        // compound assigns (`x += dead_temp`). Gate on the SAME data-driven rvo_slot probe
+        // that already widened the split window: a ref-returning operator pushes no dest and
+        // can never match (ret_is_ref + F/T-head are inside rvo_slot).
+        if is_operator && rvo_slot
+            && a.last()
+                .map(|x| x.is_psf && x.ty.as_deref().map(head) == ret_ty.map(head))
+                .unwrap_or(false)
+        {
+            let dest = a.pop().unwrap();
+            if let Some(w) = arity {
+                let w = w.min(a.len());
+                if a.len() > w { a.drain(..a.len() - w); }
+            }
+            match (assign_op(f), binop_method(f), a.first()) {
+                (Some(op), _, Some(rhs)) => {
+                    // compound/plain assign: the result lives in the RECEIVER; `dest` is the
+                    // dead return-value temp. Mirror the existing arm's copyctor stub gate.
+                    if op == "=" && recv.s == "this" {
+                        return Some(amm("copyctor"));
+                    }
+                    let r = params.and_then(|p| p.first()).map(|pt| cast_arg(rhs, pt, refs))
+                        .unwrap_or_else(|| rhs.s.clone());
+                    return Some(format!("{} {op} {}", recv.s, r));
+                }
+                (None, Some(op), Some(rhs)) => {
+                    // pure binop: the DEST receives the result.
+                    let r = params.and_then(|p| p.first()).map(|pt| cast_arg(rhs, pt, refs))
+                        .unwrap_or_else(|| rhs.s.clone());
+                    return Some(format!("{} = ({} {op} {})", dest.s, recv.s, r));
+                }
+                // rhs unrecovered (short/take-all stack): restore and fall through to the
+                // existing arms -> status-quo render, zero regression.
+                _ => a.push(dest),
+            }
+        }
         // trim phantom extras: keep only the last `w` user args (the cache arity may include the
         // now-popped `this`, so cap below the popped count, never above).
         if let Some(w) = arity {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -413,7 +413,17 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     let rvo_slot = is_method && ret_ty
         .map(|t| matches!(t.split('<').next().unwrap_or(t).bytes().next(), Some(b'F') | Some(b'T')))
         .unwrap_or(false);
-    let need = trusted_arity.map(|n| n + is_method as usize + rvo_slot as usize);
+    // NESTED-CALL ARG-DROP fix: when arity is untrusted (native call, no Binds -> trusted_arity=None),
+    // the old `mem::take` DRAINED the whole stack — annihilating an ENCLOSING call's already-pushed
+    // args when a nested FREE/STATIC call (e.g. `UQuestSubsystem::Get()`, a factory/getter) runs in
+    // the middle of the enclosing arg-push (proven: `Get().GetQuestByClass(TSubclassOf(...))` lost the
+    // TSubclassOf arg -> 0-arg call). For a NON-METHOD call the cache FunctionReference param count is
+    // reliable (no implicit-`this` undercount), so use it as a soft cap to take ONLY this call's own
+    // args and preserve deeper enclosing operands. METHOD calls keep take-all (their cache counts are
+    // unreliable due to the implicit `this`, and their receiver-on-top means deeper entries are rarely
+    // a separate enclosing frame). StaticClass is already special-cased (0 operands, no drain).
+    let soft_arity = trusted_arity.or_else(|| if !is_method { params.map(|p| p.len()) } else { None });
+    let need = soft_arity.map(|n| n + is_method as usize + rvo_slot as usize);
     let mut a: Vec<Arg> = match need {
         Some(k) if stack.len() > k => {
             // Split off this call's own operands (top `k`); the deeper entries belong to an

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3085,14 +3085,18 @@ impl Structurer<'_> {
                 let break_off = self.g.blocks[latch].succs.iter().copied().find(|&s| s > latch_off);
                 if let Some(break_off) = break_off {
                     let ls = LoopScope { continue_off: latch_off, break_off };
+                    // `loop_scope` must be set BEFORE Gate 2 — its nested-switch dry run
+                    // (`switch_span` -> `try_emit_switch`) consults it to accept loop
+                    // continue/break as switch exits, so the dry run and the real emit agree.
+                    let saved = self.loop_scope;
+                    self.loop_scope = Some(ls);
                     if self.body_has_inner_branch(i, latch, ls)
                         && self.loop_body_recoverable(i, latch, ls)
                     {
-                        let saved = self.loop_scope;
-                        self.loop_scope = Some(ls);
                         self.emit_range(i, latch, depth + 1, out);
                         self.loop_scope = saved;
                     } else {
+                        self.loop_scope = saved;
                         self.emit_linear(i, latch + 1, depth + 1, out, true);
                     }
                 } else {
@@ -3420,7 +3424,13 @@ impl Structurer<'_> {
                         if !self.loop_edge_ok(ib, lo, hi, ls) && !ib_in_body {
                             return false;
                         }
-                        if !self.loop_body_recoverable(bi, inner, inner_ls) {
+                        // the inner body's own dry run must see the inner loop_scope (so a switch
+                        // nested in the inner loop resolves against the inner continue/break).
+                        let saved = self.loop_scope;
+                        self.loop_scope = Some(inner_ls);
+                        let ok = self.loop_body_recoverable(bi, inner, inner_ls);
+                        self.loop_scope = saved;
+                        if !ok {
                             return false;
                         }
                         bi = inner + 1;
@@ -3598,6 +3608,12 @@ impl Structurer<'_> {
         let ctx = self.ctx;
         let g = self.g;
         let blocks = &g.blocks;
+        // batch-36 (Stage B): when this switch is emitted inside a recursed loop body, a case/DEF
+        // region that exits by falling into the loop-continue point (the increment/latch = `stop`)
+        // or by jumping to the loop break offset is a legal switch exit (`break;` out of the
+        // switch → the loop continues), not the "escapes the region" bail. `loop_scope` is set by
+        // the loop_latch arm before both the Gate-2 dry run and the real emit, so the two agree.
+        let lscope = self.loop_scope;
         if stop > blocks.len() || i + 3 > stop || i + 2 >= blocks.len() {
             return None;
         }
@@ -3708,13 +3724,20 @@ impl Structurer<'_> {
         let mut join_cands: Vec<usize> = Vec::new();
         let mut ret_rows: Vec<usize> = Vec::new();
         let mut fall_pend: Vec<usize> = Vec::new();
+        // batch-36 (Stage B): an edge to the loop break/continue offset is a valid switch exit.
+        let is_loop_exit = |x: usize| -> bool {
+            lscope.is_some_and(|ls| x == ls.continue_off || x == ls.break_off)
+        };
         for w in bounds.windows(2) {
             let last_bi = self.idx_of.get(&w[1]).copied()? - 1;
             let lb = &blocks[last_bi];
             match ctx.instrs[lb.instr_hi - 1].op.name {
                 "JMP" => {
                     let x = lb.succs.first().copied()?;
-                    if self.is_bare_ret_off(x) {
+                    if is_loop_exit(x) {
+                        // `break;`/`continue;` out of the switch to the enclosing loop
+                        join_cands.push(x);
+                    } else if self.is_bare_ret_off(x) {
                         if !register_based {
                             return None;
                         }
@@ -3727,14 +3750,31 @@ impl Structurer<'_> {
                 }
                 "RET" => {}
                 name if is_cond_op(name) => return None,
-                _ => fall_pend.push(w[1]), // falls into next boundary: legal only into JOIN
+                // falls into the next boundary: legal into the JOIN, or (in a loop) into the
+                // loop-continue point which IS `stop` == the next boundary past the switch.
+                _ => fall_pend.push(w[1]),
             }
         }
         join_cands.sort_unstable();
         join_cands.dedup();
         ret_rows.sort_unstable();
         ret_rows.dedup();
+        // batch-36 (Stage B): inside a loop, the natural JOIN of a switch whose non-returning
+        // regions fall through / break to the loop-continue is that continue offset (== `stop`,
+        // the loop increment/latch). Prefer it so the returning cases stay `return`s and the DEF
+        // falls into the increment as a `break;`. Only when NO explicit forward join exists.
+        let loop_join = lscope.and_then(|ls| {
+            let cont_idx = self.idx_of.get(&ls.continue_off).copied();
+            if cont_idx == Some(stop) && join_cands.iter().all(|&j| is_loop_exit(j)) {
+                Some(ls.continue_off)
+            } else {
+                None
+            }
+        });
         let join_off = match (join_cands.as_slice(), ret_rows.as_slice()) {
+            _ if loop_join.is_some() && join_cands.iter().all(|&j| is_loop_exit(j)) => {
+                loop_join.unwrap()
+            }
             ([j], _) => *j,
             // every region returns: the shared bare RET row is the join/epilogue
             ([], [r]) => *r,

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1390,6 +1390,26 @@ fn cast_to_typename(rhs: &str, tyname: &str) -> Option<String> {
     None
 }
 
+/// batch-32c (D9 pure-element carry): true for a side-effect-free container element read
+/// rendered from a LOCAL receiver — `local_N.opIndex(<simple>)` with a parenthesis-free,
+/// quote-free arg (constants / bare locals / plain member chains). Only such pendings may
+/// be tagged carryable across a cast diamond (see `pending_is_pure_elem`): a local
+/// container cannot be mutated by the diamond's D7-constrained arms (opCast+TYPEID) or the
+/// pure pre-join getters of the proven population, so re-evaluating the read at the join
+/// observes the same element.
+fn is_pure_elem_read(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix("local_") else { return false };
+    let Some((idx, call)) = rest.split_once('.') else { return false };
+    if idx.is_empty() || !idx.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    let Some(args) = call.strip_prefix("opIndex(").and_then(|c| c.strip_suffix(')')) else {
+        return false;
+    };
+    args.bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b',' | b' ' | b'-'))
+}
+
 /// True if a rendered operand is an integer slot/constant (safe to cast to bool/enum).
 /// Excludes already-typed operands (params, fields, calls) so we never double-cast.
 fn looks_int(s: &str) -> bool {
@@ -1496,6 +1516,16 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
     // flag can never pair with a live non-literal `pending`. Deliberately NOT widened to
     // other pendings (opIndex results etc. are side-effect-bearing — N4 territory).
     let mut pending_is_static_name: bool = false;
+    // batch-32c (N4 site-1, spec batch31-nomatch-illegalop §1.8 corrected by disasm): the
+    // pending is a side-effect-free container ELEMENT READ from a LOCAL receiver
+    // (`local_12.opIndex(0)` — TArray opIndex Thiscall1). Its PshRPtr push may be tagged
+    // `.carry()`: re-evaluating the read at the diamond join cannot observe a different
+    // value (D7 restricts the arms to opCast+TYPEID, and the pre-join calls of the proven
+    // population are pure getters that cannot mutate a local container). Without the tag D9
+    // bailed and BOTH leftover args died (IgnoreActorWhenMoving rendered 0-arg ×2). Same
+    // lifecycle as pending_is_static_name: set only by the CALLSYS/Thiscall1 arm, reset by
+    // every other pending producer.
+    let mut pending_is_pure_elem: bool = false;
     let mut ret_val: Option<String> = None;
     // Target type of the most recent TYPEID push — the implicit type operand of the following
     // `opCast` behaviour call (the lowered form of `Cast<T>(x)`). Resolved to a typename so the
@@ -1659,11 +1689,13 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                         let lhs = lhs.to_string();
                         out.push(format!("{p};"));
                         stack.push(Arg::typed(lhs, pending_ty.take()));
-                    } else if pending_is_static_name {
+                    } else if pending_is_static_name || pending_is_pure_elem {
                         // batch-31b (N2b): the pending is the PURE `n"..."`/`FName(...)`
                         // literal of the __STATIC_NAME idiom — no side effect can be
                         // reordered by carrying it across a cast diamond, so it may pass
                         // the D9 carryability gate like any plain const push.
+                        // batch-32c widens this to pure local-container element reads
+                        // (`local_12.opIndex(0)` — see pending_is_pure_elem).
                         stack.push(Arg::typed(p, pending_ty.take()).carry());
                     } else {
                         stack.push(Arg::typed(p, pending_ty.take()));
@@ -2193,6 +2225,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, owner, ctx.class_name, n == "CALL", pending_ty.as_deref(), ret_is_ref, global_shadowed, ctx.refs)
                 };
                 pending_is_static_name = false;
+                pending_is_pure_elem = false;
             }
             "CALLSYS" | "Thiscall1" => {
                 test_after_call = false;
@@ -2386,6 +2419,9 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 // build_call returns the literal only for the accessor name; a failed gate
                 // (non-constant Id operand) falls to the `$`-drop and returns None.
                 pending_is_static_name = f == "__STATIC_NAME" && pending.is_some();
+                // batch-32c: tag a pure local-container element read (see the flag's doc).
+                pending_is_pure_elem =
+                    f == "opIndex" && pending.as_deref().map(is_pure_elem_read).unwrap_or(false);
             }
             "CallPtr" => {
                 let f = name(w(ins, 0));
@@ -2393,6 +2429,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 pending_const = false;
                 pending_is_ref = false;
                 pending_is_static_name = false;
+                pending_is_pure_elem = false;
                 pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, None, ctx.class_name, false, None, false, false, ctx.refs);
             }
             // ---- object construction ----
@@ -2403,6 +2440,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 pending_ty = Some(ty.clone());
                 pending_const = false;
                 pending_is_ref = false;
+                pending_is_pure_elem = false;
                 pending_is_static_name = false;
                 pending = Some(format!("{ty}({})", args.join(", ")));
             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -21,7 +21,7 @@ use super::walk_modules::FuncCode;
 
 /// A pushed call argument: its rendered text plus whether it originated from an integer
 /// value (a constant or `int` slot), so it can be cast to the callee's expected `bool`/enum.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq)]
 struct Arg {
     s: String,
     is_int: bool,
@@ -50,6 +50,10 @@ struct Arg {
     /// (scoped option: it is deliberately NOT merged into `ty`, so call-arg/argtype gates
     /// never see it).
     nfty: Option<String>,
+    /// batch-27 (Cast-diamond carry): pushed by a plain slot/const/global push opcode in
+    /// `block_stmts` — safe to carry across a recognized Cast diamond; never set for
+    /// pending-call-result pushes (`PshRPtr`) or synthetic pushes.
+    carryable: bool,
 }
 impl Arg {
     fn int(s: String) -> Arg {
@@ -72,6 +76,13 @@ impl Arg {
     /// A synthesized implicit `__WorldContext` marker (see `is_ctx`).
     fn ctx() -> Arg {
         Arg { is_ctx: true, ..Default::default() }
+    }
+    /// Tag this arg as originating from a plain push opcode (see `carryable`). Applied at the
+    /// `block_stmts` push SITES, deliberately not inside the constructors — `build_call` also
+    /// constructs Args, which must never be carried.
+    fn carry(mut self) -> Arg {
+        self.carryable = true;
+        self
     }
 }
 
@@ -142,7 +153,7 @@ pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, supe
     let idx_of: HashMap<usize, usize> =
         g.blocks.iter().enumerate().map(|(i, b)| (b.start_dw, i)).collect();
     let mut body = String::new();
-    let mut st = Structurer { ctx: &ctx, g: &g, idx_of: &idx_of, exit_join: None, exit_join_is_ret: false, exit_ret_rows_ok: false, exit_scan_floor: 0 };
+    let mut st = Structurer { ctx: &ctx, g: &g, idx_of: &idx_of, exit_join: None, exit_join_is_ret: false, exit_ret_rows_ok: false, exit_scan_floor: 0, carry: None };
     st.emit_range(0, g.blocks.len(), depth, &mut body);
     body
 }
@@ -439,7 +450,7 @@ fn narrowing_cast_target(n: &str) -> Option<&'static str> {
 
 /// The raw bits of a `SetV*` constant written to a slot — so a later store into a float/
 /// double field can reinterpret them as the real IEEE-754 value instead of an int literal.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 enum ConstBits {
     W4(u32),
     W8(u64),
@@ -1293,10 +1304,19 @@ fn esc(s: &str) -> String {
 /// Decompile one block's instruction range into statements; also return the
 /// pending comparison (operands of the last CMP*) for condition recovery.
 fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
+    let (out, cmp, _) = block_stmts_in(ctx, lo, hi, Vec::new());
+    (out, cmp)
+}
+
+/// [`block_stmts`] with an explicit INITIAL operand stack and the block's LEFTOVER stack in
+/// the return (batch-27 Cast-diamond carry): the carried entries occupy the DEEPEST positions,
+/// below everything the block pushes — exactly the runtime layout — and the leftover is
+/// returned verbatim after the final flush (the UNRESOLVED retain applies to statements only).
+fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<String>, Option<Cmp>, Vec<Arg>) {
     let mut out = Vec::new();
     let mut cmp: Option<Cmp> = None;
     let mut cond: Option<(String, bool)> = None; // (bool value tested by a jump, is-bool-typed)
-    let mut stack: Vec<Arg> = Vec::new(); // pushed pointer/value expressions
+    let mut stack: Vec<Arg> = init; // pushed pointer/value expressions
     let mut value_reg: Option<String> = None;
     let mut obj_reg: Option<String> = None;
     let mut ref_reg: Option<String> = None; // Idiom-B member address
@@ -1382,13 +1402,15 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
         }
         match n {
             // ---- pushes ----
+            // (plain slot/const/global pushes are tagged `.carry()` — safe to carry across a
+            // recognized Cast diamond; see `Arg::carryable`.)
             "PshC4" => {
                 let b = ins.dwords.first().copied().unwrap_or(0);
-                stack.push(Arg::iconst((b as i32).to_string(), ConstBits::W4(b)));
+                stack.push(Arg::iconst((b as i32).to_string(), ConstBits::W4(b)).carry());
             }
             "PshC8" => {
                 let b = ins.qwords.first().copied().unwrap_or(0);
-                stack.push(Arg::iconst((b as i64).to_string(), ConstBits::W8(b)));
+                stack.push(Arg::iconst((b as i64).to_string(), ConstBits::W8(b)).carry());
             }
             "PshV4" | "PshV8" => {
                 // A bool slot pushed as an arg must render BARE (`WasCancelled`), not as
@@ -1398,40 +1420,40 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 // enum/int slots stay int so their enum/`!= 0` casts still fire.
                 let off = w(ins, 0);
                 if ctx.slot_type(off).as_deref() == Some("bool") {
-                    stack.push(Arg::typed(name(off), Some("bool".to_string())));
+                    stack.push(Arg::typed(name(off), Some("bool".to_string())).carry());
                 } else if matches!(ctx.slot_type(off).as_deref(), Some("float" | "float32" | "double")) {
                     // batch-20 Class C: a float-family slot pushed by value is a REAL arg (e.g.
                     // SetByCallerMagnitude's Magnitude pushed before a chained GetSpec()); typed
                     // (is_int=false) it survives the nested-call stack-split retain and renders
                     // bare. Left as Arg::int it was dropped as a stranded temporary (17 in-game
                     // errors: "No matching signatures to 'SetByCallerMagnitude(FGameplayTag)'").
-                    stack.push(Arg::typed(name(off), ctx.slot_type(off)));
+                    stack.push(Arg::typed(name(off), ctx.slot_type(off)).carry());
                 } else if let Some(cb) = set_consts.get(&off).copied() {
                     // The slot holds a tracked SetV constant (the SetV1/SetV4 -> PshV4 idiom for a
                     // literal flag/amount, e.g. Say's `bUnskippable`). Carry its cbits so the
                     // nested-call retain (`!is_int || cbits.is_some()`) keeps it as a REAL arg
                     // instead of dropping it as a stranded temporary.
-                    stack.push(Arg::iconst(name(off), cb));
+                    stack.push(Arg::iconst(name(off), cb).carry());
                 } else if member_read_slots.contains(&off) {
                     // Member-read value (this.XP_... amount) — a real arg the retain must keep.
-                    stack.push(Arg { s: name(off), is_int: true, keep: true, ..Default::default() });
+                    stack.push(Arg { s: name(off), is_int: true, keep: true, ..Default::default() }.carry());
                 } else if ctx.keep_ints.is_some_and(|s| s.contains(&off)) {
                     // batch-25g (spec family G kin): the emit-side pairing proved every value
                     // push of this slot feeds a KNOWN int-family parameter — a real arg
                     // (Math::Min's second operand below a nested call), not a stranded SetV
                     // temporary; the nested-call retain must keep it.
-                    stack.push(Arg { s: name(off), is_int: true, keep: true, ..Default::default() });
+                    stack.push(Arg { s: name(off), is_int: true, keep: true, ..Default::default() }.carry());
                 } else {
-                    stack.push(Arg::int(name(off)));
+                    stack.push(Arg::int(name(off)).carry());
                 }
             }
-            "PshVPtr" => stack.push(Arg::typed(name(w(ins, 0)), ctx.slot_type(w(ins, 0)))),
+            "PshVPtr" => stack.push(Arg::typed(name(w(ins, 0)), ctx.slot_type(w(ins, 0))).carry()),
             "PSF" => {
                 // &local, unless it's the destination of a following ALLOC
                 if insns.get(k + 1).map(|i| i.op.name) != Some("ALLOC") {
                     // &local at the AS source level is implicit (param decides &in/&out) — no `&`.
                     // Tag is_psf so a following `$beh0` construct can recover `slot = T(args)`.
-                    stack.push(Arg::psf(name(w(ins, 0)), ctx.slot_type(w(ins, 0))));
+                    stack.push(Arg::psf(name(w(ins, 0)), ctx.slot_type(w(ins, 0))).carry());
                 }
                 // else: this PSF is the destination local for the following ALLOC; don't push.
             }
@@ -1452,12 +1474,12 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             "PGA" | "PshGPtr" | "PshG4" => {
                 let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
                 if ctx.refs.global_is_string(ptr) {
-                    stack.push(Arg::obj(format!("\"{}\"", esc(ctx.refs.global_by_ptr(ptr).unwrap_or("")))));
+                    stack.push(Arg::obj(format!("\"{}\"", esc(ctx.refs.global_by_ptr(ptr).unwrap_or("")))).carry());
                 } else {
                     let nm = ctx.refs.global_by_ptr(ptr).unwrap_or("global?");
                     if let Some(cls) = nm.strip_prefix("__StaticType_") {
                         // generator class-pointer global -> the real UClass accessor
-                        stack.push(Arg::obj(format!("{cls}::StaticClass()")));
+                        stack.push(Arg::obj(format!("{cls}::StaticClass()")).carry());
                     } else if nm.starts_with("__") {
                         // other implicit generator global (e.g. __WorldContext) — not a
                         // source-level identifier. Push a MARKER (not dropped): the native's arity
@@ -1465,15 +1487,15 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         // split take one entry too deep and steal a neighbouring call's arg
                         // (GetNPCState family). The marker keeps stack arithmetic honest;
                         // build_call strips it from the rendered args + lowers arity by 1.
-                        stack.push(Arg::ctx());
+                        stack.push(Arg::ctx().carry());
                     } else if let Some(ns) = ctx.refs.global_ns(ptr) {
-                        stack.push(Arg::obj(format!("{ns}::{nm}"))); // e.g. `FColor::Red`
+                        stack.push(Arg::obj(format!("{ns}::{nm}")).carry()); // e.g. `FColor::Red`
                     } else {
-                        stack.push(Arg::obj(nm.to_string()));
+                        stack.push(Arg::obj(nm.to_string()).carry());
                     }
                 }
             }
-            "PshNull" => stack.push(Arg::obj("nullptr".into())),
+            "PshNull" => stack.push(Arg::obj("nullptr".into()).carry()),
             "VAR" => stack.push(Arg::int(name(w(ins, 0)))),
             "FuncPtr" => stack.push(Arg::obj("funcptr".into())),
             // ---- member access (Idiom A: rewrite top of stack in place) ----
@@ -2290,7 +2312,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             }
         }
     }
-    (out, cmp)
+    (out, cmp, stack)
 }
 
 /// Condition rendered for the branch being TAKEN, given the CMP operands + jump op.
@@ -2373,6 +2395,11 @@ struct Structurer<'a> {
     /// Instruction-index floor for the synthesized-return value scan (the current case
     /// region's first instruction — a value must not leak in from a preceding region).
     exit_scan_floor: usize,
+    /// batch-27: (join block index, operand stack surviving a recognized Cast diamond).
+    /// Created at the end of the is_cond arm ONLY when [`Self::diamond_join`] proves the
+    /// construct is exactly the null-check Cast diamond; consumed exactly once (`take()`)
+    /// by the very next loop iteration of `emit_range`.
+    carry: Option<(usize, Vec<Arg>)>,
 }
 
 impl Structurer<'_> {
@@ -2396,6 +2423,16 @@ impl Structurer<'_> {
             let b = &self.g.blocks[i];
             let mut next;
 
+            // batch-27: operand stack carried across a recognized Cast diamond — consumed by
+            // the join block (always the immediately-next emitted block; see carry creation
+            // below). take() unconditionally: if this block is emitted by an arm that cannot
+            // accept an initial stack (switch / loop heads), the carry is dropped -> status-quo
+            // behavior.
+            let init: Vec<Arg> = match self.carry.take() {
+                Some((t, s)) if t == i => s,
+                _ => Vec::new(),
+            };
+
             if let Some(after) = self.try_emit_switch(i, stop, depth, out) {
                 // recovered compiler switch idiom (guards + JMPP dispatch); the whole
                 // construct was emitted, continue after its JOIN.
@@ -2416,7 +2453,7 @@ impl Structurer<'_> {
                 let _ = writeln!(out, "{ind}}}");
                 next = latch + 1;
             } else if self.is_cond(i) {
-                let (stmts, cmp) = block_stmts(self.ctx, b.instr_lo, b.instr_hi);
+                let (stmts, cmp, leftover) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init);
                 for s in &stmts {
                     let _ = writeln!(out, "{ind}{s}");
                 }
@@ -2453,8 +2490,17 @@ impl Structurer<'_> {
                         }
                     }
                 }
+                // batch-27: a guard block's leftover operand stack survives into the JOIN
+                // block's initial stack — ONLY when the construct is provably the null-check
+                // Cast diamond (see diamond_join). Everything else keeps drop-at-boundary.
+                if !leftover.is_empty() {
+                    if let Some(j) = self.diamond_join(i, next, &leftover, &cmp) {
+                        self.carry = Some((j, leftover));
+                    }
+                }
             } else {
-                let (stmts, _) = block_stmts(self.ctx, b.instr_lo, b.instr_hi);
+                // (linear fallthrough-carry is out of scope — the plain arm's leftover is dropped.)
+                let (stmts, _, _) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init);
                 for s in &stmts {
                     let _ = writeln!(out, "{ind}{s}");
                 }
@@ -2880,6 +2926,188 @@ impl Structurer<'_> {
         ) && self.g.blocks[bi].succs.len() == 2
             // forward only (backward = loop latch, handled elsewhere)
             && self.g.blocks[bi].succs.iter().all(|&s| s > self.g.blocks[bi].start_dw)
+    }
+
+    /// batch-27 (Cast-diamond carry, design `specs/batch26-castdiamond.md` §2.3): decide
+    /// whether cond block `i` — whose `block_stmts_in` left `l` on the operand stack — is the
+    /// GUARD of exactly the null-check Cast diamond
+    /// `if (x != nullptr) { y = Cast<T>(x); } else { <housekeeping> }`, so `l` may be carried
+    /// into the JOIN block's initial stack. Returns the join's block index, or None on ANY
+    /// deviation (bail-by-default: a false negative costs nothing — status-quo drop).
+    ///
+    /// Stage 1 gates (D1-D11): JZ-on-CmpPtrNull guard; then-arm = exactly one block
+    /// whitelisted to the lowered `Cast<T>` shape (TYPEID/PSF/PshVPtr/CALLSYS-opCast/JMP);
+    /// else-arm absent or one housekeeping block; join sole-entry and == the `next` the
+    /// is_cond arm just computed; every carried entry pushed by a plain push opcode
+    /// (`carryable`); dual simulation proves the arms' emission + net stack effect are
+    /// independent of the carried entries; the join's first call is a CALLSYS/Thiscall1 with
+    /// TRUSTED arity (split path, never take-all). Stage 2 (own harness batch) relaxes the
+    /// consumer gate to CALL/CALLINTF script consumers.
+    fn diamond_join(&self, i: usize, next: usize, l: &[Arg], cmp: &Option<Cmp>) -> Option<usize> {
+        let ctx = self.ctx;
+        let blocks = &self.g.blocks;
+        let b = &blocks[i];
+        // D9 carryability: every carried entry originates from a plain slot/const/global push
+        // (never a pending-call-result PshRPtr — carrying one would reorder side effects).
+        if !l.iter().all(|a| a.carryable) {
+            return None;
+        }
+        // D1 guard shape: `JZ` over a bare `CmpPtrNull` (`x == nullptr`, no T*-op, no expr).
+        if self.jump_op(i) != "JZ" {
+            return None;
+        }
+        let c = cmp.as_ref()?;
+        if c.b != "nullptr" || c.op.is_some() || c.expr.is_some() {
+            return None;
+        }
+        // D2 then-arm entry: the fallthrough successor is the physically-next block.
+        let fall = *b.succs.get(1)?;
+        if self.idx_of.get(&fall).copied() != Some(i + 1) {
+            return None;
+        }
+        // D3 then-arm exit: a single block, JMP-terminated, sole successor = the join.
+        let t = blocks.get(i + 1)?;
+        if ctx.instrs[t.instr_hi - 1].op.name != "JMP" || t.succs.len() != 1 {
+            return None;
+        }
+        let join_off = t.succs[0];
+        // D4 else-arm: absent (guard's taken edge goes straight to the join), or exactly one
+        // non-cond block (fallthrough or JMP) whose sole successor is the join.
+        let taken = *b.succs.first()?;
+        let else_idx = if taken == join_off {
+            None
+        } else {
+            if self.idx_of.get(&taken).copied() != Some(i + 2) {
+                return None;
+            }
+            let e = blocks.get(i + 2)?;
+            if is_cond_op(ctx.instrs[e.instr_hi - 1].op.name) || e.succs.as_slice() != [join_off] {
+                return None;
+            }
+            Some(i + 2)
+        };
+        // D5 join index: must be exactly the `next` the is_cond arm just emitted (creation and
+        // consumption are then adjacent iterations of the same emit_range loop, or — via the
+        // sole-entry proof below — the next emission of block j in an enclosing range).
+        let j = *self.idx_of.get(&join_off)?;
+        if j != next {
+            return None;
+        }
+        // D6 sole-entry edges (precedent: try_emit_switch's outside-entry scan): the only edge
+        // into the then-arm (and else-arm, if present) comes from the guard; the only edges
+        // into the join come from the diamond's arm set.
+        let then_off = t.start_dw;
+        let else_off = else_idx.map(|e| blocks[e].start_dw);
+        for (bi, bb) in blocks.iter().enumerate() {
+            for &s in &bb.succs {
+                if s == then_off && bi != i {
+                    return None;
+                }
+                if Some(s) == else_off && bi != i {
+                    return None;
+                }
+                if s == join_off {
+                    let legal = match else_idx {
+                        None => bi == i || bi == i + 1,
+                        Some(e) => bi == i + 1 || bi == e,
+                    };
+                    if !legal {
+                        return None;
+                    }
+                }
+            }
+        }
+        // D7 then-arm content whitelist (stage-1 belt): only the lowered `Cast<T>` shape, with
+        // exactly one CALLSYS (resolving to `opCast`) and exactly one TYPEID.
+        let (mut ncast, mut ntypeid) = (0usize, 0usize);
+        for k in t.instr_lo..t.instr_hi {
+            let ins = &ctx.instrs[k];
+            match ins.op.name {
+                "SUSPEND" | "JitEntry" | "PSF" | "PshVPtr" | "JMP" => {}
+                "TYPEID" => ntypeid += 1,
+                "CALLSYS" => {
+                    let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+                    if ctx.refs.func_by_ptr(ptr) != Some("opCast") {
+                        return None;
+                    }
+                    ncast += 1;
+                }
+                _ => return None,
+            }
+        }
+        if ncast != 1 || ntypeid != 1 {
+            return None;
+        }
+        // D8 else-arm content whitelist: housekeeping only.
+        if let Some(e) = else_idx {
+            let eb = &blocks[e];
+            for k in eb.instr_lo..eb.instr_hi {
+                if !matches!(
+                    ctx.instrs[k].op.name,
+                    "SUSPEND" | "JitEntry" | "ClrVPtr" | "FREE" | "FreeNullV8" | "JMP"
+                ) {
+                    return None;
+                }
+            }
+        }
+        // D10 dual-simulation safety gate (authoritative — subsumes D7/D8 semantically, both
+        // kept for belt-and-suspenders): each arm must be stack-net-zero on its own, emit the
+        // IDENTICAL statements with and without the carried entries, and return the carried
+        // entries verbatim. Then on BOTH runtime paths the stack at the join equals `l`, and
+        // the arm's actual emission (done with an empty init) is unchanged.
+        for arm in std::iter::once(i + 1).chain(else_idx) {
+            let ab = &blocks[arm];
+            let (s0, _, r0) = block_stmts_in(ctx, ab.instr_lo, ab.instr_hi, Vec::new());
+            let (s1, _, r1) = block_stmts_in(ctx, ab.instr_lo, ab.instr_hi, l.to_vec());
+            if !r0.is_empty() || s1 != s0 || r1.as_slice() != l {
+                return None;
+            }
+        }
+        // D11 stage-1 consumer gate: the join's FIRST call-class instruction must be a
+        // CALLSYS/Thiscall1 whose callee has a TRUSTED arity (Binds native arity, or the cache
+        // FunctionReference param count — the same fallback the CALLSYS arm's split uses), so
+        // the split path, not take-all, consumes the carry. No call at all in the join -> bail
+        // (no proven consumer in stage 1).
+        let jb = &blocks[j];
+        let mut consumer = false;
+        for k in jb.instr_lo..jb.instr_hi {
+            let ins = &ctx.instrs[k];
+            match ins.op.name {
+                "CALLSYS" | "Thiscall1" => {
+                    let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+                    let f = ctx.refs.func_by_ptr(ptr).unwrap_or("");
+                    let na = ctx.refs.native_arity_by_ptr(ptr, f);
+                    if na.or_else(|| ctx.refs.func_params_by_ptr(ptr).map(|p| p.len())).is_none() {
+                        return None;
+                    }
+                    consumer = true;
+                    break;
+                }
+                "CALL" | "CALLINTF" | "CALLBND" | "CallPtr" => return None,
+                _ => {}
+            }
+        }
+        if !consumer {
+            return None;
+        }
+        // D12 (batch-27 addition beyond the spec, raw-gate belt): consumer simulation.
+        // Pre-run the JOIN block with and without the carried entries (pure function — the
+        // real emission is exactly the with-init run). Bail when carrying
+        //   (a) introduces an ARGMISMATCH sentinel the empty-init run does not have (the
+        //       carried window is misaligned for this consumer — e.g. the big-operand-window
+        //       MagicScript::GetSingleActorTargetFromCamera* family — and emitting it would
+        //       force-stub the WHOLE function), or
+        //   (b) changes the join's statement COUNT (the carry must only let existing
+        //       statements gain args, never create/destroy statements — a spurious
+        //       consumption by a non-call opcode, or a statement dropped as unresolved).
+        // False negatives cost nothing: status-quo drop-at-boundary.
+        let has_amm = |v: &[String]| v.iter().any(|s| s.contains('\u{2}'));
+        let (j0, _, _) = block_stmts_in(ctx, jb.instr_lo, jb.instr_hi, Vec::new());
+        let (j1, _, _) = block_stmts_in(ctx, jb.instr_lo, jb.instr_hi, l.to_vec());
+        if j1.len() != j0.len() || (has_amm(&j1) && !has_amm(&j0)) {
+            return None;
+        }
+        Some(j)
     }
 
     /// If block `i` begins a bottom-test loop within [.., stop), return the latch block

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1710,7 +1710,18 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 // overwritten. Drops sentinel/unresolved pendings (see flush_b2 doc).
                 flush_b2!();
                 let id = ins.dwords.first().copied().unwrap_or(0) as i32;
-                let f = ctx.refs.func_by_id(id).unwrap_or("func?").to_string();
+                let orig = ctx.refs.func_by_id(id).unwrap_or("func?").to_string();
+                // batch-25f: a free fn whose declaration was collision-renamed (`Name_g<mi>`)
+                // must resolve to the renamed leaf at call sites in EVERY module — the
+                // emit-side text pass only rewrites the DECLARING module's source, so
+                // cross-module callers kept the now-nonexistent original name (14 in-game
+                // errors: GetCurrent/FetchContext/ApplyTo/GetTuning). Name-keyed lookups
+                // (native arity) keep the ORIGINAL name; only the render uses the rename.
+                let f = ctx
+                    .refs
+                    .renamed_free_fn_by_id(id)
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| orig.clone());
                 pending = if f == "StaticClass" {
                     // Fix b1 — StaticClass takes 0 operands; the stack holds the ENCLOSING call's
                     // already-pushed args. Do NOT clear it (clearing destroys those args).
@@ -1730,7 +1741,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // tail-table entry spuriously carries bIsObjectConst (2757 GetG1R stores compile
                     // CLEAN in the batch-19 capture). Never const-wrap script-call results.
                     pending_const = false;
-                    let na = ctx.refs.native_arity_by_id(id, &f);
+                    let na = ctx.refs.native_arity_by_id(id, &orig);
                     // SCRIPT call by id: the cache FunctionReference param count is authoritative
                     // (only NATIVE param lists undercount), so trust it for the EDIT B-PRIME split.
                     let trusted = ctx.refs.func_params_by_id(id).map(|p| p.len());

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -816,9 +816,8 @@ fn field_assign_rhs(rhs: &str, tyname: &str) -> String {
 }
 
 /// True if `tyname` is a UE enum type (`E<Upper>...`) — same shape `cast_to_typename` keys on.
-/// Tolerates a leading `const ` (a const-qualified enum is still an enum for cast purposes).
 fn is_enum_name(tyname: &str) -> bool {
-    let b = tyname.trim_start_matches("const ").as_bytes();
+    let b = tyname.as_bytes();
     b.len() >= 2 && b[0] == b'E' && b[1].is_ascii_uppercase()
 }
 
@@ -1087,31 +1086,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 if let Some(r) = &ref_reg {
                     let dst_slot = w(ins, 0);
                     let dst_is_int = dst_slot > 0 && ctx.slot_type(dst_slot).is_none();
-                    // Known-enum source -> int(...) (existing). Source of UNKNOWN value type ->
-                    // wrap too: the cache carries NO value type for a foreign field
-                    // (PropertyReferences.OldTypeId = the OWNER — proven: SurfaceType->
-                    // UPhysicalMaterial, Relationship->FPerceivedAgent — and an ADDSi chain's
-                    // fty lookup covers only this-class fields), so `ref_reg_ty` being absent
-                    // or owner-shaped (U*/A*/F*/T* head) hides every foreign ENUM field read
-                    // (`local = Perception.Affected.Relationship`, ~164 enum->int in-game
-                    // errors). `int(x)` is compile-neutral for every other primitive an RDR
-                    // can produce here: int/float are explicit-constructible and bool->int is
-                    // legal in UE-AS (0 'bool to int' errors across the whole capture).
-                    // RDR8 stays on the old path: no UE enum is 8 bytes (double/int64/handle
-                    // reads keep their bare, already-compiling render).
-                    let unknowable = match ref_reg_ty.as_deref() {
-                        None => true,
-                        Some(t) => {
-                            let t = t.trim_start_matches("const ");
-                            matches!(t.bytes().next(), Some(b'U') | Some(b'A') | Some(b'F') | Some(b'T'))
-                                && t.as_bytes().get(1).map(|c| c.is_ascii_uppercase()).unwrap_or(false)
-                        }
-                    };
-                    let rhs = if dst_is_int && unknowable && n != "RDR8" {
-                        format!("int({r})")
-                    } else {
-                        enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int)
-                    };
+                    let rhs = enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int);
                     out.push(format!("{} = {rhs};", name(dst_slot)));
                 }
             }
@@ -1135,21 +1110,11 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // decompiled const-`0` bool). Cast the RHS to bool. Guard: the RHS was NOT
                     // already transformed above (a bare slot), is resolved, and is not a KNOWN
                     // bool slot (which compiles bare and must not become the illegal `bool != 0`).
-                    // ENUM guards: uint8 ENUMS are also 1-byte writes. When the SOURCE slot is a
-                    // known enum (an enum param stored into a same-enum field:
-                    // `this.FocusCharacterType = PerceptionCharacterType` — the bool wrap made it
-                    // `(Param != 0)` -> "bool -> EPerceptionCharacterType&", 41+ in-game errors),
-                    // or the FIELD's value type is a known enum (this-class fields map), the write
-                    // is enum->enum: keep it bare. (A foreign enum field written from an INT const
-                    // remains unfixable here — the cache carries no value type for foreign fields
-                    // and the enum's NAME is required for the cast; see cant-convert-cleanup.md.)
                     if n == "WRTV1"
                         && ref_reg_ty.as_deref() != Some("bool")
-                        && !ref_reg_ty.as_deref().map(is_enum_name).unwrap_or(false)
                         && rhs == raw
                         && rhs != UNRESOLVED
                         && ctx.slot_type(slot).as_deref() != Some("bool")
-                        && !ctx.slot_type(slot).as_deref().map(is_enum_name).unwrap_or(false)
                     {
                         rhs = format!("({rhs} != 0)");
                     }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2272,6 +2272,106 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                     .renamed_free_fn_by_id(id)
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| orig.clone());
+                // batch-39 (Idiom C, ctor-member-init.md §3/§4.2): a SCRIPT-STRUCT in-place
+                // multi-arg constructor with an RVO out-slot. Shape (WeaponBehaviorSet family,
+                // ~135 ctors): `<args...> ; PSF <out> ; CALL <StructType-ctor>`, where the ctor
+                // is registered as a struct METHOD returning VOID (it constructs AT the PSF'd
+                // out-slot, the receiver on stack TOP), and a following `CopyScript` copies the
+                // out-slot into a member (`this.AttackRightSingle = local_60`). build_call pops
+                // the out-slot as the receiver, hits `is_type_name(f) -> return None` (line ~867),
+                // and DROPS the whole build — leaving the member assigned a default-constructed
+                // struct and the recovered arg scalars dead. Recover it as `out = Struct(args);`
+                // so the build FLOWS into the CopyScript store (which already renders). The
+                // nested sub-struct temp args (FGameplayTag/TSet/TSubclassOf via $beh0/RVO) are
+                // separate slots that the $beh0 / RVO-free-call arms already assign or default-
+                // construct in EMIT mode (obj_locals gives them types -> the RVO out-slot probe
+                // fires and the duplicate is consumed); the FGameplayTag 0-arg default temp is
+                // dropped but its slot stays a legal DECLARED default-constructed local, exactly
+                // as vanilla passes a default temp. This arm runs only in EMIT mode where slots
+                // are typed; decompile mode (untyped slots) fails the gates below and is unchanged.
+                //
+                // SAFETY (spec top risk — a WRONG/partial arg list is worse than a dropped one):
+                // recover ONLY when ALL args resolve CLEANLY. Bail (fall through to the status-quo
+                // drop) on ANY of: arg count != declared params; a value-type PSF temp arg with an
+                // UNKNOWN type (an unrecovered slot, not a declared temp); an empty/UNRESOLVED/
+                // $-/~-/\u{1}-/\u{2}-marked arg; or a render that yields the \u{2} arg-mismatch
+                // sentinel (a definite arg-type mismatch, e.g. a mis-resolved const). Never emit a
+                // partial or guessed arg list.
+                let idiom_c_done = 'idiom_c: {
+                    if n != "CALL"
+                        || !ctx.refs.is_type_name(&f)
+                        || !ctx.refs.is_method_by_id(id)
+                        || ctx.refs.func_ret_by_id(id).map(|d| d.base_name(ctx.refs)).as_deref() != Some("void")
+                    {
+                        break 'idiom_c false;
+                    }
+                    let Some(params) = ctx.refs.func_params_by_id(id).filter(|p| !p.is_empty()) else {
+                        break 'idiom_c false;
+                    };
+                    let np = params.len();
+                    // out-slot = stack TOP: a PSF'd slot whose type head == the struct name and
+                    // whose name is a plain local/member lvalue (never a sentinel). is_lvalue_arg
+                    // rejects PSF outright (it targets the non-PSF member-store receiver), so the
+                    // out-slot's plain-name check is inlined here.
+                    fn head(s: &str) -> &str { s.split('<').next().unwrap_or(s) }
+                    let plain_lvalue = |s: &str| -> bool {
+                        !s.is_empty()
+                            && s != UNRESOLVED
+                            && !s.contains('\u{1}')
+                            && !s.contains('\u{2}')
+                            && s.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_' || c == b'.')
+                            && (s.starts_with("local_") || s.starts_with("this."))
+                    };
+                    let out_ok = stack.last().map(|r| {
+                        r.is_psf && r.ty.as_deref().map(head) == Some(f.as_str()) && plain_lvalue(&r.s)
+                    }).unwrap_or(false);
+                    // Need out-slot + exactly `np` args below it (STRICT: `>` not `>=` so a
+                    // short stack that can't supply the full arg list bails, never guesses).
+                    if !out_ok || stack.len() <= np {
+                        break 'idiom_c false;
+                    }
+                    // Validate the args WITHOUT popping (peek), so a bail leaves the stack
+                    // untouched and falls through to build_call (exact status-quo behaviour).
+                    let base = stack.len() - 1 - np; // index of the deepest of this ctor's args
+                    let mut args: Vec<Arg> = stack[base..stack.len() - 1].to_vec();
+                    maybe_reverse_args(&mut args, Some(params), ctx.refs);
+                    // Bail unless every arg is a cleanly-recovered value:
+                    //  - a PSF temp arg MUST carry a known type (a declared temp slot); an
+                    //    untyped PSF is an unrecovered slot -> a dangling local reference.
+                    //  - no empty / UNRESOLVED / $-/~-/\u{1}-/\u{2}-marked arg.
+                    let args_clean = args.iter().all(|a| {
+                        !a.s.is_empty()
+                            && a.s != UNRESOLVED
+                            && !a.s.starts_with('$')
+                            && !a.s.starts_with('~')
+                            && !a.s.contains('\u{1}')
+                            && !a.s.contains('\u{2}')
+                            && !(a.is_psf && a.ty.is_none())
+                    });
+                    if !args_clean {
+                        break 'idiom_c false;
+                    }
+                    let rendered = render_args(&args, Some(params), ctx.refs);
+                    // A definite arg-type mismatch surfaces as the \u{2} sentinel from cast_arg
+                    // -> bail (keep the member's default-constructed struct) rather than emit an
+                    // uncompilable build.
+                    if rendered.contains('\u{2}') || rendered.contains('\u{1}') {
+                        break 'idiom_c false;
+                    }
+                    // All args resolved cleanly: commit. Pop the out-slot + args and emit the
+                    // build; the following CopyScript store (already recovered) flows it into the
+                    // member (`this.<field> = <out_slot>`).
+                    let out_s = stack[stack.len() - 1].s.clone();
+                    stack.truncate(base);
+                    flush!();
+                    out.push(format!("{out_s} = {f}({rendered});"));
+                    true
+                };
+                if idiom_c_done {
+                    pending_is_static_name = false;
+                    pending_is_pure_elem = false;
+                    continue;
+                }
                 pending = if f == "StaticClass" {
                     // Fix b1 — StaticClass takes 0 operands; the stack holds the ENCLOSING call's
                     // already-pushed args. Do NOT clear it (clearing destroys those args).

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -816,8 +816,9 @@ fn field_assign_rhs(rhs: &str, tyname: &str) -> String {
 }
 
 /// True if `tyname` is a UE enum type (`E<Upper>...`) — same shape `cast_to_typename` keys on.
+/// Tolerates a leading `const ` (a const-qualified enum is still an enum for cast purposes).
 fn is_enum_name(tyname: &str) -> bool {
-    let b = tyname.as_bytes();
+    let b = tyname.trim_start_matches("const ").as_bytes();
     b.len() >= 2 && b[0] == b'E' && b[1].is_ascii_uppercase()
 }
 
@@ -1110,11 +1111,19 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // decompiled const-`0` bool). Cast the RHS to bool. Guard: the RHS was NOT
                     // already transformed above (a bare slot), is resolved, and is not a KNOWN
                     // bool slot (which compiles bare and must not become the illegal `bool != 0`).
+                    // ENUM guards: uint8 ENUMS are also 1-byte writes. When the SOURCE slot is a
+                    // known enum (an enum param stored into a same-enum field:
+                    // `this.FocusCharacterType = PerceptionCharacterType` — the bool wrap made it
+                    // `(Param != 0)` -> "bool -> EPerceptionCharacterType&", 41 in-game errors),
+                    // or the FIELD's value type is a known enum (this-class fields map), the write
+                    // is enum->enum: keep it bare.
                     if n == "WRTV1"
                         && ref_reg_ty.as_deref() != Some("bool")
+                        && !ref_reg_ty.as_deref().map(is_enum_name).unwrap_or(false)
                         && rhs == raw
                         && rhs != UNRESOLVED
                         && ctx.slot_type(slot).as_deref() != Some("bool")
+                        && !ctx.slot_type(slot).as_deref().map(is_enum_name).unwrap_or(false)
                     {
                         rhs = format!("({rhs} != 0)");
                     }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -95,10 +95,25 @@ pub(crate) const RVODEF: &str = "\u{3}rvodef";
 /// `const T` — the vanilla form; a same-type `Cast<T>` wrap does NOT strip const in-game.
 pub(crate) const CONSTSTORE: char = '\u{4}';
 
+/// batch-25g: call-argument slot hints derived on the emit side by pairing value-pushed
+/// slots with the callee's declared parameter types (`infer_slot_types`' stack model):
+/// - `float_slots`: slots pushed into a FLOAT-FAMILY by-value parameter — their `SetV*`
+///   constants are IEEE-754 bits (the SavePuzzleState switch cases wrote `local_1 =
+///   1073741824;` = 2.0f) and extend the float-literal render set;
+/// - `keep_ints`: slots pushed into an INT-FAMILY by-value parameter — REAL args a nested
+///   call's stack-split retain must not purge (`Math::Min(a, <nested call>)` lost `a`,
+///   spec batch23-nomatch.md family G; the float member of the same purge family was the
+///   SaveWorldFloatData payload).
+#[derive(Default)]
+pub struct ArgSlotHints {
+    pub float_slots: std::collections::HashSet<i32>,
+    pub keep_ints: std::collections::HashSet<i32>,
+}
+
 /// Structured statement body for a function (no signature wrapper), indented at `depth`.
 /// Returns an error annotation string on disasm failure (never panics).
 pub fn body_statements(f: &FuncCode, refs: &RefResolver, depth: usize) -> String {
-    body_statements_ctor(f, refs, depth, None, None, None, None, None, None)
+    body_statements_ctor(f, refs, depth, None, None, None, None, None, None, None)
 }
 
 /// Like [`body_statements`], but with class context for type-aware casts:
@@ -107,17 +122,23 @@ pub fn body_statements(f: &FuncCode, refs: &RefResolver, depth: usize) -> String
 /// - `fields`: the owning class's field name -> base type name, so a `this.field = <int>`
 ///   assignment casts the RHS to a `bool`/enum field.
 #[allow(clippy::too_many_arguments)]
-pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, super_ctor: Option<&str>, ret_ty: Option<&DataType>, fields: Option<&HashMap<String, String>>, param_types: Option<&[String]>, class_name: Option<&str>, local_types: Option<&HashMap<i32, String>>) -> String {
+pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, super_ctor: Option<&str>, ret_ty: Option<&DataType>, fields: Option<&HashMap<String, String>>, param_types: Option<&[String]>, class_name: Option<&str>, local_types: Option<&HashMap<i32, String>>, hints: Option<&ArgSlotHints>) -> String {
     let instrs = match disassemble(&f.bytecode) {
         Ok(i) => i,
         Err(e) => return format!("{}// disasm error: {e}\n", "    ".repeat(depth)),
     };
     let g = cfg::build(&instrs);
-    let float_slots = float_operand_slots(&instrs, ret_ty);
+    let mut float_slots = float_operand_slots(&instrs, ret_ty);
+    // batch-25g: slots pushed into a float-family by-value parameter carry IEEE-754 bits in
+    // their SetV* constants too (evidence = the callee's declared signature).
+    if let Some(h) = hints {
+        float_slots.extend(h.float_slots.iter().copied());
+    }
     // AS_PTR_SIZE-aware frame-offset -> param-index map (2-dword handles/refs + hidden RVO slot),
     // self-correcting on observed offsets. Built once per function; consulted by slot_name/slot_type.
     let (param_off_map, rvo_off) = super::decompile::build_param_off_map_rvo(f, &instrs, refs);
-    let ctx = Ctx { f, refs, instrs: &instrs, super_ctor, ret_ty, fields, param_types, class_name, local_types, float_slots, param_off_map, rvo_off };
+    let keep_ints = hints.map(|h| &h.keep_ints);
+    let ctx = Ctx { f, refs, instrs: &instrs, super_ctor, ret_ty, fields, param_types, class_name, local_types, float_slots, param_off_map, rvo_off, keep_ints };
     let idx_of: HashMap<usize, usize> =
         g.blocks.iter().enumerate().map(|(i, b)| (b.start_dw, i)).collect();
     let mut body = String::new();
@@ -181,6 +202,10 @@ struct Ctx<'a> {
     /// Frame offset of the hidden RVO out-pointer slot for a by-value-struct return, if any.
     /// A `CopyScript` writing this slot is the function's `return <src>`.
     rvo_off: Option<i32>,
+    /// batch-25g: slots value-pushed into a KNOWN int-family by-value parameter (see
+    /// [`ArgSlotHints::keep_ints`]) — pushed with `keep` so the nested-call stack-split
+    /// retain spares them.
+    keep_ints: Option<&'a std::collections::HashSet<i32>>,
 }
 
 /// Collect slots used as an operand of a float/double arithmetic or compare op. Every word
@@ -1348,6 +1373,12 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     stack.push(Arg::iconst(name(off), cb));
                 } else if member_read_slots.contains(&off) {
                     // Member-read value (this.XP_... amount) — a real arg the retain must keep.
+                    stack.push(Arg { s: name(off), is_int: true, keep: true, ..Default::default() });
+                } else if ctx.keep_ints.is_some_and(|s| s.contains(&off)) {
+                    // batch-25g (spec family G kin): the emit-side pairing proved every value
+                    // push of this slot feeds a KNOWN int-family parameter — a real arg
+                    // (Math::Min's second operand below a nested call), not a stranded SetV
+                    // temporary; the nested-call retain must keep it.
                     stack.push(Arg { s: name(off), is_int: true, keep: true, ..Default::default() });
                 } else {
                     stack.push(Arg::int(name(off)));

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2578,6 +2578,15 @@ impl Structurer<'_> {
             if r.is_def {
                 let _ = writeln!(out, "{ind}default:");
             }
+            // batch-24d: the in-game compiler rejects "Variables cannot be declared in
+            // switch cases, except inside statement blocks". Declarations are INTRODUCED
+            // into case bodies only later, by the emit-side decl-init rewrites (auto
+            // iterator decls, executor decl-inits, __na temp-splits) — the structurer
+            // cannot know which cases will end up carrying one, so brace EVERY case body
+            // unconditionally (a statement block is always-legal AS; stacked case/default
+            // labels stay outside the braces, the body and its trailing break;/return
+            // exits go inside).
+            let _ = writeln!(out, "{ind}{{");
             self.exit_join = Some(join_off);
             self.exit_join_is_ret = join_is_ret;
             self.exit_ret_rows_ok = register_based;
@@ -2587,6 +2596,7 @@ impl Structurer<'_> {
             if r.append_break {
                 let _ = writeln!(out, "{ind}    break;");
             }
+            let _ = writeln!(out, "{ind}}}");
         }
         let _ = writeln!(out, "{ind}}}");
         Some(switch_end)

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1557,6 +1557,30 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 // else: this PSF is the destination local for the following ALLOC; don't push.
             }
             "PshRPtr" => {
+                // batch-31a (N9, batch29-3f residue): a VOID call leaves the value register
+                // untouched — its pending render can never be what PshRPtr pushes. Consuming
+                // it as an arg passed a void call EXPRESSION into the enclosing call
+                // ("No matching signatures to 'TMap::Add(AGothicCharacter&, void)'" —
+                // AICombatRoleSystem:534 / FXDefinitions_Human:69). Flush the void call as
+                // its own statement (flush_b2 keeps the drop-discipline for sentinel/
+                // unresolved pendings) and fall through to the register path: ref_reg may
+                // hold the REAL operand; an empty register pushes UNRESOLVED (statement-level
+                // drop beats silent arg theft, per spec batch31-nomatch-illegalop §1.11).
+                // The recovered operand is pushed UNTYPED: `ref_reg_ty` for a foreign member
+                // load is member_type's OWNER type (the documented ADDSi poison), and letting
+                // it reach cast_arg's value-head guard false-flags the genuinely-recovered
+                // operand (AICombatRoleSystem: `TargetRoleGroup.RoleType` typed
+                // FCombatRoleGroup vs the TMap's ECombatRole value -> spurious argtype stub).
+                // None = unknown = conservative match, same rule the ADDSi arm documents.
+                if pending.is_some() && pending_ty.as_deref() == Some("void") {
+                    flush_b2!();
+                    let s = match value_reg.take() {
+                        Some(v) => v,
+                        None => ref_reg.clone().unwrap_or_else(|| UNRESOLVED.into()),
+                    };
+                    stack.push(Arg::typed(s, None));
+                    continue;
+                }
                 // The value register holds a just-completed call's return value; PshRPtr pushes it
                 // back onto the operand stack as the NEXT call's argument (e.g. the receiver/arg of
                 // a chained call). Prefer that live call result over the stale member-ref register.
@@ -3357,11 +3381,20 @@ impl Structurer<'_> {
                 return None;
             }
         }
-        // D11 stage-1 consumer gate: the join's FIRST call-class instruction must be a
-        // CALLSYS/Thiscall1 whose callee has a TRUSTED arity (Binds native arity, or the cache
-        // FunctionReference param count — the same fallback the CALLSYS arm's split uses), so
-        // the split path, not take-all, consumes the carry. No call at all in the join -> bail
-        // (no proven consumer in stage 1).
+        // D11 consumer gate: the join's FIRST call-class instruction must have a TRUSTED
+        // arity, so the split path, not take-all, consumes the carry.
+        //   - stage 1 (batch-27): CALLSYS/Thiscall1 — Binds native arity, or the cache
+        //     FunctionReference param count (the same fallback the CALLSYS arm's split uses).
+        //   - stage 2 (batch-31a, spec batch31-nomatch-illegalop §1.1 N2a): CALL/CALLINTF/
+        //     CALLBND — script functions always carry a FunctionReference param list, so the
+        //     by-id count has the same trust level as the CALLSYS by-ptr fallback (it is what
+        //     the CALL arm's EDIT B-PRIME split already uses). Note the join's first call need
+        //     NOT itself be the carry's consumer (Proof D — ANotifySpellCategoryActor::
+        //     OnBeginOverlap: the carried entry sits at the stack BOTTOM and a LATER CALLSYS
+        //     in the same join consumes it); trusting the first call's split arithmetic is
+        //     what keeps the carried entry in place for that later consumer.
+        //   - CallPtr keeps the bail (no id, no trusted arity). No call at all -> bail
+        //     (no proven consumer).
         let jb = &blocks[j];
         let mut consumer = false;
         for k in jb.instr_lo..jb.instr_hi {
@@ -3377,7 +3410,15 @@ impl Structurer<'_> {
                     consumer = true;
                     break;
                 }
-                "CALL" | "CALLINTF" | "CALLBND" | "CallPtr" => return None,
+                "CALL" | "CALLINTF" | "CALLBND" => {
+                    let id = ins.dwords.first().copied().unwrap_or(0) as i32;
+                    if ctx.refs.func_params_by_id(id).is_none() {
+                        return None;
+                    }
+                    consumer = true;
+                    break;
+                }
+                "CallPtr" => return None,
                 _ => {}
             }
         }
@@ -3395,6 +3436,9 @@ impl Structurer<'_> {
         //       statements gain args, never create/destroy statements — a spurious
         //       consumption by a non-call opcode, or a statement dropped as unresolved).
         // False negatives cost nothing: status-quo drop-at-boundary.
+        // batch-31a note: with stage-2 CALL/CALLINTF consumers the WITH-init run may now
+        // RESOLVE a sentinel the empty-init run HAS (a previously-missing arg recovered by
+        // the carry) — that direction stays legal; only a NEW sentinel bails.
         let has_amm = |v: &[String]| v.iter().any(|s| s.contains('\u{2}'));
         let (j0, _, _) = block_stmts_in(ctx, jb.instr_lo, jb.instr_hi, Vec::new());
         let (j1, _, _) = block_stmts_in(ctx, jb.instr_lo, jb.instr_hi, l.to_vec());

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -21,7 +21,7 @@ use super::walk_modules::FuncCode;
 
 /// A pushed call argument: its rendered text plus whether it originated from an integer
 /// value (a constant or `int` slot), so it can be cast to the callee's expected `bool`/enum.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct Arg {
     s: String,
     is_int: bool,
@@ -35,24 +35,33 @@ struct Arg {
     /// is the ADDRESS of a slot, used as an out / RVO / in-place-ctor receiver. Lets the CALLSYS
     /// handler recover `slot = T(args)` from a `$beh0` construct behaviour instead of dropping it.
     is_psf: bool,
+    /// True for a synthesized implicit-context marker (`__WorldContext` generator global): it
+    /// occupies a stack slot so the split arithmetic matches the native's real frame (whose arity
+    /// counts the hidden `WorldContextObject`), but it is NOT a source-level arg — build_call
+    /// strips it after collection and reduces the render arity accordingly.
+    is_ctx: bool,
 }
 impl Arg {
     fn int(s: String) -> Arg {
-        Arg { s, is_int: true, ty: None, cbits: None, is_psf: false }
+        Arg { s, is_int: true, ..Default::default() }
     }
     fn iconst(s: String, cbits: ConstBits) -> Arg {
-        Arg { s, is_int: true, ty: None, cbits: Some(cbits), is_psf: false }
+        Arg { s, is_int: true, cbits: Some(cbits), ..Default::default() }
     }
     fn obj(s: String) -> Arg {
-        Arg { s, is_int: false, ty: None, cbits: None, is_psf: false }
+        Arg { s, ..Default::default() }
     }
     fn typed(s: String, ty: Option<String>) -> Arg {
-        Arg { s, is_int: false, ty, cbits: None, is_psf: false }
+        Arg { s, ty, ..Default::default() }
     }
     /// A `PSF`-pushed slot address (out / RVO / in-place-ctor receiver), carrying the slot's
     /// recovered type so the construct can render `slot = <ty>(args)`.
     fn psf(s: String, ty: Option<String>) -> Arg {
-        Arg { s, is_int: false, ty, cbits: None, is_psf: true }
+        Arg { s, ty, is_psf: true, ..Default::default() }
+    }
+    /// A synthesized implicit `__WorldContext` marker (see `is_ctx`).
+    fn ctx() -> Arg {
+        Arg { is_ctx: true, ..Default::default() }
     }
 }
 
@@ -434,7 +443,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
             }
         };
     let need = trusted_arity.map(|n| n + is_method as usize + rvo_slot as usize);
-    let mut a: Vec<Arg> = match need {
+    let collected: Vec<Arg> = match need {
         Some(k) if stack.len() > k => {
             // Split off this call's own operands (top `k`); the deeper entries belong to an
             // ENCLOSING call. Drop STRANDED slot-sourced ints (SetV*+PshV4 temporaries) left over
@@ -448,13 +457,21 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
             own
         }
         _ => std::mem::take(stack),
-    }
-        .into_iter()
-        .filter(|x| !x.s.is_empty() && x.s != UNRESOLVED)
+    };
+    // Implicit `__WorldContext` markers occupied a stack slot so the split arithmetic matched the
+    // native's real frame (whose declared arity counts the hidden WorldContextObject param). They
+    // are NOT source args — the UE-AngelScript compiler auto-injects the world context — so strip
+    // them from the rendered args and lower the effective arity by the count removed. Without this,
+    // dropping them at push time made the split one entry too deep and stole a neighbouring call's
+    // arg (GetNPCState-shifts-args family).
+    let ctx_count = collected.iter().filter(|x| x.is_ctx).count();
+    let mut a: Vec<Arg> = collected.into_iter()
+        .filter(|x| !x.is_ctx && !x.s.is_empty() && x.s != UNRESOLVED)
         .collect();
     // Effective arity: the in-game compile validates against the shipped Binds.Cache, so its native
     // arity is authoritative — prefer it over the script FunctionReferences param count. Falls back.
-    let arity = native_arity.or_else(|| params.map(|p| p.len()));
+    // Subtract any stripped implicit-context markers (they inflate both the frame and the arity).
+    let arity = native_arity.or_else(|| params.map(|p| p.len())).map(|n| n.saturating_sub(ctx_count));
     // Receiver: a METHOD call always pushes its receiver as the top entry (the cache param count is
     // unreliable here — it often COUNTS the implicit `this`), so detect by the bIsMethod flag.
     let has_recv = is_method && !a.is_empty();
@@ -1007,7 +1024,12 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         stack.push(Arg::obj(format!("{cls}::StaticClass()")));
                     } else if nm.starts_with("__") {
                         // other implicit generator global (e.g. __WorldContext) — not a
-                        // source-level identifier and not a real arg; drop it.
+                        // source-level identifier. Push a MARKER (not dropped): the native's arity
+                        // counts the hidden WorldContextObject param, so dropping it makes the
+                        // split take one entry too deep and steal a neighbouring call's arg
+                        // (GetNPCState family). The marker keeps stack arithmetic honest;
+                        // build_call strips it from the rendered args + lowers arity by 1.
+                        stack.push(Arg::ctx());
                     } else if let Some(ns) = ctx.refs.global_ns(ptr) {
                         stack.push(Arg::obj(format!("{ns}::{nm}"))); // e.g. `FColor::Red`
                     } else {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3568,12 +3568,29 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                         && !dst.s.is_empty()
                         && dst.s != UNRESOLVED
                         && !dst.s.contains('\u{2}');
+                    // batch-47c (FIX-1b, specs/final-tail-triage.md §3.7): accept a MEMBER-ACCESS
+                    // source (`this.m_XardasChar`, built by `PshVPtr this; ADDSi member; RDSPtr`)
+                    // into a member/struct-temp dest — `local_44.Instigator = this.m_XardasChar;`
+                    // (DoTeleport) / `this.<dst> = this.<src>;`. This mirrors the widen batch-41a
+                    // applied to the RefCpyV *read* arm (`member_src`), now for the REFCPY *store*
+                    // arm. A member handle field is a legal RHS of a handle assignment. Gates:
+                    // contains '.' (a real member access), no '(' (never a call/ctor expr — those
+                    // have their own path and could reorder side effects), and — CRITICALLY —
+                    // NON-const: `nf_const` set means the source is a `const T` native field, and
+                    // storing it into a non-const member is the b41d "Can't implicitly convert from
+                    // 'const T' to 'T'" cascade, so a const member source stays dropped exactly as
+                    // before. A bare `this` has no '.' and is already excluded (its back-link store
+                    // stays bailed). BAIL-safe: any un-provable source keeps the current drop.
+                    let member_src = src.s.contains('.')
+                        && !src.s.contains('(')
+                        && src.nf_const.is_none();
                     let src_ok = !src.s.is_empty()
                         && src.s != UNRESOLVED
                         && !src.s.contains('\u{2}')
                         && (src.s.starts_with("local_")
                             || src.s.starts_with("Cast<")
                             || src.s == "nullptr"
+                            || member_src
                             || ctx.param_src_ok(&src.s));
                     // batch-41d (CLASS 1b): the source slot holds a CONST object handle (a
                     // const-returning call result / const member read). Storing it into a

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -901,17 +901,56 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         Some(format!("{}.{f}({})", wrap_uobject_recv(&recv, target_owner, refs), render_args(&a, params, refs)))
     } else {
         if refs.is_type_name(f) {
-            // EDIT C: a value-type factory call (FName/E*/T* — NOT U*/A*, which use ALLOC) whose
+            // A factory GLOBAL whose name collides with a registered type name. Two flavours:
+            //
+            // EDIT C: a VALUE-type factory call (FName/E*/T* — NOT U*/A*, which use ALLOC) whose
             // result is built into the return register and re-pushed by a following `PshRPtr` as
             // an ENCLOSING call's arg. Dropping it (return None) loses that arg → the consuming
             // call renders 0-arg (`this.GetCharacter()`). Instead render it as `T(args)` so it
             // FLOWS into `pending` and PshRPtr recovers it (`this.GetCharacter(FName(...))`).
             // Restores ARITY; the literal may be a name-table index (acceptable per spec). Gate
             // strictly: value type AND non-empty args (a 0-arg in-place default ctor stays None).
-            let is_value = matches!(f.bytes().next(), Some(b'F') | Some(b'E') | Some(b'T'));
+            //
+            // batch-42: an OBJECT-factory GLOBAL (U*/A*) — a CALL-dispatched global that RETURNS a
+            // handle (NOT an ALLOC in-place ctor: ALLOC is the factory's OWN body, not the call
+            // site). Names like `UCBT_Root(prio)`, `UTauntConfigManager()`,
+            // `UCBT_AttackTokenRequest()`, the BT-wrapper family `Inverter`/`Succeeder`/… collide
+            // with their return type name, so `is_type_name` is true and the arm dropped them as if
+            // they were struct ctors — stranding the `STOREOBJ wN` slot that the downstream member
+            // store (`this.x = local_N`), chained call receiver (`Parent.DoNode(local_N, …)`), or
+            // `LOADOBJ; RET` then reads as a phantom (near-empty factories degenerate to `return;`).
+            // Recover as `f(args)` so it FLOWS into `pending`; the bytecode's own `STOREOBJ` then
+            // captures it into `local_N` (so the member-ref REFCPY store — batch-41b — sees a plain
+            // `local_N` src that already passes its gate, and `LOADOBJ; RET` renders `return f(…)`).
+            // DISCRIMINATOR (both data points already in hand): a real in-place ctor returns VOID
+            // (token 0x52) and/or is a METHOD the idiom-C ctor path consumed BEFORE build_call; a
+            // factory returns a non-void OBJECT handle (ret_ty head U/A, token 5) AND is a non-method
+            // free global. Gate on the RETURN TYPE, NOT arg count — a 0-arg `UCBT_AttackTokenRequest()`
+            // MUST recover. Any un-provable operand (no U/A class-head return, void, sentinel/
+            // unresolved arg) BAILS to the current drop below — never guess (a wrong factory fed into
+            // a member store / return is worse than a dropped one, and a mis-fire on a genuine in-place
+            // ctor = silent DOUBLE construction).
+            let head = f.split('<').next().unwrap_or(f);
+            let is_value = matches!(head.bytes().next(), Some(b'F') | Some(b'E') | Some(b'T'));
             if is_value && !a.is_empty() {
                 maybe_reverse_args(&mut a, params, refs);
                 return Some(format!("{f}({})", render_args(&a, params, refs)));
+            }
+            // OBJECT factory: non-method (structurally: an in-place ctor is void and/or a method the
+            // idiom-C arm consumed first), return type resolves to a real U/A class head, non-void.
+            let is_object_factory = !is_method
+                && matches!(ret_ty.map(tyhead), Some(rh) if
+                    matches!(rh.bytes().next(), Some(b'U') | Some(b'A'))
+                    // U/A + uppercase-2nd-char = a real class head (rejects `uint`-ish primitives).
+                    && rh.as_bytes().get(1).map(|c| c.is_ascii_uppercase()).unwrap_or(false)
+                    && rh != "void");
+            if is_object_factory {
+                maybe_reverse_args(&mut a, params, refs);
+                let rendered = render_args(&a, params, refs);
+                // Never emit a sentinel-marked / unresolved arg list (a definite mismatch): bail.
+                if !rendered.contains('\u{2}') && !rendered.contains('\u{1}') && rendered != UNRESOLVED {
+                    return Some(format!("{f}({rendered})"));
+                }
             }
             return None; // free-standing in-place constructor — implicit in AS source
         }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3343,13 +3343,97 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                         guard_param_alias.insert(dst_slot0, top.s.clone());
                         continue;
                     }
+                    // batch-46c (FIX-7): the RefCpyV result is consumed ONLY by a following
+                    // `CmpPtr` in this block (the `if (this.Children.Last() == FailedNode)` guard of
+                    // the UCBT `OnChildNode{Failed,Succeeded}` overrides). A getter CALL-expression
+                    // source (`this.Children.Last()`) and a bare object PARAMETER source both drop
+                    // today (the `ok` whitelist rejects `(`-bearing call exprs and non-local params),
+                    // leaving `local_4`/`local_6` UNDECLARED in `if (local_4 != local_6)`. Accept the
+                    // copy ONLY when the destination slot is an operand of a following `CmpPtr` BEFORE
+                    // it is re-defined — the copy materialises the compare operand, so it cannot
+                    // reorder a side effect past its sole consumer (the batch-43 call-src caution was
+                    // about copies flowing into arbitrary non-return locals; here the copy is
+                    // immediately compared, never re-observed). Bounded forward scan within the block
+                    // locates that `CmpPtr` and returns the PAIRED operand slot (the compare partner).
+                    let cmp_paired_slot: Option<i32> = {
+                        let mut paired = None;
+                        for j in (k + 1)..insns.len().min(k + 9) {
+                            let nx = &insns[j];
+                            match nx.op.name {
+                                "CmpPtr" if w(nx, 0) == dst_slot0 => {
+                                    paired = Some(w(nx, 1));
+                                    break;
+                                }
+                                "CmpPtr" if w(nx, 1) == dst_slot0 => {
+                                    paired = Some(w(nx, 0));
+                                    break;
+                                }
+                                // the slot is re-defined (output word 0) by another value producer
+                                // before any compare -> not this idiom, bail.
+                                "RefCpyV" | "CpyRtoV4" | "CpyRtoV8" | "RDR4" | "RDR8"
+                                | "SetV4" | "SetV8" | "SetV1"
+                                    if w(nx, 0) == dst_slot0 =>
+                                {
+                                    break;
+                                }
+                                _ => {}
+                            }
+                        }
+                        paired
+                    };
+                    let feeds_following_cmp = cmp_paired_slot.is_some();
+                    // A getter is a resolved CALL expression (ends `)`, no sentinel/unresolved).
+                    let src_is_getter = top.s.ends_with(')')
+                        && !top.s.contains('\u{2}')
+                        && !top.s.contains('\u{1}')
+                        && top.s != UNRESOLVED
+                        && !top.s.starts_with('~');
+                    // batch-46c (FIX-7): recover the getter feeding a `CmpPtr` — a container
+                    // accessor (`this.Nodes.Last(0)`, `this.m_Targets.opIndex(0)`) whose result is
+                    // consumed only by the compare. Safe: a call result is non-const, materialising
+                    // it into a slot for the compare cannot reorder a side effect past its sole use.
+                    let getter_into_cmp = feeds_following_cmp && src_is_getter;
+                    // batch-46c (FIX-7): recover the PARAM operand of a getter-vs-param compare
+                    // (`if (this.Nodes.Last() == FailedNode)` — the OnChildNode override idiom, and
+                    // the `opIndex(0) == OtherActor` overlap checks). Gated HARD on the paired
+                    // CmpPtr operand being a GETTER-produced slot (a `RefCpyV <paired>` whose source
+                    // is a call expression, scanned across the whole block): this scopes the param
+                    // materialisation to the getter-compare idiom and AVOIDS the wide "every param
+                    // into a null/identity guard" population. CRITICAL: use `param_src_ok` (NOT the
+                    // const-agnostic `param_object_ref`) so a CONST/read-only param is EXCLUDED —
+                    // materialising `const AActor TargetActor` into a non-const slot is the batch-41/
+                    // 45c "const -> non-const" generate-mode cascade (a const compare partner would
+                    // stay dropped; FIX-4 folds const params, it never materialises them). The
+                    // OnChildNode `FailedNode`/`SucceededNode` + overlap `OtherActor` params are all
+                    // non-const, so the idiom is fully covered; const-param compares bail safely.
+                    let param_into_cmp = ctx.param_src_ok(&top.s)
+                        && cmp_paired_slot.is_some_and(|ps| {
+                            // find the `RefCpyV <ps>` that produced the paired slot, then confirm it
+                            // is a GETTER result and NOT another param. The getter idiom lowers as
+                            // `Thiscall1/CALLSYS; PshRPtr; RDSPtr; RefCpyV <ps>` — the deref `RDSPtr`
+                            // IMMEDIATELY precedes the copy (a PARAM copy is `PshVPtr; RefCpyV`, with
+                            // no RDSPtr). Requiring `insns[qj-1] == RDSPtr` AND a getter call in the
+                            // short lead distinguishes a getter partner from a param-vs-param compare
+                            // (CheckTargetChanged's `PreviousTarget == NewTarget`, where a nearby
+                            // FStatID profiler CALLSYS falsely satisfied a call-only probe).
+                            (1..insns.len()).any(|qj| {
+                                insns[qj].op.name == "RefCpyV"
+                                    && w(&insns[qj], 0) == ps
+                                    && insns[qj - 1].op.name == "RDSPtr"
+                                    && insns[qj.saturating_sub(4)..qj]
+                                        .iter()
+                                        .any(|g| matches!(g.op.name, "Thiscall1" | "CALLSYS"))
+                            })
+                        });
                     let ok = !top.s.is_empty()
                         && top.s != dst
                         && !const_ret_getter
                         && (top.s.starts_with("local_")
                             || top.s.starts_with("Cast<")
                             || member_src
-                            || call_src_to_out);
+                            || call_src_to_out
+                            || getter_into_cmp
+                            || param_into_cmp);
                     if ok {
                         flush!();
                         // batch-25b (G4 assign shape): a slot-to-slot handle copy whose DEST

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -45,6 +45,11 @@ struct Arg {
     /// temporary. The nested-call retain keeps these (`GiveExperience(hero, local_23)` must not
     /// lose its `this.XP_...`-sourced Amount to an intervening `GetHero()`).
     keep: bool,
+    /// batch-25a (G2): ENUM value type of a NATIVE struct's field, from the ADDSi arm's
+    /// `native_field_type` lookup — carried ONLY so PopRPtr can hand it to the WRTV1 guard
+    /// (scoped option: it is deliberately NOT merged into `ty`, so call-arg/argtype gates
+    /// never see it).
+    nfty: Option<String>,
 }
 impl Arg {
     fn int(s: String) -> Arg {
@@ -1140,6 +1145,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
     let mut obj_reg: Option<String> = None;
     let mut ref_reg: Option<String> = None; // Idiom-B member address
     let mut ref_reg_ty: Option<String> = None; // field type name behind ref_reg (for casts)
+    // batch-25a (G2): ENUM value type of a native struct's field behind ref_reg, from the
+    // in-crate native-field table (`refs::native_field_type`). Consumed ONLY by the WRTV1
+    // guard so the render becomes `field = EEnum(slot)` instead of the bool-wrap.
+    let mut ref_reg_nfty: Option<String> = None;
     let mut set_consts: HashMap<i32, ConstBits> = HashMap::new(); // last SetV* constant per slot
     // Slots whose current value came from a MEMBER READ (RDR* after a member-ref load) — real
     // data values, kept by the nested-call retain (see Arg.keep). Invalidated on overwrite.
@@ -1324,10 +1333,23 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         .and_then(|cls| ctx.refs.field_type_by_class(cls, &field))
                         .map(|s| s.to_string())
                 });
+                // batch-25a (G2): when the normal chain can't type the field (NATIVE struct
+                // owner), consult the in-crate native-field table — carried in the SEPARATE
+                // nfty channel so only the WRTV1 guard sees it (never the call-arg gates).
+                let nfty = if fty.is_none() {
+                    ctx.refs
+                        .type_by_id(tid)
+                        .and_then(|cls| ctx.refs.native_field_type(cls, &field))
+                        .filter(|t| is_enum_name(t))
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                };
                 if let Some(top) = stack.last_mut() {
                     top.s = format!("{}.{field}", top.s);
                     top.is_int = false; // now a member access, not a bare int slot
                     top.ty = fty;
+                    top.nfty = nfty;
                 }
             }
             "RDSPtr" => {} // deref in place: no change to the rendered name
@@ -1341,6 +1363,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 // field type — so prefer the map and only fall back to member_type.
                 ref_reg_ty = ctx.fields.and_then(|m| m.get(&field)).cloned()
                     .or_else(|| ctx.refs.member_type(tid, off).map(|s| s.to_string()));
+                ref_reg_nfty = ctx.refs.type_by_id(tid)
+                    .and_then(|cls| ctx.refs.native_field_type(cls, &field))
+                    .filter(|t| is_enum_name(t))
+                    .map(|s| s.to_string());
                 // LoadThisR loads from slot 0. In a METHOD that is `this`; in a FREE (mixin)
                 // function slot 0 is parameter 0, so hardcoding `this.` emits an undeclared base
                 // -> "'field' is not a member of 'Unknown'". slot_name(0) renders both correctly.
@@ -1352,6 +1378,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let field = ctx.refs.member(tid, off).map(|s| s.to_string()).unwrap_or_else(|| format!("field_0x{off:x}"));
                 ref_reg_ty = ctx.refs.member_type(tid, off).map(|s| s.to_string()); // foreign object field
+                ref_reg_nfty = ctx.refs.type_by_id(tid)
+                    .and_then(|cls| ctx.refs.native_field_type(cls, &field))
+                    .filter(|t| is_enum_name(t))
+                    .map(|s| s.to_string());
                 ref_reg = Some(format!("{obj}.{field}"));
             }
             _ if n.starts_with("RDR") => {
@@ -1406,6 +1436,27 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         Some(t) if looks_int(&raw) => field_assign_rhs(&raw, t),
                         _ => raw.clone(),
                     };
+                    // batch-25a (G2, specs/batch23-cantconvert.md): a 1-byte write to a NATIVE
+                    // struct's field whose value type the in-crate native-field table resolves
+                    // to an ENUM is the enum ORDINAL store (`SetV1 w80, 0x2 ... WRTV1 w80`), not
+                    // a bool — render `field = EVerticalAlignment(local_80);` via the existing
+                    // enum machinery instead of letting the bool heuristic below produce
+                    // `(local_80 != 0)` ("bool -> E*&", 50 in-game errors, 14 fns). Guards
+                    // mirror the bool heuristic: untransformed bare int slot only, and never a
+                    // slot already KNOWN bool/enum (bare enum->enum / bool sources stay bare).
+                    if n == "WRTV1"
+                        && rhs == raw
+                        && rhs != UNRESOLVED
+                        && looks_int(&raw)
+                        && ctx.slot_type(slot).as_deref() != Some("bool")
+                        && !ctx.slot_type(slot).as_deref().map(is_enum_name).unwrap_or(false)
+                    {
+                        if let Some(ety) = ref_reg_nfty.as_deref() {
+                            if let Some(c) = cast_to_typename(&raw, ety) {
+                                rhs = c;
+                            }
+                        }
+                    }
                     // A 1-byte write (WRTV1) to a field whose type we could NOT resolve to bool
                     // (a foreign nested member -> ref_reg_ty is the owner/None) is almost always a
                     // bool UPROPERTY, whose auto-generated accessor is `bool&`: `field = intSlot`
@@ -1870,6 +1921,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 if let Some(top) = stack.pop() {
                     ref_reg = Some(top.s);
                     ref_reg_ty = top.ty;
+                    ref_reg_nfty = top.nfty; // batch-25a: native enum field type for WRTV1
                 }
             }
             // RefCpyV (wW_ARG): copy the top-of-stack handle into the destination slot named by

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3068,6 +3068,29 @@ impl Structurer<'_> {
                 self.emit_range(i + 1, body_end, depth + 1, out);
                 let _ = writeln!(out, "{ind}}}");
                 next = body_end;
+            } else if let Some((latch, cond, cont_off, brk_off)) =
+                self.uncond_latch_loop_recoverable(i, stop)
+            {
+                // batch-36 Stage C: mid-test loop with an UNCONDITIONAL-JMP latch, clean top-test
+                // form, AND a FULLY recoverable body (Gate 2 passed inside the detector). The
+                // header block `i` holds the `while (cond)` test (excluded); the body is
+                // [i+1, latch) (the latch JMPs back to `i`, also excluded). `continue_off` =
+                // header offset; `break_off` = the exit-test target.
+                //
+                // SAFETY: unlike loop_latch (where the loop is ALWAYS already detected), a
+                // NEWLY-detected uncond-JMP loop only wins when its body fully structures — if
+                // Gate 2 bails, `uncond_latch_loop_recoverable` returns None and this block falls
+                // through to the `is_cond` arm, keeping the EXACT status-quo emission (the header
+                // as an `if`). A newly-detected loop never emits a linearized/lossy body.
+                let _ = writeln!(out, "{ind}while ({cond})");
+                let _ = writeln!(out, "{ind}{{");
+                let ls = LoopScope { continue_off: cont_off, break_off: brk_off };
+                let saved = self.loop_scope;
+                self.loop_scope = Some(ls);
+                self.emit_range(i + 1, latch, depth + 1, out);
+                self.loop_scope = saved;
+                let _ = writeln!(out, "{ind}}}");
+                next = latch + 1;
             } else if let Some(latch) = self.loop_latch(i, stop) {
                 let lcmp = block_stmts(self.ctx, self.g.blocks[latch].instr_lo, self.g.blocks[latch].instr_hi).1;
                 let cond = branch_cond(&lcmp, self.jump_op(latch));
@@ -4330,6 +4353,111 @@ impl Structurer<'_> {
             self.jump_op(bi),
             "JS" | "JNS" | "JP" | "JNP" | "JZ" | "JNZ" | "JLowZ" | "JLowNZ"
         ) && b.succs.iter().any(|&s| s <= b.start_dw)
+    }
+
+    /// batch-36 Stage C — block `bi` ends in an UNCONDITIONAL `JMP` back to an earlier-or-equal
+    /// offset (an uncond-JMP loop latch: `while(true)`/mid-test loops that `loop_latch`
+    /// (cond-only) and `top_test_while` (strict block-before-taken rule) both miss).
+    fn is_backward_jump(&self, bi: usize) -> bool {
+        let b = &self.g.blocks[bi];
+        self.jump_op(bi) == "JMP" && b.succs.first().is_some_and(|&s| s <= b.start_dw)
+    }
+
+    /// batch-36 Stage C (conservative first cut, spec §2.3) — detect a mid-test loop whose latch
+    /// is an UNCONDITIONAL `JMP` back to the header block `i`, in the CLEAN top-test form only:
+    /// block `i` is itself a single-block conditional (`is_cond`) that tests the loop condition,
+    /// one edge continues the body (`i+1`), the other is the loop EXIT (`break_off`, forward past
+    /// the latch), and the last body block JMPs unconditionally back to `i`. Returns
+    /// `(latch_idx, cond, continue_off, break_off)`. Bails (None) on any compound-header /
+    /// mid-body-test / multi-exit shape — those stay on their status-quo emission (a stub or
+    /// flat chain), never a guessed `while(true)`.
+    fn uncond_latch_loop(&self, i: usize, stop: usize) -> Option<(usize, String, usize, usize)> {
+        // never steal a block a conditional latch or top-test already claims
+        if self.loop_latch(i, stop).is_some() || self.top_test_while(i, stop).is_some() {
+            return None;
+        }
+        let header_off = self.g.blocks[i].start_dw;
+        // the header block must be a single 2-succ conditional = the loop test
+        if !self.is_cond(i) {
+            return None;
+        }
+        let b = &self.g.blocks[i];
+        let taken = *b.succs.first()?;
+        let fall = *b.succs.get(1)?;
+        // find the uncond-JMP latch: a block in (i, stop) whose JMP targets exactly `header_off`
+        let mut latch = None;
+        for bi in (i + 1)..stop {
+            if self.is_backward_jump(bi) && self.g.blocks[bi].succs.first() == Some(&header_off) {
+                if latch.is_some() {
+                    return None; // more than one back-edge to the header — not the clean shape
+                }
+                latch = Some(bi);
+            }
+        }
+        let latch = latch?;
+        let latch_off = self.g.blocks[latch].start_dw;
+        // exactly one of {taken, fall} continues the body (== i+1 offset), the other is the exit
+        let fall_idx = *self.idx_of.get(&fall)?;
+        let taken_idx = *self.idx_of.get(&taken)?;
+        // body must be the fall-through run [i+1, latch); the exit is the other edge, and it must
+        // lie strictly after the latch (a genuine loop exit, not an in-body forward jump)
+        let (body_continue_idx, exit_off) = if fall_idx == i + 1 {
+            (fall_idx, taken)
+        } else if taken_idx == i + 1 {
+            (taken_idx, fall)
+        } else {
+            return None;
+        };
+        let _ = body_continue_idx;
+        let exit_idx = *self.idx_of.get(&exit_off)?;
+        // the exit must be OUTSIDE the loop span (past the latch) — else it is an inner branch,
+        // and this is not a clean top-test loop.
+        if exit_idx <= latch || exit_off <= latch_off {
+            return None;
+        }
+        // no OTHER back-edge inside the body may target an offset <= header (irreducible / a
+        // second loop we are not modeling) — keep this to the single-latch reducible shape.
+        for bi in (i + 1)..latch {
+            let bb = &self.g.blocks[bi];
+            if bb.succs.iter().any(|&s| s <= header_off) {
+                return None;
+            }
+        }
+        // condition renders so the loop CONTINUES on the fall edge (body) and EXITS on the other:
+        // if fall is the body, the taken edge is the exit → `while (!taken_cond)`; if taken is the
+        // body, `while (taken_cond)`. Mirror `top_test_while` (which always has fall = body).
+        let cmp = block_stmts(self.ctx, b.instr_lo, b.instr_hi).1;
+        let raw = branch_cond(&cmp, self.jump_op(i));
+        let cond = if fall_idx == i + 1 { negate(&raw) } else { raw };
+        Some((latch, cond, header_off, exit_off))
+    }
+
+    /// batch-36 Stage C — [`Self::uncond_latch_loop`] PLUS the two body gates, run with the loop
+    /// scope active so the Gate-2 dry run's nested-switch probe agrees with the real emit. Returns
+    /// the loop tuple ONLY when the body has a genuine inner branch (Gate 1) AND fully structures
+    /// (Gate 2). If either gate fails, returns None so the caller falls through to the `is_cond`
+    /// arm — a newly-detected loop must NOT emit a linearized/lossy body (that would be a QUALITY
+    /// regression vs the status-quo `if` the is_cond arm produces, and risks mis-binding an inner
+    /// break/continue). This is the "a newly-detected loop only wins when fully recoverable" rule.
+    fn uncond_latch_loop_recoverable(
+        &mut self,
+        i: usize,
+        stop: usize,
+    ) -> Option<(usize, String, usize, usize)> {
+        let (latch, cond, cont_off, brk_off) = self.uncond_latch_loop(i, stop)?;
+        let ls = LoopScope { continue_off: cont_off, break_off: brk_off };
+        if !self.body_has_inner_branch(i + 1, latch, ls) {
+            return None;
+        }
+        let saved = self.loop_scope;
+        self.loop_scope = Some(ls);
+        let ok = self.loop_body_recoverable(i + 1, latch, ls);
+        self.loop_scope = saved;
+        if ok {
+            Some((latch, cond, cont_off, brk_off))
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1404,16 +1404,39 @@ fn cast_to_typename(rhs: &str, tyname: &str) -> Option<String> {
 /// pure pre-join getters of the proven population, so re-evaluating the read at the join
 /// observes the same element.
 fn is_pure_elem_read(s: &str) -> bool {
-    let Some(rest) = s.strip_prefix("local_") else { return false };
-    let Some((idx, call)) = rest.split_once('.') else { return false };
-    if idx.is_empty() || !idx.bytes().all(|b| b.is_ascii_digit()) {
-        return false;
-    }
-    let Some(args) = call.strip_prefix("opIndex(").and_then(|c| c.strip_suffix(')')) else {
+    let Some((recv, call)) = s.split_once(".opIndex(") else { return false };
+    let Some(args) = call.strip_suffix(')') else { return false };
+    // batch-33c: receiver widened from bare locals to `this.`-rooted plain member chains
+    // (`this.m_MinionsDieHandles.opIndex(local_6)` — MCQueen OnMinionDie's dropped
+    // UDelegateHandleContainer arg). The purity argument is unchanged: the D7-constrained
+    // diamond arms (opCast+TYPEID only) cannot mutate ANY container, member or local —
+    // the LOCAL restriction was belt, not load-bearing. Receivers with calls/indexing/
+    // quotes stay rejected by the charset.
+    let recv_ok = if let Some(rest) = recv.strip_prefix("local_") {
+        !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit())
+    } else if let Some(rest) = recv.strip_prefix("this.") {
+        !rest.is_empty()
+            && rest.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.'))
+    } else {
+        false
+    };
+    recv_ok
+        && args
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b',' | b' ' | b'-'))
+}
+
+/// batch-33c (D9 pure-read carry, iterator getters): true for a rendered 0-arg
+/// `GetKey()`/`GetValue()` on a plain identifier-chain receiver (`Entry.GetKey()` — the
+/// UGE_Ex_Damage::GetDamageByMagicCircle param iterator, whose FGameplayTag DamageTag arg
+/// died at the D9 bail). Owner-gated at the tagging site to TMap(Const)Iterator, whose
+/// getters are pure reads: re-evaluating at the diamond join cannot observe a different
+/// value (the D7-constrained arms cannot advance an iterator).
+fn is_pure_iter_get(s: &str) -> bool {
+    let Some(recv) = s.strip_suffix(".GetKey()").or_else(|| s.strip_suffix(".GetValue()")) else {
         return false;
     };
-    args.bytes()
-        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b',' | b' ' | b'-'))
+    !recv.is_empty() && recv.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.'))
 }
 
 /// True if a rendered operand is an integer slot/constant (safe to cast to bool/enum).
@@ -2432,8 +2455,16 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 // (non-constant Id operand) falls to the `$`-drop and returns None.
                 pending_is_static_name = f == "__STATIC_NAME" && pending.is_some();
                 // batch-32c: tag a pure local-container element read (see the flag's doc).
-                pending_is_pure_elem =
-                    f == "opIndex" && pending.as_deref().map(is_pure_elem_read).unwrap_or(false);
+                // batch-33c: + TMap(Const)Iterator's pure GetKey/GetValue getters (owner-
+                // gated by-ptr; see is_pure_iter_get).
+                pending_is_pure_elem = (f == "opIndex"
+                    && pending.as_deref().map(is_pure_elem_read).unwrap_or(false))
+                    || (matches!(f.as_str(), "GetKey" | "GetValue")
+                        && matches!(
+                            ctx.refs.func_owner_by_ptr(ptr),
+                            Some("TMapIterator" | "TMapConstIterator")
+                        )
+                        && pending.as_deref().map(is_pure_iter_get).unwrap_or(false));
             }
             "CallPtr" => {
                 let f = name(w(ins, 0));

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -289,6 +289,18 @@ impl Ctx<'_> {
         }
     }
 
+    /// True when the return VALUE travels through the hidden RVO out-pointer slot (a genuine
+    /// by-value struct return) — so the value/object registers can never carry the payload
+    /// (batch-24a, specs/batch23-cantconvert.md G1). `rvo_off` alone is NOT sufficient: the
+    /// param-map heuristic also classifies ENUM returns (token 5) as RVO, yet enums return in
+    /// the value register — mirroring the switch recovery's `register_based` test, an enum
+    /// return stays register-based here too (else every enum function's CpyVtoR* return
+    /// capture would be discarded).
+    fn ret_via_rvo(&self) -> bool {
+        self.rvo_off.is_some()
+            && !self.ret_ty.map(|t| is_enum_name(&t.base_name(self.refs))).unwrap_or(true)
+    }
+
     /// Name for parameter slot `idx`: the stored name, else `arg{idx}` — which MUST match
     /// how `emit::render_params` declares unnamed params (also `arg{idx}`), so a body
     /// reference resolves to a declared parameter.
@@ -1748,7 +1760,15 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 if pending.is_some() && pending_ty.as_deref() == Some("void") {
                     flush!();
                 }
-                ret_val = pending.take().or_else(|| Some(name(w(ins, 0))));
+                // batch-24a (G1): in an RVO function the 4/8-byte value register NEVER carries
+                // the on-stack struct payload — it holds branch/loop condition values (e.g.
+                // `local_11 = int(iter.CanProceed)`), and a stale capture surviving to RET
+                // emitted `return local_11;` from an FVector function (138 int -> F*/T*
+                // cant-convert errors). The one legitimate ret_val source for RVO functions is
+                // the CopyScript-to-`__return` capture below.
+                if !ctx.ret_via_rvo() {
+                    ret_val = pending.take().or_else(|| Some(name(w(ins, 0))));
+                }
             }
             "CpyVtoR1" => {
                 // a bool moved into the test register: feeds either RET or a conditional jump.
@@ -1770,7 +1790,12 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     || (pending.is_none() && ctx.slot_type(w(ins, 0)).as_deref() == Some("bool"));
                 let v = pending.take().unwrap_or_else(|| name(w(ins, 0)));
                 cond = Some((v.clone(), is_bool));
-                ret_val = Some(v);
+                // batch-24a (G1): `cond` handling unchanged (CpyVtoR1 still feeds branches),
+                // but a test-register bool is never an RVO struct payload — don't let it
+                // linger as a stale return-value candidate (see CpyVtoR4/R8 above).
+                if !ctx.ret_via_rvo() {
+                    ret_val = Some(v);
+                }
             }
             "RET" => {
                 let non_void = ctx.ret_ty.map(|t| t.token != 0x52).unwrap_or(false);
@@ -1779,7 +1804,24 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 // Capture the return value BEFORE flush!: a directly-returned call/ctor result
                 // lives in `pending` (e.g. `CALL`/`ALLOC` then `RET`), and flush! would emit it
                 // as a standalone statement, leaving the return a default (RVODEF).
-                let mut v = if non_void {
+                let mut v = if non_void && ctx.ret_via_rvo() {
+                    // batch-24a (G1): an RVO struct payload never travels through the
+                    // object/value registers — `ret_val` here can only be the CopyScript-to-
+                    // `__return` capture, or a pending CALLSYS opAssign that writes the RVO
+                    // slot ITSELF (`__return = <rhs>`; strip_return_assign folds it back to
+                    // `return <rhs>;` — the pre-fix text of those legitimate sites). No
+                    // obj_reg/other-pending fallback, no scan-back (both resurrect stale
+                    // branch-condition captures -> `return local_11;` from an FVector
+                    // function). None -> RVODEF; the emitter folds it to `return __return;`
+                    // when the body wrote the slot.
+                    ret_val.take().or_else(|| {
+                        pending
+                            .as_deref()
+                            .is_some_and(|p| p.starts_with("__return = "))
+                            .then(|| pending.take())
+                            .flatten()
+                    })
+                } else if non_void {
                     // batch-21 Class C shape 3: a pending VOID call is never the return VALUE
                     // (`return CalculateDistanceToTarget(...);` from a bool function fails
                     // "No conversion from 'void' to 'bool'") — leave it for flush! below
@@ -1791,7 +1833,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     None
                 };
                 flush!();
-                if non_void && v.is_none() {
+                if non_void && v.is_none() && !ctx.ret_via_rvo() {
                     v = scan_back_retval(ctx, lo + k);
                 }
                 // value fix-ups (RVO-assign strip, declared-bool, int -> bool/enum cast) and

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -465,7 +465,12 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
                         if a.len() > w { a.drain(..a.len() - w); }
                     }
                     maybe_reverse_args(&mut a, params, refs);
-                    return Some(format!("{out} = {f}({})", render_args(&a, params, refs)));
+                    // Include the receiver — this is a METHOD RVO struct-return (has_recv popped
+                    // `recv`); omitting it emitted `out = Iterator()` (495×) / `out =
+                    // GetActorLocation()` instead of `out = recv.Iterator()` -> "No matching
+                    // signatures". `this`-receivers render `this.Method()` (legal, matches the
+                    // normal method-render path below).
+                    return Some(format!("{out} = {}.{f}({})", recv.s, render_args(&a, params, refs)));
                 }
             }
         }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -410,9 +410,23 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     // Untrusted -> keep the original take-all (cache native param counts are unreliable).
     // A method returning a struct BY VALUE (F*/T* head) also pushes a hidden RVO out-slot, so its
     // frame is params + receiver + 1; account for it or the split drops a real leading arg.
-    let rvo_slot = is_method && ret_ty
-        .map(|t| matches!(t.split('<').next().unwrap_or(t).bytes().next(), Some(b'F') | Some(b'T')))
-        .unwrap_or(false);
+    // A method returning a struct BY VALUE pushes a hidden RVO out-slot, so its frame is
+    // params + receiver + 1. But a method returning by REFERENCE (`TArray& Last()`, container
+    // accessors) does NOT — and ret_ty is only the base-name string, so the is_reference flag is
+    // erased. Blindly adding +1 for any F/T-head return over-widens the split window and EATS an
+    // enclosing call's arg (proven: TArray::Last inside `container.Last(i).AddTag(tag)` ate the
+    // tag). Data-driven guard: only count the RVO slot when it is ACTUALLY on the stack — the
+    // entry directly below the receiver is a PSF slot whose type head equals the return-type head
+    // (the same condition the Fix-b3 out-slot probe uses). This can only SHRINK the window vs the
+    // old heuristic, never widen, so it cannot break a real by-value RVO recovery.
+    fn tyhead(s: &str) -> &str { s.split('<').next().unwrap_or(s) }
+    let rvo_slot = is_method
+        && ret_ty.map(|t| matches!(tyhead(t).bytes().next(), Some(b'F') | Some(b'T'))).unwrap_or(false)
+        && stack.len() >= 2
+        && {
+            let below = &stack[stack.len() - 2];
+            below.is_psf && below.ty.as_deref().map(tyhead) == ret_ty.map(tyhead)
+        };
     let need = trusted_arity.map(|n| n + is_method as usize + rvo_slot as usize);
     let mut a: Vec<Arg> = match need {
         Some(k) if stack.len() > k => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3080,6 +3080,32 @@ impl Structurer<'_> {
             let _ = writeln!(out, "{ind}}}");
         }
         let _ = writeln!(out, "{ind}}}");
+        // batch-30b (C9 'Unreachable code', specs/batch29-errortail.md §9): when the JOIN is
+        // the shared bare RET row, a REAL `default:` region was emitted, and every region
+        // leaves by RETURNING (terminator RET, or JMP rendered as `return ...;` by the exit
+        // hook — never an appended `break;`), control cannot fall out of the switch. Emitting
+        // the RET row after it is dead code the compiler flags ("Unreachable code" [W],
+        // a module-killer under warnings-as-errors) — skip the row. Conservative gates:
+        // a trap DEF (no `default:` emitted) keeps the row (a non-matching selector falls
+        // through in the recompiled source), as does any external jump to the row (another
+        // path may rely on its emission).
+        if join_is_ret && switch_end == join_idx && join_idx < stop {
+            let every_region_returns = regions.iter().all(|r| {
+                !r.trap
+                    && !r.append_break
+                    && matches!(
+                        ctx.instrs[blocks[r.end - 1].instr_hi - 1].op.name,
+                        "JMP" | "RET"
+                    )
+            });
+            let has_real_default = regions.iter().any(|r| r.is_def && !r.trap);
+            let externally_referenced = blocks.iter().enumerate().any(|(bi2, bb)| {
+                (bi2 < i || bi2 >= switch_end) && bb.succs.contains(&join_off)
+            });
+            if every_region_returns && has_real_default && !externally_referenced {
+                return Some(join_idx + 1);
+            }
+        }
         Some(switch_end)
     }
 

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -176,6 +176,36 @@ fn strip_return_assign(v: &str) -> &str {
     v
 }
 
+/// batch-27b: if `v` is a top-level assignment expression `lhs = rhs` with a PLAIN slot /
+/// member-path lhs (the batch-26 operator/RVO fold shapes: `local_4 = this.GetDisplayName()`,
+/// `local_18 = (a + b)`), return the lhs. The in-game compiler rejects an assignment
+/// expression consumed as a call argument ("[E] No matching signatures to
+/// 'FString::Append(local_4 = FString)'", capture.batch26-0705 CombatMoves.as), so the
+/// `PshRPtr` arm flushes such a pending as its own statement and pushes the (now-written)
+/// lhs slot instead. Comparisons never match (`==`/`!=`/`<=`/`>=` are not ` = `); anything
+/// with a non-identifier lhs (literal, string, expression) returns None.
+fn assign_lhs(v: &str) -> Option<&str> {
+    let b = v.as_bytes();
+    let mut depth = 0i32;
+    for i in 0..b.len().saturating_sub(2) {
+        match b[i] {
+            b'(' | b'[' => depth += 1,
+            b')' | b']' => depth -= 1,
+            // a quote before the top-level ` = ` -> lhs would contain a string literal; the
+            // depth counter does not model quoting, so never match past one.
+            b'"' => return None,
+            b' ' if depth == 0 && b[i + 1] == b'=' && b[i + 2] == b' ' => {
+                let lhs = v[..i].trim();
+                let plain = !lhs.is_empty()
+                    && lhs.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_' || c == b'.');
+                return plain.then_some(lhs);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Decompile a function to a self-contained `function(...) { ... }` (readable, not recompilable).
 pub fn decompile(f: &FuncCode, refs: &RefResolver) -> String {
     let params: Vec<String> = f
@@ -1462,7 +1492,19 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 // back onto the operand stack as the NEXT call's argument (e.g. the receiver/arg of
                 // a chained call). Prefer that live call result over the stale member-ref register.
                 if let Some(p) = pending.take() {
-                    stack.push(Arg::typed(p, pending_ty.take()));
+                    // batch-27b: an ASSIGNMENT-shaped pending (batch-26 operator/RVO fold,
+                    // `local_4 = this.GetDisplayName()`) must not flow into an arg/receiver
+                    // position — the fork rejects assignment expressions as call arguments.
+                    // Emit it as its own statement first and push the written lhs slot: the
+                    // assignment completes before the consuming call on both renders, so the
+                    // dataflow is identical.
+                    if let Some(lhs) = assign_lhs(&p) {
+                        let lhs = lhs.to_string();
+                        out.push(format!("{p};"));
+                        stack.push(Arg::typed(lhs, pending_ty.take()));
+                    } else {
+                        stack.push(Arg::typed(p, pending_ty.take()));
+                    }
                 } else {
                     let (s, ty) = match value_reg.take() {
                         Some(v) => (v, None),

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -288,6 +288,26 @@ impl Ctx<'_> {
                     }
                     _ => v,
                 };
+                // batch-25b (G4 RET shape, specs/batch23-nomatch.md): `return local_N;` where
+                // the slot's recovered type is a PROVABLY less-derived object type than the
+                // function's return type (a covariant-erased producer: `UCBT_Tree local` vs
+                // `UCBT_Tree_SelectAttackBase` return) fails "Can't implicitly convert".
+                // Wrap in the game's own null-safe downcast: `return Cast<RetTy>(local_N);`.
+                // Gate: bare local slot, BOTH heads known object types (U*/A*), and the
+                // return head provably derives from the slot head (script hierarchy, or the
+                // engine axioms in `provably_derived`) — never wrapped when unsure.
+                let v = match (self.ret_ty, v.strip_prefix("local_").and_then(|d| d.parse::<i32>().ok())) {
+                    (Some(rt), Some(slot)) => {
+                        let rh = rt.base_name(self.refs);
+                        match self.slot_type(slot) {
+                            Some(st) if provably_derived(&rh, &st, self.refs) => {
+                                format!("Cast<{rh}>({v})")
+                            }
+                            _ => v,
+                        }
+                    }
+                    _ => v,
+                };
                 format!("return {v};")
             }
             None => format!("return {RVODEF};"),
@@ -1055,6 +1075,42 @@ fn field_assign_rhs(rhs: &str, tyname: &str) -> String {
         | "float" | "float32" | "double" | "?" => rhs.to_string(),
         _ => UNRESOLVED.to_string(),
     }
+}
+
+/// batch-25b (G4): true when object type `dst` PROVABLY derives from (and differs from)
+/// object type `src` — the gate for the Cast-wrap on RET / RefCpyV dataflow. Sources of
+/// proof, in order:
+/// - the script-class hierarchy (walks script supers; super NAMES may be native classes,
+///   so e.g. `ALightningRayVisual -> ... -> AActor` resolves),
+/// - `src == UObject`: every U*/A* type derives UObject (engine axiom),
+/// - `src == AActor` and `dst` is `A*`-prefixed: the UE naming convention reserves the `A`
+///   prefix for AActor-derived classes.
+/// Native-only pairs with no recorded chain return false (never wrap when unsure) —
+/// documented residue: base-typed slots between two NATIVE classes stay unwrapped.
+/// Template heads (`TSubclassOf<...>`) and value types never qualify.
+fn provably_derived(dst: &str, src: &str, refs: &RefResolver) -> bool {
+    fn head(s: &str) -> &str {
+        s.split('<').next().unwrap_or(s).trim_start_matches("const ")
+    }
+    let (dst, src) = (head(dst), head(src));
+    let is_obj = |s: &str| {
+        let b = s.as_bytes();
+        matches!(b.first(), Some(b'U') | Some(b'A'))
+            && b.get(1).map(|c| c.is_ascii_uppercase()).unwrap_or(false)
+    };
+    if dst == src || !is_obj(dst) || !is_obj(src) {
+        return false;
+    }
+    if refs.is_subclass(dst, src) {
+        return true;
+    }
+    if src == "UObject" {
+        return true;
+    }
+    if src == "AActor" && dst.starts_with('A') {
+        return true;
+    }
+    false
 }
 
 /// True if `tyname` is a UE enum type (`E<Upper>...`) — same shape `cast_to_typename` keys on.
@@ -1943,7 +1999,25 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         && (top.s.starts_with("local_") || top.s.starts_with("Cast<"));
                     if ok {
                         flush!();
-                        out.push(format!("{dst} = {};", top.s));
+                        // batch-25b (G4 assign shape): a slot-to-slot handle copy whose DEST
+                        // type provably derives from the SOURCE type (`AGothicCharacter
+                        // local_8 = UObject local_24;` — an iterator/temp producer erased the
+                        // covariant type) fails "Can't implicitly convert". Wrap the source in
+                        // the standard downcast. Same provably_derived gate as the RET shape;
+                        // unknown/unprovable pairs render bare (status quo).
+                        let dst_slot = w(ins, 0);
+                        let rhs = match (dst_slot > 0).then(|| ctx.slot_type(dst_slot)).flatten() {
+                            Some(dt) if top
+                                .ty
+                                .as_deref()
+                                .map(|st| provably_derived(&dt, st, ctx.refs))
+                                .unwrap_or(false) =>
+                            {
+                                format!("Cast<{dt}>({})", top.s)
+                            }
+                            _ => top.s.clone(),
+                        };
+                        out.push(format!("{dst} = {rhs};"));
                     }
                 }
             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1781,6 +1781,17 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
     // const decl (batch-41 cascade risk); a direct null-compare of the const param has no
     // conversion. Consumed + cleared by the very next `CmpPtrNull`.
     let mut guard_param_alias: HashMap<i32, String> = HashMap::new();
+    // batch-46a (FIX-5): slot NAME -> value-type name, recorded when a 0-param `$beh0` CONSTRUCT
+    // behaviour default-initialises a PSF'd temp slot of a value type (`PSF t; CALLSYS $beh0`,
+    // owner e.g. `FGameplayTag`). The construct's own arm skips it (the PSF slot carries no `.ty`,
+    // so the `is_value` gate is false) and it falls through the generic `$`-drop — but the temp is
+    // then copy-assigned into a member (`PSF t; PshVPtr this; ADDSi <field>; CALLSYS $beh0(1-param)`
+    // = the FGameplayTag default-init triad). Recorded here so the Idiom-S copy-assign arm can
+    // recover `this.<field> = T();` (a default-constructed value) instead of dropping the whole
+    // triad to an empty ctor body. Keyed on the CONSTRUCT owner type so the copy-assign only fires
+    // when the source temp was default-built of the SAME value type. Cleared when the slot is
+    // overwritten by any non-construct producer.
+    let mut default_ctor_temp: HashMap<String, String> = HashMap::new();
     let mut pending: Option<String> = None; // unconsumed call/ctor result
     let mut pending_ty: Option<String> = None; // recovered type of `pending` (call return type)
     // batch-20 Class B: the call returns a CONST object handle (`const UCharacterAIState`).
@@ -2719,6 +2730,27 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                     continue;
                 }
                 if f == "$beh0" {
+                    // batch-46a (FIX-5, GameplayTag default-init triad): a 0-param `$beh0` CONSTRUCT
+                    // on a PSF'd temp slot of a VALUE type (owner F*/T*/E*) default-initialises that
+                    // temp (`PSF t; CALLSYS $beh0(0-param)`). The temp carries no `.ty` (a bare PSF
+                    // slot), so the value-construct arm below skips it and it falls through the
+                    // generic `$`-drop. RECORD `slot -> owner_type` here so the following 1-param
+                    // copy-assign into a member (`… ADDSi <field>; CALLSYS $beh0(1-param)`) can
+                    // recover `this.<field> = T();` from an otherwise-empty ctor body. Recording
+                    // only (no `continue`) — the existing arms proceed exactly as before, so this is
+                    // additive and cannot alter any current render. Gate: 0-param, PSF receiver, a
+                    // value-type owner (never U*/A* objects, which use ALLOC not this behaviour).
+                    if ctx.refs.func_params_by_ptr(ptr).map(|p| p.len()) == Some(0) {
+                        if let Some(top) = stack.last() {
+                            if top.is_psf {
+                                if let Some(owner) = ctx.refs.func_owner_by_ptr(ptr) {
+                                    if matches!(owner.bytes().next(), Some(b'F') | Some(b'T') | Some(b'E')) {
+                                        default_ctor_temp.insert(top.s.clone(), owner.to_string());
+                                    }
+                                }
+                            }
+                        }
+                    }
                     // `$beh0` is the AngelScript value-type / struct in-place CONSTRUCT behaviour:
                     // `PSF <slot> ; <args...> ; CALLSYS $beh0` constructs the value AT the PSF'd
                     // slot (the receiver, top of stack). build_call drops every `$`-prefixed
@@ -2841,6 +2873,30 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                             && stack.len() >= 2
                         {
                             let rhs = stack[stack.len() - 2].clone();
+                            // batch-46a (FIX-5): GameplayTag default-init triad. The 1-param `$beh0`
+                            // COPY-ASSIGN (`this.<field> = t`) whose source `t` is a PSF temp that a
+                            // preceding 0-param `$beh0` default-CONSTRUCTED (recorded in
+                            // `default_ctor_temp`). The generic Idiom-S `rhs_ok` rejects a PSF source,
+                            // so the whole triad dropped -> empty ctor. Recover `this.<field> = T();`
+                            // (a default-constructed value). SAFETY: fire ONLY when (a) the source
+                            // slot was default-constructed of a value type, and (b) that type EQUALS
+                            // this copy-assign's owner (the field's value type) — so the render is
+                            // provably `<field's own type>()`, never a fabricated value. Any mismatch
+                            // or unrecorded slot falls through to the normal `rhs_ok` bail. `T()` is a
+                            // pure default ctor (no args), so it cannot introduce a wrong value.
+                            if rhs.is_psf {
+                                if let Some(ctor_ty) = default_ctor_temp.get(&rhs.s) {
+                                    let assign_owner = ctx.refs.func_owner_by_ptr(ptr);
+                                    if assign_owner == Some(ctor_ty.as_str()) {
+                                        let ty = ctor_ty.clone();
+                                        default_ctor_temp.remove(&rhs.s); // consume the record
+                                        stack.truncate(stack.len() - 2); // consume recv + temp
+                                        flush!();
+                                        out.push(format!("{} = {ty}();", recv.s));
+                                        continue;
+                                    }
+                                }
+                            }
                             let rhs_ok = !rhs.is_psf
                                 && !rhs.s.is_empty()
                                 && rhs.s != UNRESOLVED

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -555,6 +555,36 @@ impl Ctx<'_> {
         }
         format!("arg{idx}")
     }
+
+    /// batch-45a (FIX-1): true when `name` is EXACTLY a declared parameter (by rendered name)
+    /// whose type is a NON-CONST object handle or reference — the only source a REFCPY
+    /// object-store may accept beyond `local_`/`Cast<`/`nullptr`. A REFCPY copies a handle, so
+    /// the param must be an object handle or a reference (`this.m_Target = NewTarget;`); a const
+    /// param (`is_read_only`/`is_object_const`) is EXCLUDED (copying it into a non-const member
+    /// fails generate-mode "Can't implicitly convert 'const T' to 'T'" — the batch-41d cascade
+    /// class, and the documented AddFitnessMultiplier-style const-param bail). Matches against the
+    /// same names `param_or_arg` renders, so a body `src.s` resolves back to its param slot. `this`
+    /// is not a param name, so it never matches here (its back-link store stays bailed).
+    fn param_src_ok(&self, name: &str) -> bool {
+        // Locate the param by its rendered name (stored name, or the `arg{idx}` fallback that
+        // `param_or_arg` emits for an unnamed param).
+        let idx = self.f.param_names.iter().position(|n| !n.is_empty() && n == name)
+            .or_else(|| {
+                name.strip_prefix("arg")
+                    .and_then(|d| d.parse::<usize>().ok())
+                    .filter(|&i| i < self.f.param_types.len()
+                        && self.f.param_names.get(i).map(|n| n.is_empty()).unwrap_or(false))
+            });
+        let Some(idx) = idx else { return false };
+        let ty = match self.f.param_types.get(idx) {
+            Some(t) => t,
+            None => return false,
+        };
+        // Object handle OR reference (a REFCPY targets handles/refs), and NON-const.
+        (ty.is_object_handle || ty.is_reference)
+            && !ty.is_read_only
+            && !ty.is_object_const
+    }
 }
 
 fn s16(w: u16) -> i32 {
@@ -3238,21 +3268,29 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                 if let (Some(dst), Some(src)) = (&dst, &src) {
                     // GATE:
                     //  dst is a MEMBER lvalue: contains '.', not empty/UNRESOLVED/sentinel, and NOT
-                    //  a bare slot (a bare local_N dst would be a RefCpyV, not a REFCPY member store).
-                    //  src is a PROVEN handle: `local_N` (a STOREOBJ/allocated slot), a `Cast<…>`, or
-                    //  `nullptr` (the S3 clear via PshNull). NEVER a member/param/temp whose const-ness
-                    //  or aliasing we can't prove (mirrors the RefCpyV arm's original caution — copying
-                    //  a const param/member handle into a non-const dest fails "Can't implicitly
-                    //  convert"), so those bail to the drop.
+                    //  a BARE slot (a bare local_N dst would be a RefCpyV, not a REFCPY member
+                    //  store). batch-45a (FIX-1) permits a dotted `local_N.field` STRUCT-TEMP field
+                    //  dest (e.g. `local_2.EventTag = SourceActor;` — a config/FGameplayEventData
+                    //  field init before a SendGameplayEvent/validator call); only a bare `local_N`
+                    //  with no `.` (which the '.'-contains test already excludes) is rejected.
+                    //  src is a PROVEN handle: `local_N` (a STOREOBJ/allocated slot), a `Cast<…>`,
+                    //  `nullptr` (the S3 clear via PshNull), or — batch-45a (FIX-1) — a NON-CONST
+                    //  object/ref PARAMETER (`this.m_Target = NewTarget;`, `SetParentNode(Value)`).
+                    //  NEVER a member/temp/`this`/const-param whose const-ness or aliasing we can't
+                    //  prove (mirrors the RefCpyV arm's original caution — copying a const
+                    //  param/member handle into a non-const dest fails "Can't implicitly convert";
+                    //  `this` back-links stay bailed, `param_src_ok` never matches `this`).
                     let dst_ok = dst.s.contains('.')
                         && !dst.s.is_empty()
                         && dst.s != UNRESOLVED
-                        && !dst.s.contains('\u{2}')
-                        && !dst.s.starts_with("local_");
+                        && !dst.s.contains('\u{2}');
                     let src_ok = !src.s.is_empty()
                         && src.s != UNRESOLVED
                         && !src.s.contains('\u{2}')
-                        && (src.s.starts_with("local_") || src.s.starts_with("Cast<") || src.s == "nullptr");
+                        && (src.s.starts_with("local_")
+                            || src.s.starts_with("Cast<")
+                            || src.s == "nullptr"
+                            || ctx.param_src_ok(&src.s));
                     // batch-41d (CLASS 1b): the source slot holds a CONST object handle (a
                     // const-returning call result / const member read). Storing it into a
                     // (non-const) member is a "Can't implicitly convert from 'const T' to 'T'"

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1135,6 +1135,19 @@ fn cast_arg(arg: &Arg, pt: &DataType, refs: &RefResolver) -> String {
                 }
             }
         }
+        // batch-31c (N3 Fix 1, spec batch31-nomatch-illegalop §1.5): enum-as-int at enum
+        // params of ANY refness — a PSF'd UNTYPED slot (int locals are not in the typed-
+        // locals map) feeding an enum param takes the same E(x) wrap the by-value int path
+        // below applies. `const E&in` accepts the temporary; a Fix-2-typed `E&out` slot
+        // arrives with ty=Some so this gate never fires for it (arg gate identical to
+        // cast_container_args, structure.rs batch-25e). Damage.as SendGameplayEvent ×4 /
+        // CreateRelativeMemoriesToCrime ×3.
+        if pt.token == 5 && arg.is_psf && arg.ty.is_none() {
+            let base = pt.base_name(refs);
+            if is_enum_name(&base) {
+                return format!("{base}({})", arg.s);
+            }
+        }
         // a KNOWN-enum arg feeding an INT-family param needs the explicit int(...) cast
         // (AngelScript has no implicit enum->int): `SetLevel(int)` fed an ERelationship
         // fails "Can't implicitly convert from 'ERelationship' to 'int'" (~150 in-game).
@@ -1288,7 +1301,7 @@ fn provably_derived(dst: &str, src: &str, refs: &RefResolver) -> bool {
 
 /// True if `tyname` is a UE enum type (`E<Upper>...`) — same shape `cast_to_typename` keys on.
 /// Tolerates a leading `const ` (a const-qualified enum is still an enum for cast purposes).
-fn is_enum_name(tyname: &str) -> bool {
+pub(crate) fn is_enum_name(tyname: &str) -> bool {
     let b = tyname.trim_start_matches("const ").as_bytes();
     b.len() >= 2 && b[0] == b'E' && b[1].is_ascii_uppercase()
 }
@@ -1908,6 +1921,11 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 set_consts.insert(w(ins, 0), ConstBits::W4(bits));
                 let rhs = if ctx.float_slots.contains(&w(ins, 0)) {
                     fmt_float(ConstBits::W4(bits), false)
+                } else if ctx.slot_type(w(ins, 0)).as_deref().is_some_and(is_enum_name) {
+                    // batch-31c (N3 Fix 2): an ENUM-typed slot (out-param slot typing)
+                    // written a raw ordinal needs the explicit conversion — AS has no
+                    // implicit int->enum (`EInventoryTypes local_7 = 0;` fails).
+                    format!("{}({})", ctx.slot_type(w(ins, 0)).unwrap(), bits as i32)
                 } else {
                     (bits as i32).to_string()
                 };
@@ -1938,6 +1956,14 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     // batch-30c: float64 -> float32 slot copy warns too; float32(x) is the
                     // batch-28 in-game-proven explicit-narrowing syntax.
                     format!("float32({})", name(src))
+                } else if ctx.slot_type(dst).as_deref().is_some_and(is_enum_name)
+                    && ctx.slot_type(src).is_none()
+                    && looks_int(&name(src))
+                {
+                    // batch-31c (N3 Fix 2): ENUM-typed dst (out-param slot typing) written
+                    // from an int slot — mirror of the bool wrap above (no implicit
+                    // int->enum in AS): `local_7 = EInventoryTypes(local_8);`.
+                    format!("{}({})", ctx.slot_type(dst).unwrap(), name(src))
                 } else {
                     name(src)
                 };

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -218,6 +218,47 @@ fn assign_lhs(v: &str) -> Option<&str> {
     None
 }
 
+/// batch-37 (Idiom S, ctor-member-init.md §4.1): true iff `arg` is a clean ASSIGNABLE member/
+/// local lvalue — a `this.<field>` (or deeper `this.a.b`) member path, or a bare `local_N` slot.
+/// Used to gate the ctor value-type member-default-init recovery: the `$beh0` copy/value-init
+/// behaviour whose receiver is such an lvalue is `this.<field> = <value>;`, not a temp construct.
+/// FALSE for: bare `this` (that is the whole-object copyctor stub, which must stay authoritative),
+/// the hidden `__return` RVO slot (handled by the `$beh0(__return, src)` return arm above), a PSF
+/// address, and any `$`/`~`/`\u{2}`/UNRESOLVED behaviour/sentinel marker. Same "plain lhs"
+/// character rule as `assign_lhs` (identifiers, `_`, `.`), so no expression/literal can slip in.
+fn is_lvalue_arg(arg: &Arg) -> bool {
+    if arg.is_psf {
+        return false;
+    }
+    let s = arg.s.as_str();
+    // reject sentinels / behaviour markers / empties outright.
+    if s.is_empty()
+        || s == UNRESOLVED
+        || s.starts_with('$')
+        || s.starts_with('~')
+        || s.contains('\u{2}')
+        || s.contains('\u{1}')
+    {
+        return false;
+    }
+    // bare `this` = whole-object copyctor (no source form); `__return` = RVO slot (own arm).
+    if s == "this" || s == "__return" {
+        return false;
+    }
+    // plain member/local path: identifier chars + `.` only, and the HEAD must be an assignable
+    // root (`this`, a `local_` slot, or a plain identifier param) — never a call/index/literal.
+    if !s.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_' || c == b'.') {
+        return false;
+    }
+    let head = s.split('.').next().unwrap_or(s);
+    (s.starts_with("this.")) || head.starts_with("local_") || {
+        // a bare param/slot name (`Foo`, `local_3`) with no `.` is assignable; a bare `this`
+        // was already rejected. A dotted head that is a plain identifier (a param.member) is
+        // also assignable. Require the head be a valid identifier start (not a digit).
+        head.bytes().next().is_some_and(|b| b.is_ascii_alphabetic() || b == b'_')
+    }
+}
+
 /// Decompile a function to a self-contained `function(...) { ... }` (readable, not recompilable).
 pub fn decompile(f: &FuncCode, refs: &RefResolver) -> String {
     let params: Vec<String> = f
@@ -2402,8 +2443,59 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                             }
                             continue;
                         }
+                        // batch-37 (Idiom S, ctor-member-init.md §2/§4.1): value-type FIELD
+                        // default-init. `PGA/CALL <const> ; PshVPtr this ; ADDSi this.<field> ;
+                        // CALLSYS $beh0` is the ctor-path 1-arg value copy/init behaviour whose
+                        // receiver is a `this.<field>` member LVALUE (not PSF -> the construct arm
+                        // above skipped it; not `__return` -> the return arm above skipped it). The
+                        // A/B control proves the render path exists: the RUNTIME `FString::opAssign`
+                        // (a DIFFERENT ptr, name `opAssign` not `$beh0`) renders the identical shape
+                        // via build_call's method arm, but this ctor-init `$beh0` was dropped by the
+                        // generic `$`-behaviour guard -> the store vanished (Armor ctors decompiled
+                        // to an EMPTY body; corpus-wide 0 `this.X = "..."` stores). Recover it as
+                        // `this.<field> = <value>;` so the member default FLOWS. Census (cache_A):
+                        // 1867 member-store sites across FString/FName/FGameplayTag/FVector/
+                        // TSoftObjectPtr/FRotator/FKey — every clean rhs a literal/enum/global.
+                        //
+                        // SAFETY (spec top risk): a WRONG rhs (mis-resolved const / dropped &inout
+                        // cast) is WORSE than a dropped one. Fire ONLY on a 1-value-param behaviour
+                        // whose receiver `is_lvalue_arg` (this.<field>/local_N; NOT bare `this`,
+                        // NOT __return, NOT PSF/sentinel) AND whose rhs is a cleanly-resolved value
+                        // (not empty/UNRESOLVED/$/~/\u{2}, not PSF). Any failure BAILS to the
+                        // status-quo drop (fall through to the generic `$`-guard). The rhs is cast
+                        // to the param type via the SAME `cast_arg` path as the method arm, so a
+                        // definite value-type head mismatch force-drops via the `\u{2}` sentinel.
+                        if is_lvalue_arg(&recv)
+                            && ctx.refs.func_params_by_ptr(ptr).map(|p| p.len()) == Some(1)
+                            && stack.len() >= 2
+                        {
+                            let rhs = stack[stack.len() - 2].clone();
+                            let rhs_ok = !rhs.is_psf
+                                && !rhs.s.is_empty()
+                                && rhs.s != UNRESOLVED
+                                && !rhs.s.starts_with('$')
+                                && !rhs.s.starts_with('~')
+                                && !rhs.s.contains('\u{2}')
+                                && !rhs.s.contains('\u{1}');
+                            if rhs_ok {
+                                // cast the rhs to the init param type exactly like the method
+                                // operator arm — an FName/enum/soft-object default takes its proper
+                                // literal form; a definite value-type mismatch yields the `\u{2}`
+                                // sentinel, which the guard below turns into a status-quo drop.
+                                let r = ctx.refs.func_params_by_ptr(ptr).and_then(|p| p.first())
+                                    .map(|pt| cast_arg(&rhs, pt, ctx.refs))
+                                    .unwrap_or_else(|| rhs.s.clone());
+                                if !r.contains('\u{2}') && !r.contains('\u{1}') {
+                                    stack.truncate(stack.len() - 2); // consume recv + rhs
+                                    flush!();
+                                    out.push(format!("{} = {};", recv.s, r));
+                                    continue;
+                                }
+                            }
+                        }
                     }
-                    // not a recoverable in-place construct -> fall through to the generic `$` drop.
+                    // not a recoverable in-place construct / member-init -> fall through to the
+                    // generic `$` drop (operands cleared by build_call; status-quo behaviour).
                 }
                 pending = if f == "StaticClass" {
                     // Fix b1 — do NOT clear the stack; StaticClass takes 0 operands and the entries

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1422,6 +1422,17 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         .type_by_id(tid)
                         .and_then(|cls| ctx.refs.field_type_by_class(cls, &field))
                         .map(|s| s.to_string())
+                })
+                // batch-25e (E): composed CONTAINER types of KNOWN native-class fields — the
+                // receiver's `TMap<K, V>` must reach cast_container_args or the int keys of
+                // Add/FindOrAdd/Find on e.g. `m_CustomCollisionResponse` never get their enum
+                // wrap (native owners store no field value type in the script cache).
+                // Table-driven (refs::known_native_field_subtype), capture-candidate-verified.
+                .or_else(|| {
+                    ctx.refs
+                        .type_by_id(tid)
+                        .and_then(|cls| ctx.refs.known_native_field_subtype(cls, &field))
+                        .map(|s| s.to_string())
                 });
                 // batch-25a (G2): when the normal chain can't type the field (NATIVE struct
                 // owner), consult the in-crate native-field table — carried in the SEPARATE

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -404,6 +404,18 @@ impl Ctx<'_> {
             && !self.ret_ty.map(|t| is_enum_name(&t.base_name(self.refs))).unwrap_or(true)
     }
 
+    /// True when the function returns a value BY REFERENCE (`T& f()`): the return payload is a
+    /// live lvalue (a member-container element like `this.RoleGroups[i]`), not an RVO struct
+    /// copy or a register scalar. batch-35a: a ref-returning function whose RET row is a shared
+    /// bare `RET wN` fed by an opIndex/member chain built in EACH predecessor block loses that
+    /// chain at the block boundary (block_stmts flushes a live pending as a bare statement, and
+    /// the bare-RET scan-back then defaults to a garbage int slot -> "Not a valid reference").
+    /// Used to opt those predecessor blocks into rendering their trailing ref-pending as
+    /// `return <chain>;` (the cross-block reference carry).
+    fn ret_is_ref(&self) -> bool {
+        self.ret_ty.map(|t| t.token != 0x52 && t.is_reference).unwrap_or(false)
+    }
+
     /// Name for parameter slot `idx`: the stored name, else `arg{idx}` — which MUST match
     /// how `emit::render_params` declares unnamed params (also `arg{idx}`), so a body
     /// reference resolves to a declared parameter.
@@ -1494,7 +1506,7 @@ fn esc(s: &str) -> String {
 /// Decompile one block's instruction range into statements; also return the
 /// pending comparison (operands of the last CMP*) for condition recovery.
 fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
-    let (out, cmp, _) = block_stmts_in(ctx, lo, hi, Vec::new());
+    let (out, cmp, _) = block_stmts_in(ctx, lo, hi, Vec::new(), false);
     (out, cmp)
 }
 
@@ -1502,7 +1514,14 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
 /// the return (batch-27 Cast-diamond carry): the carried entries occupy the DEEPEST positions,
 /// below everything the block pushes — exactly the runtime layout — and the leftover is
 /// returned verbatim after the final flush (the UNRESOLVED retain applies to statements only).
-fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<String>, Option<Cmp>, Vec<Arg>) {
+///
+/// batch-35a (cross-block reference carry): when `ret_ref_tail` is set (this block flows to a
+/// ref-returning function's shared bare `RET` row and ends with a live by-reference pending),
+/// the FINAL flush renders that pending as `return <chain>;` instead of a discarded bare
+/// statement — the reference lvalue survives the block boundary the RET-row scan-back cannot
+/// cross. Only the by-reference pending (`pending_is_ref`) qualifies; any other trailing
+/// pending flushes as a bare statement exactly as before.
+fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail: bool) -> (Vec<String>, Option<Cmp>, Vec<Arg>) {
     let mut out = Vec::new();
     let mut cmp: Option<Cmp> = None;
     let mut cond: Option<(String, bool)> = None; // (bool value tested by a jump, is-bool-typed)
@@ -2879,6 +2898,21 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
             }
         }
     }
+    // batch-35a (cross-block reference carry): this block flows to a ref-returning function's
+    // shared bare RET row and its trailing pending is a live by-reference lvalue chain
+    // (`this.RoleCategoryContainers.opIndex(...).RoleGroups.opIndex(...)` -> FCombatRoleGroup&).
+    // Render it as the return value the RET row cannot recover by scan-back (the reference is
+    // not a slot). Gated to a genuine ref pending that carries no sentinel/unresolved marker
+    // (those must never become a return) — everything else flushes as a bare statement below.
+    if ret_ref_tail
+        && pending_is_ref
+        && pending
+            .as_deref()
+            .is_some_and(|p| !p.contains('\u{2}') && !p.contains(UNRESOLVED))
+    {
+        let chain = pending.take().unwrap();
+        out.push(format!("return {chain};"));
+    }
     flush!();
     out.retain(|s| !s.contains(UNRESOLVED)); // drop statements with an unresolved value
     // no binary comparison but a bool value was tested -> use it as the branch condition so
@@ -3031,7 +3065,7 @@ impl Structurer<'_> {
                 let _ = writeln!(out, "{ind}}}");
                 next = latch + 1;
             } else if self.is_cond(i) {
-                let (stmts, cmp, leftover) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init);
+                let (stmts, cmp, leftover) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init, false);
                 for s in &stmts {
                     let _ = writeln!(out, "{ind}{s}");
                 }
@@ -3076,9 +3110,17 @@ impl Structurer<'_> {
                         self.carry = Some((j, leftover));
                     }
                 }
+            } else if self.suppress_ref_ret_row(i) {
+                // batch-35a: the shared bare `RET wN` row of a ref-returning function whose
+                // EVERY predecessor block already rendered its own `return <chain>;` (the
+                // cross-block reference carry). Its scan-back value is a garbage int slot
+                // ("Not a valid reference"); emit nothing (both arms returned) rather than a
+                // wrong `return local_1;`. Same shape as the switch RET-row dead-code skip.
+                next = i + 1;
             } else {
                 // (linear fallthrough-carry is out of scope — the plain arm's leftover is dropped.)
-                let (stmts, _, _) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init);
+                let ret_ref_tail = self.ctx.ret_is_ref() && self.flows_to_bare_ret(i);
+                let (stmts, _, _) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init, ret_ref_tail);
                 for s in &stmts {
                     let _ = writeln!(out, "{ind}{s}");
                 }
@@ -3115,7 +3157,7 @@ impl Structurer<'_> {
                 Some(j) if bi <= j => std::mem::take(&mut carry),
                 _ => Vec::new(),
             };
-            let (stmts, cmp, leftover) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init);
+            let (stmts, cmp, leftover) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init, false);
             for s in &stmts {
                 let _ = writeln!(out, "{ind}{s}");
             }
@@ -3171,6 +3213,77 @@ impl Structurer<'_> {
             let b = &self.g.blocks[bi];
             b.instr_hi - b.instr_lo == 1 && self.ctx.instrs[b.instr_lo].op.name == "RET"
         })
+    }
+
+    /// batch-35a (cross-block reference carry): block `bi` reaches the function's shared bare
+    /// `RET` row via its SOLE successor — either an unconditional `JMP` to it, or a fallthrough
+    /// into it (a block ending in a value-producing call, e.g. the trailing opIndex chain of a
+    /// ref-returning `FindRoleGroup` predecessor). Requires exactly one successor (no
+    /// conditional fork) and that the block does NOT already end in `RET` (the RET arm handles
+    /// its own block). Used only when `ctx.ret_is_ref()`; the block's trailing by-reference
+    /// pending then renders as `return <chain>;` (see `block_stmts_in`'s `ret_ref_tail`).
+    fn flows_to_bare_ret(&self, bi: usize) -> bool {
+        let b = &self.g.blocks[bi];
+        if self.ctx.instrs[b.instr_hi - 1].op.name == "RET" {
+            return false;
+        }
+        b.succs.len() == 1 && self.is_bare_ret_off(b.succs[0]) && self.block_tail_is_ref_call(bi)
+    }
+
+    /// batch-35a: the block's last value-producing instruction is a call whose cache return
+    /// DataType `is_reference` — i.e. the block ends by leaving a by-reference lvalue in the
+    /// register (`... .RoleGroups.opIndex(i)` -> FCombatRoleGroup&), the exact producer the
+    /// reference carry turns into `return <chain>;`. Trailing pure housekeeping (JMP, PopPtr,
+    /// FreeNullV8, ...) is skipped. A block NOT ending in a ref-returning call (a value store,
+    /// a void call, a bare fallthrough) fails — so a legitimate register-value return through
+    /// the shared bare RET row is never suppressed. Bails (false) on any non-call tail.
+    fn block_tail_is_ref_call(&self, bi: usize) -> bool {
+        let b = &self.g.blocks[bi];
+        for j in (b.instr_lo..b.instr_hi).rev() {
+            let ins = &self.ctx.instrs[j];
+            match ins.op.name {
+                // pure control/stack housekeeping that can trail a value-producing call
+                "JMP" | "PopPtr" | "PshRPtr" | "SwapPtr" | "ClrHi" | "ClrVPtr" | "FreeNullV8"
+                | "FREE" | "CHKREF" | "ChkRefS" | "ChkNullV" | "ChkNullS" | "SUSPEND"
+                | "SaveReturnValue" | "ResolveObjectPtr" => continue,
+                "CALLSYS" | "Thiscall1" => {
+                    let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+                    return self.ctx.refs.func_ret_by_ptr(ptr).map(|d| d.is_reference).unwrap_or(false);
+                }
+                "CALL" | "CALLINTF" | "CALLBND" => {
+                    let id = ins.dwords.first().copied().unwrap_or(0) as i32;
+                    return self.ctx.refs.func_ret_by_id(id).map(|d| d.is_reference).unwrap_or(false);
+                }
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    /// batch-35a: block `bi` is the shared bare `RET` row of a ref-returning function whose
+    /// EVERY predecessor is a `flows_to_bare_ret` block — i.e. each predecessor renders its own
+    /// `return <chain>;` via the reference carry, so this row's own `return <scan-back>;` (a
+    /// garbage int slot -> "Not a valid reference") is dead. Emit nothing. Gated hard: at least
+    /// one predecessor must exist, the function must return by reference, and NO predecessor may
+    /// be a normal fall-in that DIDN'T get the carry (that would drop a legitimate return).
+    fn suppress_ref_ret_row(&self, bi: usize) -> bool {
+        if !self.ctx.ret_is_ref() {
+            return false;
+        }
+        let off = self.g.blocks[bi].start_dw;
+        if !self.is_bare_ret_off(off) {
+            return false;
+        }
+        let mut preds = 0usize;
+        for (pi, pb) in self.g.blocks.iter().enumerate() {
+            if pb.succs.contains(&off) {
+                preds += 1;
+                if !self.flows_to_bare_ret(pi) {
+                    return false;
+                }
+            }
+        }
+        preds > 0
     }
 
     /// Detect and emit the Hazelight compiler's `switch` lowering rooted at block `i`
@@ -3768,8 +3881,8 @@ impl Structurer<'_> {
         // the arm's actual emission (done with an empty init) is unchanged.
         for arm in std::iter::once(i + 1).chain(else_idx) {
             let ab = &blocks[arm];
-            let (s0, _, r0) = block_stmts_in(ctx, ab.instr_lo, ab.instr_hi, Vec::new());
-            let (s1, _, r1) = block_stmts_in(ctx, ab.instr_lo, ab.instr_hi, l.to_vec());
+            let (s0, _, r0) = block_stmts_in(ctx, ab.instr_lo, ab.instr_hi, Vec::new(), false);
+            let (s1, _, r1) = block_stmts_in(ctx, ab.instr_lo, ab.instr_hi, l.to_vec(), false);
             if !r0.is_empty() || s1 != s0 || r1.as_slice() != l {
                 return None;
             }
@@ -3833,8 +3946,8 @@ impl Structurer<'_> {
         // RESOLVE a sentinel the empty-init run HAS (a previously-missing arg recovered by
         // the carry) — that direction stays legal; only a NEW sentinel bails.
         let has_amm = |v: &[String]| v.iter().any(|s| s.contains('\u{2}'));
-        let (j0, _, _) = block_stmts_in(ctx, jb.instr_lo, jb.instr_hi, Vec::new());
-        let (j1, _, _) = block_stmts_in(ctx, jb.instr_lo, jb.instr_hi, l.to_vec());
+        let (j0, _, _) = block_stmts_in(ctx, jb.instr_lo, jb.instr_hi, Vec::new(), false);
+        let (j1, _, _) = block_stmts_in(ctx, jb.instr_lo, jb.instr_hi, l.to_vec(), false);
         if j1.len() != j0.len() || (has_amm(&j1) && !has_amm(&j0)) {
             return None;
         }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1010,7 +1010,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 // field type — so prefer the map and only fall back to member_type.
                 ref_reg_ty = ctx.fields.and_then(|m| m.get(&field)).cloned()
                     .or_else(|| ctx.refs.member_type(tid, off).map(|s| s.to_string()));
-                ref_reg = Some(format!("this.{field}"));
+                // LoadThisR loads from slot 0. In a METHOD that is `this`; in a FREE (mixin)
+                // function slot 0 is parameter 0, so hardcoding `this.` emits an undeclared base
+                // -> "'field' is not a member of 'Unknown'". slot_name(0) renders both correctly.
+                ref_reg = Some(format!("{}.{field}", name(0)));
             }
             "LoadRObjR" | "LoadVObjR" => {
                 let obj = name(w(ins, 0));

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -578,6 +578,17 @@ fn arg_mismatch_count(a: &[Arg], params: &[DataType], refs: &RefResolver) -> usi
         if pt.token != 5 {
             continue; // primitive/enum param: int casts handle it, not a definite mismatch
         }
+        // mirror cast_arg: an int-origin arg feeding a token-5 param that is NOT an enum
+        // (the only int-castable token-5 target) can never match — this is the exact
+        // condition that produces amm("argint") at render time. Count it so
+        // maybe_reverse_args sees the evidence and can flip a reverse-pushed call. An int
+        // const carries `ty: None`, so without this it was invisible to the scorer.
+        if arg.is_int {
+            if cast_to_typename("0", &pt.base_name(refs)).is_none() {
+                n += 1;
+            }
+            continue;
+        }
         let Some(at) = &arg.ty else { continue };
         let (ph, ah) = (head(&pt.base_name(refs)), head(at));
         if is_value(&ph) && is_value(&ah) && ph != ah {
@@ -887,7 +898,19 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 let b = ins.qwords.first().copied().unwrap_or(0);
                 stack.push(Arg::iconst((b as i64).to_string(), ConstBits::W8(b)));
             }
-            "PshV4" | "PshV8" => stack.push(Arg::int(name(w(ins, 0)))),
+            "PshV4" | "PshV8" => {
+                // A bool slot pushed as an arg must render BARE (`WasCancelled`), not as
+                // `(WasCancelled != 0)` — AngelScript has no `bool != 0`. cast_arg wraps every
+                // is_int arg feeding a bool param, so a genuine bool slot has to carry its type
+                // (is_int=false) to pass through unwrapped. Only exactly-`bool` slots are typed;
+                // enum/int slots stay int so their enum/`!= 0` casts still fire.
+                let off = w(ins, 0);
+                if ctx.slot_type(off).as_deref() == Some("bool") {
+                    stack.push(Arg::typed(name(off), Some("bool".to_string())));
+                } else {
+                    stack.push(Arg::int(name(off)));
+                }
+            }
             "PshVPtr" => stack.push(Arg::typed(name(w(ins, 0)), ctx.slot_type(w(ins, 0)))),
             "PSF" => {
                 // &local, unless it's the destination of a following ALLOC

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1032,15 +1032,31 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             _ if n.starts_with("WRTV") => {
                 flush!();
                 if let Some(r) = &ref_reg {
-                    let rhs = name(w(ins, 0));
+                    let slot = w(ins, 0);
+                    let raw = name(slot);
                     // a constant slot stored into a float/double field carries IEEE-754 bits,
                     // not an int — decode it; else apply the bool/enum/incompatible cast.
-                    let rhs = match ref_reg_ty.as_deref() {
-                        Some("float32") => float_lit(&set_consts, w(ins, 0), false).unwrap_or(rhs),
-                        Some("float") | Some("double") => float_lit(&set_consts, w(ins, 0), true).unwrap_or(rhs),
-                        Some(t) if looks_int(&rhs) => field_assign_rhs(&rhs, t),
-                        _ => rhs,
+                    let mut rhs = match ref_reg_ty.as_deref() {
+                        Some("float32") => float_lit(&set_consts, slot, false).unwrap_or(raw.clone()),
+                        Some("float") | Some("double") => float_lit(&set_consts, slot, true).unwrap_or(raw.clone()),
+                        Some(t) if looks_int(&raw) => field_assign_rhs(&raw, t),
+                        _ => raw.clone(),
                     };
+                    // A 1-byte write (WRTV1) to a field whose type we could NOT resolve to bool
+                    // (a foreign nested member -> ref_reg_ty is the owner/None) is almost always a
+                    // bool UPROPERTY, whose auto-generated accessor is `bool&`: `field = intSlot`
+                    // fails "int -> bool&" (e.g. `m_CanAttack = local_1` where local_1 is a
+                    // decompiled const-`0` bool). Cast the RHS to bool. Guard: the RHS was NOT
+                    // already transformed above (a bare slot), is resolved, and is not a KNOWN
+                    // bool slot (which compiles bare and must not become the illegal `bool != 0`).
+                    if n == "WRTV1"
+                        && ref_reg_ty.as_deref() != Some("bool")
+                        && rhs == raw
+                        && rhs != UNRESOLVED
+                        && ctx.slot_type(slot).as_deref() != Some("bool")
+                    {
+                        rhs = format!("({rhs} != 0)");
+                    }
                     out.push(format!("{r} = {rhs};"));
                 }
             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2342,6 +2342,34 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                             }
                         }
                     }
+                    // batch-49a (FIX-3-ext, specs/final-residue.md §A.3a OnGracefulExitRequested):
+                    // a 1-byte member write (`SetV1 w1,1; LoadThisR bShouldExitState; WRTV1 w1`)
+                    // where BOTH type channels failed — `ref_reg_ty` resolved to the OWNER class
+                    // (`member_type`'s OldTypeId is the owner, e.g. `UCharacterAIState`) and
+                    // `ref_reg_vty` is None (the field is an INHERITED native bool not in the
+                    // this-class map) — so `field_assign_rhs` bailed to UNRESOLVED and the store
+                    // dropped: `this.bShouldExitState = true` was LOST before the
+                    // `StopWaitingAndContinueTask` call (a REAL exit-state write loss, 2 fns).
+                    // Rescue ONLY when the field name follows the engine-enforced UE bool
+                    // convention (`b` + ASCII-uppercase), so the field PROVABLY denotes a bool
+                    // UPROPERTY (UHT reserves the `b<Upper>` prefix for bools; a non-bool field
+                    // never carries it). Bail-safe: rewrites ONLY an already-DROPPED store
+                    // (rhs still UNRESOLVED), only for a 1-byte write (bool/int8/uint8 width),
+                    // only for an int-family source, and renders the same `(x != 0)` bool wrap the
+                    // heuristic below produces for owner-typed fields — so no working store changes.
+                    if rhs == UNRESOLVED
+                        && n == "WRTV1"
+                        && looks_int(&raw)
+                    {
+                        let field_name = r.rsplit('.').next().unwrap_or("");
+                        let fb = field_name.as_bytes();
+                        let is_ue_bool = fb.len() >= 2
+                            && fb[0] == b'b'
+                            && fb[1].is_ascii_uppercase();
+                        if is_ue_bool {
+                            rhs = format!("({raw} != 0)");
+                        }
+                    }
                     // batch-25a (G2, specs/batch23-cantconvert.md): a 1-byte write to a NATIVE
                     // struct's field whose value type the in-crate native-field table resolves
                     // to an ENUM is the enum ORDINAL store (`SetV1 w80, 0x2 ... WRTV1 w80`), not

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -623,7 +623,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
                     // GetActorLocation()` instead of `out = recv.Iterator()` -> "No matching
                     // signatures". `this`-receivers render `this.Method()` (legal, matches the
                     // normal method-render path below).
-                    return Some(format!("{out} = {}.{f}({})", wrap_uobject_recv(&recv, target_owner), render_args(&a, params, refs)));
+                    return Some(format!("{out} = {}.{f}({})", wrap_uobject_recv(&recv, target_owner, refs), render_args(&a, params, refs)));
                 }
             }
         }
@@ -688,7 +688,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         }
         maybe_reverse_args(&mut a, params, refs);
         cast_container_args(f, recv.ty.as_deref(), &mut a);
-        Some(format!("{}.{f}({})", wrap_uobject_recv(&recv, target_owner), render_args(&a, params, refs)))
+        Some(format!("{}.{f}({})", wrap_uobject_recv(&recv, target_owner, refs), render_args(&a, params, refs)))
     } else {
         if refs.is_type_name(f) {
             // EDIT C: a value-type factory call (FName/E*/T* — NOT U*/A*, which use ALLOC) whose
@@ -791,19 +791,53 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
 /// is chosen over retyping the DECLARATION (option (a)) because the slot is also written from
 /// producers (`RefCpyV` handle copies, generic getters) whose types we cannot prove compatible
 /// with the owner — a retyped declaration could break those assignments (upcast-breaking),
-/// while a local `Cast<>` can only affect the one call that is already broken. Gates: the
-/// recovered receiver type is EXACTLY `UObject` (never a subclass, never unknown), the owner
-/// is a real object class (U*/A*, excludes container/value owners like `TArray`), and the
-/// owner isn't `UObject` itself (genuine UObject methods resolve fine).
-fn wrap_uobject_recv(recv: &Arg, owner: Option<&str>) -> String {
-    if recv.ty.as_deref() == Some("UObject") && recv.s != "this" {
-        if let Some(o) = owner {
-            if o != "UObject" && matches!(o.bytes().next(), Some(b'U') | Some(b'A')) {
-                return format!("Cast<{o}>({})", recv.s);
-            }
+/// while a local `Cast<>` can only affect the one call that is already broken.
+///
+/// batch-25d (specs/batch23-nomatch.md D): the original gate `recv.ty == "UObject"` EXACTLY
+/// was too narrow — the same disease presents on the other engine BASE types the cache
+/// records for iterator/temp producers (`AActor local_28; local_28.GetCharacterState();`,
+/// 26 in-game errors: GetCharacterState x12, GetInventory x3, GetAvatar x3, GetAI x2, ...).
+/// The receiver gate is widened to a short EXPLICIT base-class list (never arbitrary types),
+/// with a matching skip for calls the receiver ALREADY satisfies: the owner being the
+/// receiver type itself, one of its known ENGINE ancestors (methods genuinely on AActor must
+/// not wrap an ACharacter receiver — the spec's `owner != AActor` caution, generalized), or
+/// a script-hierarchy-proven ancestor. Owner must still be a real object class (U*/A*).
+fn wrap_uobject_recv(recv: &Arg, owner: Option<&str>, refs: &RefResolver) -> String {
+    /// The explicit base-receiver list (spec batch23-nomatch.md §4) — do NOT widen to
+    /// arbitrary recovered types.
+    const BASE_RECV: &[&str] = &[
+        "UObject",
+        "AActor",
+        "APawn",
+        "ACharacter",
+        "UActorComponent",
+        "UAbilitySystemComponent",
+    ];
+    /// Known ENGINE ancestors of each listed base (UObject < AActor < APawn < ACharacter;
+    /// UObject < UActorComponent < UAbilitySystemComponent).
+    fn engine_ancestors(t: &str) -> &'static [&'static str] {
+        match t {
+            "AActor" => &["UObject"],
+            "APawn" => &["AActor", "UObject"],
+            "ACharacter" => &["APawn", "AActor", "UObject"],
+            "UActorComponent" => &["UObject"],
+            "UAbilitySystemComponent" => &["UActorComponent", "UObject"],
+            _ => &[],
         }
     }
-    recv.s.clone()
+    let Some(rt) = recv.ty.as_deref() else { return recv.s.clone() };
+    if recv.s == "this" || !BASE_RECV.contains(&rt) {
+        return recv.s.clone();
+    }
+    let Some(o) = owner else { return recv.s.clone() };
+    if o == rt
+        || !matches!(o.bytes().next(), Some(b'U') | Some(b'A'))
+        || engine_ancestors(rt).contains(&o)
+        || refs.is_subclass(rt, o)
+    {
+        return recv.s.clone();
+    }
+    format!("Cast<{o}>({})", recv.s)
 }
 
 /// Count DEFINITE type mismatches when pairing args[i] with params[i] (mirrors `cast_arg`'s

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3627,6 +3627,31 @@ impl Structurer<'_> {
                 self.loop_scope = saved;
                 let _ = writeln!(out, "{ind}}}");
                 next = latch + 1;
+            } else if let Some((test_idx, cond, body_head, break_off)) =
+                self.test_first_foreach(i, stop)
+            {
+                // batch-44b (E2): a TEST-FIRST foreach. Block `i` is a bare `JMP →test` that enters
+                // the loop AT the CanProceed test (guarding the first iteration). The iterator
+                // SETUP (`PSF wIt; CALLSYS Iterator`) lives in block `i` before the JMP — emit it
+                // ONCE, before the loop (loop-invariant construction). Then render the top-test
+                // `while (it.CanProceed) { body }` where body = [body_head, test_idx) (the test
+                // block IS the condition, re-lowered by the compiler to the same entry-JMP form) —
+                // never the bottom-test `while (uninit_slot != 0)` the status-quo `loop_latch` arm
+                // would emit. `continue_off` = test block start (a `continue;` re-tests);
+                // `break_off` = the test's forward exit. Gate 2 already proved (in the detector)
+                // that the body fully structures under this scope; on ANY deviation the detector
+                // returned None and this arm never fired (the status-quo bottom-test stands).
+                self.emit_linear(i, i + 1, depth, out, true);
+                let _ = writeln!(out, "{ind}while ({cond})");
+                let _ = writeln!(out, "{ind}{{");
+                let test_off = self.g.blocks[test_idx].start_dw;
+                let ls = LoopScope { continue_off: test_off, break_off };
+                let saved = self.loop_scope;
+                self.loop_scope = Some(ls);
+                self.emit_range(body_head, test_idx, depth + 1, out);
+                self.loop_scope = saved;
+                let _ = writeln!(out, "{ind}}}");
+                next = test_idx + 1;
             } else if let Some(latch) = self.loop_latch(i, stop) {
                 let lcmp = block_stmts(self.ctx, self.g.blocks[latch].instr_lo, self.g.blocks[latch].instr_hi).1;
                 let cond = branch_cond(&lcmp, self.jump_op(latch));
@@ -4981,6 +5006,101 @@ impl Structurer<'_> {
         let cmp = block_stmts(self.ctx, b.instr_lo, b.instr_hi).1;
         let cond = negate(&branch_cond(&cmp, self.jump_op(i)));
         Some((taken_idx, cond))
+    }
+
+    /// batch-44b (E2, specs/loop-body-cfg-ext.md §2.2): the `it.CanProceed` top-test condition of
+    /// a test-first foreach whose latch/test block is `test_idx`. The iterator test lowers as
+    /// `LoadVObjR wIt, ?, <CanProceed-off>; RDR1 wS; CpyVtoR1 wS; JLowNZ/JLowZ →body`. Render the
+    /// condition DIRECTLY from the member load (`local_It.CanProceed`) instead of the
+    /// bottom-test's uninitialized slot read (`local_S != 0`), oriented so the loop CONTINUES on
+    /// the back-edge sense. Returns None on ANY deviation from the exact iterator idiom (bail-safe:
+    /// the caller then keeps the current bottom-test emission).
+    fn foreach_test_cond(&self, test_idx: usize) -> Option<String> {
+        let b = &self.g.blocks[test_idx];
+        let jop = self.jump_op(test_idx);
+        // the test terminator must be the conditional back-edge itself
+        if !matches!(jop, "JLowNZ" | "JLowZ") || !self.is_backward_cond(test_idx) {
+            return None;
+        }
+        // find the member load feeding the test register: LoadVObjR wIt, ?, off -> a `CanProceed`
+        // field on the iterator. Require the field name to be exactly `CanProceed` — the iterator
+        // termination predicate — so no other member-tested loop can match.
+        let mut recv_field: Option<String> = None;
+        for j in b.instr_lo..b.instr_hi {
+            let ins = &self.ctx.instrs[j];
+            if ins.op.name == "LoadVObjR" {
+                let obj = self.ctx.slot_name(ins.words.first().copied().map(s16).unwrap_or(0));
+                let off = ins.words.get(1).copied().unwrap_or(0) as i32;
+                let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
+                if let Some(field) = self.ctx.refs.member(tid, off) {
+                    if field == "CanProceed" {
+                        recv_field = Some(format!("{obj}.{field}"));
+                    }
+                }
+            }
+        }
+        let expr = recv_field?;
+        // back-edge (loop body) is taken when the iterator can proceed. JLowNZ → body when the
+        // test is non-zero (true): loop continues while `expr`. JLowZ → body when zero (a NOT'd
+        // form): loop continues while `!expr`.
+        Some(match jop {
+            "JLowNZ" => expr,
+            _ => format!("!({expr})"),
+        })
+    }
+
+    /// batch-44b (E2, specs/loop-body-cfg-ext.md §2.2): detect a TEST-FIRST `foreach` whose ENTRY
+    /// block `e` is a bare `JMP →T` into the CanProceed test block `T` (the loop is entered at the
+    /// test, guarding the first iteration). The loop IS already detected by `loop_latch` (firing at
+    /// `e+1`, latch=`T`), but the current emission renders it as a BOTTOM-test `while (slot != 0)`
+    /// reading an uninitialized test slot — an invalid `.as` that collapses. When this exact
+    /// signature holds, the caller renders the correct top-test `while (it.CanProceed) { body }`.
+    ///
+    /// Signature (ALL required; any deviation ⇒ None ⇒ status-quo bottom-test):
+    ///   1. block `e` ends in a bare `JMP →jt` with a SINGLE successor (no fall-through);
+    ///   2. `T = idx_of[jt]`, `e < T < stop`, and `T` is the CanProceed test block
+    ///      (`is_backward_cond`, terminator `JLowNZ`/`JLowZ`, `foreach_test_cond` recognizes it);
+    ///   3. `T`'s back-edge target is exactly `blocks[e+1].start_dw` — the body head is `e+1`;
+    ///   4. the body `[e+1, T)` is Gate-2 recoverable under `loop_scope = {continue: T, break:
+    ///      T's forward exit}`.
+    /// Returns `(test_idx, cond, body_head, break_off)`.
+    fn test_first_foreach(&mut self, e: usize, stop: usize) -> Option<(usize, String, usize, usize)> {
+        // 1. entry block `e` must be a bare single-successor JMP.
+        if self.jump_op(e) != "JMP" {
+            return None;
+        }
+        let eb = &self.g.blocks[e];
+        if eb.succs.len() != 1 {
+            return None;
+        }
+        let jt = eb.succs[0];
+        let test_idx = *self.idx_of.get(&jt)?;
+        if test_idx <= e || test_idx >= stop {
+            return None;
+        }
+        // 2. `T` is the CanProceed test with a recognized condition.
+        let cond = self.foreach_test_cond(test_idx)?;
+        // 3. `T`'s back-edge target is the body head = block e+1.
+        let tb = &self.g.blocks[test_idx];
+        let test_off = tb.start_dw;
+        let back = *tb.succs.iter().find(|&&s| s <= test_off)?;
+        let body_head = e + 1;
+        if body_head >= test_idx || self.g.blocks[body_head].start_dw != back {
+            return None;
+        }
+        // break_off = the test's forward (non-back-edge) successor (the loop exit).
+        let break_off = *tb.succs.iter().find(|&&s| s > test_off)?;
+        // 4. Gate 2 — the body must fully structure under the loop scope. (No Gate 1: a foreach
+        //    body is legitimately straight-line; Gate 2 alone proves every edge is recoverable.)
+        let ls = LoopScope { continue_off: test_off, break_off };
+        let saved = self.loop_scope;
+        self.loop_scope = Some(ls);
+        let ok = self.loop_body_recoverable(body_head, test_idx, ls);
+        self.loop_scope = saved;
+        if !ok {
+            return None;
+        }
+        Some((test_idx, cond, body_head, break_off))
     }
 
     fn is_backward_cond(&self, bi: usize) -> bool {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1162,6 +1162,18 @@ fn cast_arg(arg: &Arg, pt: &DataType, refs: &RefResolver) -> String {
         // bool param
         return format!("({} != 0)", arg.s);
     }
+    // batch-30c: an int-family SLOT feeding a SMALL-int parameter warns twice in-game
+    // ("signed to unsigned" + "truncates", warnings-as-errors) — the batch-28b small-int
+    // RETYPE residue (slots whose op profile failed its SetV-only gate, e.g. the
+    // SetMovementMode NewCustomMode args fed from reads). Explicit narrowing cast; a
+    // slot already retyped small renders a same-type no-op cast.
+    match pt.token {
+        0x45 => return format!("int8({})", arg.s),
+        0x46 => return format!("int16({})", arg.s),
+        0x4C => return format!("uint8({})", arg.s),
+        0x4D => return format!("uint16({})", arg.s),
+        _ => {}
+    }
     if pt.token == 5 {
         // object/enum identifier type: UE enums are `E<Upper>...`; cast int -> enum
         let base = pt.base_name(refs);
@@ -1299,6 +1311,18 @@ fn ty_family(t: &str) -> &str {
 /// implicit enum->int conversion, so an enum field-read / enum-returning call stored into an
 /// `int` local fails to compile. Only fires when the value is a known enum AND the dest is an
 /// int slot (so enum->enum and enum->enum-param copies stay bare).
+/// batch-30c: FLOAT-FAMILY-gated field VALUE type for a member load — cross-module script
+/// field maps first, then the in-crate native rows (FVector/FRotator components). Returns
+/// None for everything non-float so the callers' conservative fallbacks stay in charge
+/// (a broad precise-type flip would change bool/enum member renders that compile today).
+fn float_field_type(refs: &RefResolver, tid: i32, field: &str) -> Option<String> {
+    let cls = refs.type_by_id(tid)?;
+    refs.field_type_by_class(cls, field)
+        .or_else(|| refs.native_field_type(cls, field))
+        .filter(|t| matches!(*t, "float" | "float32" | "double"))
+        .map(|s| s.to_string())
+}
+
 fn enum_to_int(rhs: String, src_ty: Option<&str>, dst_is_int: bool) -> String {
     match src_ty {
         Some(t) if dst_is_int && is_enum_name(t) => format!("int({rhs})"),
@@ -1380,6 +1404,9 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
     let mut out = Vec::new();
     let mut cmp: Option<Cmp> = None;
     let mut cond: Option<(String, bool)> = None; // (bool value tested by a jump, is-bool-typed)
+    // batch-30c: true when a compare / register-load executed AFTER the newest call —
+    // order gate for the stale-cmp-vs-live-bool-pending decision at conditional jumps.
+    let mut test_after_call = true;
     let mut stack: Vec<Arg> = init; // pushed pointer/value expressions
     let mut value_reg: Option<String> = None;
     let mut obj_reg: Option<String> = None;
@@ -1640,7 +1667,14 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 // The class field-type map holds the real field VALUE type; member_type()
                 // resolves PropertyReferences OldTypeId which is the OWNER class, not the
                 // field type — so prefer the map and only fall back to member_type.
+                // batch-30c: before that owner-name fallback, try the FLOAT-FAMILY-gated
+                // precise sources (cross-module script field maps + the in-crate native
+                // float rows) so a float64 member read into an int slot takes the RDR8
+                // int(...) wrap instead of the bare precision-warning render. Gated to
+                // float names only: a broad flip (e.g. foreign bool fields going bare
+                // where the unknowable int(...) wrap compiles today) would regress.
                 ref_reg_ty = ctx.fields.and_then(|m| m.get(&field)).cloned()
+                    .or_else(|| float_field_type(ctx.refs, tid, &field))
                     .or_else(|| ctx.refs.member_type(tid, off).map(|s| s.to_string()));
                 ref_reg_nfty = ctx.refs.type_by_id(tid)
                     .and_then(|cls| ctx.refs.native_field_type(cls, &field))
@@ -1656,7 +1690,11 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 let off = ins.words.get(1).copied().unwrap_or(0) as i32;
                 let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let field = ctx.refs.member(tid, off).map(|s| s.to_string()).unwrap_or_else(|| format!("field_0x{off:x}"));
-                ref_reg_ty = ctx.refs.member_type(tid, off).map(|s| s.to_string()); // foreign object field
+                // batch-30c: float-family-gated precise resolution first (see LoadThisR) —
+                // e.g. `local = Start.Z;` (FVector, double) into an int slot must know the
+                // source is float so the RDR8 wrap fires.
+                ref_reg_ty = float_field_type(ctx.refs, tid, &field)
+                    .or_else(|| ctx.refs.member_type(tid, off).map(|s| s.to_string())); // foreign object field
                 ref_reg_nfty = ctx.refs.type_by_id(tid)
                     .and_then(|cls| ctx.refs.native_field_type(cls, &field))
                     .filter(|t| is_enum_name(t))
@@ -1681,6 +1719,11 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     // bare; RDR8 stays bare (no UE enum is 8 bytes).
                     let unknowable = match pending_ty.as_deref() {
                         None => true,
+                        // batch-30c: a template-`?` return (iterator Proceed/opIndex element)
+                        // read into an int-declared slot takes the wrap too — int(x) is
+                        // neutral for real ints, and the float32-element reads were the
+                        // NormalizeWeights precision-warning residue.
+                        Some("?") => true,
                         Some(t) => {
                             let t = t.trim_start_matches("const ");
                             matches!(t.bytes().next(), Some(b'U') | Some(b'A') | Some(b'F') | Some(b'T'))
@@ -1691,7 +1734,10 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                         pending_ty.as_deref().map(|t| t.trim_start_matches("const ")),
                         Some("float" | "float32" | "double")
                     );
-                    let rhs = if dst_is_int && (unknowable || float_src) && n != "RDR8" {
+                    // batch-30c: RDR8 joins the wrap when the source is KNOWN float-family —
+                    // a float64 read into an int slot warns (module-killer); int64 reads
+                    // (the reason RDR8 was excluded) stay bare via !float_src.
+                    let rhs = if dst_is_int && (unknowable || float_src) && (n != "RDR8" || float_src) {
                         format!("int({p})")
                     } else {
                         enum_to_int(p, pending_ty.as_deref(), dst_is_int)
@@ -1732,7 +1778,10 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                         ref_reg_ty.as_deref().map(|t| t.trim_start_matches("const ")),
                         Some("float" | "float32" | "double")
                     );
-                    let rhs = if dst_is_int && (unknowable || float_src) && n != "RDR8" {
+                    // batch-30c: RDR8 joins the wrap for KNOWN float-family members (the
+                    // float64 member -> int slot precision-warning residue: foreign script
+                    // config floats, FVector.Z/FRotator.Yaw); int64 member reads stay bare.
+                    let rhs = if dst_is_int && (unknowable || float_src) && (n != "RDR8" || float_src) {
                         format!("int({r})")
                     } else {
                         enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int)
@@ -1836,6 +1885,20 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     && looks_int(&name(src))
                 {
                     format!("({} != 0)", name(src))
+                } else if ctx.slot_type(dst).is_none()
+                    && matches!(ctx.slot_type(src).as_deref(), Some("float" | "float32" | "double"))
+                {
+                    // batch-30c: a float-family-typed slot copied into an UNTYPED
+                    // (int-declared) slot is the batch-28 poison residue — the explicit
+                    // int(...) kills the precision warning (module-killer), mirroring the
+                    // member-RDR wraps; a genuinely-int destination truncates identically.
+                    format!("int({})", name(src))
+                } else if ctx.slot_type(dst).as_deref() == Some("float32")
+                    && matches!(ctx.slot_type(src).as_deref(), Some("float" | "double"))
+                {
+                    // batch-30c: float64 -> float32 slot copy warns too; float32(x) is the
+                    // batch-28 in-game-proven explicit-narrowing syntax.
+                    format!("float32({})", name(src))
                 } else {
                     name(src)
                 };
@@ -1889,9 +1952,11 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
             }
             // ---- comparisons ----
             "CMPi" | "CMPu" | "CMPf" | "CMPd" | "CMPi64" | "CMPu64" => {
+                test_after_call = true;
                 cmp = Some(Cmp { a: name(w(ins, 0)), b: name(w(ins, 1)), ..Default::default() });
             }
             "CMPIi" | "CMPIu" => {
+                test_after_call = true;
                 let c = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let s = w(ins, 0);
                 // an enum compared to an int literal needs explicit int(enum) — AngelScript has
@@ -1904,6 +1969,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
             // CMPIf's dword immediate is an IEEE-754 float payload, not an int — render it as
             // a float literal so e.g. `x < 1.0f` doesn't become `x < 1065353216`.
             "CMPIf" => {
+                test_after_call = true;
                 let bits = ins.dwords.first().copied().unwrap_or(0);
                 cmp = Some(Cmp {
                     a: name(w(ins, 0)),
@@ -1911,7 +1977,10 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     ..Default::default()
                 });
             }
-            "CmpPtrNull" => cmp = Some(Cmp { a: name(w(ins, 0)), b: "nullptr".into(), ..Default::default() }),
+            "CmpPtrNull" => {
+                test_after_call = true;
+                cmp = Some(Cmp { a: name(w(ins, 0)), b: "nullptr".into(), ..Default::default() });
+            }
             // a test op turns the CMP register into a bool; it carries the real relational
             // operator (the jump only carries the true/false sense).
             "TZ" => { if let Some(c) = &mut cmp { c.op = Some("=="); } }
@@ -1922,6 +1991,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
             "TNP" => { if let Some(c) = &mut cmp { c.op = Some("<="); } }
             // ---- calls ----
             "CALL" | "CALLINTF" | "CALLBND" => {
+                test_after_call = false;
                 // Fix b2 — FLUSH a pending statement-position call result before this call starts,
                 // so a chained statement call (e.g. MakeRequirement then Add) isn't silently
                 // overwritten. Drops sentinel/unresolved pendings (see flush_b2 doc).
@@ -1966,6 +2036,15 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     let owner = ctx.refs.func_owner_by_id(id);
                     let ret_is_ref = ctx.refs.func_ret_by_id(id).map(|d| d.is_reference).unwrap_or(false);
                     pending_is_ref = ret_is_ref; // batch-29a: RDR may consume this call's result
+                    // batch-30c: a ref-returning call clobbers the VM value register — the
+                    // same register member loads fill — so a stale member `ref_reg` can no
+                    // longer be what a later RDR reads (the 29a gate-rest: GetResult()
+                    // discarded + a stale member read consumed in its place).
+                    if ret_is_ref {
+                        ref_reg = None;
+                        ref_reg_ty = None;
+                        ref_reg_nfty = None;
+                    }
                     // batch-24b shadow gate: a free SCRIPT global (no owner, global namespace)
                     // rendered inside a class method is shadowed by any same-named member in
                     // the class's (native or script) ancestry. Member-name existence (T3
@@ -1982,6 +2061,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 };
             }
             "CALLSYS" | "Thiscall1" => {
+                test_after_call = false;
                 // Fix b2 — flush a pending statement-position call result before this call begins
                 // (e.g. MakeRequirement's result must be emitted before `Add(...)` overwrites it).
                 flush_b2!();
@@ -2133,6 +2213,13 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     // generated-accessor qualification see the owning class of CALLSYS methods.
                     let ret_is_ref = ctx.refs.func_ret_by_ptr(ptr).map(|d| d.is_reference).unwrap_or(false);
                     pending_is_ref = ret_is_ref; // batch-29a: RDR may consume this call's result
+                    // batch-30c: mirror of the by-id arm — a ref-returning native call
+                    // clobbers the value register; invalidate a stale member ref_reg.
+                    if ret_is_ref {
+                        ref_reg = None;
+                        ref_reg_ty = None;
+                        ref_reg_nfty = None;
+                    }
                     build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, ctx.refs.func_owner_by_ptr(ptr), ctx.class_name, false, pending_ty.as_deref(), ret_is_ref, false, ctx.refs)
                 };
             }
@@ -2183,6 +2270,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
             }
             "LOADOBJ" => obj_reg = Some(name(w(ins, 0))),
             "CpyVtoR4" | "CpyVtoR8" => {
+                test_after_call = true;
                 // batch-21 Class C shape 3: a pending VOID call has no value to copy — the
                 // register content comes from the SLOT operand (e.g. a bool& out-param the call
                 // just wrote: `CalculateDistanceToTarget(.., local_3); return local_3;`).
@@ -2218,6 +2306,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 }
             }
             "CpyVtoR1" => {
+                test_after_call = true;
                 // a bool moved into the test register: feeds either RET or a conditional jump.
                 // A call result is already bool-typed; a slot holds the bool as an int —
                 // EXCEPT a slot DECLARED bool (a `bool` param / bool-typed local), which must
@@ -2443,6 +2532,21 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     if let Some(p) = pending.take() {
                         cond = Some((p, pending_ty.as_deref() == Some("bool")));
                     }
+                } else if pending.is_some()
+                    && pending_ty.as_deref() == Some("bool")
+                    && !test_after_call
+                {
+                    // batch-30c (C9, the Conversation IsVisible family): a BOOL-returning
+                    // call issued AFTER the recovered comparison clobbered the value
+                    // register — the jump tests the call's result, not the stale compare
+                    // (`....IsValid();` discarded + `if (local_9 != 1)` testing a compare
+                    // from several statements earlier). Prefer the live bool pending —
+                    // but ONLY when no compare/register-load executed after the call
+                    // (`test_after_call`): a CmpPtrNull/CpyVtoR between the call and the
+                    // jump re-fills the register, and that test stays authoritative.
+                    let p = pending.take().unwrap();
+                    cond = Some((p, true));
+                    cmp = None;
                 }
             }
             // ---- pure VM housekeeping / flow: ignore ----

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1870,7 +1870,20 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                         .type_by_id(tid)
                         .and_then(|cls| ctx.refs.known_native_field_subtype(cls, &field))
                         .map(|s| s.to_string())
-                });
+                })
+                // batch-40 (specs/rgt-and-methods-triage.md PART 1): the FLOAT-FAMILY-gated
+                // precise field type for a NATIVE-struct member store — mirrors the LoadThisR/
+                // LoadRObjR Idiom-B path (line ~1915/1941). The stack-built Idiom-A member store
+                // (`PSF; ADDSi field; PopRPtr; WRTV4 <constSlot>`) never consulted native_field_type
+                // for float, so a `SetV4 w,0x437a0000` const feeding `FLightValues.SourceWidth`
+                // (float32) left `top.ty = None` -> `ref_reg_ty = None` -> the WRTV float_lit
+                // reinterpret didn't fire -> `SourceWidth = 1132068864` (int bits of 250.0f), which
+                // the AS compiler then iTOf-coerces to 1.13e9 (WideShot camera / SetupTransitions
+                // weights, ~140 fns). float_field_type only ever returns float/float32/double, so
+                // this is the PROVABLY-float gate the safety rule demands; every non-float field
+                // stays None and the int RHS is untouched. Absent binds (raw baseline) this
+                // resolves None too, so the stub gate is unaffected.
+                .or_else(|| float_field_type(ctx.refs, tid, &field));
                 // batch-25a (G2): when the normal chain can't type the field (NATIVE struct
                 // owner), consult the in-crate native-field table — carried in the SEPARATE
                 // nfty channel so only the WRTV1 guard sees it (never the call-arg gates).

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2361,6 +2361,44 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     let dst_is_int = dst_slot > 0 && ctx.slot_type(dst_slot).is_none();
                     let rhs = enum_to_int(p, pending_ty.as_deref(), dst_is_int);
                     out.push(format!("{} = {rhs};", name(dst_slot)));
+                } else if n == "CpyRtoV8" && ref_reg.is_some() {
+                    // batch-32a (A5, specs/batch29-errortail.md §1.2 / illegal-op-round2.md A5):
+                    // `LoadRObjR/LoadVObjR ; CpyRtoV8 wD` captures the member ADDRESS the load
+                    // just put in the register into a slot — an alias the body then uses as the
+                    // member's value (`local_52.opIndex(i).RoleType`, RebalanceRoles: 22
+                    // "Illegal operation on 'int'"). Emit `dst = obj.field;`. Two hard gates:
+                    // (1) the PREVIOUS instruction must be the member load — a stale `ref_reg`
+                    //     surviving across calls/compares must not resurrect here (CMPd;TZ;
+                    //     CpyRtoV4 copies TEST results, and only CALL arms clear ref_reg);
+                    // (2) the emit-side typing half must have adopted the field's VALUE type
+                    //     for the destination (final slot_type == the cross-module-resolved
+                    //     value type) — untypeable/conflicted sites keep the status-quo DROP
+                    //     instead of assigning an object expression into an `int` decl.
+                    // Value semantics are a deep copy where the bytecode held a reference —
+                    // the documented A5 caveat (uses in the proven cluster are reads/element
+                    // refs); decompile mode (no local_types) fails gate (2) and is unchanged.
+                    let prev_load = k
+                        .checked_sub(1)
+                        .map(|j| &insns[j])
+                        .filter(|p| matches!(p.op.name, "LoadRObjR" | "LoadVObjR"));
+                    if let Some(pl) = prev_load {
+                        let off = pl.words.get(1).copied().unwrap_or(0) as i32;
+                        let tid = pl.dwords.first().copied().unwrap_or(0) as i32;
+                        let vty = ctx.refs.member(tid, off).and_then(|fname| {
+                            ctx.refs
+                                .type_by_id(tid)
+                                .and_then(|cls| ctx.refs.field_type_by_class(cls, fname))
+                        });
+                        let dst_slot = w(ins, 0);
+                        if let Some(vty) = vty {
+                            if ctx.slot_type(dst_slot).as_deref() == Some(vty) {
+                                if let Some(r) = &ref_reg {
+                                    out.push(format!("{} = {r};", name(dst_slot)));
+                                    member_read_slots.insert(dst_slot); // real data value, not a SetV temporary
+                                }
+                            }
+                        }
+                    }
                 }
                 pending_ty = None;
                 pending_const = false;

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -648,13 +648,18 @@ fn maybe_reverse_args(a: &mut Vec<Arg>, params: Option<&[DataType]>, refs: &RefR
     if a.len() < 2 || a.len() > params.len() {
         return;
     }
+    // Bytecode pushes call args in REVERSE source order for EVERY call type (proven across method,
+    // free, super, native calls — 7 opcode-level confirmations, 0 counterexamples). So the
+    // collected order is reverse-source and reversal is the PRIOR, not the exception. Keep the
+    // collected order only when reversing makes the type pairing strictly WORSE (the list is
+    // corrupted and reversal would misalign it further). This corrects the large class of
+    // type-symmetric multi-arg calls (both orders type-check, so the old strict-improvement gate
+    // left them in the wrong push order) — a byte-faithfulness win, and un-stubs the asymmetric
+    // ones. A genuinely source-ordered correct call is asymmetric (fwd=0 < rev) -> not touched.
     let fwd = arg_mismatch_count(a, params, refs);
-    if fwd == 0 {
-        return; // already matches -> leave untouched
-    }
     let mut rev = a.clone();
     rev.reverse();
-    if arg_mismatch_count(&rev, params, refs) < fwd {
+    if arg_mismatch_count(&rev, params, refs) <= fwd {
         a.reverse();
     }
 }
@@ -932,6 +937,12 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 let off = w(ins, 0);
                 if ctx.slot_type(off).as_deref() == Some("bool") {
                     stack.push(Arg::typed(name(off), Some("bool".to_string())));
+                } else if let Some(cb) = set_consts.get(&off).copied() {
+                    // The slot holds a tracked SetV constant (the SetV1/SetV4 -> PshV4 idiom for a
+                    // literal flag/amount, e.g. Say's `bUnskippable`). Carry its cbits so the
+                    // nested-call retain (`!is_int || cbits.is_some()`) keeps it as a REAL arg
+                    // instead of dropping it as a stranded temporary.
+                    stack.push(Arg::iconst(name(off), cb));
                 } else {
                     stack.push(Arg::int(name(off)));
                 }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -816,8 +816,9 @@ fn field_assign_rhs(rhs: &str, tyname: &str) -> String {
 }
 
 /// True if `tyname` is a UE enum type (`E<Upper>...`) — same shape `cast_to_typename` keys on.
+/// Tolerates a leading `const ` (a const-qualified enum is still an enum for cast purposes).
 fn is_enum_name(tyname: &str) -> bool {
-    let b = tyname.as_bytes();
+    let b = tyname.trim_start_matches("const ").as_bytes();
     b.len() >= 2 && b[0] == b'E' && b[1].is_ascii_uppercase()
 }
 
@@ -1086,7 +1087,31 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 if let Some(r) = &ref_reg {
                     let dst_slot = w(ins, 0);
                     let dst_is_int = dst_slot > 0 && ctx.slot_type(dst_slot).is_none();
-                    let rhs = enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int);
+                    // Known-enum source -> int(...) (existing). Source of UNKNOWN value type ->
+                    // wrap too: the cache carries NO value type for a foreign field
+                    // (PropertyReferences.OldTypeId = the OWNER — proven: SurfaceType->
+                    // UPhysicalMaterial, Relationship->FPerceivedAgent — and an ADDSi chain's
+                    // fty lookup covers only this-class fields), so `ref_reg_ty` being absent
+                    // or owner-shaped (U*/A*/F*/T* head) hides every foreign ENUM field read
+                    // (`local = Perception.Affected.Relationship`, ~164 enum->int in-game
+                    // errors). `int(x)` is compile-neutral for every other primitive an RDR
+                    // can produce here: int/float are explicit-constructible and bool->int is
+                    // legal in UE-AS (0 'bool to int' errors across the whole capture).
+                    // RDR8 stays on the old path: no UE enum is 8 bytes (double/int64/handle
+                    // reads keep their bare, already-compiling render).
+                    let unknowable = match ref_reg_ty.as_deref() {
+                        None => true,
+                        Some(t) => {
+                            let t = t.trim_start_matches("const ");
+                            matches!(t.bytes().next(), Some(b'U') | Some(b'A') | Some(b'F') | Some(b'T'))
+                                && t.as_bytes().get(1).map(|c| c.is_ascii_uppercase()).unwrap_or(false)
+                        }
+                    };
+                    let rhs = if dst_is_int && unknowable && n != "RDR8" {
+                        format!("int({r})")
+                    } else {
+                        enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int)
+                    };
                     out.push(format!("{} = {rhs};", name(dst_slot)));
                 }
             }
@@ -1110,11 +1135,21 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // decompiled const-`0` bool). Cast the RHS to bool. Guard: the RHS was NOT
                     // already transformed above (a bare slot), is resolved, and is not a KNOWN
                     // bool slot (which compiles bare and must not become the illegal `bool != 0`).
+                    // ENUM guards: uint8 ENUMS are also 1-byte writes. When the SOURCE slot is a
+                    // known enum (an enum param stored into a same-enum field:
+                    // `this.FocusCharacterType = PerceptionCharacterType` — the bool wrap made it
+                    // `(Param != 0)` -> "bool -> EPerceptionCharacterType&", 41+ in-game errors),
+                    // or the FIELD's value type is a known enum (this-class fields map), the write
+                    // is enum->enum: keep it bare. (A foreign enum field written from an INT const
+                    // remains unfixable here — the cache carries no value type for foreign fields
+                    // and the enum's NAME is required for the cast; see cant-convert-cleanup.md.)
                     if n == "WRTV1"
                         && ref_reg_ty.as_deref() != Some("bool")
+                        && !ref_reg_ty.as_deref().map(is_enum_name).unwrap_or(false)
                         && rhs == raw
                         && rhs != UNRESOLVED
                         && ctx.slot_type(slot).as_deref() != Some("bool")
+                        && !ctx.slot_type(slot).as_deref().map(is_enum_name).unwrap_or(false)
                     {
                         rhs = format!("({rhs} != 0)");
                     }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2252,6 +2252,31 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     Some(format!("{cls}::StaticClass()"))
                 } else {
                     pending_ty = ctx.refs.func_ret_by_ptr(ptr).map(|d| d.base_name(ctx.refs));
+                    // batch-31e (capture.batch30-0705 ForceRemoveDamage regression): the T3
+                    // entry for `TSubclassOf::GetDefaultObject` records the call-site
+                    // SPECIALIZED return (UElectrifiedArena_GornSleeper), but our render
+                    // collapses the TSubclassOf receiver onto the raw `T::StaticClass()`
+                    // expression, which the LIVE compiler resolves to the UClass overload
+                    // returning UObject ("Can't implicitly convert from 'UObject' to
+                    // 'UElectrifiedArena_GornSleeper'"). Render with the SOURCE-level type:
+                    // with the specialized pending_ty the STOREOBJ downcast saw src == dst
+                    // (30a's exact-type merge keeps the vanilla obj_locals type) and skipped
+                    // the load-bearing Cast — batch-29 only compiled here by accident (a
+                    // member MIS-typing to UWeaponDefinition forced a Cast). Gated to the
+                    // exact broken shape — an untyped receiver whose rendered expression IS
+                    // a `T::StaticClass()` call (statically UClass in-game). Receivers
+                    // recovered as TSubclassOf<T> (or unrecovered foreign members, which
+                    // resolve the typed overload in-game) keep the specialized type; a wider
+                    // untyped-receiver gate added a benign-but-unfaithful Cast on 9 clean
+                    // sites (incl. the CombatMoves sentinel) — rejected as non-minimal.
+                    if f == "GetDefaultObject"
+                        && ctx.refs.func_owner_by_ptr(ptr) == Some("TSubclassOf")
+                        && stack.last().is_some_and(|r| {
+                            r.ty.is_none() && r.s.ends_with("::StaticClass()")
+                        })
+                    {
+                        pending_ty = Some("UObject".to_string());
+                    }
                     pending_const = ctx.refs.func_ret_by_ptr(ptr)
                         .is_some_and(|d| d.is_object_handle && d.is_object_const);
                     let na = ctx.refs.native_arity_by_ptr(ptr, &f);

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -779,6 +779,19 @@ fn cast_arg(arg: &Arg, pt: &DataType, refs: &RefResolver) -> String {
                 }
             }
         }
+        // a KNOWN-enum arg feeding an INT-family param needs the explicit int(...) cast
+        // (AngelScript has no implicit enum->int): `SetLevel(int)` fed an ERelationship
+        // fails "Can't implicitly convert from 'ERelationship' to 'int'" (~150 in-game).
+        if pt.token != 5 {
+            if let Some(at) = &arg.ty {
+                if is_enum_name(at)
+                    && matches!(pt.base_name(refs).as_str(),
+                        "int" | "int8" | "int16" | "int64" | "uint" | "uint8" | "uint16" | "uint64")
+                {
+                    return format!("int({})", arg.s);
+                }
+            }
+        }
         return arg.s.clone();
     }
     // an integer constant feeding a float/double param carries IEEE-754 bits, not an int.
@@ -1130,7 +1143,27 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 if let Some(r) = &ref_reg {
                     let dst_slot = w(ins, 0);
                     let dst_is_int = dst_slot > 0 && ctx.slot_type(dst_slot).is_none();
-                    let rhs = enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int);
+                    // Known-enum source -> int(...) (enum_to_int). Source of UNKNOWN value type
+                    // (a FOREIGN member: the cache stores no value type for foreign fields —
+                    // PropertyReferences.OldTypeId is the OWNER — and the fields map covers only
+                    // this-class) -> wrap too: `local = int(agent.Relationship)` — the hidden
+                    // foreign ENUM reads (~150 in-game "Can't implicitly convert E* to int")
+                    // compile, and int(x) is neutral for every other type an RDR1/2/4 can read
+                    // into an int-defaulted slot (int/bool/float are explicit-int-constructible).
+                    // RDR8 keeps the old path (no UE enum is 8 bytes; int64/double reads stay bare).
+                    let unknowable = match ref_reg_ty.as_deref() {
+                        None => true,
+                        Some(t) => {
+                            let t = t.trim_start_matches("const ");
+                            matches!(t.bytes().next(), Some(b'U') | Some(b'A') | Some(b'F') | Some(b'T'))
+                                && t.as_bytes().get(1).map(|c| c.is_ascii_uppercase()).unwrap_or(false)
+                        }
+                    };
+                    let rhs = if dst_is_int && unknowable && n != "RDR8" {
+                        format!("int({r})")
+                    } else {
+                        enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int)
+                    };
                     out.push(format!("{} = {rhs};", name(dst_slot)));
                     member_read_slots.insert(dst_slot); // real data value, not a SetV temporary
                 }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -362,7 +362,7 @@ struct Cmp {
 /// methods (opAssign/opAdd/opEquals/...) render as the source operator. Returns None for
 /// compiler-generated behaviors ($behN construct/destruct) that have no source form.
 #[allow(clippy::too_many_arguments)]
-fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option<&str>, params: Option<&[DataType]>, native_arity: Option<usize>, trusted_arity: Option<usize>, target_owner: Option<&str>, cur_class: Option<&str>, non_virtual: bool, ret_ty: Option<&str>, refs: &RefResolver) -> Option<String> {
+fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option<&str>, params: Option<&[DataType]>, native_arity: Option<usize>, trusted_arity: Option<usize>, target_owner: Option<&str>, cur_class: Option<&str>, non_virtual: bool, ret_ty: Option<&str>, ret_is_ref: bool, refs: &RefResolver) -> Option<String> {
     if f.starts_with('$') || f.starts_with('~') || f == "__STATIC_NAME" {
         // EDIT C (the dominant FName form): `__STATIC_NAME` is the synthesized name-table accessor
         // (`const FName& __STATIC_NAME(int Id)` per the exe's registered decl) that fetches
@@ -433,8 +433,15 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     // entry directly below the receiver is a PSF slot whose type head equals the return-type head
     // (the same condition the Fix-b3 out-slot probe uses). This can only SHRINK the window vs the
     // old heuristic, never widen, so it cannot break a real by-value RVO recovery.
+    // batch-20 Class D: a method returning BY REFERENCE (`FString& Append(...)` — fluent
+    // builders) has NO hidden RVO out-slot, but `ret_ty` is the base-name string with the
+    // refness erased — the probes below misread a genuine PSF'd struct ARG of the same type
+    // (Append's `const FString&in` fed by a ToString RVO local) as the out-slot, stealing the
+    // arg (`.Append()`) and prefixing a bogus `out =` (48 in-game errors). `ret_is_ref` carries
+    // the T3 DataType's bIsReference; every RVO probe is gated on it.
     fn tyhead(s: &str) -> &str { s.split('<').next().unwrap_or(s) }
-    let rvo_slot = ret_ty.map(|t| matches!(tyhead(t).bytes().next(), Some(b'F') | Some(b'T'))).unwrap_or(false)
+    let rvo_slot = !ret_is_ref
+        && ret_ty.map(|t| matches!(tyhead(t).bytes().next(), Some(b'F') | Some(b'T'))).unwrap_or(false)
         && {
             // The hidden RVO out-slot sits BELOW the receiver for a method (top = receiver) and
             // ON TOP for a free call (no receiver pushed). Same data-driven evidence gate as the
@@ -497,7 +504,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         // value), which would falsely match the out-slot probe and rewrite `states = opAssign()`.
         fn head(s: &str) -> &str { s.split('<').next().unwrap_or(s) }
         let is_operator = assign_op(f).is_some() || binop_method(f).is_some();
-        if let Some(rh) = ret_ty.map(head).filter(|_| !is_operator) {
+        if let Some(rh) = ret_ty.map(head).filter(|_| !is_operator && !ret_is_ref) {
             if matches!(rh.bytes().next(), Some(b'F') | Some(b'T') | Some(b'E')) {
                 // the RVO out-slot = a PSF arg whose type head equals the return-type head
                 if let Some(pos) = a.iter().position(|x| x.is_psf
@@ -633,8 +640,10 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         // returning a struct BY VALUE pushes a hidden PSF out-slot. Recover `out = f(args)`
         // instead of leaking the out-slot as a leading arg (GotoPosition/Say/GiveItemTo/
         // FInGameTime::Now). Same data-driven gate as Fix-b3: a PSF arg whose type head equals the
-        // return-type head; a call without a genuine out-slot can't match.
-        if let Some(rh) = ret_ty.map(tyhead) {
+        // return-type head; a call without a genuine out-slot can't match. Gated on !ret_is_ref
+        // (batch-20 Class D): a BY-REFERENCE return has no out-slot, and the probe would steal a
+        // same-typed by-ref struct arg.
+        if let Some(rh) = ret_ty.map(tyhead).filter(|_| !ret_is_ref) {
             if matches!(rh.bytes().next(), Some(b'F') | Some(b'T') | Some(b'E')) {
                 if let Some(pos) = a.iter().position(|x| x.is_psf
                     && x.ty.as_deref().map(tyhead) == Some(rh)) {
@@ -848,7 +857,16 @@ fn cast_arg(arg: &Arg, pt: &DataType, refs: &RefResolver) -> String {
 /// different (derived) type — the cache erases the covariant return type of template getters
 /// like `GetTypedOuter<T>`/`SpawnedStorage<T>` to the base, so AS rejects the implicit
 /// downcast. Only applies between UObject/AActor types (`U*`/`A*`).
-fn downcast(rhs: String, src_ty: Option<String>, dst_ty: Option<&String>, refs: &RefResolver) -> String {
+///
+/// batch-20 Class B: when the call returns a CONST object handle (`src_const`) and the
+/// destination local is the SAME (non-const) type, the plain store fails "Can't implicitly
+/// convert from 'const UCharacterAIState' to 'UCharacterAIState'". `Cast<T>` strips the const:
+/// PROVEN in the batch-19 capture — `local_4 = Cast<AGothicCharacter>(Querier);` with
+/// `const UObject Querier` compiles clean (AIAgentConfig_Navigation_Human.as GetAIFromQuerier),
+/// same in PersonalRelationshipModifiers.as with `const AGothicCharacterState` params. Only the
+/// exact-type pair is wrapped (every capture site is 'const X' -> 'X'); a const UPCAST keeps the
+/// status-quo error rather than risking the known Cast<Base>(derived) in-game failure.
+fn downcast(rhs: String, src_ty: Option<String>, src_const: bool, dst_ty: Option<&String>, refs: &RefResolver) -> String {
     let is_obj = |s: &str| s.starts_with('U') || s.starts_with('A');
     match (src_ty, dst_ty) {
         (Some(s), Some(d)) if is_obj(&s) && is_obj(d) && s != *d => {
@@ -861,6 +879,7 @@ fn downcast(rhs: String, src_ty: Option<String>, dst_ty: Option<&String>, refs: 
                 format!("Cast<{d}>({rhs})")
             }
         }
+        (Some(s), Some(d)) if src_const && is_obj(&s) && s == *d => format!("Cast<{d}>({rhs})"),
         _ => rhs,
     }
 }
@@ -975,6 +994,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
     let mut member_read_slots: std::collections::HashSet<i32> = std::collections::HashSet::new();
     let mut pending: Option<String> = None; // unconsumed call/ctor result
     let mut pending_ty: Option<String> = None; // recovered type of `pending` (call return type)
+    // batch-20 Class B: the call returns a CONST object handle (`const UCharacterAIState`).
+    // `pending_ty` is the const-stripped base name (comparisons everywhere key on it), so the
+    // constness travels in this parallel flag; the STOREOBJ arm uses it to Cast-strip.
+    let mut pending_const: bool = false;
     let mut ret_val: Option<String> = None;
     // Target type of the most recent TYPEID push — the implicit type operand of the following
     // `opCast` behaviour call (the lowered form of `Cast<T>(x)`). Resolved to a typename so the
@@ -986,6 +1009,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
     macro_rules! flush {
         () => {
             pending_ty = None;
+            pending_const = false;
             if let Some(p) = pending.take() {
                 out.push(format!("{p};"));
             }
@@ -1007,6 +1031,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 }
             }
             pending_ty = None;
+            pending_const = false;
         };
     }
 
@@ -1057,6 +1082,13 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 let off = w(ins, 0);
                 if ctx.slot_type(off).as_deref() == Some("bool") {
                     stack.push(Arg::typed(name(off), Some("bool".to_string())));
+                } else if matches!(ctx.slot_type(off).as_deref(), Some("float" | "float32" | "double")) {
+                    // batch-20 Class C: a float-family slot pushed by value is a REAL arg (e.g.
+                    // SetByCallerMagnitude's Magnitude pushed before a chained GetSpec()); typed
+                    // (is_int=false) it survives the nested-call stack-split retain and renders
+                    // bare. Left as Arg::int it was dropped as a stranded temporary (17 in-game
+                    // errors: "No matching signatures to 'SetByCallerMagnitude(FGameplayTag)'").
+                    stack.push(Arg::typed(name(off), ctx.slot_type(off)));
                 } else if let Some(cb) = set_consts.get(&off).copied() {
                     // The slot holds a tracked SetV constant (the SetV1/SetV4 -> PshV4 idiom for a
                     // literal flag/amount, e.g. Say's `bUnskippable`). Carry its cbits so the
@@ -1257,7 +1289,19 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             }
             "CpyVtoV4" | "CpyVtoV8" => {
                 flush!();
-                out.push(format!("{} = {};", name(w(ins, 0)), name(w(ins, 1))));
+                let (dst, src) = (w(ins, 0), w(ins, 1));
+                // batch-20 Class C: a slot declared `bool` (bool& out-ref retype) written from an
+                // int-family slot needs the explicit wrap — AS has no implicit int->bool. A
+                // genuine bool source stays bare (`bool != 0` doesn't compile either).
+                let rhs = if ctx.slot_type(dst).as_deref() == Some("bool")
+                    && ctx.slot_type(src).is_none()
+                    && looks_int(&name(src))
+                {
+                    format!("({} != 0)", name(src))
+                } else {
+                    name(src)
+                };
+                out.push(format!("{} = {rhs};", name(dst)));
             }
             _ if bin_op(n).is_some() && ins.words.len() >= 3 => {
                 flush!();
@@ -1350,6 +1394,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // Fix b1 — StaticClass takes 0 operands; the stack holds the ENCLOSING call's
                     // already-pushed args. Do NOT clear it (clearing destroys those args).
                     pending_ty = None;
+                    pending_const = false;
                     // The class is the StaticClass func's NAMESPACE last-segment (objtype is
                     // NULL for StaticClass; the target class lives in the namespace), not the
                     // calling class — `local = UFoo::StaticClass()` from inside UBar must say UFoo.
@@ -1359,12 +1404,18 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     Some(format!("{cls}::StaticClass()"))
                 } else {
                     pending_ty = ctx.refs.func_ret_by_id(id).map(|d| d.base_name(ctx.refs));
+                    // CALL-by-id = SCRIPT function: its authoritative signature is the module-region
+                    // one WE emit (GetG1R renders `UStoryG1R GetG1R()`, no const), while the
+                    // tail-table entry spuriously carries bIsObjectConst (2757 GetG1R stores compile
+                    // CLEAN in the batch-19 capture). Never const-wrap script-call results.
+                    pending_const = false;
                     let na = ctx.refs.native_arity_by_id(id, &f);
                     // SCRIPT call by id: the cache FunctionReference param count is authoritative
                     // (only NATIVE param lists undercount), so trust it for the EDIT B-PRIME split.
                     let trusted = ctx.refs.func_params_by_id(id).map(|p| p.len());
                     let owner = ctx.refs.func_owner_by_id(id);
-                    build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, owner, ctx.class_name, n == "CALL", pending_ty.as_deref(), ctx.refs)
+                    let ret_is_ref = ctx.refs.func_ret_by_id(id).map(|d| d.is_reference).unwrap_or(false);
+                    build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, owner, ctx.class_name, n == "CALL", pending_ty.as_deref(), ret_is_ref, ctx.refs)
                 };
             }
             "CALLSYS" | "Thiscall1" => {
@@ -1462,12 +1513,15 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // Fix b1 — do NOT clear the stack; StaticClass takes 0 operands and the entries
                     // present belong to an ENCLOSING call.
                     pending_ty = None;
+                    pending_const = false;
                     let cls = ctx.refs.staticclass_class_by_ptr(ptr)
                         .or_else(|| ctx.refs.func_owner_by_ptr(ptr))
                         .or(ctx.class_name).unwrap_or("UObject");
                     Some(format!("{cls}::StaticClass()"))
                 } else {
                     pending_ty = ctx.refs.func_ret_by_ptr(ptr).map(|d| d.base_name(ctx.refs));
+                    pending_const = ctx.refs.func_ret_by_ptr(ptr)
+                        .is_some_and(|d| d.is_object_handle && d.is_object_const);
                     let na = ctx.refs.native_arity_by_ptr(ptr, &f);
                     // A free/static native function in a namespace (Gameplay, Math, System, ...)
                     // must be called qualified `Namespace::func(...)` or the global lookup fails
@@ -1491,13 +1545,15 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // target_owner (T3 ObjectType) was only wired for CALL/CALLINTF; pass it for
                     // native calls too so the UObject-receiver Cast wrap (batch19 class 1) and the
                     // generated-accessor qualification see the owning class of CALLSYS methods.
-                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, ctx.refs.func_owner_by_ptr(ptr), ctx.class_name, false, pending_ty.as_deref(), ctx.refs)
+                    let ret_is_ref = ctx.refs.func_ret_by_ptr(ptr).map(|d| d.is_reference).unwrap_or(false);
+                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, ctx.refs.func_owner_by_ptr(ptr), ctx.class_name, false, pending_ty.as_deref(), ret_is_ref, ctx.refs)
                 };
             }
             "CallPtr" => {
                 let f = name(w(ins, 0));
                 pending_ty = None;
-                pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, None, ctx.class_name, false, None, ctx.refs);
+                pending_const = false;
+                pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, None, ctx.class_name, false, None, false, ctx.refs);
             }
             // ---- object construction ----
             "ALLOC" => {
@@ -1505,13 +1561,14 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 let ty = ctx.refs.type_by_ptr(tptr).unwrap_or("Object").to_string();
                 let args: Vec<String> = std::mem::take(&mut stack).into_iter().filter(|a| !a.s.is_empty()).map(|a| a.s).collect();
                 pending_ty = Some(ty.clone());
+                pending_const = false;
                 pending = Some(format!("{ty}({})", args.join(", ")));
             }
             // ---- result capture ----
             "STOREOBJ" => {
                 let slot = w(ins, 0);
                 let rhs = match pending.take() {
-                    Some(p) => Some(downcast(p, pending_ty.take(), ctx.local_types.and_then(|m| m.get(&slot)), ctx.refs)),
+                    Some(p) => Some(downcast(p, pending_ty.take(), std::mem::take(&mut pending_const), ctx.local_types.and_then(|m| m.get(&slot)), ctx.refs)),
                     None => obj_reg.take(),
                 };
                 flush_store(&mut out, name(slot), rhs);
@@ -1525,6 +1582,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     out.push(format!("{} = {rhs};", name(dst_slot)));
                 }
                 pending_ty = None;
+                pending_const = false;
             }
             "LOADOBJ" => obj_reg = Some(name(w(ins, 0))),
             "CpyVtoR4" | "CpyVtoR8" => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -85,6 +85,10 @@ fn amm(code: &str) -> String {
 /// this does NOT stub the whole function: the emitter replaces it with a default-valued
 /// return so the recovered body survives (far more faithful than a bare stub).
 pub(crate) const RVODEF: &str = "\u{3}rvodef";
+/// Marks a store whose RHS is a CONST object handle of the destination local's EXACT type
+/// (batch-21 Class C). The emitter strips the marker and declares the destination local
+/// `const T` — the vanilla form; a same-type `Cast<T>` wrap does NOT strip const in-game.
+pub(crate) const CONSTSTORE: char = '\u{4}';
 
 /// Structured statement body for a function (no signature wrapper), indented at `depth`.
 /// Returns an error annotation string on disasm failure (never panics).
@@ -143,7 +147,9 @@ pub fn decompile(f: &FuncCode, refs: &RefResolver) -> String {
         .enumerate()
         .map(|(i, n)| if n.is_empty() { format!("arg{i}") } else { n.clone() })
         .collect();
-    let body = body_statements(f, refs, 1).replace(RVODEF, "/* unrecovered */ {}");
+    let body = body_statements(f, refs, 1)
+        .replace(RVODEF, "/* unrecovered */ {}")
+        .replace(CONSTSTORE, "");
     format!(
         "// {}\nfunction({})\n{{\n{}}}\n",
         f.func,
@@ -584,6 +590,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
             }
         }
         maybe_reverse_args(&mut a, params, refs);
+        cast_container_args(f, recv.ty.as_deref(), &mut a);
         Some(format!("{}.{f}({})", wrap_uobject_recv(&recv, target_owner), render_args(&a, params, refs)))
     } else {
         if refs.is_type_name(f) {
@@ -768,6 +775,62 @@ fn maybe_reverse_args(a: &mut Vec<Arg>, params: Option<&[DataType]>, refs: &RefR
     }
 }
 
+/// Batch-21 Class B: container methods (`TArray`/`TSet::Add`, `TMap::Add`/`opIndex`) take the
+/// receiver's template SUBTYPE(s) as parameters, but the native bind's stored param DataTypes
+/// are generic placeholders — so `cast_arg` can't see that an int arg feeds an enum/bool
+/// subtype (AngelScript has no implicit int->enum/int->bool): `TArray<EPhysicalSurface>
+/// local; local.Add(1);` fails "No matching signatures to 'TArray::Add(int)'" (54 in-game).
+/// Derive the expected types from the receiver's COMPOSED type name (`TMap<ECombatRole,
+/// float>` — locals via obj_locals, this-class members via the fields map) and wrap int args
+/// in place. Foreign-member receivers with unknown types stay untouched (status-quo error).
+fn cast_container_args(method: &str, recv_ty: Option<&str>, a: &mut [Arg]) {
+    let Some(t) = recv_ty else { return };
+    let t = t.trim_start_matches("const ");
+    let Some((head, rest)) = t.split_once('<') else { return };
+    let Some(inner) = rest.strip_suffix('>') else { return };
+    // top-level comma split (subtypes can nest: TMap<ECombatRole, TArray<int>>)
+    let mut subs: Vec<&str> = Vec::new();
+    let (mut depth, mut start) = (0usize, 0usize);
+    for (i, c) in inner.char_indices() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                subs.push(inner[start..i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    subs.push(inner[start..].trim());
+    let expect: &[&str] = match (head, method, subs.len()) {
+        // single-value element methods (capture shapes: Add(int) 28x, Contains(int) 10x,
+        // AddUnique/Remove(int) 2x) — the arg is the element type T.
+        ("TArray" | "TSet", "Add" | "AddUnique" | "Remove" | "RemoveSingle" | "Contains", 1) => &subs[..1],
+        // Add(K, V) takes both subtypes positionally.
+        ("TMap", "Add", 2) => &subs[..2],
+        // key-first methods: only the K arg is wrapped (Find's 2nd arg is the V out-slot,
+        // FindOrAdd/opIndex/Contains/Remove take just the key).
+        ("TMap", "opIndex" | "Find" | "FindOrAdd" | "Contains" | "Remove", 2) => &subs[..1],
+        _ => return,
+    };
+    for (arg, want) in a.iter_mut().zip(expect) {
+        // The container natives take `const T&in`, so int-slot args arrive PSF-pushed
+        // (address of the slot: is_psf=true, is_int=false, ty=None — int locals aren't in
+        // the typed-locals map). A slot with a KNOWN non-int type (bool/float/object local)
+        // is a real typed value and must stay bare.
+        if !(arg.is_int || (arg.is_psf && arg.ty.is_none())) {
+            continue;
+        }
+        if let Some(c) = cast_to_typename(&arg.s, want) {
+            arg.s = c;
+            arg.is_int = false;
+            arg.cbits = None;
+            arg.ty = Some((*want).to_string());
+        }
+    }
+}
+
 /// Render args joined by ", ", casting each int arg to the callee's expected param type.
 fn render_args(a: &[Arg], params: Option<&[DataType]>, refs: &RefResolver) -> String {
     a.iter()
@@ -860,12 +923,19 @@ fn cast_arg(arg: &Arg, pt: &DataType, refs: &RefResolver) -> String {
 ///
 /// batch-20 Class B: when the call returns a CONST object handle (`src_const`) and the
 /// destination local is the SAME (non-const) type, the plain store fails "Can't implicitly
-/// convert from 'const UCharacterAIState' to 'UCharacterAIState'". `Cast<T>` strips the const:
-/// PROVEN in the batch-19 capture — `local_4 = Cast<AGothicCharacter>(Querier);` with
-/// `const UObject Querier` compiles clean (AIAgentConfig_Navigation_Human.as GetAIFromQuerier),
-/// same in PersonalRelationshipModifiers.as with `const AGothicCharacterState` params. Only the
-/// exact-type pair is wrapped (every capture site is 'const X' -> 'X'); a const UPCAST keeps the
-/// status-quo error rather than risking the known Cast<Base>(derived) in-game failure.
+/// convert from 'const UCharacterAIState' to 'UCharacterAIState'". `Cast<T>` strips the const
+/// when it actually CASTS: PROVEN in the batch-19 capture — `local_4 =
+/// Cast<AGothicCharacter>(Querier);` with `const UObject Querier` compiles clean
+/// (AIAgentConfig_Navigation_Human.as GetAIFromQuerier).
+///
+/// batch-21 Class C REVISION: the batch-20 EXACT-TYPE wrap `Cast<X>(const X)` does NOT strip
+/// const in-game — the batch-20 capture shows every exact-type Cast site still failing
+/// "No conversion from 'const X' to 'X'" (site counts match 1:1: UTerritoryConfig 12/12,
+/// UCharacterDefinition 9/9, UComboAttackConfig 5/5, ...). A same-type Cast is a no-op that
+/// keeps the const. The vanilla form is a CONST local declaration, so the exact-type arm now
+/// emits the store BARE prefixed with the [`CONSTSTORE`] marker; the emitter strips it and
+/// declares the destination local `const T` (assigning a later NON-const value to a const
+/// handle stays legal, so mixed-source slots are safe).
 fn downcast(rhs: String, src_ty: Option<String>, src_const: bool, dst_ty: Option<&String>, refs: &RefResolver) -> String {
     let is_obj = |s: &str| s.starts_with('U') || s.starts_with('A');
     match (src_ty, dst_ty) {
@@ -879,7 +949,7 @@ fn downcast(rhs: String, src_ty: Option<String>, src_const: bool, dst_ty: Option
                 format!("Cast<{d}>({rhs})")
             }
         }
-        (Some(s), Some(d)) if src_const && is_obj(&s) && s == *d => format!("Cast<{d}>({rhs})"),
+        (Some(s), Some(d)) if src_const && is_obj(&s) && s == *d => format!("{CONSTSTORE}{rhs}"),
         _ => rhs,
     }
 }
@@ -1158,12 +1228,20 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 let off = ins.words.first().copied().unwrap_or(0) as i32;
                 let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
                 let field = ctx.refs.member(tid, off).map(|s| s.to_string()).unwrap_or_else(|| format!("field_0x{off:x}"));
-                // field VALUE type — ONLY from the enclosing class map. `member_type(tid,off)`
+                // field VALUE type — from the enclosing class map, else (batch-21 Class B) the
+                // injected per-class field maps keyed by the ADDSi type-id's class name, which
+                // resolve FOREIGN script-class/struct members correctly (`SaveState.WeatherModifiers`
+                // -> `TMap<EWeather, float32>`). `member_type(tid,off)` stays unused here: it
                 // returns the OWNER struct (PropertyReferences.OldTypeId = the CONTAINING type),
                 // NOT the field's value type; using it poisons foreign member reads (e.g.
                 // `HitResult.BoneName` typed as `FHitResult` instead of `FName`) -> false
                 // value-head mismatch -> spurious argtype stub. None = unknown = conservative match.
-                let fty = ctx.fields.and_then(|m| m.get(&field)).cloned();
+                let fty = ctx.fields.and_then(|m| m.get(&field)).cloned().or_else(|| {
+                    ctx.refs
+                        .type_by_id(tid)
+                        .and_then(|cls| ctx.refs.field_type_by_class(cls, &field))
+                        .map(|s| s.to_string())
+                });
                 if let Some(top) = stack.last_mut() {
                     top.s = format!("{}.{field}", top.s);
                     top.is_int = false; // now a member access, not a bare int slot
@@ -1215,7 +1293,16 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                                 && t.as_bytes().get(1).map(|c| c.is_ascii_uppercase()).unwrap_or(false)
                         }
                     };
-                    let rhs = if dst_is_int && unknowable && n != "RDR8" {
+                    // A KNOWN float-family member read into an int-declared slot keeps the
+                    // int(...) wrap: warnings are errors in the game compile, and the bare read
+                    // is "Implicit conversion from float to integer loses precision". (Before
+                    // batch-21's inherited-fields map these reads were mostly `None`-typed and
+                    // took the unknowable wrap; a KNOWN bool/int stays bare — proven clean.)
+                    let float_src = matches!(
+                        ref_reg_ty.as_deref().map(|t| t.trim_start_matches("const ")),
+                        Some("float" | "float32" | "double")
+                    );
+                    let rhs = if dst_is_int && (unknowable || float_src) && n != "RDR8" {
                         format!("int({r})")
                     } else {
                         enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int)
@@ -1574,7 +1661,15 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 flush_store(&mut out, name(slot), rhs);
             }
             "CpyRtoV4" | "CpyRtoV8" => {
-                if let Some(p) = pending.take() {
+                // batch-21 Class C shape 3: a VOID call has no register value to copy —
+                // `local_N = VoidCall();` fails "No conversion from 'void' to 'int'". Emit the
+                // call as its own statement; the copied register value (stale, unmodeled) is
+                // unrecoverable, so the assignment is dropped (slot keeps its prior value).
+                if pending.is_some() && pending_ty.as_deref() == Some("void") {
+                    if let Some(p) = pending.take() {
+                        out.push(format!("{p};"));
+                    }
+                } else if let Some(p) = pending.take() {
                     // an enum-returning call stored into an int slot needs an explicit int(...)
                     let dst_slot = w(ins, 0);
                     let dst_is_int = dst_slot > 0 && ctx.slot_type(dst_slot).is_none();
@@ -1586,12 +1681,33 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
             }
             "LOADOBJ" => obj_reg = Some(name(w(ins, 0))),
             "CpyVtoR4" | "CpyVtoR8" => {
+                // batch-21 Class C shape 3: a pending VOID call has no value to copy — the
+                // register content comes from the SLOT operand (e.g. a bool& out-param the call
+                // just wrote: `CalculateDistanceToTarget(.., local_3); return local_3;`).
+                // Flush the call as its own statement and use the slot.
+                if pending.is_some() && pending_ty.as_deref() == Some("void") {
+                    flush!();
+                }
                 ret_val = pending.take().or_else(|| Some(name(w(ins, 0))));
             }
             "CpyVtoR1" => {
                 // a bool moved into the test register: feeds either RET or a conditional jump.
-                // A call result is already bool-typed; a slot holds the bool as an int.
-                let is_bool = pending.is_some() && pending_ty.as_deref() == Some("bool");
+                // A call result is already bool-typed; a slot holds the bool as an int —
+                // EXCEPT a slot DECLARED bool (a `bool` param / bool-typed local), which must
+                // render bare: `if (bIncludeDefeated != 0)` fails "No conversion from 'int'
+                // to 'bool'" (batch-21 Class C, 36 in-game errors).
+                //
+                // batch-21 Class C shape 3: a pending VOID call can never be the tested/returned
+                // VALUE — the register content genuinely comes from the SLOT operand (typically a
+                // bool& out-param the call just wrote: `CalculateDistanceToTarget(.., local_3);
+                // return local_3;`). Folding it in rendered `return VoidCall(...)` / `if
+                // (VoidCall(...) == 0)` ("No conversion from 'void' to ..."). Flush the call as
+                // its own statement and use the slot.
+                if pending.is_some() && pending_ty.as_deref() == Some("void") {
+                    flush!();
+                }
+                let is_bool = (pending.is_some() && pending_ty.as_deref() == Some("bool"))
+                    || (pending.is_none() && ctx.slot_type(w(ins, 0)).as_deref() == Some("bool"));
                 let v = pending.take().unwrap_or_else(|| name(w(ins, 0)));
                 cond = Some((v.clone(), is_bool));
                 ret_val = Some(v);
@@ -1604,7 +1720,13 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 // lives in `pending` (e.g. `CALL`/`ALLOC` then `RET`), and flush! would emit it
                 // as a standalone statement, leaving the return a default (RVODEF).
                 let mut v = if non_void {
-                    ret_val.take().or_else(|| obj_reg.take()).or_else(|| pending.take())
+                    // batch-21 Class C shape 3: a pending VOID call is never the return VALUE
+                    // (`return CalculateDistanceToTarget(...);` from a bool function fails
+                    // "No conversion from 'void' to 'bool'") — leave it for flush! below
+                    // (statement position) and fall back to scan-back / the typed default.
+                    ret_val.take().or_else(|| obj_reg.take()).or_else(|| {
+                        (pending_ty.as_deref() != Some("void")).then(|| pending.take()).flatten()
+                    })
                 } else {
                     None
                 };
@@ -1619,8 +1741,16 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         // which is a syntax error (aborts the whole module's parse). The
                         // assignment RHS is the actual returned value.
                         let v = strip_return_assign(&v).to_string();
+                        // a slot DECLARED bool must return bare: `return (boolSlot != 0);`
+                        // is an int-compare on a bool ("No conversion from 'int' to 'bool'").
+                        let declared_bool = v
+                            .strip_prefix("local_")
+                            .and_then(|d| d.parse::<i32>().ok())
+                            .and_then(|n| ctx.slot_type(n))
+                            .as_deref()
+                            == Some("bool");
                         let v = match ctx.ret_ty {
-                            Some(rt) if looks_int(&v) => {
+                            Some(rt) if looks_int(&v) && !declared_bool => {
                                 let tn = if rt.token == 0x41 { "bool".to_string() } else { rt.base_name(ctx.refs) };
                                 cast_to_typename(&v, &tn).unwrap_or(v)
                             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -165,7 +165,7 @@ pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, supe
     let idx_of: HashMap<usize, usize> =
         g.blocks.iter().enumerate().map(|(i, b)| (b.start_dw, i)).collect();
     let mut body = String::new();
-    let mut st = Structurer { ctx: &ctx, g: &g, idx_of: &idx_of, exit_join: None, exit_join_is_ret: false, exit_ret_rows_ok: false, exit_scan_floor: 0, carry: None };
+    let mut st = Structurer { ctx: &ctx, g: &g, idx_of: &idx_of, exit_join: None, exit_join_is_ret: false, exit_ret_rows_ok: false, exit_scan_floor: 0, carry: None, loop_scope: None };
     st.emit_range(0, g.blocks.len(), depth, &mut body);
     body
 }
@@ -3012,6 +3012,18 @@ struct Structurer<'a> {
     /// construct is exactly the null-check Cast diamond; consumed exactly once (`take()`)
     /// by the very next loop iteration of `emit_range`.
     carry: Option<(usize, Vec<Arg>)>,
+    /// batch-36: active loop-exit context, set only while emitting a loop body via `emit_range`.
+    /// `continue_off` = the loop-continue dword offset (where a `continue;` lands: the latch
+    /// block start for a bottom-test loop). `break_off` = the loop-exit dword offset (where
+    /// `break;` lands: the latch's non-back-edge successor). Saved/restored around the recursive
+    /// body emission; nested loops push/pop so break/continue always bind to the innermost loop.
+    loop_scope: Option<LoopScope>,
+}
+
+#[derive(Clone, Copy)]
+struct LoopScope {
+    continue_off: usize,
+    break_off: usize,
 }
 
 impl Structurer<'_> {
@@ -3061,9 +3073,47 @@ impl Structurer<'_> {
                 let cond = branch_cond(&lcmp, self.jump_op(latch));
                 let _ = writeln!(out, "{ind}while ({cond})");
                 let _ = writeln!(out, "{ind}{{");
-                self.emit_linear(i, latch + 1, depth + 1, out, true);
+                // batch-36 (Stage A): the loop body is blocks [i, latch) — block `i` (the loop
+                // header the latch back-edges to) holds the first body statements + often the
+                // first inner guard; the latch itself supplies the `while (cond)` test and is
+                // excluded (stop = latch). `continue_off` = latch start (a `continue;` re-tests);
+                // `break_off` = the latch's non-back-edge successor (the loop exit). Only recurse
+                // when the body has a genuine inner branch (Gate 1) AND every branch resolves to a
+                // recognized if/switch/break/continue/return shape (Gate 2); otherwise keep the
+                // exact status-quo `emit_linear` call byte-for-byte.
+                let latch_off = self.g.blocks[latch].start_dw;
+                let break_off = self.g.blocks[latch].succs.iter().copied().find(|&s| s > latch_off);
+                if let Some(break_off) = break_off {
+                    let ls = LoopScope { continue_off: latch_off, break_off };
+                    if self.body_has_inner_branch(i, latch, ls)
+                        && self.loop_body_recoverable(i, latch, ls)
+                    {
+                        let saved = self.loop_scope;
+                        self.loop_scope = Some(ls);
+                        self.emit_range(i, latch, depth + 1, out);
+                        self.loop_scope = saved;
+                    } else {
+                        self.emit_linear(i, latch + 1, depth + 1, out, true);
+                    }
+                } else {
+                    self.emit_linear(i, latch + 1, depth + 1, out, true);
+                }
                 let _ = writeln!(out, "{ind}}}");
                 next = latch + 1;
+            } else if let Some((cond, brk)) = self.loop_break_continue(i) {
+                // batch-36 (Stage A): inside a recursed loop body, a conditional jump whose taken
+                // target is the loop break/continue offset — render `if (cond) { break;/continue; }`
+                // and fall through to the remainder. `cond` is oriented so the keyword fires on the
+                // TAKEN edge; the fall edge (block i+1) continues the body.
+                let (stmts, _, _) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init, false);
+                for s in &stmts {
+                    let _ = writeln!(out, "{ind}{s}");
+                }
+                let _ = writeln!(out, "{ind}if ({cond})");
+                let _ = writeln!(out, "{ind}{{");
+                let _ = writeln!(out, "{ind}    {brk}");
+                let _ = writeln!(out, "{ind}}}");
+                next = i + 1;
             } else if self.is_cond(i) {
                 let (stmts, cmp, leftover) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init, false);
                 for s in &stmts {
@@ -3086,7 +3136,19 @@ impl Structurer<'_> {
                 let _ = writeln!(out, "{ind}}}");
                 next = then_end;
                 if let Some(ei) = else_idx {
-                    if ei >= then_end && ei > 0 && self.jump_op(ei - 1) == "JMP" {
+                    // batch-36: inside a recursed loop body, a guard whose THEN branch exits the
+                    // loop (its last block `JMP`s to the break/continue offset or to a bare-RET
+                    // row = a `return`) has NO else — the taken target (`ei`) is the loop-body
+                    // CONTINUATION, not an else clause. Emitting `else { <continuation> }` would
+                    // wrongly nest the rest of the body. Only skip when in loop scope AND the
+                    // then-block's JMP is such an exit; the non-loop diamond path is unchanged.
+                    let then_exits_loop = self.loop_scope.is_some_and(|ls| {
+                        ei > 0 && self.jump_op(ei - 1) == "JMP" &&
+                        self.g.blocks[ei - 1].succs.first().is_some_and(|&t| {
+                            t == ls.break_off || t == ls.continue_off || self.is_bare_ret_off(t)
+                        })
+                    });
+                    if ei >= then_end && ei > 0 && self.jump_op(ei - 1) == "JMP" && !then_exits_loop {
                         let after_idx = self.g.blocks[ei - 1]
                             .succs
                             .first()
@@ -3124,7 +3186,14 @@ impl Structurer<'_> {
                 for s in &stmts {
                     let _ = writeln!(out, "{ind}{s}");
                 }
+                // Precedence: a switch case region (`exit_join`) is always the tighter scope when
+                // set (its join is nearer than the enclosing loop's continue/break), so consult it
+                // first; only fall to the loop-exit hook when no switch exit applies. batch-36:
+                // `loop_exit_stmt` renders a bare `JMP` to the loop break/continue offset (or to a
+                // bare-RET row inside the body) as `break;`/`continue;`/`return ...;`.
                 if let Some(x) = self.region_exit_stmt(i) {
+                    let _ = writeln!(out, "{ind}{x}");
+                } else if let Some(x) = self.loop_exit_stmt(i) {
                     let _ = writeln!(out, "{ind}{x}");
                 }
                 next = i + 1;
@@ -3213,6 +3282,225 @@ impl Structurer<'_> {
             let b = &self.g.blocks[bi];
             b.instr_hi - b.instr_lo == 1 && self.ctx.instrs[b.instr_lo].op.name == "RET"
         })
+    }
+
+    /// batch-36 (Stage A) — mirrors [`Self::region_exit_stmt`] for the loop body. Inside a
+    /// recursed loop body (`loop_scope` set), a block ending in a bare unconditional `JMP` to
+    /// the loop `break_off`/`continue_off` renders `break;`/`continue;`; a `JMP` to a bare `RET`
+    /// row (a `return <expr>;` from inside the loop, e.g. GetFreeArm) renders the synthesized
+    /// return. Returns None outside loop emission or for any other terminator (status quo: the
+    /// JMP is just a block end that the diamond machinery / plain arm drops).
+    fn loop_exit_stmt(&self, bi: usize) -> Option<String> {
+        let ls = self.loop_scope?;
+        let b = &self.g.blocks[bi];
+        if self.ctx.instrs[b.instr_hi - 1].op.name != "JMP" {
+            return None;
+        }
+        let t = *b.succs.first()?;
+        if t == ls.break_off {
+            return Some("break;".into());
+        }
+        if t == ls.continue_off {
+            return Some("continue;".into());
+        }
+        // an in-body `return <expr>;` compiled as a JMP to the function's shared bare RET row —
+        // recover the returned value from the block's trailing register write (scan floored to
+        // this block so no value leaks in from a preceding block).
+        if self.is_bare_ret_off(t) {
+            return Some(self.ctx.return_stmt(scan_back_retval_floor(self.ctx, b.instr_hi - 1, b.instr_lo)));
+        }
+        None
+    }
+
+    /// batch-36 (Stage A) — a conditional jump inside a recursed loop body whose TAKEN target is
+    /// the loop break/continue offset. Returns `(cond, keyword)` where `cond` fires the keyword on
+    /// the taken edge and the fall edge (block `bi+1`) continues the body — rendered as
+    /// `if (cond) { break;/continue; }`. `None` when not inside a loop, not a 2-succ conditional,
+    /// or the taken target is not exactly the break/continue offset (a genuine inner diamond is
+    /// left to the `is_cond` arm). The fall successor MUST be the physically next block so the
+    /// remaining body flows straight on.
+    fn loop_break_continue(&self, bi: usize) -> Option<(String, &'static str)> {
+        let ls = self.loop_scope?;
+        let b = &self.g.blocks[bi];
+        let jop = self.jump_op(bi);
+        if !matches!(jop, "JZ" | "JNZ" | "JS" | "JNS" | "JP" | "JNP" | "JLowZ" | "JLowNZ") {
+            return None;
+        }
+        if b.succs.len() != 2 {
+            return None;
+        }
+        let taken = *b.succs.first()?;
+        let fall = *b.succs.get(1)?;
+        // the fall edge must be the immediately-following block (straight-line body remainder)
+        if self.idx_of.get(&fall).copied() != Some(bi + 1) {
+            return None;
+        }
+        let kw = if taken == ls.break_off {
+            "break;"
+        } else if taken == ls.continue_off {
+            "continue;"
+        } else {
+            return None;
+        };
+        let cmp = block_stmts(self.ctx, b.instr_lo, b.instr_hi).1;
+        // the keyword fires on the TAKEN edge, so the rendered condition is the jump's own sense
+        // (not negated — negation is for the fall-through-then pattern of `is_cond`).
+        let cond = branch_cond(&cmp, jop);
+        Some((cond, kw))
+    }
+
+    /// batch-36 Gate 1 — true iff the loop body `[lo, hi)` (block indices) contains a GENUINE
+    /// inner conditional: a 2-successor conditional jump (not the latch) that either forks
+    /// forward inside the body (a real `if`) or exits to break/continue/return. A body with no
+    /// such branch is straight-line (or a diamond-carry body) and keeps the exact status-quo
+    /// `emit_linear` call byte-for-byte — this preserves the clean loops and the diamond-carry
+    /// loops. Cheap linear scan.
+    fn body_has_inner_branch(&self, lo: usize, hi: usize, ls: LoopScope) -> bool {
+        for bi in lo..hi {
+            let b = &self.g.blocks[bi];
+            let jop = self.jump_op(bi);
+            if !matches!(jop, "JZ" | "JNZ" | "JS" | "JNS" | "JP" | "JNP" | "JLowZ" | "JLowNZ") {
+                continue;
+            }
+            if b.succs.len() != 2 {
+                continue;
+            }
+            // an inner forward diamond (both succs strictly inside the body), OR a conditional
+            // exit to break/continue/an in-body return
+            let forward_inner = b.succs.iter().all(|&s| {
+                self.idx_of.get(&s).is_some_and(|&si| si > bi && si <= hi)
+            });
+            let exits = b.succs.iter().any(|&s| {
+                s == ls.break_off || s == ls.continue_off || self.is_bare_ret_off(s)
+            });
+            if forward_inner || exits {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// batch-36 Gate 2 — non-emitting dry run over the loop body `[lo, hi)`: assert that EVERY
+    /// block's terminator resolves to a recognized shape so the recursive emit can never produce
+    /// wrong control flow. On ANY anomaly return false ⇒ the loop falls back to the exact
+    /// status-quo `emit_linear` (a dropped-but-compiling body, never a wrong one). Recognized
+    /// per block:
+    ///   * plain fallthrough (no jump) to the next in-body block;
+    ///   * `RET` of its own;
+    ///   * an unconditional `JMP` to break/continue/an in-body bare-RET row (an exit keyword or
+    ///     return), or to a forward in-body block (an `if`/`else` skip);
+    ///   * a 2-succ conditional whose BOTH targets are in-body-forward (a diamond) OR whose taken
+    ///     is break/continue/return and whose fall is the next in-body block (a guard);
+    ///   * a recognized nested switch or nested loop (dry-run detection).
+    /// Any edge that leaves `[header, break_off]` other than via continue/break/return, an
+    /// irreducible edge, a `JMPP` we cannot map, or a conditional we cannot classify ⇒ false.
+    fn loop_body_recoverable(&mut self, lo: usize, hi: usize, ls: LoopScope) -> bool {
+        let header_off = self.g.blocks[lo].start_dw;
+        let mut bi = lo;
+        while bi < hi {
+            // a nested switch consumes its own multi-block region — trust its self-validating
+            // dry run and skip past it (it internally bounds itself by `hi`).
+            if let Some(end) = self.switch_span(bi, hi) {
+                if end <= bi || end > hi {
+                    return false;
+                }
+                bi = end;
+                continue;
+            }
+            // a nested loop: its latch back-edges to an in-body header; recurse the recognizer
+            // over its own body, then skip past its latch.
+            if let Some(inner) = self.loop_latch(bi, hi) {
+                let inner_off = self.g.blocks[inner].start_dw;
+                let inner_break = self.g.blocks[inner].succs.iter().copied().find(|&s| s > inner_off);
+                match inner_break {
+                    Some(ib) => {
+                        let inner_ls = LoopScope { continue_off: inner_off, break_off: ib };
+                        // the inner loop's exit must stay inside our body or be our own exit.
+                        let ib_in_body = self.idx_of.get(&ib).copied().is_some_and(|x| x >= lo && x <= hi);
+                        if !self.loop_edge_ok(ib, lo, hi, ls) && !ib_in_body {
+                            return false;
+                        }
+                        if !self.loop_body_recoverable(bi, inner, inner_ls) {
+                            return false;
+                        }
+                        bi = inner + 1;
+                        continue;
+                    }
+                    None => return false,
+                }
+            }
+            let succs = self.g.blocks[bi].succs.clone();
+            let jop = self.jump_op(bi);
+            match jop {
+                "RET" => {}
+                "JMP" => {
+                    let t = match succs.first() {
+                        Some(&t) => t,
+                        None => return false,
+                    };
+                    if !self.loop_edge_ok(t, lo, hi, ls) {
+                        return false;
+                    }
+                }
+                "JMPP" => return false, // a nested JMPP not recognized as a switch — cannot map
+                j if matches!(j, "JZ" | "JNZ" | "JS" | "JNS" | "JP" | "JNP" | "JLowZ" | "JLowNZ") => {
+                    if succs.len() != 2 {
+                        return false;
+                    }
+                    let taken = succs[0];
+                    let fall = succs[1];
+                    // a backward conditional inside the body that is NOT the recognized inner
+                    // loop latch (handled above) is irreducible — bail.
+                    if taken <= header_off && taken != ls.continue_off {
+                        return false;
+                    }
+                    // fall must always continue in-body (the physically next block)
+                    if self.idx_of.get(&fall).copied() != Some(bi + 1) {
+                        return false;
+                    }
+                    // taken: an in-body forward diamond, an exit keyword, or an in-body return
+                    let taken_ok = self.loop_edge_ok(taken, lo, hi, ls)
+                        || self.idx_of.get(&taken).copied().is_some_and(|ti| ti > bi && ti <= hi);
+                    if !taken_ok {
+                        return false;
+                    }
+                }
+                _ => {
+                    // plain fallthrough terminator: the single successor (if any) must continue
+                    // in-body (into the next block or the latch/continue).
+                    if let Some(&s) = succs.first() {
+                        if succs.len() != 1 || !self.loop_edge_ok(s, lo, hi, ls) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            bi += 1;
+        }
+        true
+    }
+
+    /// An in-body edge target `s` is legal iff it lands on a block inside `[lo, hi]`, OR is a
+    /// recognized exit (loop break/continue offset, or an in-body `return` via a bare-RET row).
+    fn loop_edge_ok(&self, s: usize, lo: usize, hi: usize, ls: LoopScope) -> bool {
+        if s == ls.break_off || s == ls.continue_off || self.is_bare_ret_off(s) {
+            return true;
+        }
+        self.idx_of.get(&s).copied().is_some_and(|si| si >= lo && si <= hi)
+    }
+
+    /// batch-36 — non-emitting probe: if a recognized compiler `switch` idiom starts at block
+    /// `bi` and is fully self-validating within `[bi, cap)`, return the block index just past its
+    /// JOIN; otherwise None. Used by [`Self::loop_body_recoverable`] to skip a nested switch
+    /// during the dry run. Implemented by a throwaway emit into a scratch buffer under the
+    /// current `loop_scope` (the same context the real emit will use), reusing the exact
+    /// `try_emit_switch` validation so the dry run and the real run agree.
+    fn switch_span(&mut self, bi: usize, cap: usize) -> Option<usize> {
+        let saved_carry = self.carry.take();
+        let mut scratch = String::new();
+        let r = self.try_emit_switch(bi, cap, 0, &mut scratch);
+        self.carry = saved_carry; // discard any carry the dry run produced
+        r
     }
 
     /// batch-35a (cross-block reference carry): block `bi` reaches the function's shared bare

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -474,6 +474,11 @@ fn narrowing_cast_target(n: &str) -> Option<&'static str> {
         "fTOu" | "dTOu" => "uint",
         "fTOi64" | "dTOi64" => "int64",
         "fTOu64" | "dTOu64" => "uint64",
+        // batch-28 (specs/batch27-floatwarnings.md §3): float(=f64) -> float32 narrows too —
+        // the bare copy render was the whole C2 class ("Implicit conversion from float64 to
+        // float32 loses precision"). Vanilla compiled clean, so the source carried this cast;
+        // the dTOf in the bytecode IS that cast.
+        "dTOf" => "float32",
         _ => return None,
     })
 }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2256,6 +2256,47 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                 }
             }
             _ if n.starts_with("WRTV") => {
+                // batch-47d (opIndex-lvalue WRTV, specs/final-tail-triage.md §3.9 DropEmptyTeams):
+                // an array-element WRITE `arr[i] = <value>;` lowers as `PshV4 i; PSF arr;
+                // Thiscall1 opIndex; WRTV*` — the opIndex Thiscall1 returns a REFERENCE to the
+                // element (into `pending`, `pending_is_ref`), and the following WRTV writes the
+                // value THROUGH it. There is no PopRPtr, so `ref_reg` is unset and the store
+                // dropped: `flush!` emitted the opIndex as a bare `arr[i];` statement and the WRTV
+                // silently vanished (DropEmptyTeams' `_IdxToRemappedIdx[i] = <newIdx>` compaction
+                // store-backs [0085],[0099] — a REAL mutation bug: the remap table never written).
+                // Capture the ref-returning opIndex lvalue BEFORE flush! and route the WRTV into
+                // it. Gated HARD: `ref_reg` genuinely unset, `pending_is_ref` (the opIndex returns
+                // a reference — a value-returning opIndex would be a temp, never an lvalue), and
+                // the pending is a RESOLVED `.opIndex(` call expr (ends ')', no sentinel/unresolved)
+                // — so the lvalue is provable and the store cannot target a garbage receiver.
+                let opindex_lvalue = if ref_reg.is_none() && pending_is_ref {
+                    pending.as_deref().filter(|p| {
+                        p.contains(".opIndex(")
+                            && p.ends_with(')')
+                            && !p.contains('\u{2}')
+                            && !p.contains('\u{1}')
+                            && *p != UNRESOLVED
+                    }).map(|p| p.to_string())
+                } else {
+                    None
+                };
+                if let Some(lval) = opindex_lvalue {
+                    // consume the pending (do NOT flush it as a bare statement) and set it as the
+                    // write destination; a following field-typed cast is not needed for an element
+                    // write (the element type is the array's, matched by the value's own decl).
+                    pending = None;
+                    pending_ty = None;
+                    pending_is_ref = false;
+                    let slot = w(ins, 0);
+                    let raw = name(slot);
+                    let rhs = match ref_reg_ty.as_deref() {
+                        Some("float32") => float_lit(&set_consts, slot, false).unwrap_or(raw.clone()),
+                        Some("float") | Some("double") => float_lit(&set_consts, slot, true).unwrap_or(raw.clone()),
+                        _ => raw,
+                    };
+                    out.push(format!("{lval} = {rhs};"));
+                    continue;
+                }
                 flush!();
                 if let Some(r) = &ref_reg {
                     let slot = w(ins, 0);

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -585,6 +585,25 @@ impl Ctx<'_> {
             && !ty.is_read_only
             && !ty.is_object_const
     }
+
+    /// batch-45c (FIX-4): true when `name` is EXACTLY a declared object/reference PARAMETER —
+    /// const-AGNOSTIC (unlike `param_src_ok`), because the only use is a null-guard fold
+    /// (`if (<param> == nullptr)`), a comparison that is const-safe. Never matches `this` (not a
+    /// param name) or a `local_`/temp.
+    fn param_object_ref(&self, name: &str) -> bool {
+        let idx = self.f.param_names.iter().position(|n| !n.is_empty() && n == name)
+            .or_else(|| {
+                name.strip_prefix("arg")
+                    .and_then(|d| d.parse::<usize>().ok())
+                    .filter(|&i| i < self.f.param_types.len()
+                        && self.f.param_names.get(i).map(|n| n.is_empty()).unwrap_or(false))
+            });
+        let Some(idx) = idx else { return false };
+        match self.f.param_types.get(idx) {
+            Some(t) => t.is_object_handle || t.is_reference,
+            None => false,
+        }
+    }
 }
 
 fn s16(w: u16) -> i32 {
@@ -1753,6 +1772,15 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
     // store is dropped, exactly as pre-batch-41, keeping the slot's const decl intact). Cleared
     // when the slot is re-written with a non-const value.
     let mut const_obj_slots: std::collections::HashSet<i32> = std::collections::HashSet::new();
+    // batch-45c (FIX-4): slot -> PARAMETER name, recorded when `RefCpyV wSlot` copies a param
+    // into a slot immediately consumed by `CmpPtrNull wSlot` in a short-circuit null-guard
+    // (`Me != null && …`). The copy is FOLDED (not materialised) so the guard renders
+    // `if (<param> == nullptr)` on the param directly — the vanilla dropped the RefCpyV, leaving
+    // the guard testing an UNWRITTEN slot. Folding (vs materialising `local_N = <param>;`) is
+    // const-safe: the GVL `Me` param is `const AGothicCharacterState`, so a slot copy would need a
+    // const decl (batch-41 cascade risk); a direct null-compare of the const param has no
+    // conversion. Consumed + cleared by the very next `CmpPtrNull`.
+    let mut guard_param_alias: HashMap<i32, String> = HashMap::new();
     let mut pending: Option<String> = None; // unconsumed call/ctor result
     let mut pending_ty: Option<String> = None; // recovered type of `pending` (call return type)
     // batch-20 Class B: the call returns a CONST object handle (`const UCharacterAIState`).
@@ -2451,7 +2479,13 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
             }
             "CmpPtrNull" => {
                 test_after_call = true;
-                cmp = Some(Cmp { a: name(w(ins, 0)), b: "nullptr".into(), ..Default::default() });
+                // batch-45c (FIX-4): if the preceding RefCpyV folded a param into this guard slot
+                // (`RefCpyV wN(<param>) ; CmpPtrNull wN`), render the guard on the param directly
+                // (`<param> == nullptr`) — the vanilla copy was dropped, leaving `local_N`
+                // unwritten. `remove` so a later reuse of the slot never re-aliases.
+                let slot = w(ins, 0);
+                let a = guard_param_alias.remove(&slot).unwrap_or_else(|| name(slot));
+                cmp = Some(Cmp { a, b: "nullptr".into(), ..Default::default() });
             }
             // a test op turns the CMP register into a bool; it carries the real relational
             // operator (the jump only carries the true/false sense).
@@ -3235,6 +3269,24 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                         && !top.s.contains('\u{1}')
                         && top.s != UNRESOLVED
                         && !top.s.starts_with('~');
+                    // batch-45c (FIX-4): a param copied into a slot that the VERY NEXT op
+                    // null-guards (`RefCpyV wN(<param>) ; CmpPtrNull wN`) in a short-circuit
+                    // `<param> != null && …` chain. Vanilla drops the RefCpyV, so `local_N` is
+                    // never written and `if (local_N == nullptr)` guards garbage. FOLD the copy:
+                    // record slot -> param so the following CmpPtrNull renders `if (<param> ==
+                    // nullptr)` directly (no slot decl -> const-safe for the `const` GVL `Me`).
+                    // Hard gate: source is an object/ref PARAM, and insns[k+1] is exactly
+                    // `CmpPtrNull` on this SAME slot (never touches a non-guard RefCpyV).
+                    let dst_slot0 = w(ins, 0);
+                    let param_guard_fold = ctx.param_object_ref(&top.s)
+                        && insns
+                            .get(k + 1)
+                            .is_some_and(|nx| nx.op.name == "CmpPtrNull" && w(nx, 0) == dst_slot0);
+                    if param_guard_fold {
+                        flush!();
+                        guard_param_alias.insert(dst_slot0, top.s.clone());
+                        continue;
+                    }
                     let ok = !top.s.is_empty()
                         && top.s != dst
                         && !const_ret_getter

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -413,17 +413,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     let rvo_slot = is_method && ret_ty
         .map(|t| matches!(t.split('<').next().unwrap_or(t).bytes().next(), Some(b'F') | Some(b'T')))
         .unwrap_or(false);
-    // NESTED-CALL ARG-DROP fix: when arity is untrusted (native call, no Binds -> trusted_arity=None),
-    // the old `mem::take` DRAINED the whole stack — annihilating an ENCLOSING call's already-pushed
-    // args when a nested FREE/STATIC call (e.g. `UQuestSubsystem::Get()`, a factory/getter) runs in
-    // the middle of the enclosing arg-push (proven: `Get().GetQuestByClass(TSubclassOf(...))` lost the
-    // TSubclassOf arg -> 0-arg call). For a NON-METHOD call the cache FunctionReference param count is
-    // reliable (no implicit-`this` undercount), so use it as a soft cap to take ONLY this call's own
-    // args and preserve deeper enclosing operands. METHOD calls keep take-all (their cache counts are
-    // unreliable due to the implicit `this`, and their receiver-on-top means deeper entries are rarely
-    // a separate enclosing frame). StaticClass is already special-cased (0 operands, no drain).
-    let soft_arity = trusted_arity.or_else(|| if !is_method { params.map(|p| p.len()) } else { None });
-    let need = soft_arity.map(|n| n + is_method as usize + rvo_slot as usize);
+    let need = trusted_arity.map(|n| n + is_method as usize + rvo_slot as usize);
     let mut a: Vec<Arg> = match need {
         Some(k) if stack.len() > k => {
             // Split off this call's own operands (top `k`); the deeper entries belong to an
@@ -1255,10 +1245,18 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                         Some(ns) => format!("{ns}::{f}"),
                         None => f.clone(),
                     };
-                    // NATIVE call by ptr: the cache param list undercounts, so trust ONLY the
-                    // Binds native arity (`na`) for the EDIT B-PRIME split; None falls back to
-                    // take-all (byte-identical to today when Binds is absent).
-                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, na, None, ctx.class_name, false, pending_ty.as_deref(), ctx.refs)
+                    // NATIVE call by ptr: prefer the Binds native arity (`na`) for RENDER arity,
+                    // but for the STACK SPLIT fall back to the cache FunctionReference param count
+                    // when Binds is absent, instead of take-all. Take-all (`mem::take`) DRAINED the
+                    // whole operand stack, so a nested native call (e.g. `Topic.GetOther()`,
+                    // `state.GetAI()` — 0-param getters) run in the middle of an enclosing call's
+                    // arg-push ANNIHILATED the enclosing args -> 0/under-arg calls (Remember(),
+                    // UnlockDocumentSegment(), AddTag(), Subdialog). This is rendering-neutral for
+                    // the call being built (the existing top-`w` trim selects the same args; an
+                    // implicit-`this` overcount steals one deeper entry that the trim then drops),
+                    // and only PRESERVES deeper enclosing operands that take-all destroyed.
+                    let trusted = na.or_else(|| ctx.refs.func_params_by_ptr(ptr).map(|p| p.len()));
+                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, None, ctx.class_name, false, pending_ty.as_deref(), ctx.refs)
                 };
             }
             "CallPtr" => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -420,12 +420,18 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     // (the same condition the Fix-b3 out-slot probe uses). This can only SHRINK the window vs the
     // old heuristic, never widen, so it cannot break a real by-value RVO recovery.
     fn tyhead(s: &str) -> &str { s.split('<').next().unwrap_or(s) }
-    let rvo_slot = is_method
-        && ret_ty.map(|t| matches!(tyhead(t).bytes().next(), Some(b'F') | Some(b'T'))).unwrap_or(false)
-        && stack.len() >= 2
+    let rvo_slot = ret_ty.map(|t| matches!(tyhead(t).bytes().next(), Some(b'F') | Some(b'T'))).unwrap_or(false)
         && {
-            let below = &stack[stack.len() - 2];
-            below.is_psf && below.ty.as_deref().map(tyhead) == ret_ty.map(tyhead)
+            // The hidden RVO out-slot sits BELOW the receiver for a method (top = receiver) and
+            // ON TOP for a free call (no receiver pushed). Same data-driven evidence gate as the
+            // Fix-b3 probe (is_psf + type-head == return head), so it only widens the window when
+            // the out-slot is genuinely present. (Free calls returning a struct by value push it:
+            // GotoPosition/Say/GiveItemTo/FInGameTime::Now.)
+            let idx = if is_method { 2 } else { 1 };
+            stack.len() >= idx && {
+                let slot = &stack[stack.len() - idx];
+                slot.is_psf && slot.ty.as_deref().map(tyhead) == ret_ty.map(tyhead)
+            }
         };
     let need = trusted_arity.map(|n| n + is_method as usize + rvo_slot as usize);
     let mut a: Vec<Arg> = match need {
@@ -576,6 +582,25 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         // receiver) — never a free call; drop it (the conversion re-fires from the target type).
         if matches!(f, "opImplConv" | "opConv") {
             return None;
+        }
+        // Free-call RVO struct-return (mirror of the method Fix-b3 arm): a free/static function
+        // returning a struct BY VALUE pushes a hidden PSF out-slot. Recover `out = f(args)`
+        // instead of leaking the out-slot as a leading arg (GotoPosition/Say/GiveItemTo/
+        // FInGameTime::Now). Same data-driven gate as Fix-b3: a PSF arg whose type head equals the
+        // return-type head; a call without a genuine out-slot can't match.
+        if let Some(rh) = ret_ty.map(tyhead) {
+            if matches!(rh.bytes().next(), Some(b'F') | Some(b'T') | Some(b'E')) {
+                if let Some(pos) = a.iter().position(|x| x.is_psf
+                    && x.ty.as_deref().map(tyhead) == Some(rh)) {
+                    let out = a.remove(pos).s;
+                    if let Some(w) = arity {
+                        let w = w.min(a.len());
+                        if a.len() > w { a.drain(..a.len() - w); }
+                    }
+                    maybe_reverse_args(&mut a, params, refs);
+                    return Some(format!("{out} = {f}({})", render_args(&a, params, refs)));
+                }
+            }
         }
         // trim leading phantom extras for a known free arity too.
         if let Some(w) = arity {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2411,6 +2411,15 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                     // one WE emit (GetG1R renders `UStoryG1R GetG1R()`, no const), while the
                     // tail-table entry spuriously carries bIsObjectConst (2757 GetG1R stores compile
                     // CLEAN in the batch-19 capture). Never const-wrap script-call results.
+                    // batch-41e CONFIRMED: the return DataType flag `is_object_const` is NOT a
+                    // reliable const-return signal — GetG1R (UG1RQuest) carries is_object_const=true
+                    // identically to GetSelectedItem, yet its emitted decl is legitimately non-const
+                    // (emit.rs `ret_sig` re-adds `const` only when the BODY returns a const-marked
+                    // slot, which GetG1R does not). Const-wrapping on the flag alone cascades const
+                    // to ~900 GetG1R + GetRootNode call sites that contradict their non-const decls.
+                    // So the blanket stays; GetSelectedItem's const-member-getter recovery is
+                    // reverted at the source instead (the RefCpyV `const_ret_getter` bail below,
+                    // batch-41e).
                     pending_const = false;
                     let na = ctx.refs.native_arity_by_id(id, &orig);
                     // SCRIPT call by id: the cache FunctionReference param count is authoritative
@@ -2961,8 +2970,33 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                         && !top.s.contains('(')
                         && !top.s.contains('\u{2}')
                         && top.s != UNRESOLVED;
+                    // batch-41e (CASE B): BAIL when this const native-field member read would
+                    // become the function's RETURNED value, forcing an object-const RETURN type.
+                    // A const-member getter body (`return this.<constMember>;`) makes emit.rs render
+                    // `const T GetX()`; every caller then needs a `const T` slot, and the script
+                    // CALL arm cannot const-propagate (the return DataType flag is unreliable —
+                    // GetG1R carries is_object_const=true identically yet is legitimately non-const,
+                    // so flagging on it cascades const to ~900 unrelated call sites). Rather than a
+                    // fragile, wide const-cascade, keep the ONE getter stubbed (its pre-batch-41
+                    // state): dropping this store leaves the returned slot undeclared, so the
+                    // LOADOBJ..RET stubs the whole function (1 stub, ZERO caller cascade).
+                    // Precise gate: source is a const native-field read (`top.nf_const`) AND the
+                    // enclosing function returns an object-const handle of the SAME type. This
+                    // matches ONLY GetSelectedItem (`const UItemDefinition` return). It does NOT
+                    // touch GetSelectedItemAction (return is non-const UActionKeywords) nor the
+                    // CharacterAI_Gothic const-member READS that feed null-checks / GetClass()
+                    // receivers (their functions return FItemActionHandler / bool / void, never an
+                    // object-const handle of the member's type) — those keep their batch-32d/41
+                    // `const T` local recovery.
+                    let const_ret_getter = top.nf_const.is_some()
+                        && ctx.ret_ty.is_some_and(|d| {
+                            d.is_object_handle
+                                && d.is_object_const
+                                && d.base_name(ctx.refs) == *top.nf_const.as_deref().unwrap_or("")
+                        });
                     let ok = !top.s.is_empty()
                         && top.s != dst
+                        && !const_ret_getter
                         && (top.s.starts_with("local_") || top.s.starts_with("Cast<") || member_src);
                     if ok {
                         flush!();

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -513,7 +513,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
                     // GetActorLocation()` instead of `out = recv.Iterator()` -> "No matching
                     // signatures". `this`-receivers render `this.Method()` (legal, matches the
                     // normal method-render path below).
-                    return Some(format!("{out} = {}.{f}({})", recv.s, render_args(&a, params, refs)));
+                    return Some(format!("{out} = {}.{f}({})", wrap_uobject_recv(&recv, target_owner), render_args(&a, params, refs)));
                 }
             }
         }
@@ -577,7 +577,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
             }
         }
         maybe_reverse_args(&mut a, params, refs);
-        Some(format!("{}.{f}({})", recv.s, render_args(&a, params, refs)))
+        Some(format!("{}.{f}({})", wrap_uobject_recv(&recv, target_owner), render_args(&a, params, refs)))
     } else {
         if refs.is_type_name(f) {
             // EDIT C: a value-type factory call (FName/E*/T* — NOT U*/A*, which use ALLOC) whose
@@ -657,6 +657,30 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         maybe_reverse_args(&mut a, params, refs);
         Some(format!("{f}({})", render_args(&a, params, refs)))
     }
+}
+
+/// Batch19 class 1 — UObject-typed method receivers: a receiver slot the cache records as
+/// plain `UObject` (a compiler temp for a `&&`-chain / IsValid arg, or a generic-getter result
+/// like `GetTypedOuter`) fails method lookup on every non-UObject method ("No matching
+/// signatures to 'UObject::GetCharacterState()'", 255 in-game errors). The CONSUMING method's
+/// owner class is known from the callee's T3 ObjectType — wrap the receiver in the standard
+/// UE-AS downcast idiom `Cast<Owner>(recv)` AT THE CALL SITE. Call-site wrapping (option (b))
+/// is chosen over retyping the DECLARATION (option (a)) because the slot is also written from
+/// producers (`RefCpyV` handle copies, generic getters) whose types we cannot prove compatible
+/// with the owner — a retyped declaration could break those assignments (upcast-breaking),
+/// while a local `Cast<>` can only affect the one call that is already broken. Gates: the
+/// recovered receiver type is EXACTLY `UObject` (never a subclass, never unknown), the owner
+/// is a real object class (U*/A*, excludes container/value owners like `TArray`), and the
+/// owner isn't `UObject` itself (genuine UObject methods resolve fine).
+fn wrap_uobject_recv(recv: &Arg, owner: Option<&str>) -> String {
+    if recv.ty.as_deref() == Some("UObject") && recv.s != "this" {
+        if let Some(o) = owner {
+            if o != "UObject" && matches!(o.bytes().next(), Some(b'U') | Some(b'A')) {
+                return format!("Cast<{o}>({})", recv.s);
+            }
+        }
+    }
+    recv.s.clone()
 }
 
 /// Count DEFINITE type mismatches when pairing args[i] with params[i] (mirrors `cast_arg`'s
@@ -1399,12 +1423,19 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                             // EDIT A/B-PRIME) — a whole-stack `mem::take` would also drain the
                             // ENCLOSING call's operands (the 4 EQuestState args of MakeRequirement),
                             // re-dropping them once Fix b1 keeps them on the stack.
-                            let args: Vec<Arg> = match params.map(|p| p.len()) {
+                            let mut args: Vec<Arg> = match params.map(|p| p.len()) {
                                 Some(k) if stack.len() > k => stack.split_off(stack.len() - k),
                                 _ => std::mem::take(&mut stack),
                             }
                                 .into_iter()
                                 .filter(|x| !x.s.is_empty() && x.s != UNRESOLVED).collect();
+                            // Ctor args are reverse-pushed like every other call's (top =
+                            // params[0]); rendering the collected (deepest-first) order emitted
+                            // them BACKWARDS — `FTimerDynamicDelegate(n"Fn", this)` against the
+                            // declared `(UObject Object, FName FunctionName)` ctor (43 in-game
+                            // "No matching signatures to 'FTimerDynamicDelegate(const FName,
+                            // <obj> const)'"). Same reverse-by-default scoring as every call arm.
+                            maybe_reverse_args(&mut args, params, ctx.refs);
                             // Gate (b): no arg is itself a PSF slot — that is a copy/convert ctor
                             // whose true source is an unrecovered pending call result; rendering it
                             // as `T(&slot)` would be wrong, so drop (prior behaviour).
@@ -1457,7 +1488,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // implicit-`this` overcount steals one deeper entry that the trim then drops),
                     // and only PRESERVES deeper enclosing operands that take-all destroyed.
                     let trusted = na.or_else(|| ctx.refs.func_params_by_ptr(ptr).map(|p| p.len()));
-                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, None, ctx.class_name, false, pending_ty.as_deref(), ctx.refs)
+                    // target_owner (T3 ObjectType) was only wired for CALL/CALLINTF; pass it for
+                    // native calls too so the UObject-receiver Cast wrap (batch19 class 1) and the
+                    // generated-accessor qualification see the owning class of CALLSYS methods.
+                    build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, ctx.refs.func_owner_by_ptr(ptr), ctx.class_name, false, pending_ty.as_deref(), ctx.refs)
                 };
             }
             "CallPtr" => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -40,6 +40,11 @@ struct Arg {
     /// counts the hidden `WorldContextObject`), but it is NOT a source-level arg — build_call
     /// strips it after collection and reduces the render arity accordingly.
     is_ctx: bool,
+    /// True for an int-slot arg whose value provably came from a MEMBER READ (RDR* after a
+    /// member-ref load) — a real data value (an XP amount, a config int), not a stranded SetV
+    /// temporary. The nested-call retain keeps these (`GiveExperience(hero, local_23)` must not
+    /// lose its `this.XP_...`-sourced Amount to an intervening `GetHero()`).
+    keep: bool,
 }
 impl Arg {
     fn int(s: String) -> Arg {
@@ -453,7 +458,7 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
             // an int MinCount, a builder-chain weight/cooldown — that the enclosing call needs
             // (proven: IsCloseToCharacter(a, b, 699.0) lost its 699.0 to this drop).
             let own = stack.split_off(stack.len() - k);
-            stack.retain(|x| !x.is_int || x.cbits.is_some());
+            stack.retain(|x| !x.is_int || x.cbits.is_some() || x.keep);
             own
         }
         _ => std::mem::take(stack),
@@ -928,6 +933,9 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
     let mut ref_reg: Option<String> = None; // Idiom-B member address
     let mut ref_reg_ty: Option<String> = None; // field type name behind ref_reg (for casts)
     let mut set_consts: HashMap<i32, ConstBits> = HashMap::new(); // last SetV* constant per slot
+    // Slots whose current value came from a MEMBER READ (RDR* after a member-ref load) — real
+    // data values, kept by the nested-call retain (see Arg.keep). Invalidated on overwrite.
+    let mut member_read_slots: std::collections::HashSet<i32> = std::collections::HashSet::new();
     let mut pending: Option<String> = None; // unconsumed call/ctor result
     let mut pending_ty: Option<String> = None; // recovered type of `pending` (call return type)
     let mut ret_val: Option<String> = None;
@@ -983,6 +991,14 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
         if overwrites_slot {
             if let Some(&wd) = ins.words.first() {
                 set_consts.remove(&(wd as i16 as i32));
+                member_read_slots.remove(&(wd as i16 as i32)); // (RDR* re-inserts in its arm)
+            }
+        }
+        // SetV* is excluded from overwrites_slot (it REGISTERS a const) but still replaces a
+        // member-read value with a temporary — invalidate the keep flag.
+        if matches!(n, "SetV4" | "SetV8" | "SetV1") {
+            if let Some(&wd) = ins.words.first() {
+                member_read_slots.remove(&(wd as i16 as i32));
             }
         }
         match n {
@@ -1010,6 +1026,9 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // nested-call retain (`!is_int || cbits.is_some()`) keeps it as a REAL arg
                     // instead of dropping it as a stranded temporary.
                     stack.push(Arg::iconst(name(off), cb));
+                } else if member_read_slots.contains(&off) {
+                    // Member-read value (this.XP_... amount) — a real arg the retain must keep.
+                    stack.push(Arg { s: name(off), is_int: true, keep: true, ..Default::default() });
                 } else {
                     stack.push(Arg::int(name(off)));
                 }
@@ -1113,6 +1132,7 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     let dst_is_int = dst_slot > 0 && ctx.slot_type(dst_slot).is_none();
                     let rhs = enum_to_int(r.clone(), ref_reg_ty.as_deref(), dst_is_int);
                     out.push(format!("{} = {rhs};", name(dst_slot)));
+                    member_read_slots.insert(dst_slot); // real data value, not a SetV temporary
                 }
             }
             _ if n.starts_with("WRTV") => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -351,16 +351,31 @@ struct Cmp {
 fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option<&str>, params: Option<&[DataType]>, native_arity: Option<usize>, trusted_arity: Option<usize>, target_owner: Option<&str>, cur_class: Option<&str>, non_virtual: bool, ret_ty: Option<&str>, refs: &RefResolver) -> Option<String> {
     if f.starts_with('$') || f.starts_with('~') || f == "__STATIC_NAME" {
         // EDIT C (the dominant FName form): `__STATIC_NAME` is the synthesized name-table accessor
-        // that produces an FName from a pushed name-table INDEX into the return register; a
-        // following `PshRPtr` re-pushes it as the ENCLOSING call's arg. Dropping it (return None)
-        // loses that arg → `this.GetCharacter()` (0-arg). Recover it as a renderable `FName(<idx>)`
-        // value so it FLOWS into `pending` and PshRPtr restores ARITY (`this.GetCharacter(FName(...))`).
-        // The literal is the name-table index, not the string (acceptable per spec: correct arity
-        // beats a dropped arg). Gate: exactly one int operand on top (the index).
+        // (`const FName& __STATIC_NAME(int Id)` per the exe's registered decl) that fetches
+        // `FAngelscriptManager::StaticNames[Id]` — populated at load from the cache's StaticNames
+        // tail table (table 5) — into the return register; a following `PshRPtr` re-pushes it as
+        // the ENCLOSING call's arg. Dropping it (return None) loses that arg → `this.GetCharacter()`
+        // (0-arg). Resolve the pushed Id through RefResolver::static_name and render the UE-AS
+        // FName literal `n"Name"` so it FLOWS into `pending` and PshRPtr restores both ARITY and
+        // VALUE (`this.GetCharacter(n"Hero")`). AS FName has NO int ctor, so the historical
+        // `FName(<idx>)` render never compiled ("No matching signatures to 'FName(const int)'");
+        // it remains only as the arity-preserving fallback for an unresolvable Id (non-constant
+        // operand or out-of-range index, e.g. a mini-cache with empty tail tables).
+        // Gate: exactly one int operand on top (the Id).
         if f == "__STATIC_NAME" {
             if let Some(top) = stack.last() {
                 if top.is_int && !top.s.is_empty() {
                     let idx = stack.pop().unwrap();
+                    // constant bits first (authoritative for PshC4), rendered text as fallback
+                    // (covers a tracked int slot whose rendered form is the decimal value).
+                    let id = match idx.cbits {
+                        Some(ConstBits::W4(b)) => Some(b as i32 as i64),
+                        Some(ConstBits::W8(b)) => Some(b as i64),
+                        None => idx.s.parse::<i64>().ok(),
+                    };
+                    if let Some(name) = id.and_then(|i| refs.static_name(i)) {
+                        return Some(format!("n\"{}\"", esc(name)));
+                    }
                     return Some(format!("FName({})", idx.s));
                 }
             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -50,6 +50,12 @@ struct Arg {
     /// (scoped option: it is deliberately NOT merged into `ty`, so call-arg/argtype gates
     /// never see it).
     nfty: Option<String>,
+    /// batch-32d: base value type of a CONST object-handle NATIVE field
+    /// (`refs::native_field_const_object`) — carried ONLY so the RefCpyV arm can emit the
+    /// CONSTSTORE marker when such a member read is copied into a same-typed local
+    /// (`const UItemDefinition` -> `UItemDefinition` implconv, CharacterAI_Gothic:3002).
+    /// Like `nfty`, deliberately NOT merged into `ty`.
+    nf_const: Option<String>,
     /// batch-27 (Cast-diamond carry): pushed by a plain slot/const/global push opcode in
     /// `block_stmts` — safe to carry across a recognized Cast diamond; never set for
     /// pending-call-result pushes (`PshRPtr`) or synthetic pushes.
@@ -1789,6 +1795,12 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     top.is_int = false; // now a member access, not a bare int slot
                     top.ty = fty;
                     top.nfty = nfty;
+                    // batch-32d: const object-handle native field (always assigned so a
+                    // stale flag from an earlier chain link can never leak forward).
+                    top.nf_const = ctx.refs
+                        .type_by_id(tid)
+                        .and_then(|cls| ctx.refs.native_field_const_object(cls, &field))
+                        .map(|s| s.to_string());
                 }
             }
             "RDSPtr" => {} // deref in place: no change to the rendered name
@@ -2680,7 +2692,21 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                             }
                             _ => top.s.clone(),
                         };
-                        out.push(format!("{dst} = {rhs};"));
+                        // batch-32d: the copied source is a CONST object-handle native field
+                        // of the destination's EXACT declared type (`const UItemDefinition`
+                        // member read into `UItemDefinition local_20;` — a same-type Cast
+                        // does NOT strip const in-game, batch-21 Class C). Emit the
+                        // CONSTSTORE marker so the emitter declares the destination
+                        // `const T` — the downcast() exact-type rule, mirrored for the
+                        // RefCpyV member-read shape (CharacterAI_Gothic:3002).
+                        if top.nf_const.is_some()
+                            && top.nf_const.as_deref()
+                                == (dst_slot > 0).then(|| ctx.slot_type(dst_slot)).flatten().as_deref()
+                        {
+                            out.push(format!("{dst} = {CONSTSTORE}{rhs};"));
+                        } else {
+                            out.push(format!("{dst} = {rhs};"));
+                        }
                     }
                 }
             }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3764,7 +3764,35 @@ impl Structurer<'_> {
                 // `break_off` = the test's forward exit. Gate 2 already proved (in the detector)
                 // that the body fully structures under this scope; on ANY deviation the detector
                 // returned None and this arm never fired (the status-quo bottom-test stands).
-                self.emit_linear(i, i + 1, depth, out, true);
+                //
+                // batch-44d: emit the entry block's setup statements WITH the incoming operand-stack
+                // carry (`init`) — the Cast-diamond carry from a preceding block. A setup call whose
+                // args were pushed BEFORE a Cast diamond (e.g. `BrushComponent.GetOverlappingActors(
+                // out, filter)` — out/filter PSF'd in an earlier block, carried across the
+                // null-check diamond into this entry/join block) needs that carry, else the call
+                // renders 0-arg ("No matching signatures"). `emit_linear` starts with an EMPTY stack
+                // and dropped those args; `block_stmts_in` with `init` restores them.
+                let (mut stmts, _, _) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init, false);
+                // batch-44d: the entry block's trailing `<coll>.Iterator()` result is dropped by
+                // build_call (the TMap/TSet Iterator lowers with NO PSF out-slot → a bare statement).
+                // The iterator local has NO default constructor, so the hoisted `TMapIterator
+                // local_It;` + `local_It.CanProceed` fails to compile. Capture the trailing
+                // `Iterator()` into the iterator slot so `rewrite_iterator_decl_init` turns it into
+                // `auto local_It = coll.Iterator();`.
+                if let Some(it_slot) = self.foreach_iter_slot(test_idx) {
+                    let it_name = self.ctx.slot_name(it_slot);
+                    if let Some(last) = stmts.iter_mut().rev().find(|s| !s.trim().is_empty()) {
+                        let t = last.trim();
+                        if (t.ends_with(".Iterator();") || t.ends_with(".Iterator()"))
+                            && assign_lhs(t).is_none()
+                        {
+                            *last = format!("{it_name} = {t}");
+                        }
+                    }
+                }
+                for s in &stmts {
+                    let _ = writeln!(out, "{ind}{s}");
+                }
                 let _ = writeln!(out, "{ind}while ({cond})");
                 let _ = writeln!(out, "{ind}{{");
                 let test_off = self.g.blocks[test_idx].start_dw;
@@ -5170,6 +5198,25 @@ impl Structurer<'_> {
             "JLowNZ" => expr,
             _ => format!("!({expr})"),
         })
+    }
+
+    /// batch-44d: the iterator SLOT of a test-first foreach — the `wIt` operand of the test
+    /// block's `LoadVObjR wIt, ?, CanProceed`. Used to capture the entry block's `Iterator()`
+    /// result into a decl-init (`auto local_It = coll.Iterator();`) — the iterator local has NO
+    /// default constructor, so a bare hoisted `TMapIterator local_It;` fails to compile.
+    fn foreach_iter_slot(&self, test_idx: usize) -> Option<i32> {
+        let b = &self.g.blocks[test_idx];
+        for j in b.instr_lo..b.instr_hi {
+            let ins = &self.ctx.instrs[j];
+            if ins.op.name == "LoadVObjR" {
+                let off = ins.words.get(1).copied().unwrap_or(0) as i32;
+                let tid = ins.dwords.first().copied().unwrap_or(0) as i32;
+                if self.ctx.refs.member(tid, off) == Some("CanProceed") {
+                    return Some(ins.words.first().copied().map(s16).unwrap_or(0));
+                }
+            }
+        }
+        None
     }
 
     /// batch-44b (E2, specs/loop-body-cfg-ext.md §2.2): detect a TEST-FIRST `foreach` whose ENTRY

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3072,7 +3072,7 @@ impl Structurer<'_> {
                 // block's initial stack — ONLY when the construct is provably the null-check
                 // Cast diamond (see diamond_join). Everything else keeps drop-at-boundary.
                 if !leftover.is_empty() {
-                    if let Some(j) = self.diamond_join(i, next, &leftover, &cmp) {
+                    if let Some(j) = self.diamond_join(i, Some(next), &leftover, &cmp) {
                         self.carry = Some((j, leftover));
                     }
                 }
@@ -3094,16 +3094,48 @@ impl Structurer<'_> {
 
     /// Emit a linear run of blocks [i, end) as statements (loop body); the last block's
     /// trailing comparison/jump is dropped when `skip_term_cond`.
+    ///
+    /// batch-33e: the diamond carry works here too. Loop bodies flatten their diamonds
+    /// (arms emitted sequentially), so a guard block's leftover operand stack used to die
+    /// at every block boundary — an arg pushed BEFORE an in-loop Cast diamond never reached
+    /// its consumer in the join (ANotifySpellCategoryActor::EndPlay rendered
+    /// `RemoveTag()` 0-arg inside its m_Targets iterator loop). The SAME diamond_join proof
+    /// applies unchanged: D10's dual-sim guarantees each arm emits identical statements
+    /// with the carry as initial stack and returns it verbatim — so threading the carry
+    /// through the flattened arm blocks up to the join is exactly the runtime stack on
+    /// BOTH paths. `next` is None (no emission adjacency in linear mode); instead the
+    /// join must lie inside this linear range.
     fn emit_linear(&mut self, i: usize, end: usize, depth: usize, out: &mut String, _skip: bool) {
         let ind = "    ".repeat(depth);
+        let mut carry: Vec<Arg> = Vec::new();
+        let mut carry_until: Option<usize> = None;
         for bi in i..end {
             let b = &self.g.blocks[bi];
-            let (stmts, _) = block_stmts(self.ctx, b.instr_lo, b.instr_hi);
+            let init = match carry_until {
+                Some(j) if bi <= j => std::mem::take(&mut carry),
+                _ => Vec::new(),
+            };
+            let (stmts, cmp, leftover) = block_stmts_in(self.ctx, b.instr_lo, b.instr_hi, init);
             for s in &stmts {
                 let _ = writeln!(out, "{ind}{s}");
             }
             if let Some(x) = self.region_exit_stmt(bi) {
                 let _ = writeln!(out, "{ind}{x}");
+            }
+            match carry_until {
+                // still strictly inside the proven diamond: D10 returned the carry verbatim.
+                Some(j) if bi < j => carry = leftover,
+                _ => {
+                    carry_until = None;
+                    if !leftover.is_empty() {
+                        if let Some(j) = self.diamond_join(bi, None, &leftover, &cmp) {
+                            if j > bi && j < end {
+                                carry = leftover;
+                                carry_until = Some(j);
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -3547,7 +3579,7 @@ impl Structurer<'_> {
     /// independent of the carried entries; the join's first call is a CALLSYS/Thiscall1 with
     /// TRUSTED arity (split path, never take-all). Stage 2 (own harness batch) relaxes the
     /// consumer gate to CALL/CALLINTF script consumers.
-    fn diamond_join(&self, i: usize, next: usize, l: &[Arg], cmp: &Option<Cmp>) -> Option<usize> {
+    fn diamond_join(&self, i: usize, next: Option<usize>, l: &[Arg], cmp: &Option<Cmp>) -> Option<usize> {
         let ctx = self.ctx;
         let blocks = &self.g.blocks;
         let b = &blocks[i];
@@ -3597,9 +3629,15 @@ impl Structurer<'_> {
         // D5 join index: must be exactly the `next` the is_cond arm just emitted (creation and
         // consumption are then adjacent iterations of the same emit_range loop, or — via the
         // sole-entry proof below — the next emission of block j in an enclosing range).
+        // batch-33e: `next` is None when called from emit_linear (loop bodies) — there the
+        // caller checks the join lies inside the linear range instead; every other proof
+        // (topology D2-D4/D6, dual-sim D10, consumer D11/D12) is graph/simulation-based and
+        // emission-mode-independent.
         let j = *self.idx_of.get(&join_off)?;
-        if j != next {
-            return None;
+        if let Some(nx) = next {
+            if j != nx {
+                return None;
+            }
         }
         // D6 sole-entry edges (precedent: try_emit_switch's outside-entry scan): the only edge
         // into the then-arm (and else-arm, if present) comes from the guard; the only edges

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2771,21 +2771,19 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                             let src = stack[stack.len() - 2].clone();
                             if !src.s.is_empty() && src.s != UNRESOLVED && !src.s.starts_with('\u{2}') {
                                 stack.truncate(stack.len() - 2);
-                                // batch-43 (Fix 2): a `$beh0(__return, src)` inside a struct-RVO
-                                // SWITCH CASE region (JMP-terminated, `ctx.rvo_switch_region` set)
-                                // has NO RET here to consume `ret_val` — the JMP goes to the shared
-                                // bare RET, and `ret_val` is block-local, so the value would be
-                                // LOST. Emit `__return = src;` as a STATEMENT so the switch's per-
-                                // case `return <val>;` fold (region_exit_stmt + fold_rvo_return)
-                                // recovers it. EVERYWHERE ELSE (the normal single-region struct
-                                // return, and — deliberately out of batch-43 scope — branch/loop
-                                // early returns) keep the byte-identical `ret_val` path: its RET arm
-                                // folds `ret_val`/pending to `return src;` with no duplicate stmt.
-                                // Scoping to switch regions keeps the general branch/loop RVO-return
-                                // recovery to the deferred Fix 3 / loop-body-cfg lever.
-                                if ctx.rvo_switch_region.get()
-                                    && ctx.instrs[hi - 1].op.name != "RET"
-                                {
+                                // batch-43 (Fix 2) / batch-47b (FIX-2b): a `$beh0(__return, src)`
+                                // that DEFAULT-CONSTRUCTS-then-returns the RVO struct in a block
+                                // ending in JMP (not RET) — the JMP goes to the shared tail RET and
+                                // `ret_val` is block-local, so the value would be LOST (the tail RET
+                                // ships the RVODEF default). Emit `__return = src;` as a STATEMENT so
+                                // emit.rs declares `{ret} __return;` and folds the tail
+                                // `return RVODEF;` to `return __return;` (region_exit_stmt +
+                                // fold_rvo_return in the switch case). batch-43 scoped this to
+                                // `rvo_switch_region`; FIX-2b generalises it to ANY non-RET block
+                                // (the branch/loop early-return that was deferred). When the block
+                                // ends in RET, keep the byte-identical `ret_val` path (folds to
+                                // `return src;` with no duplicate store).
+                                if ctx.instrs[hi - 1].op.name != "RET" {
                                     flush!();
                                     out.push(format!("__return = {};", src.s));
                                 } else {
@@ -3644,9 +3642,9 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
             "OBJTYPE" => stack.push(Arg::obj("objtype".into())), // +2: RTTI objtype ptr
             "STR" => stack.push(Arg::obj("\"\"".into())),         // +3: string-constant push
             "PshListElmnt" => stack.push(Arg::int(name(w(ins, 0)))), // +2: list element
-            "COPY" => { stack.pop(); }                           // -2: pop the source ptr
-            // asBC_CopyScript (QW_ARG = object-type ptr; stack -2): a script value-type / struct
-            // copy = the source-level assignment `dest = src;`. Per asBC_COPY (as_context.cpp) the
+            // asBC_COPY (W_DW_ARG = byte-size + object-type ptr) and asBC_CopyScript (QW_ARG =
+            // object-type ptr) are the SAME operation — a script value-type / struct copy =
+            // the source-level assignment `dest = src;`. Per asBC_COPY (as_context.cpp) the
             // DESTINATION pointer is popped FIRST (it is the stack TOP), the SOURCE is the next
             // entry below it. The compiler pushes SRC first then DEST, so DEST ends up on top —
             // e.g. `PSF <localSrc>; PshVPtr this; ADDSi <member>; CopyScript` is `this.member =
@@ -3655,7 +3653,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
             // every struct copy/member-init/RVO-return BACKWARDS — `local = this.member` and
             // `local = retSlot`.) Both operands arrive as fully-rendered member/local exprs;
             // dropping it left the destination (member or RVO temp) unwritten -> garbage/null.
-            "CopyScript" => {
+            "CopyScript" | "COPY" => {
                 let dst = stack.pop();
                 let src = stack.pop();
                 if let (Some(dst), Some(src)) = (dst, src) {
@@ -3664,7 +3662,25 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                         // function's `return <src>;` — capture it as the return value (the slot
                         // itself has no source name) instead of emitting `__return = <src>;`.
                         if dst.s == "__return" {
-                            ret_val = Some(src.s);
+                            // batch-47b (FIX-2b, specs/final-tail-triage.md §3.2): the RVO copy-out
+                            // (`CopyScript` into `__return`) can sit in a mid-function BRANCH/LOOP
+                            // block that ends in JMP to the shared tail RET (e.g. an early
+                            // `if (…) return FRelativeCrimeMemoryFilter(local_16, Witness);`). There
+                            // `ret_val` is block-local and NEVER consumed — the tail RET emits the
+                            // RVODEF default, so `return __r;` (a default-constructed struct) ships
+                            // on that path, LOSING the built value. This generalises the batch-43
+                            // switch-region carry (which emitted `__return = src;` only inside a
+                            // `rvo_switch_region`) to ANY non-RET-terminated block: emit the store as
+                            // a STATEMENT so emit.rs declares `{ret} __return;` and folds the tail
+                            // `return RVODEF;` to `return __return;` — the value flows on this path.
+                            // When the block DOES end in RET, keep the byte-identical `ret_val` path
+                            // (its RET arm folds to `return <src>;` with no duplicate store).
+                            if ctx.instrs[hi - 1].op.name != "RET" {
+                                flush!();
+                                out.push(format!("__return = {};", src.s));
+                            } else {
+                                ret_val = Some(src.s);
+                            }
                         } else if !dst.s.is_empty() && dst.s != UNRESOLVED && dst.s != src.s {
                             flush!();
                             out.push(format!("{} = {};", dst.s, src.s));
@@ -3740,10 +3756,10 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
             | "DestructScript" | "SaveReturnValue" | "ResolveObjectPtr" | "GETOBJ"
             | "GETOBJREF" | "GETREF"
             | "JMP" => {}
-            // CopyScript performs a script-value copy (an assignment), not housekeeping — it's
-            // unmodeled, so fall through to the marker + stub rather than dropping the copy.
-            // (FinConstruct/DestructScript stay ignored: implicit AS construct/destruct that
-            // appear in nearly every function — emitting/stubbing them would be wrong.)
+            // (CopyScript/COPY are handled above as `dest = src;`. FinConstruct/DestructScript
+            // stay ignored: implicit AS construct/destruct that appear in nearly every function —
+            // emitting/stubbing them would be wrong.) Any genuinely unmodeled opcode falls through
+            // to the marker + stub rather than emitting recompilable source with it silently dropped.
             _ => {
                 flush!();
                 out.push(format!("// {} {}", n, operand_str(ins)));

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1875,6 +1875,23 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                     // vanished, leaving the slot uninitialised (then read downstream as garbage /
                     // passed to a call). Recover it as `slot = T(args);` so the value FLOWS.
                     if let Some(recv) = stack.last().cloned() {
+                        // G1c-b (batch-26 stage 2): 1-arg copy-construct whose receiver is the
+                        // hidden RVO return slot (PshVPtr-pushed -> is_psf false):
+                        // `$beh0(__return, src)` == `return src;`. The PSF gate below can never
+                        // match it (return slot is not PSF'd), so it fell to the generic `$`-drop
+                        // and the function returned the RVODEF default (`return __r;` — compiles,
+                        // loses the value). Mirrors the CopyScript dst=="__return" capture.
+                        if recv.s == "__return" && !recv.is_psf
+                            && ctx.refs.func_params_by_ptr(ptr).map(|p| p.len()) == Some(1)
+                            && stack.len() >= 2
+                        {
+                            let src = stack[stack.len() - 2].clone();
+                            if !src.s.is_empty() && src.s != UNRESOLVED && !src.s.starts_with('\u{2}') {
+                                stack.truncate(stack.len() - 2);
+                                ret_val = Some(src.s);
+                                continue;
+                            }
+                        }
                         // Gate (a): receiver is a PSF'd slot with a known VALUE/struct/template
                         // type (F*/T*/E*). Never a `$`/`?` placeholder, never an object (U*/A*):
                         // object construction uses ALLOC, not this in-place behaviour.

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -1370,6 +1370,12 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
     // `pending_ty` is the const-stripped base name (comparisons everywhere key on it), so the
     // constness travels in this parallel flag; the STOREOBJ arm uses it to Cast-strip.
     let mut pending_const: bool = false;
+    // batch-29a (C8): the last CALL* returns BY REFERENCE (ret DataType.is_reference from the
+    // cache) — the following RDRx dereferences the register the call just filled, so the RDR
+    // destination slot receives the call's VALUE. Set alongside `pending_ty` at every call
+    // producer (false for non-call producers: ALLOC/CallPtr), so a stale flag can never pair
+    // with a live `pending`; cleared by the flush macros with the rest of the pending state.
+    let mut pending_is_ref: bool = false;
     let mut ret_val: Option<String> = None;
     // Target type of the most recent TYPEID push — the implicit type operand of the following
     // `opCast` behaviour call (the lowered form of `Cast<T>(x)`). Resolved to a typename so the
@@ -1382,6 +1388,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
         () => {
             pending_ty = None;
             pending_const = false;
+            pending_is_ref = false;
             if let Some(p) = pending.take() {
                 out.push(format!("{p};"));
             }
@@ -1404,6 +1411,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
             }
             pending_ty = None;
             pending_const = false;
+            pending_is_ref = false;
         };
     }
 
@@ -1627,6 +1635,45 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 ref_reg = Some(format!("{obj}.{field}"));
             }
             _ if n.starts_with("RDR") => {
+                // batch-29a (C8, specs/batch29-errortail.md §8): a ref-RETURNING call immediately
+                // dereferenced — RDRx reads the register the call just filled, so the destination
+                // slot receives the call's VALUE (`local_1 = Task.GetResult();`). Without this the
+                // pending was flushed as a discarded statement (91 "Result of expression is
+                // unused" [W] module-killers) and the destination slot stayed garbage. Gates:
+                // `ref_reg` empty (member loads keep the path below byte-identical) and the
+                // call's ret DataType.is_reference (data-driven from the cache).
+                if ref_reg.is_none() && pending.is_some() && pending_is_ref {
+                    let p = pending.take().unwrap();
+                    let dst_slot = w(ins, 0);
+                    let dst_is_int = dst_slot > 0 && ctx.slot_type(dst_slot).is_none();
+                    // Mirror the member-RDR wraps below: an UNKNOWN/object-typed or float-family
+                    // ref-returned value read into an int-declared slot takes int(...) (warnings
+                    // are errors in-game); a known enum takes enum_to_int; known bool/int stay
+                    // bare; RDR8 stays bare (no UE enum is 8 bytes).
+                    let unknowable = match pending_ty.as_deref() {
+                        None => true,
+                        Some(t) => {
+                            let t = t.trim_start_matches("const ");
+                            matches!(t.bytes().next(), Some(b'U') | Some(b'A') | Some(b'F') | Some(b'T'))
+                                && t.as_bytes().get(1).map(|c| c.is_ascii_uppercase()).unwrap_or(false)
+                        }
+                    };
+                    let float_src = matches!(
+                        pending_ty.as_deref().map(|t| t.trim_start_matches("const ")),
+                        Some("float" | "float32" | "double")
+                    );
+                    let rhs = if dst_is_int && (unknowable || float_src) && n != "RDR8" {
+                        format!("int({p})")
+                    } else {
+                        enum_to_int(p, pending_ty.as_deref(), dst_is_int)
+                    };
+                    out.push(format!("{} = {rhs};", name(dst_slot)));
+                    member_read_slots.insert(dst_slot); // real data value, not a SetV temporary
+                    pending_ty = None;
+                    pending_const = false;
+                    pending_is_ref = false;
+                    continue;
+                }
                 flush!();
                 if let Some(r) = &ref_reg {
                     let dst_slot = w(ins, 0);
@@ -1868,6 +1915,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     // already-pushed args. Do NOT clear it (clearing destroys those args).
                     pending_ty = None;
                     pending_const = false;
+                    pending_is_ref = false;
                     // The class is the StaticClass func's NAMESPACE last-segment (objtype is
                     // NULL for StaticClass; the target class lives in the namespace), not the
                     // calling class — `local = UFoo::StaticClass()` from inside UBar must say UFoo.
@@ -1888,6 +1936,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     let trusted = ctx.refs.func_params_by_id(id).map(|p| p.len());
                     let owner = ctx.refs.func_owner_by_id(id);
                     let ret_is_ref = ctx.refs.func_ret_by_id(id).map(|d| d.is_reference).unwrap_or(false);
+                    pending_is_ref = ret_is_ref; // batch-29a: RDR may consume this call's result
                     // batch-24b shadow gate: a free SCRIPT global (no owner, global namespace)
                     // rendered inside a class method is shadowed by any same-named member in
                     // the class's (native or script) ancestry. Member-name existence (T3
@@ -2016,6 +2065,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     // present belong to an ENCLOSING call.
                     pending_ty = None;
                     pending_const = false;
+                    pending_is_ref = false;
                     let cls = ctx.refs.staticclass_class_by_ptr(ptr)
                         .or_else(|| ctx.refs.func_owner_by_ptr(ptr))
                         .or(ctx.class_name).unwrap_or("UObject");
@@ -2048,6 +2098,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     // native calls too so the UObject-receiver Cast wrap (batch19 class 1) and the
                     // generated-accessor qualification see the owning class of CALLSYS methods.
                     let ret_is_ref = ctx.refs.func_ret_by_ptr(ptr).map(|d| d.is_reference).unwrap_or(false);
+                    pending_is_ref = ret_is_ref; // batch-29a: RDR may consume this call's result
                     build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, ctx.refs.func_owner_by_ptr(ptr), ctx.class_name, false, pending_ty.as_deref(), ret_is_ref, false, ctx.refs)
                 };
             }
@@ -2055,6 +2106,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 let f = name(w(ins, 0));
                 pending_ty = None;
                 pending_const = false;
+                pending_is_ref = false;
                 pending = build_call(&mut stack, &f, false, ctx.super_ctor, None, None, None, None, ctx.class_name, false, None, false, false, ctx.refs);
             }
             // ---- object construction ----
@@ -2064,6 +2116,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 let args: Vec<String> = std::mem::take(&mut stack).into_iter().filter(|a| !a.s.is_empty()).map(|a| a.s).collect();
                 pending_ty = Some(ty.clone());
                 pending_const = false;
+                pending_is_ref = false;
                 pending = Some(format!("{ty}({})", args.join(", ")));
             }
             // ---- result capture ----

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -60,6 +60,12 @@ struct Arg {
     /// `block_stmts` — safe to carry across a recognized Cast diamond; never set for
     /// pending-call-result pushes (`PshRPtr`) or synthetic pushes.
     carryable: bool,
+    /// batch-33d: the carried render is a CONTAINER READ (the batch-32c/33c pure-elem
+    /// pendings) whose re-evaluation at the join is only proven safe under the CLASSIC
+    /// D7-constrained (opCast+TYPEID) arms. RELAXED guarded-assignment arms may contain
+    /// arbitrary calls that could mutate the container, so such entries must not pass the
+    /// relaxed carry gate. Static-name FName literals stay `false` (pure literals).
+    reeval: bool,
 }
 impl Arg {
     fn int(s: String) -> Arg {
@@ -1725,7 +1731,11 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                         // the D9 carryability gate like any plain const push.
                         // batch-32c widens this to pure local-container element reads
                         // (`local_12.opIndex(0)` — see pending_is_pure_elem).
-                        stack.push(Arg::typed(p, pending_ty.take()).carry());
+                        // batch-33d: container reads are tagged reeval — they may only
+                        // cross CLASSIC (opCast-arm) diamonds, never the relaxed ones.
+                        let mut a = Arg::typed(p, pending_ty.take()).carry();
+                        a.reeval = pending_is_pure_elem;
+                        stack.push(a);
                     } else {
                         stack.push(Arg::typed(p, pending_ty.take()));
                     }
@@ -3546,12 +3556,16 @@ impl Structurer<'_> {
         if !l.iter().all(|a| a.carryable) {
             return None;
         }
-        // D1 guard shape: `JZ` over a bare `CmpPtrNull` (`x == nullptr`, no T*-op, no expr).
-        if self.jump_op(i) != "JZ" {
+        // D1 guard shape: `JZ` over a bare `CmpPtrNull` (`x == nullptr`, no T*-op, no expr)
+        // — the classic Cast diamond. batch-33d: `JLowZ` (bool-register test, e.g. an
+        // `IsValid(...)`-guarded assignment diamond) is also accepted; such guards can never
+        // be the classic Cast shape, so they always take the RELAXED arm rules below.
+        let jop = self.jump_op(i);
+        if jop != "JZ" && jop != "JLowZ" {
             return None;
         }
         let c = cmp.as_ref()?;
-        if c.b != "nullptr" || c.op.is_some() || c.expr.is_some() {
+        if jop == "JZ" && (c.b != "nullptr" || c.op.is_some() || c.expr.is_some()) {
             return None;
         }
         // D2 then-arm entry: the fallthrough successor is the physically-next block.
@@ -3611,9 +3625,15 @@ impl Structurer<'_> {
                 }
             }
         }
-        // D7 then-arm content whitelist (stage-1 belt): only the lowered `Cast<T>` shape, with
-        // exactly one CALLSYS (resolving to `opCast`) and exactly one TYPEID.
+        // D7 then-arm content whitelist (stage-1 belt): the CLASSIC arm is exactly the
+        // lowered `Cast<T>` shape — one CALLSYS resolving to `opCast` plus one TYPEID.
+        // batch-33d: any other content no longer bails outright but falls to the RELAXED
+        // guarded-assignment rules below (SayVoicelineWithContext lost its Context/Loudness
+        // args and BroadcastPerceptionEventInRadius its Affected arg to the old bail: the
+        // guard is an `IsValid(...)`/null test and the then-arm a `local = <calls>;`
+        // assignment, not a Cast).
         let (mut ncast, mut ntypeid) = (0usize, 0usize);
+        let mut classic = jop == "JZ";
         for k in t.instr_lo..t.instr_hi {
             let ins = &ctx.instrs[k];
             match ins.op.name {
@@ -3622,15 +3642,74 @@ impl Structurer<'_> {
                 "CALLSYS" => {
                     let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
                     if ctx.refs.func_by_ptr(ptr) != Some("opCast") {
-                        return None;
+                        classic = false;
+                    } else {
+                        ncast += 1;
                     }
-                    ncast += 1;
                 }
-                _ => return None,
+                _ => classic = false,
             }
         }
-        if ncast != 1 || ntypeid != 1 {
-            return None;
+        if classic && (ncast != 1 || ntypeid != 1) {
+            classic = false;
+        }
+        if !classic {
+            // batch-33d RELAXED guarded-assignment diamond. The D10 dual-sim below remains
+            // the authoritative stack-semantics gate (arms provably net-zero, emission
+            // unchanged, carry returned verbatim); these rules close the REORDERING hole
+            // the classic D7 whitelist closed structurally — the carried renders are
+            // re-evaluated at the join, AFTER the arm's statements run:
+            //  (R1) every carried entry renders as a bare slot/param identifier or an
+            //       integer constant — no member chains (an arm call could mutate the
+            //       object behind `this.m_X`), no container reads (`reeval`, see Arg).
+            //  (R2) both arms contain only whitelisted ops, and every slot-writing op's
+            //       destination differs from every carried identifier — so the value a
+            //       carried name renders to at the join equals the value the bytecode
+            //       pushed before the guard.
+            let bare_ident = |s: &str| {
+                let b = s.as_bytes();
+                !s.is_empty()
+                    && (b[0].is_ascii_alphabetic() || b[0] == b'_')
+                    && b.iter().all(|c| c.is_ascii_alphanumeric() || *c == b'_')
+            };
+            let int_const = |a: &Arg| {
+                a.cbits.is_some()
+                    || (!a.s.is_empty()
+                        && a.s.trim_start_matches('-').bytes().all(|b| b.is_ascii_digit()))
+            };
+            for a in l {
+                if a.reeval || !(bare_ident(&a.s) || int_const(a)) {
+                    return None;
+                }
+            }
+            let carried: Vec<&str> = l.iter().map(|a| a.s.as_str()).collect();
+            for arm in std::iter::once(i + 1).chain(else_idx) {
+                let ab = &blocks[arm];
+                for k in ab.instr_lo..ab.instr_hi {
+                    let ins = &ctx.instrs[k];
+                    match ins.op.name {
+                        // non-writing ops: pushes, member-address/deref, register loads,
+                        // calls (their arg consumption is proven balanced by D10).
+                        "SUSPEND" | "JitEntry" | "JMP" | "PSF" | "PshVPtr" | "PshV4"
+                        | "PshV8" | "PshC4" | "PshC8" | "PshNull" | "PGA" | "PshGPtr"
+                        | "ADDSi" | "RDSPtr" | "TYPEID" | "CALL" | "CALLINTF" | "CALLBND"
+                        | "CALLSYS" | "Thiscall1" | "LoadThisR" | "LoadVObjR"
+                        | "LoadRObjR" => {}
+                        // slot-writing ops: legal unless the destination is carried.
+                        "STOREOBJ" | "FreeNullV8" | "ClrVPtr" | "FREE" | "RDR1" | "RDR2"
+                        | "RDR4" | "RDR8" | "CpyRtoV4" | "CpyRtoV8" | "SetV1" | "SetV4"
+                        | "SetV8" | "CpyVtoV4" | "CpyVtoV8" => {
+                            let dst = ctx.slot_name(s16(ins.words.first().copied().unwrap_or(0)));
+                            if carried.iter().any(|c| *c == dst) {
+                                return None;
+                            }
+                        }
+                        // anything else (register-indirect writes WRTV*/PopRPtr, arithmetic,
+                        // control flow) -> bail: destination untrackable.
+                        _ => return None,
+                    }
+                }
+            }
         }
         // D8 else-arm content whitelist: housekeeping only.
         if let Some(e) = else_idx {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3071,8 +3071,25 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                     None
                 };
                 flush!();
-                if non_void && v.is_none() && !ctx.ret_via_rvo() {
-                    v = scan_back_retval(ctx, lo + k);
+                // batch-44a (E4, specs/loop-body-cfg-ext.md §2.4): recover the terminal
+                // register-return value when the RET's own capture is a sentinel. Today the
+                // scan-back fires ONLY when `v` is exactly None; but a value-type RVO destructor
+                // (`PSF wT; CALLSYS ~T`/`$beh2`) intervening between the value copy
+                // (`CpyRtoV4 wN`) and the terminal `CpyVtoR4 wN; RET` can leave `v` holding a
+                // sentinel string (empty / `~`-dtor / `$`-behaviour / ARGMISMATCH `\u{2}`) rather
+                // than the genuine return slot. Extend the guard so the scan-back ALSO runs for a
+                // sentinel `v` and recovers the terminal `CpyVtoR4 wN` slot as `return local_N;`.
+                // Additive + bail-safe: this can only REPLACE a broken `return;`/`return ~x;` with
+                // the scan-back slot (`.or(v)` keeps the sentinel if the scan finds nothing); a
+                // legitimate `return <expr>;` (a real slot/call) is a non-sentinel `v` and is
+                // untouched. RVO functions are excluded (they never scan-back — batch-24a G1).
+                if non_void
+                    && !ctx.ret_via_rvo()
+                    && v.as_deref().map_or(true, |s| {
+                        s.is_empty() || s.starts_with('~') || s.starts_with('$') || s.contains('\u{2}')
+                    })
+                {
+                    v = scan_back_retval(ctx, lo + k).or(v);
                 }
                 // value fix-ups (RVO-assign strip, declared-bool, int -> bool/enum cast) and
                 // the RVODEF default all live in the shared helper (also used by the switch

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -108,7 +108,7 @@ pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, supe
         Err(e) => return format!("{}// disasm error: {e}\n", "    ".repeat(depth)),
     };
     let g = cfg::build(&instrs);
-    let float_slots = float_operand_slots(&instrs);
+    let float_slots = float_operand_slots(&instrs, ret_ty);
     // AS_PTR_SIZE-aware frame-offset -> param-index map (2-dword handles/refs + hidden RVO slot),
     // self-correcting on observed offsets. Built once per function; consulted by slot_name/slot_type.
     let (param_off_map, rvo_off) = super::decompile::build_param_off_map_rvo(f, &instrs, refs);
@@ -116,7 +116,7 @@ pub fn body_statements_ctor(f: &FuncCode, refs: &RefResolver, depth: usize, supe
     let idx_of: HashMap<usize, usize> =
         g.blocks.iter().enumerate().map(|(i, b)| (b.start_dw, i)).collect();
     let mut body = String::new();
-    let mut st = Structurer { ctx: &ctx, g: &g, idx_of: &idx_of };
+    let mut st = Structurer { ctx: &ctx, g: &g, idx_of: &idx_of, exit_join: None, exit_join_is_ret: false, exit_ret_rows_ok: false, exit_scan_floor: 0 };
     st.emit_range(0, g.blocks.len(), depth, &mut body);
     body
 }
@@ -180,7 +180,11 @@ struct Ctx<'a> {
 
 /// Collect slots used as an operand of a float/double arithmetic or compare op. Every word
 /// operand of those ops is a float/double value, so a constant feeding such a slot is float.
-fn float_operand_slots(instrs: &[Instr]) -> std::collections::HashSet<i32> {
+/// Additionally, a slot copied into the VALUE REGISTER (`CpyVtoR4`/`CpyVtoR8`) in a function
+/// whose return type is the matching-width float family IS the float return payload, so its
+/// `SetV*` constants are IEEE-754 bits too (e.g. the per-case `SetV8 w4, 0xc04b...` returns
+/// in `GetScanSweepAngleDeg` are -55.0, not -4590434657685733376).
+fn float_operand_slots(instrs: &[Instr], ret_ty: Option<&DataType>) -> std::collections::HashSet<i32> {
     let is_float_op = |n: &str| {
         matches!(n,
             "ADDf" | "SUBf" | "MULf" | "DIVf" | "MODf" | "NEGf" | "IncVf" | "DecVf"
@@ -188,9 +192,22 @@ fn float_operand_slots(instrs: &[Instr]) -> std::collections::HashSet<i32> {
             | "ADDd" | "SUBd" | "MULd" | "DIVd" | "MODd" | "NEGd" | "CMPd")
     };
     let mut slots = std::collections::HashSet::new();
+    let ret_tok = ret_ty.map(|t| t.token);
     for ins in instrs {
         if is_float_op(ins.op.name) {
             for &wd in &ins.words {
+                slots.insert(wd as i16 as i32);
+            }
+        }
+        // return-register copies in a float-returning function (width-matched: 0x51 `float`
+        // and 0x5E `double` are 8-byte in this fork, 0x50 `float32` is 4-byte).
+        let ret_float_copy = match ins.op.name {
+            "CpyVtoR8" => matches!(ret_tok, Some(0x51) | Some(0x5E)),
+            "CpyVtoR4" => ret_tok == Some(0x50),
+            _ => false,
+        };
+        if ret_float_copy {
+            if let Some(&wd) = ins.words.first() {
                 slots.insert(wd as i16 as i32);
             }
         }
@@ -241,6 +258,37 @@ impl Ctx<'_> {
         }
     }
 
+    /// Render a `return` statement from an optional recovered value, applying the same
+    /// fix-ups as the `RET` arm (RVO `return slot = v` stripping, declared-bool bareness,
+    /// int -> bool/enum return casts, RVODEF default for an unrecovered non-void value).
+    /// Shared by the `RET` opcode arm and the switch-recovery `JMP -> RET-row` return exits.
+    fn return_stmt(&self, v: Option<String>) -> String {
+        let non_void = self.ret_ty.map(|t| t.token != 0x52).unwrap_or(false);
+        if !non_void {
+            return "return;".into();
+        }
+        match v {
+            Some(v) => {
+                let v = strip_return_assign(&v).to_string();
+                let declared_bool = v
+                    .strip_prefix("local_")
+                    .and_then(|d| d.parse::<i32>().ok())
+                    .and_then(|n| self.slot_type(n))
+                    .as_deref()
+                    == Some("bool");
+                let v = match self.ret_ty {
+                    Some(rt) if looks_int(&v) && !declared_bool => {
+                        let tn = if rt.token == 0x41 { "bool".to_string() } else { rt.base_name(self.refs) };
+                        cast_to_typename(&v, &tn).unwrap_or(v)
+                    }
+                    _ => v,
+                };
+                format!("return {v};")
+            }
+            None => format!("return {RVODEF};"),
+        }
+    }
+
     /// Name for parameter slot `idx`: the stored name, else `arg{idx}` — which MUST match
     /// how `emit::render_params` declares unnamed params (also `arg{idx}`), so a body
     /// reference resolves to a declared parameter.
@@ -262,7 +310,14 @@ fn s16(w: u16) -> i32 {
 /// backwards for the nearest `CpyVtoR*`/`LOADOBJ` that filled the return register in a
 /// dominating block, stopping at a previous RET so we never cross into an unrelated value.
 fn scan_back_retval(ctx: &Ctx, before: usize) -> Option<String> {
-    for i in (0..before).rev() {
+    scan_back_retval_floor(ctx, before, 0)
+}
+
+/// [`scan_back_retval`] bounded below by `floor` (instruction index): used by the switch
+/// recovery's synthesized `return`s so a case's value never leaks in from a PRECEDING case
+/// region (the linear scan would otherwise cross the region boundary).
+fn scan_back_retval_floor(ctx: &Ctx, before: usize, floor: usize) -> Option<String> {
+    for i in (floor..before).rev() {
         let ins = &ctx.instrs[i];
         match ins.op.name {
             "CpyVtoR4" | "CpyVtoR8" | "CpyVtoR1" | "LOADOBJ" => {
@@ -273,6 +328,11 @@ fn scan_back_retval(ctx: &Ctx, before: usize) -> Option<String> {
         }
     }
     None
+}
+
+/// Conditional-jump opcode (mirrors `cfg::is_cond_jump`, which is private to that module).
+fn is_cond_op(n: &str) -> bool {
+    matches!(n, "JZ" | "JNZ" | "JS" | "JNS" | "JP" | "JNP" | "JLowZ" | "JLowNZ")
 }
 
 /// Resolve a Cast/TYPEID operand to a target typename. AngelScript bytecode typeids carry
@@ -1734,35 +1794,10 @@ fn block_stmts(ctx: &Ctx, lo: usize, hi: usize) -> (Vec<String>, Option<Cmp>) {
                 if non_void && v.is_none() {
                     v = scan_back_retval(ctx, lo + k);
                 }
-                match v {
-                    Some(v) => {
-                        // RVO: a non-trivial return is built by writing the hidden return slot
-                        // then returning it -> the decompiler renders `return slot = <value>;`,
-                        // which is a syntax error (aborts the whole module's parse). The
-                        // assignment RHS is the actual returned value.
-                        let v = strip_return_assign(&v).to_string();
-                        // a slot DECLARED bool must return bare: `return (boolSlot != 0);`
-                        // is an int-compare on a bool ("No conversion from 'int' to 'bool'").
-                        let declared_bool = v
-                            .strip_prefix("local_")
-                            .and_then(|d| d.parse::<i32>().ok())
-                            .and_then(|n| ctx.slot_type(n))
-                            .as_deref()
-                            == Some("bool");
-                        let v = match ctx.ret_ty {
-                            Some(rt) if looks_int(&v) && !declared_bool => {
-                                let tn = if rt.token == 0x41 { "bool".to_string() } else { rt.base_name(ctx.refs) };
-                                cast_to_typename(&v, &tn).unwrap_or(v)
-                            }
-                            _ => v,
-                        };
-                        out.push(format!("return {v};"));
-                    }
-                    // non-void with no recovered value: keep the recovered body, return a
-                    // default (the emitter fills RVODEF with a type-correct default value).
-                    None if non_void => out.push(format!("return {RVODEF};")),
-                    None => out.push("return;".into()),
-                }
+                // value fix-ups (RVO-assign strip, declared-bool, int -> bool/enum cast) and
+                // the RVODEF default all live in the shared helper (also used by the switch
+                // recovery's `JMP -> RET-row` return exits).
+                out.push(ctx.return_stmt(v));
             }
             // Idiom-A member store: an ADDSi chain builds `this.a.b` on the stack top, then
             // PopRPtr moves that address into the reference register for the following WRTV.
@@ -1992,6 +2027,17 @@ struct Structurer<'a> {
     ctx: &'a Ctx<'a>,
     g: &'a Cfg,
     idx_of: &'a HashMap<usize, usize>,
+    /// Switch-region exit context (set only while emitting a recovered `switch` case region):
+    /// the JOIN offset a `JMP` renders as `break;` for, whether JOIN is the function's bare
+    /// `RET` row (then a `JMP` there renders as a synthesized `return ...;` instead), and
+    /// whether `JMP`s to OTHER bare-RET rows may render as returns (register-based-return
+    /// functions only — an RVO-struct return can't be synthesized from the value register).
+    exit_join: Option<usize>,
+    exit_join_is_ret: bool,
+    exit_ret_rows_ok: bool,
+    /// Instruction-index floor for the synthesized-return value scan (the current case
+    /// region's first instruction — a value must not leak in from a preceding region).
+    exit_scan_floor: usize,
 }
 
 impl Structurer<'_> {
@@ -2015,7 +2061,11 @@ impl Structurer<'_> {
             let b = &self.g.blocks[i];
             let mut next;
 
-            if let Some((body_end, cond)) = self.top_test_while(i, stop) {
+            if let Some(after) = self.try_emit_switch(i, stop, depth, out) {
+                // recovered compiler switch idiom (guards + JMPP dispatch); the whole
+                // construct was emitted, continue after its JOIN.
+                next = after;
+            } else if let Some((body_end, cond)) = self.top_test_while(i, stop) {
                 // top-test loop: `header: <cmp> Jcc exit; body; JMP header`
                 let _ = writeln!(out, "{ind}while ({cond})");
                 let _ = writeln!(out, "{ind}{{");
@@ -2073,6 +2123,9 @@ impl Structurer<'_> {
                 for s in &stmts {
                     let _ = writeln!(out, "{ind}{s}");
                 }
+                if let Some(x) = self.region_exit_stmt(i) {
+                    let _ = writeln!(out, "{ind}{x}");
+                }
                 next = i + 1;
             }
 
@@ -2090,7 +2143,389 @@ impl Structurer<'_> {
             for s in &stmts {
                 let _ = writeln!(out, "{ind}{s}");
             }
+            if let Some(x) = self.region_exit_stmt(bi) {
+                let _ = writeln!(out, "{ind}{x}");
+            }
         }
+    }
+
+    /// Inside a recovered switch's case region: if block `bi` ends with an unconditional
+    /// `JMP` that LEAVES the region, render the source-level exit statement — `break;` to
+    /// the JOIN, or a synthesized `return ...;` when the jump goes to a bare `RET` row
+    /// (the compiled form of `return <expr>;` from inside a case). Returns None outside
+    /// switch emission or for any other terminator (statu quo: the JMP is just a block end).
+    fn region_exit_stmt(&self, bi: usize) -> Option<String> {
+        let join = self.exit_join?;
+        let b = &self.g.blocks[bi];
+        if self.ctx.instrs[b.instr_hi - 1].op.name != "JMP" {
+            return None;
+        }
+        let t = *b.succs.first()?;
+        if t == join {
+            return Some(if self.exit_join_is_ret {
+                self.ctx.return_stmt(scan_back_retval_floor(self.ctx, b.instr_hi - 1, self.exit_scan_floor))
+            } else {
+                "break;".into()
+            });
+        }
+        if self.exit_ret_rows_ok && self.is_bare_ret_off(t) {
+            return Some(self.ctx.return_stmt(scan_back_retval_floor(self.ctx, b.instr_hi - 1, self.exit_scan_floor)));
+        }
+        None
+    }
+
+    /// The block at dword offset `off` is a bare `RET` row (exactly one instruction).
+    fn is_bare_ret_off(&self, off: usize) -> bool {
+        self.idx_of.get(&off).is_some_and(|&bi| {
+            let b = &self.g.blocks[bi];
+            b.instr_hi - b.instr_lo == 1 && self.ctx.instrs[b.instr_lo].op.name == "RET"
+        })
+    }
+
+    /// Detect and emit the Hazelight compiler's `switch` lowering rooted at block `i`
+    /// (see `work/reversing/gore-as/specs/illegal-op-round2.md` Part B). The 5-part idiom:
+    ///
+    /// ```text
+    /// [ ...stmts ; CMPIi wV,hi ; JP DEF ]      block i    (range guard, hi = lo+N-1)
+    /// [ CMPIi wV,lo ; JS DEF ]                 block i+1  (range guard)
+    /// [ SUBIi wS,wV,lo ; JMPP wS,N-1 ]         block i+2  (normalize + dispatch)
+    /// [ N dispatch rows: JMP tK trampolines; the LAST row may be the final case inlined ]
+    /// case regions in offset order ... [ DEF region ] JOIN
+    /// ```
+    ///
+    /// DEF handling: `ThrowException`-only DEF = compiler trap for a default-less switch ->
+    /// emit NO default clause (recompiling regenerates the trap); DEF == JOIN -> no default;
+    /// DEF sharing a case entry -> stacked `default:` label; else a real `default:` region.
+    /// Shared case targets render stacked `case a: case b:` labels; empty cases (entry ==
+    /// a JMP-to-JOIN thunk) render `break;` only.
+    ///
+    /// Returns the next block index after the construct, or None on ANY deviation from the
+    /// idiom — the caller then falls through to the existing arms and the `// JMPP` marker
+    /// keeps the function safely stubbed (never wrong control flow).
+    fn try_emit_switch(&mut self, i: usize, stop: usize, depth: usize, out: &mut String) -> Option<usize> {
+        let ctx = self.ctx;
+        let g = self.g;
+        let blocks = &g.blocks;
+        if stop > blocks.len() || i + 3 > stop || i + 2 >= blocks.len() {
+            return None;
+        }
+        // cheap pre-probe before anything costly
+        if self.jump_op(i) != "JP" || self.jump_op(i + 1) != "JS" || self.jump_op(i + 2) != "JMPP" {
+            return None;
+        }
+        // A bottom-test loop headed at this very block would be LOST if the switch were
+        // emitted in its place (the latch back-edge has no rendering); bail to the loop
+        // arm — its linear body hits the JMPP marker and the function stays stubbed.
+        if self.loop_latch(i, stop).is_some() {
+            return None;
+        }
+        let b0 = &blocks[i];
+        let b1 = &blocks[i + 1];
+        let b2 = &blocks[i + 2];
+        if b0.instr_hi - b0.instr_lo < 2 || b1.instr_hi - b1.instr_lo != 2 || b2.instr_hi - b2.instr_lo != 2 {
+            return None;
+        }
+        let g_hi = &ctx.instrs[b0.instr_hi - 2];
+        let g_lo = &ctx.instrs[b1.instr_lo];
+        let sub = &ctx.instrs[b2.instr_lo];
+        let jmpp = &ctx.instrs[b2.instr_hi - 1];
+        if g_hi.op.name != "CMPIi" || g_lo.op.name != "CMPIi" || sub.op.name != "SUBIi" {
+            return None;
+        }
+        let wv = s16(g_hi.words.first().copied()?);
+        let hi_c = g_hi.dwords.first().copied()? as i32;
+        let lo_c = g_lo.dwords.first().copied()? as i32;
+        if s16(g_lo.words.first().copied()?) != wv {
+            return None;
+        }
+        // SUBIi wS, wV, lo — selector normalization (emitted even for lo == 0); wS is dead
+        // once the switch is recovered, and never rendered (blocks i+1/i+2 emit no stmts).
+        let ws = s16(sub.words.first().copied()?);
+        if s16(sub.words.get(1).copied()?) != wv || sub.dwords.first().copied()? as i32 != lo_c {
+            return None;
+        }
+        if s16(jmpp.words.first().copied()?) != ws {
+            return None;
+        }
+        let n = jmpp.dwords.first().copied()? as usize + 1;
+        if n < 2 || hi_c != lo_c + n as i32 - 1 {
+            return None;
+        }
+        // guard edges: both guards jump to the same DEF; fallthroughs chain b0 -> b1 -> b2
+        if b0.succs.len() != 2 || b1.succs.len() != 2 {
+            return None;
+        }
+        let def_off = b0.succs[0];
+        if b0.succs[1] != b1.start_dw || b1.succs[0] != def_off || b1.succs[1] != b2.start_dw {
+            return None;
+        }
+        if b2.succs.len() != n {
+            return None; // cfg.rs could not verify the dispatch-row shape
+        }
+        // dispatch rows -> case entry offsets (row N-1 may BE the last case body, inlined)
+        let mut targets: Vec<usize> = Vec::with_capacity(n);
+        let mut inline_last = false;
+        for (k, &row) in b2.succs.iter().enumerate() {
+            if row != jmpp.offset_dw + 2 + 2 * k {
+                return None;
+            }
+            let rb = &blocks[*self.idx_of.get(&row)?];
+            if rb.instr_hi - rb.instr_lo == 1 && ctx.instrs[rb.instr_lo].op.name == "JMP" {
+                targets.push(*rb.succs.first()?);
+            } else if k == n - 1 {
+                targets.push(row);
+                inline_last = true;
+            } else {
+                return None;
+            }
+        }
+        // region boundaries: unique case entries + DEF, ascending; the first must start
+        // immediately after the dispatch rows (no unreachable gap)
+        let mut bounds: Vec<usize> = targets.clone();
+        bounds.push(def_off);
+        bounds.sort_unstable();
+        bounds.dedup();
+        let first_body = if inline_last { b2.succs[n - 1] } else { b2.succs[n - 1] + 2 };
+        if bounds[0] != first_body {
+            return None;
+        }
+        let first_region_idx = i + 3 + n - usize::from(inline_last);
+        if self.idx_of.get(&bounds[0]).copied() != Some(first_region_idx) {
+            return None;
+        }
+        // JOIN inference: every region between consecutive boundaries must END by leaving —
+        // JMP to a common exit beyond the last boundary (the JOIN), JMP to a bare RET row
+        // (a per-case `return`), a RET of its own, or a fallthrough into the JOIN itself.
+        let t_last = *bounds.last()?;
+        // register-based return (value/object register): a struct-by-value return travels
+        // through the hidden RVO slot instead, so `JMP -> RET row` can't be synthesized.
+        // Decided from the return TYPE, not `rvo_off`: the param-map heuristic misclassifies
+        // ENUM returns as RVO (token 5, see spec A4), yet enums return in the value register
+        // — `ctx.rvo_off` would wrongly bail every enum-returning switch (GetNodeStatus,
+        // the UCBT_*::Tick family).
+        let register_based = match ctx.ret_ty {
+            None => true,
+            Some(t) => {
+                t.token != 5
+                    || t.is_object_handle
+                    || t.is_reference
+                    || is_enum_name(&t.base_name(ctx.refs))
+            }
+        };
+        let non_void = ctx.ret_ty.map(|t| t.token != 0x52).unwrap_or(false);
+        let mut join_cands: Vec<usize> = Vec::new();
+        let mut ret_rows: Vec<usize> = Vec::new();
+        let mut fall_pend: Vec<usize> = Vec::new();
+        for w in bounds.windows(2) {
+            let last_bi = self.idx_of.get(&w[1]).copied()? - 1;
+            let lb = &blocks[last_bi];
+            match ctx.instrs[lb.instr_hi - 1].op.name {
+                "JMP" => {
+                    let x = lb.succs.first().copied()?;
+                    if self.is_bare_ret_off(x) {
+                        if !register_based {
+                            return None;
+                        }
+                        ret_rows.push(x);
+                    } else if x >= t_last {
+                        join_cands.push(x);
+                    } else {
+                        return None; // cross/backward jump — not a shared exit
+                    }
+                }
+                "RET" => {}
+                name if is_cond_op(name) => return None,
+                _ => fall_pend.push(w[1]), // falls into next boundary: legal only into JOIN
+            }
+        }
+        join_cands.sort_unstable();
+        join_cands.dedup();
+        ret_rows.sort_unstable();
+        ret_rows.dedup();
+        let join_off = match (join_cands.as_slice(), ret_rows.as_slice()) {
+            ([j], _) => *j,
+            // every region returns: the shared bare RET row is the join/epilogue
+            ([], [r]) => *r,
+            _ => return None,
+        };
+        if fall_pend.iter().any(|&nb| nb != join_off) {
+            return None;
+        }
+        if join_off < t_last || targets.contains(&join_off) {
+            return None;
+        }
+        let join_is_ret = self.is_bare_ret_off(join_off);
+        if join_is_ret && !register_based {
+            return None; // per-case RVO-struct returns are not recoverable from the register
+        }
+        let join_idx = self.idx_of.get(&join_off).copied()?;
+        // the construct may extend past `stop` only through its JOIN (e.g. the switch is
+        // the tail of an if-branch and its breaks target the post-if continuation)
+        let switch_end = join_idx.min(stop);
+        if switch_end <= first_region_idx {
+            return None;
+        }
+        // ---- regions: enumerate + validate (any anomaly bails BEFORE any emission) ----
+        struct Region {
+            off: usize,
+            start: usize,
+            end: usize,
+            is_def: bool,
+            trap: bool,
+            append_break: bool,
+        }
+        let mut regions: Vec<Region> = Vec::new();
+        for (k, &b) in bounds.iter().enumerate() {
+            if b == join_off {
+                continue; // DEF == JOIN: no default clause, nothing to emit
+            }
+            let start = self.idx_of.get(&b).copied()?;
+            let end = match bounds.get(k + 1) {
+                Some(nb) => self.idx_of.get(nb).copied()?.min(switch_end),
+                None => switch_end,
+            };
+            if start >= end || start < first_region_idx || end > switch_end {
+                return None;
+            }
+            let end_off = blocks[end].start_dw;
+            let mut trap_ops = true;
+            let mut has_cond_join = false;
+            for bi2 in start..end {
+                let bb = &blocks[bi2];
+                let tname = ctx.instrs[bb.instr_hi - 1].op.name;
+                for k2 in bb.instr_lo..bb.instr_hi {
+                    if !matches!(ctx.instrs[k2].op.name, "ThrowException" | "SUSPEND" | "JitEntry") {
+                        trap_ops = false;
+                    }
+                }
+                let last_of_region = bi2 + 1 == end;
+                let uncond = tname == "JMP";
+                for &s in &bb.succs {
+                    if s >= b && s < end_off {
+                        continue; // in-region (incl. internal loops' back edges)
+                    }
+                    if s == join_off {
+                        if uncond || (last_of_region && end == join_idx) {
+                            continue; // break/return exit, or the last region falling into JOIN
+                        }
+                        // conditional TAKEN edge to the JOIN (`if (x) <skip rest of case>`):
+                        // the is_cond arm renders it as the inverted `if (!x) { rest }`,
+                        // which is correct ONLY when the region abuts the JOIN so both
+                        // paths hit the appended `break;` (never in RETURN mode — the
+                        // skipped path's register value would be unrecoverable).
+                        if is_cond_op(tname)
+                            && !join_is_ret
+                            && end == join_idx
+                            && bb.succs.first() == Some(&s)
+                        {
+                            has_cond_join = true;
+                            continue;
+                        }
+                    }
+                    if uncond && register_based && self.is_bare_ret_off(s) {
+                        continue; // per-case `return` exit
+                    }
+                    return None; // escapes the region (incl. cond jumps to an exit)
+                }
+                // a return-exit must have a recoverable value INSIDE this region
+                if uncond && non_void {
+                    if let Some(&s) = bb.succs.first() {
+                        let ret_exit = (s == join_off && join_is_ret)
+                            || (s != join_off && !(s >= b && s < end_off) && self.is_bare_ret_off(s));
+                        if ret_exit
+                            && scan_back_retval_floor(ctx, bb.instr_hi - 1, blocks[start].instr_lo).is_none()
+                        {
+                            return None;
+                        }
+                    }
+                }
+            }
+            // region's last block must actually LEAVE the construct. `has_cond_join`
+            // means SOME path skips to the appended `break;` after the region body, so
+            // one must be appended even when the body's own last statement already exits.
+            let lb = &blocks[end - 1];
+            let lt = ctx.instrs[lb.instr_hi - 1].op.name;
+            let append_break;
+            if lt == "JMP" {
+                let x = lb.succs.first().copied()?;
+                let exits = x == join_off
+                    || (register_based && !(x >= b && x < end_off) && self.is_bare_ret_off(x));
+                if !exits {
+                    return None;
+                }
+                append_break = has_cond_join; // the exit hook renders break;/return at the JMP
+            } else if lt == "RET" {
+                append_break = has_cond_join;
+            } else if is_cond_op(lt) {
+                return None;
+            } else {
+                // plain fallthrough: only into a physically adjacent JOIN
+                if end != join_idx {
+                    return None;
+                }
+                append_break = true;
+            }
+            let is_def = b == def_off;
+            let trap = trap_ops && end - start == 1;
+            if trap && (!is_def || targets.contains(&b)) {
+                return None; // a case entry can never be the compiler trap
+            }
+            regions.push(Region { off: b, start, end, is_def, trap, append_break });
+        }
+        // no OUTSIDE block may enter the construct anywhere but its head
+        let span_lo = b0.start_dw;
+        let span_hi = blocks[switch_end].start_dw;
+        for (bi2, bb) in blocks.iter().enumerate() {
+            if bi2 >= i && bi2 < switch_end {
+                continue;
+            }
+            for &s in &bb.succs {
+                if s > span_lo && s < span_hi {
+                    return None;
+                }
+            }
+        }
+        // ---- emission (validated: no bail past this point) ----
+        let ind = "    ".repeat(depth);
+        let (stmts, _) = block_stmts(ctx, b0.instr_lo, b0.instr_hi);
+        for s in &stmts {
+            let _ = writeln!(out, "{ind}{s}");
+        }
+        let sel_raw = ctx.slot_name(wv);
+        // an enum selector needs the explicit int() (mirrors the CMPIi arm: AS has no
+        // implicit enum<->int, and the case labels are int literals)
+        let sel = if ctx.slot_type(wv).as_deref().map(is_enum_name).unwrap_or(false) {
+            format!("int({sel_raw})")
+        } else {
+            sel_raw
+        };
+        let _ = writeln!(out, "{ind}switch ({sel})");
+        let _ = writeln!(out, "{ind}{{");
+        let saved = (self.exit_join, self.exit_join_is_ret, self.exit_ret_rows_ok, self.exit_scan_floor);
+        for r in &regions {
+            if r.trap {
+                continue; // trap DEF = source had NO default; recompiling regenerates it
+            }
+            for (k, &tg) in targets.iter().enumerate() {
+                if tg == r.off {
+                    let _ = writeln!(out, "{ind}case {}:", lo_c + k as i32);
+                }
+            }
+            if r.is_def {
+                let _ = writeln!(out, "{ind}default:");
+            }
+            self.exit_join = Some(join_off);
+            self.exit_join_is_ret = join_is_ret;
+            self.exit_ret_rows_ok = register_based;
+            self.exit_scan_floor = blocks[r.start].instr_lo;
+            self.emit_range(r.start, r.end, depth + 1, out);
+            (self.exit_join, self.exit_join_is_ret, self.exit_ret_rows_ok, self.exit_scan_floor) = saved;
+            if r.append_break {
+                let _ = writeln!(out, "{ind}    break;");
+            }
+        }
+        let _ = writeln!(out, "{ind}}}");
+        Some(switch_end)
     }
 
     fn is_cond(&self, bi: usize) -> bool {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -3465,6 +3465,22 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                     // consumed only by the compare. Safe: a call result is non-const, materialising
                     // it into a slot for the compare cannot reorder a side effect past its sole use.
                     let getter_into_cmp = feeds_following_cmp && src_is_getter;
+                    // batch-49c (opIndex-read-into-null-compare, specs/final-tail-triage.md §3.11
+                    // Contains): a container/map element read whose result is null-guarded by the
+                    // VERY NEXT op — `… CALLSYS opIndex; PshRPtr; RDSPtr; RefCpyV wN; CmpPtrNull wN`
+                    // (`local_N = m_SpawnedAreas[type]; if (local_N == nullptr)`). Today the
+                    // getter call-expr source drops (the `ok` whitelist rejects `(`-bearing exprs
+                    // outside the out-slot), leaving `local_N` UNDECLARED and the null-guard reading
+                    // an uninitialised slot — a real bug (Contains returns garbage-nullness).
+                    // FIX-4's `param_guard_fold` only folds a PARAM into CmpPtrNull; FIX-7's
+                    // `getter_into_cmp` only fires for the binary `CmpPtr`. Add the getter→CmpPtrNull
+                    // case: materialise the copy so the compare reads the real element. Safe — the
+                    // getter result is non-const and its SOLE consumer is the immediate CmpPtrNull,
+                    // so no side effect is reordered past its use (same argument as getter_into_cmp).
+                    let getter_into_null_cmp = src_is_getter
+                        && insns
+                            .get(k + 1)
+                            .is_some_and(|nx| nx.op.name == "CmpPtrNull" && w(nx, 0) == dst_slot0);
                     // batch-46c (FIX-7): recover the PARAM operand of a getter-vs-param compare
                     // (`if (this.Nodes.Last() == FailedNode)` — the OnChildNode override idiom, and
                     // the `opIndex(0) == OtherActor` overlap checks). Gated HARD on the paired
@@ -3565,6 +3581,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
                             || member_src
                             || call_src_to_out
                             || getter_into_cmp
+                            || getter_into_null_cmp
                             || param_into_cmp
                             || param_into_later_use);
                     if ok {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -651,13 +651,39 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
     // dropping them at push time made the split one entry too deep and stole a neighbouring call's
     // arg (GetNPCState-shifts-args family).
     let ctx_count = collected.iter().filter(|x| x.is_ctx).count();
+    // batch-32b (N5, specs/batch31-nomatch-illegalop.md §1.6): the hidden WorldContextObject
+    // param must be stripped from the PARAM LIST too, not just from the args — passing the
+    // full T3 list shifted EVERY positional param consumer (maybe_reverse_args scored
+    // ShowTopSubtitle's Duration against the WCO UObject (invisible) while the reversed
+    // correct order put FText there (+1) and kept the wrong push order; cast_arg/render_args
+    // paired the same shifted types). The WCO's PARAM POSITION varies by binding: free
+    // natives push the marker LAST (= source param 0, leading — ShowTopSubtitle/SpawnAIAgent
+    // disasm), script-struct method natives push it FIRST (= trailing param —
+    // FInGameDate::IsLessThanXDaysAgo, FInGameTime::Now: `PshGPtr __WorldContext` before the
+    // real args). Classify by stack position: a marker within the top-of-frame overhead
+    // (receiver + RVO slot) is a LEADING param; anything deeper is TRAILING. A naive
+    // front-strip mis-paired the conversation IsValid/IsLessThanXDaysAgo family (int arg
+    // scored against the trailing WCO's UObject -> NEW argint stubs).
+    let overhead = is_method as usize + rvo_slot as usize;
+    let ctx_lead = collected
+        .iter()
+        .enumerate()
+        .filter(|(j, x)| x.is_ctx && collected.len() - 1 - j <= overhead)
+        .count();
+    let ctx_trail = ctx_count - ctx_lead;
     let mut a: Vec<Arg> = collected.into_iter()
         .filter(|x| !x.is_ctx && !x.s.is_empty() && x.s != UNRESOLVED)
         .collect();
+    let params = params.map(|p| {
+        let lead = ctx_lead.min(p.len());
+        let trail = ctx_trail.min(p.len() - lead);
+        &p[lead..p.len() - trail]
+    });
     // Effective arity: the in-game compile validates against the shipped Binds.Cache, so its native
     // arity is authoritative — prefer it over the script FunctionReferences param count. Falls back.
-    // Subtract any stripped implicit-context markers (they inflate both the frame and the arity).
-    let arity = native_arity.or_else(|| params.map(|p| p.len())).map(|n| n.saturating_sub(ctx_count));
+    // Subtract any stripped implicit-context markers (they inflate both the frame and the arity;
+    // the params fallback is already ctx-stripped above).
+    let arity = native_arity.map(|n| n.saturating_sub(ctx_count)).or_else(|| params.map(|p| p.len()));
     // Receiver: a METHOD call always pushes its receiver as the top entry (the cache param count is
     // unreliable here — it often COUNTS the implicit `this`), so detect by the bIsMethod flag.
     let has_recv = is_method && !a.is_empty();
@@ -878,7 +904,15 @@ fn build_call(stack: &mut Vec<Arg>, f: &str, is_method: bool, super_ctor: Option
         // same-typed by-ref struct arg.
         if let Some(rh) = ret_ty.map(tyhead).filter(|_| !ret_is_ref) {
             if matches!(rh.bytes().next(), Some(b'F') | Some(b'T') | Some(b'E')) {
-                if let Some(pos) = a.iter().position(|x| x.is_psf
+                // batch-32b (N5): the free-call ABI pushes [args..., dest] — the RVO dest is
+                // the TOP entry (build_call's own rvo_slot probe: idx=1 for free calls), so
+                // probe with rposition, mirroring the batch-29c method-arm fix (line ~691).
+                // The bottom-up probe stole a PSF'd struct ARG of the same head: ApplyFormat's
+                // FString SPECIFIER became the dest while the real dest slid into the args
+                // (`local_36 = ApplyFormat(local_44, local_14); local_40.Append(local_44);`
+                // — 6 GA_Falling errors + 1 by-accident int-overload mis-bind). Single-PSF
+                // sites (string-literal Specifier, CombatSituations ×8) pick the same entry.
+                if let Some(pos) = a.iter().rposition(|x| x.is_psf
                     && x.ty.as_deref().map(tyhead) == Some(rh)) {
                     let out = a.remove(pos).s;
                     if let Some(w) = arity {
@@ -1425,6 +1459,14 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
     let mut obj_reg: Option<String> = None;
     let mut ref_reg: Option<String> = None; // Idiom-B member address
     let mut ref_reg_ty: Option<String> = None; // field type name behind ref_reg (for casts)
+    // batch-32b (N5, TMap::Find reversal): the field's PRECISE value type behind ref_reg,
+    // resolved through the this-class fields map / cross-module class-fields index ONLY —
+    // never the member_type OWNER-type fallback (`CrimeEntry.Directness` typed FCrimeEntry
+    // instead of ECrimeDirectness false-flagged the reversed order in arg_mismatch_count,
+    // suppressing the correct `Find(Key, out)` flip). Consumed ONLY by the PshRPtr arg-push
+    // (arg typing for scoring/cast pairing); the RDR/WRTV wrap logic keeps reading
+    // `ref_reg_ty` so member-store renders are unchanged. None = unknown = status quo.
+    let mut ref_reg_vty: Option<String> = None;
     // batch-25a (G2): ENUM value type of a native struct's field behind ref_reg, from the
     // in-crate native-field table (`refs::native_field_type`). Consumed ONLY by the WRTV1
     // guard so the render becomes `field = EEnum(slot)` instead of the bool-wrap.
@@ -1629,7 +1671,14 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 } else {
                     let (s, ty) = match value_reg.take() {
                         Some(v) => (v, None),
-                        None => (ref_reg.clone().unwrap_or_else(|| UNRESOLVED.into()), ref_reg_ty.clone()),
+                        // batch-32b: prefer the poison-free precise field value type for the
+                        // ARG TYPING (ref_reg_ty may be member_type's OWNER type, which
+                        // false-flags reversal scoring / cast pairing); fall back to the old
+                        // channel so unresolvable fields keep the status-quo behavior.
+                        None => (
+                            ref_reg.clone().unwrap_or_else(|| UNRESOLVED.into()),
+                            ref_reg_vty.clone().or_else(|| ref_reg_ty.clone()),
+                        ),
                     };
                     stack.push(Arg::typed(s, ty));
                 }
@@ -1732,6 +1781,13 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     .and_then(|cls| ctx.refs.native_field_type(cls, &field))
                     .filter(|t| is_enum_name(t))
                     .map(|s| s.to_string());
+                // batch-32b: precise value type (poison-free sources only — see decl comment).
+                ref_reg_vty = ctx.fields.and_then(|m| m.get(&field)).cloned().or_else(|| {
+                    ctx.refs
+                        .type_by_id(tid)
+                        .and_then(|cls| ctx.refs.field_type_by_class(cls, &field))
+                        .map(|s| s.to_string())
+                });
                 // LoadThisR loads from slot 0. In a METHOD that is `this`; in a FREE (mixin)
                 // function slot 0 is parameter 0, so hardcoding `this.` emits an undeclared base
                 // -> "'field' is not a member of 'Unknown'". slot_name(0) renders both correctly.
@@ -1750,6 +1806,11 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                 ref_reg_nfty = ctx.refs.type_by_id(tid)
                     .and_then(|cls| ctx.refs.native_field_type(cls, &field))
                     .filter(|t| is_enum_name(t))
+                    .map(|s| s.to_string());
+                // batch-32b: precise value type (poison-free sources only — see decl comment).
+                ref_reg_vty = ctx.refs
+                    .type_by_id(tid)
+                    .and_then(|cls| ctx.refs.field_type_by_class(cls, &field))
                     .map(|s| s.to_string());
                 ref_reg = Some(format!("{obj}.{field}"));
             }
@@ -2109,6 +2170,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                         ref_reg = None;
                         ref_reg_ty = None;
                         ref_reg_nfty = None;
+                        ref_reg_vty = None;
                     }
                     // batch-24b shadow gate: a free SCRIPT global (no owner, global namespace)
                     // rendered inside a class method is shadowed by any same-named member in
@@ -2117,10 +2179,16 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     // "such a member exists somewhere" — `::`-qualifying a non-shadowed global
                     // resolves identically, so false positives are harmless; no name sources
                     // -> false (status quo).
+                    // batch-32b (N6): the namespaced-fn exclusion is GONE — the emitter never
+                    // writes namespace blocks, so a vanilla-namespaced script fn (e.g.
+                    // FPerceptionCharacterType::GetName) is a bare GLOBAL in our tree and is
+                    // shadowed inside class bodies exactly like an unnamespaced one; `::f`
+                    // resolves it. The old gate left `GetName(EPerceptionCharacterType(...))`
+                    // resolving against the inherited `UObject::GetName()` (EventResponses ×2,
+                    // + the universal-UObject-member rows in member_name_exists).
                     let global_shadowed = !ctx.refs.is_method_by_id(id)
                         && owner.is_none()
                         && ctx.class_name.is_some()
-                        && ctx.refs.func_ns_by_id(id).map_or(true, |ns| ns.is_empty())
                         && ctx.refs.member_name_exists(&f);
                     build_call(&mut stack, &f, ctx.refs.is_method_by_id(id), ctx.super_ctor, ctx.refs.func_params_by_id(id), na, trusted, owner, ctx.class_name, n == "CALL", pending_ty.as_deref(), ret_is_ref, global_shadowed, ctx.refs)
                 };
@@ -2310,6 +2378,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                         ref_reg = None;
                         ref_reg_ty = None;
                         ref_reg_nfty = None;
+                        ref_reg_vty = None;
                     }
                     build_call(&mut stack, &qualified, ctx.refs.is_method_by_ptr(ptr), ctx.super_ctor, ctx.refs.func_params_by_ptr(ptr), na, trusted, ctx.refs.func_owner_by_ptr(ptr), ctx.class_name, false, pending_ty.as_deref(), ret_is_ref, false, ctx.refs)
                 };
@@ -2533,6 +2602,7 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>) -> (Vec<Strin
                     ref_reg = Some(top.s);
                     ref_reg_ty = top.ty;
                     ref_reg_nfty = top.nfty; // batch-25a: native enum field type for WRTV1
+                    ref_reg_vty = None; // batch-32b: the popped entry's ty is already precise
                 }
             }
             // RefCpyV (wW_ARG): copy the top-of-stack handle into the destination slot named by

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -2934,9 +2934,20 @@ fn block_stmts_in(ctx: &Ctx, lo: usize, hi: usize, init: Vec<Arg>, ret_ref_tail:
             "RefCpyV" => {
                 let dst = name(w(ins, 0));
                 if let Some(top) = stack.pop() {
+                    // batch-41a (Fix 2, S2/S5): also accept a MEMBER-ACCESS source
+                    // (`this.member`, built by `PshVPtr;ADDSi;RDSPtr`). Such a source is a legal
+                    // RHS of a handle assignment (the field's accessor is `T@`) and was NEVER the
+                    // const PARAMETER the original guard excluded. This un-stubs the object-member
+                    // getters (`return this.member;`) and fixes the null-check operand for the
+                    // null-guard shape. Exclude call/ctor expressions (`(`) — those have their own
+                    // paths — sentinels (\u{2}) and UNRESOLVED.
+                    let member_src = top.s.contains('.')
+                        && !top.s.contains('(')
+                        && !top.s.contains('\u{2}')
+                        && top.s != UNRESOLVED;
                     let ok = !top.s.is_empty()
                         && top.s != dst
-                        && (top.s.starts_with("local_") || top.s.starts_with("Cast<"));
+                        && (top.s.starts_with("local_") || top.s.starts_with("Cast<") || member_src);
                     if ok {
                         flush!();
                         // batch-25b (G4 assign shape): a slot-to-slot handle copy whose DEST

--- a/crates/gore-as/tests/decompile_test.rs
+++ b/crates/gore-as/tests/decompile_test.rs
@@ -64,6 +64,44 @@ fn structures_branchtest() {
     assert!(src.contains("return local_1;"), "return:\n{src}");
 }
 
+/// batch-49 recovery locks: decompile named functions from the real vanilla cache_A sample
+/// (gitignored; graceful-skip when absent) and assert the recovered statement is present.
+/// These guard the batch-49a bool-member-store and batch-49c opIndex-getter-into-null-compare
+/// arms against future regression. Uses `structure::decompile` (ret_ty-aware since batch-49b).
+#[test]
+fn batch49_recoveries_present() {
+    let Some(b) = read_sample("cache_A.Cache") else {
+        eprintln!("skip: cache_A.Cache sample not present");
+        return;
+    };
+    let refs = RefResolver::build(&b).expect("resolver");
+    let funcs = collect_function_bytecodes(&b).expect("collect");
+    let decomp = |needle: &str| -> String {
+        funcs
+            .iter()
+            .find(|f| f.func.contains(needle))
+            .map(|f| gore_as::cache::structure::decompile(f, &refs))
+            .unwrap_or_default()
+    };
+    // batch-49a: `this.bShouldExitState = true` (WRTV1 into a UE-bool member) was dropped.
+    let og = decomp("UAIState_UseFreepoint::OnGracefulExitRequested");
+    assert!(
+        og.contains("bShouldExitState = (local_1 != 0)"),
+        "batch-49a bool member-store dropped:\n{og}"
+    );
+    // batch-49c: `local_4 = m_SpawnedAreas[type]` (opIndex getter into a null-compared slot)
+    // was dropped, leaving the null-guard reading an uninitialised slot.
+    let contains = decomp("UDemonAreaRegisterComponent::Contains");
+    assert!(
+        contains.contains("local_4 = this.m_SpawnedAreas.opIndex("),
+        "batch-49c opIndex-getter-into-null-compare dropped:\n{contains}"
+    );
+    assert!(
+        contains.contains("if (local_4 == nullptr)"),
+        "batch-49c null-guard should read the recovered element:\n{contains}"
+    );
+}
+
 /// Structured decompile must not panic or hang across many real functions (loop guard).
 #[test]
 fn structured_real_cache_no_panic() {

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -138,6 +138,23 @@ fn class_hierarchy(mods: &[gore_as::cache::model::Module]) -> std::collections::
     h
 }
 
+/// Per-class field-type maps (class -> field -> composed type name) from parsed modules, so the
+/// emitter can resolve INHERITED member types across module boundaries (batch-21 Class B).
+fn class_fields(
+    mods: &[gore_as::cache::model::Module],
+    refs: &gore_as::cache::refs::RefResolver,
+) -> HashMap<String, HashMap<String, String>> {
+    let mut out: HashMap<String, HashMap<String, String>> = HashMap::new();
+    for m in mods {
+        for c in &m.classes {
+            let fields: HashMap<String, String> =
+                c.fields.iter().map(|f| (f.name.clone(), f.ty.base_name(refs))).collect();
+            out.insert(c.name.clone(), fields);
+        }
+    }
+    out
+}
+
 pub fn run(cmd: AsCmd) -> Result<()> {
     match cmd {
         AsCmd::DecodeHeader { file } => {
@@ -171,6 +188,8 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             // decompile output matches emitted source (subclass casts, native-call trimming).
             let mods = gore_as::cache::model::parse_modules(&bytes).context("parse modules")?;
             refs.set_class_hierarchy(class_hierarchy(&mods));
+            let cf = class_fields(&mods, &refs);
+            refs.set_class_fields(cf);
             if let Some(api) = load_native_api(&file) {
                 refs.set_native_api(api);
             }
@@ -190,6 +209,8 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             let mut refs = gore_as::cache::refs::RefResolver::build(&bytes).context("resolver")?;
             let mods = gore_as::cache::model::parse_modules(&bytes).context("parse modules")?;
             refs.set_class_hierarchy(class_hierarchy(&mods));
+            let cf = class_fields(&mods, &refs);
+            refs.set_class_fields(cf);
             if let Some(api) = load_native_api(&file) {
                 refs.set_native_api(api);
             }
@@ -203,6 +224,8 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             let mut refs = gore_as::cache::refs::RefResolver::build(&bytes).context("resolver")?;
             let mods = gore_as::cache::model::parse_modules(&bytes).context("parse modules")?;
             refs.set_class_hierarchy(class_hierarchy(&mods));
+            let cf = class_fields(&mods, &refs);
+            refs.set_class_fields(cf);
             if let Some(api) = load_native_api(&file) {
                 refs.set_native_api(api);
             }

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -138,6 +138,17 @@ fn class_hierarchy(mods: &[gore_as::cache::model::Module]) -> std::collections::
     h
 }
 
+/// All script-class METHOD names from the parsed modules (batch-24b shadow-gate input): a
+/// class method shadows a same-named free global inside class scope even when the method is
+/// never referenced by any bytecode (so T3 alone can miss it).
+fn class_method_names(mods: &[gore_as::cache::model::Module]) -> Vec<String> {
+    mods.iter()
+        .flat_map(|m| m.classes.iter())
+        .flat_map(|c| c.methods.iter())
+        .map(|f| f.name.clone())
+        .collect()
+}
+
 /// Per-class field-type maps (class -> field -> composed type name) from parsed modules, so the
 /// emitter can resolve INHERITED member types across module boundaries (batch-21 Class B).
 fn class_fields(
@@ -190,6 +201,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             refs.set_class_hierarchy(class_hierarchy(&mods));
             let cf = class_fields(&mods, &refs);
             refs.set_class_fields(cf);
+            refs.add_method_names(class_method_names(&mods));
             if let Some(api) = load_native_api(&file) {
                 refs.set_native_api(api);
             }
@@ -211,6 +223,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             refs.set_class_hierarchy(class_hierarchy(&mods));
             let cf = class_fields(&mods, &refs);
             refs.set_class_fields(cf);
+            refs.add_method_names(class_method_names(&mods));
             if let Some(api) = load_native_api(&file) {
                 refs.set_native_api(api);
             }
@@ -226,6 +239,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             refs.set_class_hierarchy(class_hierarchy(&mods));
             let cf = class_fields(&mods, &refs);
             refs.set_class_fields(cf);
+            refs.add_method_names(class_method_names(&mods));
             if let Some(api) = load_native_api(&file) {
                 refs.set_native_api(api);
             }

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -104,6 +104,40 @@ pub enum AsCmd {
         #[arg(short, long)]
         out: PathBuf,
     },
+    /// Semantic byte-faithfulness oracle: diff a VANILLA cache against a REGEN (re-compilation of
+    /// our decompiled source) per function, after normalizing away build-noise (ref keys N1, jump
+    /// absolutes N3, constant encodings N4; opt-in slot-renumber N2). Classifies each aligned
+    /// function IDENTICAL / BENIGN-DIFF / SEMANTIC-DIFF. See specs/semantic-oracle.md.
+    Bytediff {
+        /// Vanilla reference cache (e.g. samples/cache_A.Cache).
+        vanilla: PathBuf,
+        /// Regen cache (re-compilation of our decompiled .as tree).
+        regen: PathBuf,
+        /// Only diff modules whose name contains this substring.
+        #[arg(long)]
+        module: Option<String>,
+        /// Only diff functions whose display name (module.Class::func) contains this substring.
+        #[arg(long)]
+        func: Option<String>,
+        /// Filter output to a verdict: identical|benign|semantic (repeatable).
+        #[arg(long = "verdict")]
+        verdicts: Vec<String>,
+        /// List which normalizers fired for BENIGN-DIFF functions (default: summary only).
+        #[arg(long)]
+        show_benign: bool,
+        /// Instruction window (±N) around each SEMANTIC divergence.
+        #[arg(long, default_value_t = 6)]
+        context: usize,
+        /// Enable the OPT-IN N2 slot-renumber normalizer (default OFF; see spec §3.2).
+        #[arg(long = "norm-slots")]
+        norm_slots: bool,
+        /// Write a machine-readable JSON scoreboard (per-verdict counts + alignment loss) here.
+        #[arg(long)]
+        json: Option<PathBuf>,
+        /// Exit non-zero if any SEMANTIC-DIFF is found (CI gate).
+        #[arg(long)]
+        fail_on_semantic: bool,
+    },
 }
 
 /// Build the script-class hierarchy (class name -> super class name) from parsed modules.
@@ -420,6 +454,167 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 counts.global_ptr, counts.func_ptr, counts.type_ptr, counts.func_id, counts.type_id,
                 counts.embed_type_ptr, counts.embed_func_id
             );
+        }
+        AsCmd::Bytediff {
+            vanilla,
+            regen,
+            module,
+            func,
+            verdicts,
+            show_benign,
+            context,
+            norm_slots,
+            json,
+            fail_on_semantic,
+        } => {
+            use gore_as::cache::bytediff::{self, Filters, NormOpts, Verdict};
+            let v_bytes = std::fs::read(&vanilla)
+                .with_context(|| format!("reading vanilla {}", vanilla.display()))?;
+            let r_bytes = std::fs::read(&regen)
+                .with_context(|| format!("reading regen {}", regen.display()))?;
+
+            let mut opts = NormOpts::default();
+            opts.n2_slots = norm_slots;
+            let filters = Filters { module: module.clone(), func: func.clone() };
+
+            let report = bytediff::run(&v_bytes, &r_bytes, &opts, &filters, context)
+                .context("bytediff")?;
+
+            // Verdict filter for per-function output (empty = show all).
+            let want = |v: Verdict| -> bool {
+                if verdicts.is_empty() {
+                    return true;
+                }
+                verdicts.iter().any(|s| match s.as_str() {
+                    "identical" => v == Verdict::Identical,
+                    "benign" => v == Verdict::Benign,
+                    "semantic" => v == Verdict::Semantic,
+                    _ => false,
+                })
+            };
+
+            // Per-function lines. SEMANTIC always prints its window; BENIGN prints its fired
+            // normalizers only under --show-benign; IDENTICAL prints a one-liner when explicitly
+            // requested via --verdict identical (otherwise summarized to keep 162k-fn runs sane).
+            let show_identical_lines = verdicts.iter().any(|s| s == "identical");
+            for d in &report.diffs {
+                if !want(d.verdict) {
+                    continue;
+                }
+                match d.verdict {
+                    Verdict::Identical => {
+                        if show_identical_lines {
+                            println!("{}  IDENTICAL  (v={} ops, r={} ops)", d.name, d.v_ops, d.r_ops);
+                        }
+                    }
+                    Verdict::Benign => {
+                        let labels = d.fired.labels();
+                        if show_benign {
+                            println!(
+                                "{}  BENIGN-DIFF  [{}]  (v={} ops, r={} ops)",
+                                d.name, labels.join(" "), d.v_ops, d.r_ops
+                            );
+                        }
+                    }
+                    Verdict::Semantic => {
+                        println!(
+                            "{}  SEMANTIC-DIFF  (v={} ops, r={} ops)",
+                            d.name, d.v_ops, d.r_ops
+                        );
+                        if let Some(h) = &d.hint {
+                            println!("    hint: {h}");
+                        }
+                        if let Some(w) = &d.window {
+                            print!("{w}");
+                        }
+                    }
+                }
+            }
+
+            // Alignment loss (always reported — a dropped/added symbol is a severe defect).
+            for m in &report.only_in_vanilla_modules {
+                println!("ONLY-IN-VANILLA module: {m}");
+            }
+            for m in &report.only_in_regen_modules {
+                println!("ONLY-IN-REGEN module: {m}");
+            }
+            if func.is_none() {
+                for f in &report.only_in_vanilla_funcs {
+                    println!("ONLY-IN-VANILLA func: {f}");
+                }
+                for f in &report.only_in_regen_funcs {
+                    println!("ONLY-IN-REGEN func: {f}");
+                }
+            }
+
+            // Summary scoreboard.
+            let n_ident = report.count(Verdict::Identical);
+            let n_benign = report.count(Verdict::Benign);
+            let n_sem = report.count(Verdict::Semantic);
+            let aligned = report.diffs.len();
+            let b1 = if aligned > 0 {
+                100.0 * (n_ident + n_benign) as f64 / aligned as f64
+            } else {
+                100.0
+            };
+            eprintln!("---- bytediff scoreboard ----");
+            eprintln!("aligned functions : {aligned}");
+            eprintln!("  IDENTICAL       : {n_ident}");
+            eprintln!("  BENIGN-DIFF     : {n_benign}");
+            eprintln!("  SEMANTIC-DIFF   : {n_sem}");
+            eprintln!(
+                "alignment loss    : {} module(s) only-in-vanilla, {} only-in-regen, {} func(s) only-in-vanilla, {} only-in-regen",
+                report.only_in_vanilla_modules.len(),
+                report.only_in_regen_modules.len(),
+                report.only_in_vanilla_funcs.len(),
+                report.only_in_regen_funcs.len()
+            );
+            eprintln!("B1 byte-faithful  : {b1:.2}%  (IDENTICAL+BENIGN / aligned)");
+            // Per-normalizer fire counts across BENIGN functions.
+            let (mut c1, mut c2, mut c3, mut c4) = (0usize, 0usize, 0usize, 0usize);
+            for d in &report.diffs {
+                if d.verdict == Verdict::Benign {
+                    c1 += d.fired.n1_refs as usize;
+                    c2 += d.fired.n2_slots as usize;
+                    c3 += d.fired.n3_jumps as usize;
+                    c4 += d.fired.n4_consts as usize;
+                }
+            }
+            eprintln!("normalizer fires  : N1:refs={c1} N2:slots={c2} N3:jumps={c3} N4:consts={c4}");
+
+            if let Some(jpath) = &json {
+                let esc = |s: &str| s.replace('\\', "\\\\").replace('"', "\\\"");
+                let mut sem_list = String::from("[");
+                let mut first = true;
+                for d in &report.diffs {
+                    if d.verdict == Verdict::Semantic {
+                        if !first {
+                            sem_list.push(',');
+                        }
+                        first = false;
+                        let hint = d.hint.as_deref().unwrap_or("");
+                        sem_list.push_str(&format!(
+                            "{{\"name\":\"{}\",\"v_ops\":{},\"r_ops\":{},\"hint\":\"{}\"}}",
+                            esc(&d.name), d.v_ops, d.r_ops, esc(hint)
+                        ));
+                    }
+                }
+                sem_list.push(']');
+                let json_out = format!(
+                    "{{\n  \"aligned\": {aligned},\n  \"identical\": {n_ident},\n  \"benign\": {n_benign},\n  \"semantic\": {n_sem},\n  \"b1_byte_faithful_pct\": {b1:.4},\n  \"only_in_vanilla_modules\": {},\n  \"only_in_regen_modules\": {},\n  \"only_in_vanilla_funcs\": {},\n  \"only_in_regen_funcs\": {},\n  \"normalizer_fires\": {{\"n1_refs\": {c1}, \"n2_slots\": {c2}, \"n3_jumps\": {c3}, \"n4_consts\": {c4}}},\n  \"semantic_list\": {sem_list}\n}}\n",
+                    report.only_in_vanilla_modules.len(),
+                    report.only_in_regen_modules.len(),
+                    report.only_in_vanilla_funcs.len(),
+                    report.only_in_regen_funcs.len(),
+                );
+                std::fs::write(jpath, &json_out)
+                    .with_context(|| format!("writing json {}", jpath.display()))?;
+                eprintln!("wrote JSON scoreboard to {}", jpath.display());
+            }
+
+            if fail_on_semantic && report.any_semantic() {
+                anyhow::bail!("{n_sem} SEMANTIC-DIFF function(s) found (--fail-on-semantic)");
+            }
         }
     }
     Ok(())

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -131,6 +131,12 @@ pub enum AsCmd {
         /// Enable the OPT-IN N2 slot-renumber normalizer (default OFF; see spec §3.2).
         #[arg(long = "norm-slots")]
         norm_slots: bool,
+        /// Disable the N5 `FScopeCycleCounter` RAII profiler-scope strip (default ON; §B.2).
+        #[arg(long = "no-norm-scope")]
+        no_norm_scope: bool,
+        /// Disable the N6 dominated boolean-cascade re-guard fold (default ON; §B.1).
+        #[arg(long = "no-norm-reguard")]
+        no_norm_reguard: bool,
         /// Write a machine-readable JSON scoreboard (per-verdict counts + alignment loss) here.
         #[arg(long)]
         json: Option<PathBuf>,
@@ -464,6 +470,8 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             show_benign,
             context,
             norm_slots,
+            no_norm_scope,
+            no_norm_reguard,
             json,
             fail_on_semantic,
         } => {
@@ -475,6 +483,8 @@ pub fn run(cmd: AsCmd) -> Result<()> {
 
             let mut opts = NormOpts::default();
             opts.n2_slots = norm_slots;
+            opts.n5_scope = !no_norm_scope;
+            opts.n6_reguard = !no_norm_reguard;
             let filters = Filters { module: module.clone(), func: func.clone() };
 
             let report = bytediff::run(&v_bytes, &r_bytes, &opts, &filters, context)
@@ -572,15 +582,20 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             eprintln!("B1 byte-faithful  : {b1:.2}%  (IDENTICAL+BENIGN / aligned)");
             // Per-normalizer fire counts across BENIGN functions.
             let (mut c1, mut c2, mut c3, mut c4) = (0usize, 0usize, 0usize, 0usize);
+            let (mut c5, mut c6) = (0usize, 0usize);
             for d in &report.diffs {
                 if d.verdict == Verdict::Benign {
                     c1 += d.fired.n1_refs as usize;
                     c2 += d.fired.n2_slots as usize;
                     c3 += d.fired.n3_jumps as usize;
                     c4 += d.fired.n4_consts as usize;
+                    c5 += d.fired.n5_scope as usize;
+                    c6 += d.fired.n6_reguard as usize;
                 }
             }
-            eprintln!("normalizer fires  : N1:refs={c1} N2:slots={c2} N3:jumps={c3} N4:consts={c4}");
+            eprintln!(
+                "normalizer fires  : N1:refs={c1} N2:slots={c2} N3:jumps={c3} N4:consts={c4} N5:scope={c5} N6:reguard={c6}"
+            );
 
             if let Some(jpath) = &json {
                 let esc = |s: &str| s.replace('\\', "\\\\").replace('"', "\\\"");
@@ -601,7 +616,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 }
                 sem_list.push(']');
                 let json_out = format!(
-                    "{{\n  \"aligned\": {aligned},\n  \"identical\": {n_ident},\n  \"benign\": {n_benign},\n  \"semantic\": {n_sem},\n  \"b1_byte_faithful_pct\": {b1:.4},\n  \"only_in_vanilla_modules\": {},\n  \"only_in_regen_modules\": {},\n  \"only_in_vanilla_funcs\": {},\n  \"only_in_regen_funcs\": {},\n  \"normalizer_fires\": {{\"n1_refs\": {c1}, \"n2_slots\": {c2}, \"n3_jumps\": {c3}, \"n4_consts\": {c4}}},\n  \"semantic_list\": {sem_list}\n}}\n",
+                    "{{\n  \"aligned\": {aligned},\n  \"identical\": {n_ident},\n  \"benign\": {n_benign},\n  \"semantic\": {n_sem},\n  \"b1_byte_faithful_pct\": {b1:.4},\n  \"only_in_vanilla_modules\": {},\n  \"only_in_regen_modules\": {},\n  \"only_in_vanilla_funcs\": {},\n  \"only_in_regen_funcs\": {},\n  \"normalizer_fires\": {{\"n1_refs\": {c1}, \"n2_slots\": {c2}, \"n3_jumps\": {c3}, \"n4_consts\": {c4}, \"n5_scope\": {c5}, \"n6_reguard\": {c6}}},\n  \"semantic_list\": {sem_list}\n}}\n",
                     report.only_in_vanilla_modules.len(),
                     report.only_in_regen_modules.len(),
                     report.only_in_vanilla_funcs.len(),

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -43,6 +43,13 @@ pub enum AsCmd {
         #[arg(long, default_value_t = 5)]
         max: usize,
     },
+    /// Dump StaticNames tail-table entries (the `n"..."` FName-literal pool indexed by
+    /// `__STATIC_NAME(Id)`). With no indices: count + first 10 entries.
+    StaticNames {
+        file: PathBuf,
+        /// Specific indices to print.
+        indices: Vec<i64>,
+    },
     /// Disassemble functions whose name contains <needle> to an asBC listing.
     Disasm {
         file: PathBuf,
@@ -208,6 +215,18 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 n += 1;
             }
             eprintln!("({n} module(s))");
+        }
+        AsCmd::StaticNames { file, indices } => {
+            let bytes = std::fs::read(&file).with_context(|| format!("reading {}", file.display()))?;
+            let refs = gore_as::cache::refs::RefResolver::build(&bytes).context("resolver")?;
+            println!("StaticNames count: {}", refs.static_name_count());
+            let show: Vec<i64> = if indices.is_empty() { (0..10).collect() } else { indices };
+            for i in show {
+                match refs.static_name(i) {
+                    Some(n) => println!("  [{i}] {n:?}"),
+                    None => println!("  [{i}] <out of range>"),
+                }
+            }
         }
         AsCmd::Disasm { file, needle, max } => {
             let bytes = std::fs::read(&file).with_context(|| format!("reading {}", file.display()))?;

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -227,6 +228,83 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             if let Some(api) = load_native_api(&file) {
                 refs.set_native_api(api);
             }
+            // batch-25f: publish the collision renames as an ID-based map in the resolver so
+            // CALL/CALLINTF render sites in EVERY module resolve the renamed leaf. emit_all_tree
+            // (below) recomputes the SAME colliding set for the per-file TEXT rename of decls; both
+            // use the identical `_g{mi}` scheme so decls and call sites cannot disagree. The
+            // security-hardened output (outdir canonicalize + per-entry symlink/`..` guards) now
+            // lives inside emit_all_tree.
+            // Cross-module free-function collisions: AngelScript compiles all loose .as into ONE
+            // global scope, so two modules each defining `Foo(<same params>)` (even with different
+            // return types) collide as "a function with the same name and parameters already
+            // exists". Find such names and rename each per-module — a function's decl and its
+            // intra-module free calls live in the same emitted file, so a file-local rename
+            // de-collides without breaking resolution (cross-module calls of these don't occur).
+            let mut sig_mods: HashMap<String, HashSet<usize>> = HashMap::new();
+            for (i, m) in mods.iter().enumerate() {
+                for f in &m.functions {
+                    // generated factory accessors are skipped at emit (not free-emitted) — never
+                    // rename them, or free CALLS to the native binding would be broken.
+                    if matches!(f.name.as_str(),
+                        "Spawn" | "Get" | "GetOrCreate" | "Create" | "GetG1R" | "StaticClass") {
+                        continue;
+                    }
+                    // precise signature (render, not base_name) so only GENUINE same-signature
+                    // collisions are flagged — a coarse match falsely flags distinct overloads and
+                    // would rename (and break) functions that are validly called cross-module.
+                    let ptys: Vec<String> = f.params.iter().map(|p| p.ty.render(&refs)).collect();
+                    sig_mods.entry(format!("{}({})", f.name, ptys.join(","))).or_default().insert(i);
+                }
+            }
+            // A name is safe to file-locally rename in a module only if EVERY emittable free
+            // function of that name in the module has a colliding signature. If the module also has
+            // a NON-colliding same-name overload, the name-based `rename_free_fn` would rewrite that
+            // overload's decl + calls too, breaking other modules that call it by its original name.
+            // In that mixed case leave the name un-renamed: the genuine collision then surfaces at
+            // generate as a "already exists" stub (rare, safe) instead of silently breaking a valid
+            // cross-module call to the non-colliding overload.
+            let colliding_sigs: HashSet<&str> = sig_mods
+                .iter()
+                .filter(|(_, modset)| modset.len() > 1)
+                .map(|(sig, _)| sig.as_str())
+                .collect();
+            let mut colliding_in: HashMap<usize, HashSet<String>> = HashMap::new();
+            for (i, m) in mods.iter().enumerate() {
+                let mut sigs_by_name: HashMap<&str, Vec<String>> = HashMap::new();
+                for f in &m.functions {
+                    if matches!(f.name.as_str(),
+                        "Spawn" | "Get" | "GetOrCreate" | "Create" | "GetG1R" | "StaticClass") {
+                        continue;
+                    }
+                    let ptys: Vec<String> = f.params.iter().map(|p| p.ty.render(&refs)).collect();
+                    sigs_by_name
+                        .entry(f.name.as_str())
+                        .or_default()
+                        .push(format!("{}({})", f.name, ptys.join(",")));
+                }
+                for (name, sigs) in sigs_by_name {
+                    if sigs.iter().any(|s| colliding_sigs.contains(s.as_str()))
+                        && sigs.iter().all(|s| colliding_sigs.contains(s.as_str()))
+                    {
+                        colliding_in.entry(i).or_default().insert(name.to_string());
+                    }
+                }
+            }
+            // batch-25f: publish the collision renames as an ID-based map in the resolver so
+            // CALL/CALLINTF render sites in EVERY module resolve the renamed leaf. The TEXT
+            // pass below still rewrites the DECLARING module (declaration line; already-
+            // renamed `Name_g<mi>(` call sites don't match its word boundary, `_` is a word
+            // char, so the two passes never double-rename). Suffixes come from the same
+            // `colliding_in` set with the same `_g{mi}` scheme — decls and call sites cannot
+            // disagree.
+            let mut rename_map: HashMap<String, HashMap<String, String>> = HashMap::new();
+            for (mi, names) in &colliding_in {
+                let e = rename_map.entry(mods[*mi].name.clone()).or_default();
+                for name in names {
+                    e.insert(name.clone(), format!("{name}_g{mi}"));
+                }
+            }
+            refs.set_free_fn_renames(&rename_map);
             let stats = gore_as::cache::emit_all::emit_all_tree(&mods, &refs, &outdir)
                 .with_context(|| format!("emitting to {}", outdir.display()))?;
             eprintln!("emitted {} modules to {} ({} contain a stubbed function)",


### PR DESCRIPTION
## gore-as: AngelScript bytecode decompiler — compile-clean + semantic byte-faithfulness

Reconstructs recompilable AngelScript source (`.as`) from Gothic 1 Remake's `PrecompiledScript` cache (Hazelight UE-AngelScript fork, 7265 modules / ~162 831 functions), so existing game logic can be read, edited, and spliced back — the foundation for script modding.

### What this branch delivers

**1. Compile-clean full-tree recovery.** The whole 7265-module tree recompiles under the in-game AngelScript compiler with only **2 genuinely-unrecoverable functions** remaining (down from thousands): a cache-vs-live signature drift and a const-object-return whose cache flag is unreliable. Verified headlessly against the game's own compiler (`-as-development-mode` + `-as-generate-precompiled-data`), including the stricter **generate-mode** value-semantic checks.

**2. A semantic byte-faithfulness oracle (`gore as bytediff`).** Diffs a regenerated cache (the game recompiling our source) against vanilla per-function, normalizing away build-noise (ref keys, jump absolutes, constant encodings, opt-in slot renumber). Self-identity gate: a cache vs itself is 162 828 IDENTICAL / 0 / 0. This is the measurement that made semantic correctness drivable.

**3. Semantic correctness driven to the floor.** Real dropped-logic (behavioral) bugs reduced from ~1120 to **~10 remaining — all either genuinely unrecoverable (3) or too-risky-to-safely-recover** (a compound-header-loop detector was implemented then reverted because it mis-fired into the batch-9 silent-corruption class). **≈99.994% behavioral correctness**; B1 byte-faithfulness 64.6% → 86.2% (the remaining gap is benign compiler-representation differences that don't change behavior). Zero generate-mode errors; self-identity held across every batch.

Real gameplay bugs fixed along the way: story/quest/document flags that were never set (892 writes), `DoDamage` always returning a default effect handle, a comparison reading uninitialized memory, dead loops, struct returns that yielded defaults, dropped member-handle assignments, a dropped Fisher-Yates shuffle, and dozens of dropped-statement classes (in-loop conditionals, member stores, float constants, ctor member-init, factory-call results, ...).

### What it does NOT do (documented, by design)

Full-tree-regen playability (swap the whole recompiled cache in and play) remains **not viable** — the regenerated global ref tables differ in layout from vanilla (re-serialization, different pointer keys) and corrupt native profile/init subsystems, independent of decompile quality or stub count (re-confirmed at ~4 stubs this branch). The correct, proven modding architecture is **cache-splice** (recompile + splice one edited module into the byte-preserved vanilla cache), which this decompiler's accuracy directly enables.

### Scope

12 files, all under `crates/gore-as/src/cache/**` (recovery + the new bytediff oracle) and `crates/gore/src/cmd/as_cache.rs` (CLI wiring). No changes outside the decompiler. Rebased onto `chore/monorepo-restructure`; the one merge point (the `emit_all_tree` helper the target extracted) is reconciled and the emit output is byte-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New bytediff normalizers (especially N5/N6 one-sided vanilla strips) could misclassify real bugs as BENIGN if domination gates fail; decompile RVO scoring affects emitted parameter names across struct-return functions.
> 
> **Overview**
> This diff adds **`bytediff`** (~1.9k lines): per-function vanilla vs regen cache comparison with normalizers N1–N6 (refs, optional slot renumber, jumps, constants, vanilla-only scope strips, dominated re-guard folds), verdicts IDENTICAL/BENIGN/SEMANTIC, alignment by resolved signature, and extensive unit/regression tests.
> 
> **`binds.rs`** now parses plain two-token struct field decls into `(class, field) -> type`, exposes `has_name`, `field_type`, and optional game-install tests that lock enum/float tables to shipped `Binds.Cache`.
> 
> **`cfg.rs`** recognizes verified **`JMPP`** dispatch tables and wires dispatch-row starts as block successors instead of leaving switches successor-less.
> 
> **`decompile.rs`** credits the hidden RVO return-slot offset when scoring the RVO vs no-RVO parameter map so struct-return functions with an unused last param no longer mis-label parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b486ee918340c1ba19115efaf88a07bdeec56c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->