### PR TITLE
chore(save-editor): 1.0.0, gore-lua rename, rebrand & repo-URL update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,7 @@ outputs/
 .flutter-plugins
 .flutter-plugins-dependencies
 .packages
-apps/goresave/.dart_tool/
-apps/goresave/build/
-apps/goresave/windows/flutter/ephemeral/
+apps/*/windows/flutter/ephemeral/
 
 # FVM
 .fvm/flutter_sdk

--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@ Gothic Remake.
 
 - **[`gore`](crates/gore) CLI** (`gore.exe`) — the one binary that does *all*
   modding from the terminal: item values, text/dialogs, audio, textures,
-  scripts. Start here if you want to mod.
+  scripts. Start here if you want to mod. **⚗️ Ready for experimental use.**
 - **[`mod-studio`](apps/mod-studio)** — a no-code Windows GUI over the same
   modding engine (incl. experimental AngelScript editing), for *authoring* one
-  mod.
+  mod. **🚧 Work in progress.**
 - **[`mod-manager`](apps/mod-manager)** — a Windows GUI for installing and
   managing *many* mods together (load order, conflict detection, one-click
-  apply); complements mod-studio (authoring).
+  apply); complements mod-studio (authoring). **🚧 Work in progress.**
 - **[`save-editor`](apps/save-editor)** — a Windows GUI for editing your save
   files (a separate job from modding — it never touches the game install).
-- **[`gorelib`](lua)** — a Lua SDK that ships into the game, for hand-writing
-  UE4SS mods.
+  **✅ Ready to use.**
+- **[`gore-lua`](lua)** — a small Lua helper library that ships into the game,
+  for hand-writing UE4SS mods. **🚧 Work in progress.**
 - **Supporting Rust crates** — the format codecs and data models the above
   share (see [Projects / layout](#projects--layout)), plus example mods under
   [`mods/`](mods).
@@ -34,7 +35,7 @@ the `gore` binary — no GUI required.
 
 Get the binary by building it (`cargo build --release -p gore` →
 `target/release/gore`) or downloading a `gore-cli-v*`
-[release](https://github.com/dh0er/goresave/releases). Examples below assume
+[release](https://github.com/dh0er/gore/releases). Examples below assume
 `gore` is on your `PATH` and use `"$GAME"` for your install root (the folder
 that contains `G1R/`). The exact `--game`/path each subcommand expects is always
 in `gore <cmd> --help`.
@@ -83,7 +84,7 @@ gore gen overrides.toml -o "$GAME/.../Mods" --model model.json
 
 The emitted mod looks up each class's CDO
 (`StaticFindObject("/Script/<module>.Default__<class>")`) and sets the field at
-load. It is self-contained — it does **not** need the gorelib SDK.
+load. It is self-contained — it does **not** need the gore-lua helpers.
 
 **Finding class & field names.** Item/NPC/knowledge classes are listed in the
 bundled catalogs (`apps/save-editor/assets/*_catalog.json`). To (re)generate the
@@ -219,8 +220,8 @@ gore mod undeploy --game "$GAME"                       # restore everything
 This is the same engine [`mod-studio`](#gore-mod-studio) drives. Other helpers:
 
 ```sh
-gore scaffold MyMod -o "$GAME/.../Mods"   # empty hand-written gorelib mod skeleton
-gore deploy-shared --game "$GAME/.../Win64"   # install the gorelib SDK (for custom Lua mods)
+gore scaffold MyMod -o "$GAME/.../Mods"   # empty hand-written gore-lua mod skeleton
+gore deploy-shared --game "$GAME/.../Win64"   # install the gore-lua helpers (for custom Lua mods)
 gore package mod_dir/ -o MyMod.zip        # zip a Lua mod for sharing
 ```
 
@@ -241,13 +242,16 @@ Every subcommand of the `gore` binary:
 | `dump` | — | Parse a UE4SS SDK header dump into a reflection model JSON. |
 | `stubs` | — | Emit LuaLS/EmmyLua type stubs from `model.json`. |
 | `gui-model` · `sync` · `dump-mod` | — | Build/refresh the data model (incl. real in-game defaults via the `gore-dump` mod). |
-| `scaffold` | — | Create a hand-written gorelib mod skeleton. |
-| `deploy-shared` | — | Install the gorelib SDK into `ue4ss/Mods/shared`. |
+| `scaffold` | — | Create a hand-written gore-lua mod skeleton. |
+| `deploy-shared` | — | Install the gore-lua helpers into `ue4ss/Mods/shared`. |
 | `package` | — | Zip a mod folder into distributable UE4SS layout. |
 
 ---
 
-# GORE Mod Studio
+# GORE Mod Studio 🚧
+
+> **Work in progress** — not yet ready for general use. For stable modding today,
+> use the [`gore` CLI](#modding-with-the-gore-cli).
 
 A no-code Windows app over the same bundle engine as the CLI — point-and-click
 modding with live previews and `.goremod` project files. Auto-updates on launch
@@ -269,13 +273,16 @@ modding with live previews and `.goremod` project files. Auto-updates on launch
 
 **It can not:**
 - Edit **save files** — that's [save-editor](#gore-save-editor).
-- Hand-write custom Lua logic — use `gore scaffold` + the [gorelib SDK](#the-gorelib-lua-sdk).
+- Hand-write custom Lua logic — use `gore scaffold` + the [gore-lua helpers](#gore-lua-helper-library).
 - Patch arbitrary game files outside the five supported domains.
 - Manage a *collection* of mods together — that's [mod-manager](#gore-mod-manager).
 
 ---
 
-# GORE Mod Manager
+# GORE Mod Manager 🚧
+
+> **Work in progress** — not yet ready for general use. For stable modding today,
+> use the [`gore` CLI](#modding-with-the-gore-cli).
 
 A Windows app for running **many** mods at once. Where [mod-studio](#gore-mod-studio)
 *authors* a single mod, mod-manager owns the multi-mod story: build a library,
@@ -307,7 +314,7 @@ Auto-updates on launch (WinSparkle). It consumes the mod bundles mod-studio (or
 
 # GORE Save Editor
 
-A Windows app (`goresave`) for editing your **save games**, backup-first. This is
+A Windows app for editing your **save games**, backup-first. This is
 *not* modding — it changes your saved progress, never the game install.
 Auto-updates on launch (WinSparkle). Tested against Steam build CL168781; should
 work across versions.
@@ -331,22 +338,26 @@ work across versions.
 
 ---
 
-# The gorelib Lua SDK
+# GORE Lua Helper Library 🚧
 
-[`gorelib`](lua) is a shared UE4SS SDK for **hand-writing** Gothic Remake mods in
-Lua — the path for behavior the override generator can't express (hooks,
-keybinds, console commands, live attribute tweaks). Override mods produced by
-`gore gen`/`mod-studio` do **not** use it; it's for custom mods.
+> **Work in progress** — a thin convenience layer, not a full SDK.
+
+[`gore-lua`](lua) is a small shared UE4SS **helper library** for hand-writing
+Gothic Remake mods in Lua — the path for behavior the override generator can't
+express (hooks, keybinds, console commands, live attribute tweaks). It's a
+handful of `pcall`-guarded wrappers over UE4SS reflection, not a large API.
+Override mods produced by `gore gen`/`mod-studio` do **not** use it; it's for
+custom mods.
 
 How a mod uses it:
 
 ```sh
-gore deploy-shared --game "$GAME/.../Win64"   # copy gorelib into ue4ss/Mods/shared (once)
+gore deploy-shared --game "$GAME/.../Win64"   # copy gore-lua into ue4ss/Mods/shared (once)
 gore scaffold MyMod -o "$GAME/.../Mods"       # new mod with the loader wired in
 ```
 
 ```lua
-local gore = require("gorelib")
+local gore = require("gore-lua")           -- load the shared gore-lua helpers
 gore.cheat.god(true)                       -- toggle god mode on the live CombatConfig + CDOs
 gore.gas.heal()                            -- set Health to MaxHealth
 gore.ui.text("hello from my mod")          -- on-screen message via the game's HUD
@@ -360,8 +371,8 @@ attributes), `gore.cheat`, `gore.cmd` (commands/keybinds/game-thread), and
 `nil`/`false` on failure — it never crashes the consuming mod. Full reference:
 [`lua/README.md`](lua/README.md) (or `gore.help.list()` at runtime).
 
-`gore deploy-shared` installs the SDK; UE4SS loads any mod folder containing an
-`enabled.txt`.
+`gore deploy-shared` installs the helpers; UE4SS loads any mod folder containing
+an `enabled.txt`.
 
 ---
 
@@ -388,9 +399,9 @@ gore/
 │  ├─ save-editor/         Flutter (Windows) savegame editor — WinSparkle auto-update
 │  ├─ mod-studio/          Flutter (Windows) no-code mod authoring GUI
 │  └─ mod-manager/         Flutter (Windows) multi-mod library/load-order/apply GUI
-├─ lua/                    gorelib UE4SS SDK (deployed into the game's Mods/shared)
+├─ lua/                    gore-lua UE4SS helper library (deployed into the game's Mods/shared)
 ├─ mods/                   first-party UE4SS mod folders
-│  ├─ example/             sample mod using gorelib
+│  ├─ example/             sample mod using gore-lua
 │  └─ gore-dump/           generated dump mod (regen: `gore dump-mod`)
 ├─ vendor/
 │  └─ retoc/               vendored IoStore reader fork (Oodle decode routed to gore-oodle)

--- a/apps/mod-manager/lib/app/domain/desktop_updater.dart
+++ b/apps/mod-manager/lib/app/domain/desktop_updater.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as p;
 /// release, so this URL is stable regardless of which product released most
 /// recently.
 const _appcastUrl =
-    'https://github.com/dh0er/goresave/releases/download/gore-manager-appcast/appcast-windows.xml';
+    'https://github.com/dh0er/gore/releases/download/gore-manager-appcast/appcast-windows.xml';
 
 const _checkIntervalSeconds = 3600;
 

--- a/apps/mod-manager/lib/app/ui/about_dialog.dart
+++ b/apps/mod-manager/lib/app/ui/about_dialog.dart
@@ -4,11 +4,11 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../l10n/app_localizations.dart';
 
-const _githubUrl = 'https://github.com/dh0er/goresave';
+const _githubUrl = 'https://github.com/dh0er/gore';
 
 const String _gitSha = String.fromEnvironment('GIT_SHA', defaultValue: 'dev');
 
-const aboutCopyrightNotice = '© 2026 goresave contributors';
+const aboutCopyrightNotice = '© 2026 GORE contributors';
 const aboutLicenseNotice = 'Licensed under the MIT License.';
 
 String aboutVersionLabel(PackageInfo? info) =>

--- a/apps/mod-manager/lib/l10n/app_de.arb
+++ b/apps/mod-manager/lib/l10n/app_de.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "Über",
-  "aboutCopyright": "© 2026 goresave-Mitwirkende",
+  "aboutCopyright": "© 2026 GORE-Mitwirkende",
   "aboutLicense": "Lizenziert unter der MIT-Lizenz.",
   "appearanceTitle": "Erscheinungsbild",
   "theme": "Design",

--- a/apps/mod-manager/lib/l10n/app_en.arb
+++ b/apps/mod-manager/lib/l10n/app_en.arb
@@ -85,7 +85,7 @@
     }
   },
   "about": "About",
-  "aboutCopyright": "© 2026 goresave contributors",
+  "aboutCopyright": "© 2026 GORE contributors",
   "aboutLicense": "Licensed under the MIT License.",
   "appearanceTitle": "Appearance",
   "theme": "Theme",

--- a/apps/mod-manager/lib/l10n/app_es.arb
+++ b/apps/mod-manager/lib/l10n/app_es.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "Acerca de",
-  "aboutCopyright": "© 2026 colaboradores de goresave",
+  "aboutCopyright": "© 2026 colaboradores de GORE",
   "aboutLicense": "Distribuido bajo la licencia MIT.",
   "appearanceTitle": "Apariencia",
   "theme": "Tema",

--- a/apps/mod-manager/lib/l10n/app_fr.arb
+++ b/apps/mod-manager/lib/l10n/app_fr.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "À propos",
-  "aboutCopyright": "© 2026 contributeurs de goresave",
+  "aboutCopyright": "© 2026 contributeurs de GORE",
   "aboutLicense": "Sous licence MIT.",
   "appearanceTitle": "Apparence",
   "theme": "Thème",

--- a/apps/mod-manager/lib/l10n/app_it.arb
+++ b/apps/mod-manager/lib/l10n/app_it.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "Informazioni",
-  "aboutCopyright": "© 2026 collaboratori di goresave",
+  "aboutCopyright": "© 2026 collaboratori di GORE",
   "aboutLicense": "Concesso in licenza secondo la licenza MIT.",
   "appearanceTitle": "Aspetto",
   "theme": "Tema",

--- a/apps/mod-manager/lib/l10n/app_ja.arb
+++ b/apps/mod-manager/lib/l10n/app_ja.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "このアプリについて",
-  "aboutCopyright": "© 2026 goresave コントリビューター",
+  "aboutCopyright": "© 2026 GORE コントリビューター",
   "aboutLicense": "MIT ライセンスの下で提供されています。",
   "appearanceTitle": "外観",
   "theme": "テーマ",

--- a/apps/mod-manager/lib/l10n/app_localizations.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations.dart
@@ -401,7 +401,7 @@ abstract class AppLocalizations {
   /// No description provided for @aboutCopyright.
   ///
   /// In en, this message translates to:
-  /// **'© 2026 goresave contributors'**
+  /// **'© 2026 GORE contributors'**
   String get aboutCopyright;
 
   /// No description provided for @aboutLicense.

--- a/apps/mod-manager/lib/l10n/app_localizations_de.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_de.dart
@@ -163,7 +163,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get about => 'Über';
 
   @override
-  String get aboutCopyright => '© 2026 goresave-Mitwirkende';
+  String get aboutCopyright => '© 2026 GORE-Mitwirkende';
 
   @override
   String get aboutLicense => 'Lizenziert unter der MIT-Lizenz.';

--- a/apps/mod-manager/lib/l10n/app_localizations_en.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_en.dart
@@ -162,7 +162,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get about => 'About';
 
   @override
-  String get aboutCopyright => '© 2026 goresave contributors';
+  String get aboutCopyright => '© 2026 GORE contributors';
 
   @override
   String get aboutLicense => 'Licensed under the MIT License.';

--- a/apps/mod-manager/lib/l10n/app_localizations_es.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_es.dart
@@ -162,7 +162,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get about => 'Acerca de';
 
   @override
-  String get aboutCopyright => '© 2026 colaboradores de goresave';
+  String get aboutCopyright => '© 2026 colaboradores de GORE';
 
   @override
   String get aboutLicense => 'Distribuido bajo la licencia MIT.';

--- a/apps/mod-manager/lib/l10n/app_localizations_fr.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_fr.dart
@@ -163,7 +163,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get about => 'À propos';
 
   @override
-  String get aboutCopyright => '© 2026 contributeurs de goresave';
+  String get aboutCopyright => '© 2026 contributeurs de GORE';
 
   @override
   String get aboutLicense => 'Sous licence MIT.';

--- a/apps/mod-manager/lib/l10n/app_localizations_it.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_it.dart
@@ -163,7 +163,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get about => 'Informazioni';
 
   @override
-  String get aboutCopyright => '© 2026 collaboratori di goresave';
+  String get aboutCopyright => '© 2026 collaboratori di GORE';
 
   @override
   String get aboutLicense => 'Concesso in licenza secondo la licenza MIT.';

--- a/apps/mod-manager/lib/l10n/app_localizations_ja.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_ja.dart
@@ -161,7 +161,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get about => 'このアプリについて';
 
   @override
-  String get aboutCopyright => '© 2026 goresave コントリビューター';
+  String get aboutCopyright => '© 2026 GORE コントリビューター';
 
   @override
   String get aboutLicense => 'MIT ライセンスの下で提供されています。';

--- a/apps/mod-manager/lib/l10n/app_localizations_pl.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_pl.dart
@@ -162,7 +162,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get about => 'O programie';
 
   @override
-  String get aboutCopyright => '© 2026 współtwórcy goresave';
+  String get aboutCopyright => '© 2026 współtwórcy GORE';
 
   @override
   String get aboutLicense => 'Udostępniane na licencji MIT.';

--- a/apps/mod-manager/lib/l10n/app_localizations_pt.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_pt.dart
@@ -163,7 +163,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get about => 'Sobre';
 
   @override
-  String get aboutCopyright => '© 2026 colaboradores do goresave';
+  String get aboutCopyright => '© 2026 colaboradores do GORE';
 
   @override
   String get aboutLicense => 'Licenciado sob a Licença MIT.';
@@ -371,7 +371,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get about => 'Sobre';
 
   @override
-  String get aboutCopyright => '© 2026 colaboradores do goresave';
+  String get aboutCopyright => '© 2026 colaboradores do GORE';
 
   @override
   String get aboutLicense => 'Licenciado sob a Licença MIT.';

--- a/apps/mod-manager/lib/l10n/app_localizations_ru.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_ru.dart
@@ -162,7 +162,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get about => 'О программе';
 
   @override
-  String get aboutCopyright => '© 2026 участники проекта goresave';
+  String get aboutCopyright => '© 2026 участники проекта GORE';
 
   @override
   String get aboutLicense => 'Распространяется по лицензии MIT.';

--- a/apps/mod-manager/lib/l10n/app_localizations_zh.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_zh.dart
@@ -160,7 +160,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get about => '关于';
 
   @override
-  String get aboutCopyright => '© 2026 goresave 贡献者';
+  String get aboutCopyright => '© 2026 GORE 贡献者';
 
   @override
   String get aboutLicense => '基于 MIT 许可证授权。';
@@ -364,7 +364,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get about => '关于';
 
   @override
-  String get aboutCopyright => '© 2026 goresave 贡献者';
+  String get aboutCopyright => '© 2026 GORE 贡献者';
 
   @override
   String get aboutLicense => '基于 MIT 许可证授权。';

--- a/apps/mod-manager/lib/l10n/app_pl.arb
+++ b/apps/mod-manager/lib/l10n/app_pl.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "O programie",
-  "aboutCopyright": "© 2026 współtwórcy goresave",
+  "aboutCopyright": "© 2026 współtwórcy GORE",
   "aboutLicense": "Udostępniane na licencji MIT.",
   "appearanceTitle": "Wygląd",
   "theme": "Motyw",

--- a/apps/mod-manager/lib/l10n/app_pt.arb
+++ b/apps/mod-manager/lib/l10n/app_pt.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "Sobre",
-  "aboutCopyright": "© 2026 colaboradores do goresave",
+  "aboutCopyright": "© 2026 colaboradores do GORE",
   "aboutLicense": "Licenciado sob a Licença MIT.",
   "appearanceTitle": "Aparência",
   "theme": "Tema",

--- a/apps/mod-manager/lib/l10n/app_pt_BR.arb
+++ b/apps/mod-manager/lib/l10n/app_pt_BR.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "Sobre",
-  "aboutCopyright": "© 2026 colaboradores do goresave",
+  "aboutCopyright": "© 2026 colaboradores do GORE",
   "aboutLicense": "Licenciado sob a Licença MIT.",
   "appearanceTitle": "Aparência",
   "theme": "Tema",

--- a/apps/mod-manager/lib/l10n/app_ru.arb
+++ b/apps/mod-manager/lib/l10n/app_ru.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "О программе",
-  "aboutCopyright": "© 2026 участники проекта goresave",
+  "aboutCopyright": "© 2026 участники проекта GORE",
   "aboutLicense": "Распространяется по лицензии MIT.",
   "appearanceTitle": "Внешний вид",
   "theme": "Тема",

--- a/apps/mod-manager/lib/l10n/app_zh.arb
+++ b/apps/mod-manager/lib/l10n/app_zh.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "关于",
-  "aboutCopyright": "© 2026 goresave 贡献者",
+  "aboutCopyright": "© 2026 GORE 贡献者",
   "aboutLicense": "基于 MIT 许可证授权。",
   "appearanceTitle": "外观",
   "theme": "主题",

--- a/apps/mod-manager/lib/l10n/app_zh_Hans.arb
+++ b/apps/mod-manager/lib/l10n/app_zh_Hans.arb
@@ -57,7 +57,7 @@
     }
   },
   "about": "关于",
-  "aboutCopyright": "© 2026 goresave 贡献者",
+  "aboutCopyright": "© 2026 GORE 贡献者",
   "aboutLicense": "基于 MIT 许可证授权。",
   "appearanceTitle": "外观",
   "theme": "主题",

--- a/apps/mod-studio/lib/app/domain/desktop_updater.dart
+++ b/apps/mod-studio/lib/app/domain/desktop_updater.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as p;
 /// appcast-windows.xml asset it overwrites on every gore-mod release, so this
 /// URL is stable regardless of which product released most recently.
 const _appcastUrl =
-    'https://github.com/dh0er/goresave/releases/download/gore-mod-appcast/appcast-windows.xml';
+    'https://github.com/dh0er/gore/releases/download/gore-mod-appcast/appcast-windows.xml';
 
 const _checkIntervalSeconds = 3600;
 

--- a/apps/save-editor/CHANGELOG.md
+++ b/apps/save-editor/CHANGELOG.md
@@ -1,10 +1,33 @@
 # Changelog
 
-All notable changes to goresave are documented here. The release workflow
+All notable changes to the GORE Save Editor are documented here. The release workflow
 publishes the section matching the released version as the GitHub release
 notes, so every release needs an entry.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [1.0.0] - 2026-07-08
+
+### Added
+
+- NPCs are now fully editable, not just the player: select any NPC and change
+  its stats/attributes and inventory the same way you edit your own character.
+- Armor is supported in the inventory — equipped and carried armor pieces show
+  up as regular items and can be edited and added like anything else.
+- Faction crimes can be cleared, resetting the hostility an NPC's guild holds
+  against you.
+- NPCs can be revived — bring a dead NPC back to life (restores health and
+  strips the death state).
+- Inventories can be reset to a clean starting state.
+- The in-game time (play clock) can now be set.
+- All talents/skills can now be edited (previously only a subset was exposed).
+
+### Changed
+
+- Reworked the UI navigation: first pick who you're editing (an NPC or the
+  player), then choose what to edit (attributes, inventory, …). The layout is
+  clearer and more consistent across tabs.
+- Improved performance, especially responsiveness when editing.
 
 ## [0.4.0] - 2026-06-24
 

--- a/apps/save-editor/README.md
+++ b/apps/save-editor/README.md
@@ -1,6 +1,6 @@
 # GORE Save Editor
 
-`gore-save` (the `goresave` app) is a savegame editor for Gothic Remake. It
+`gore-save` is the savegame editor for Gothic Remake. It
 provides a Flutter interface backed by a Rust savegame core. It is one project
 in the [gore-tools](../../README.md) monorepo.
 
@@ -25,7 +25,7 @@ Tested with Steam game version CL168781. Should work with all versions.
 ## Installation & Updates
 
 Download `GoresaveSetup-<version>.exe` from the
-[latest release](https://github.com/dh0er/goresave/releases/latest) and run it.
+[latest release](https://github.com/dh0er/gore/releases/latest) and run it.
 The app checks for updates on startup and prompts you when a new version is
 available.
 

--- a/apps/save-editor/lib/features/app/domain/desktop_updater.dart
+++ b/apps/save-editor/lib/features/app/domain/desktop_updater.dart
@@ -13,11 +13,11 @@ import 'package:url_launcher/url_launcher.dart';
 /// Stable URL: releases/latest/download/ redirects to the newest GitHub
 /// release's assets, where CI uploads the signed appcast.
 const _appcastUrl =
-    'https://github.com/dh0er/goresave/releases/latest/download/appcast-windows.xml';
+    'https://github.com/dh0er/gore/releases/latest/download/appcast-windows.xml';
 
 /// Where the portable build sends users to grab the new build. The latest
 /// release page lists both the installer and the portable zip.
-const _releasesPageUrl = 'https://github.com/dh0er/goresave/releases/latest';
+const _releasesPageUrl = 'https://github.com/dh0er/gore/releases/latest';
 
 const _checkIntervalSeconds = 3600;
 

--- a/apps/save-editor/lib/features/app/ui/about_dialog.dart
+++ b/apps/save-editor/lib/features/app/ui/about_dialog.dart
@@ -3,11 +3,11 @@ import 'package:goresave/l10n/app_localizations.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-const _githubUrl = 'https://github.com/dh0er/goresave';
+const _githubUrl = 'https://github.com/dh0er/gore';
 
 const String _gitSha = String.fromEnvironment('GIT_SHA', defaultValue: 'dev');
 
-const aboutCopyrightNotice = '© 2026 goresave contributors';
+const aboutCopyrightNotice = '© 2026 GORE contributors';
 const aboutLicenseNotice = 'Licensed under the MIT License.';
 
 String aboutVersionLabel(PackageInfo? info) =>

--- a/apps/save-editor/lib/l10n/app_de.arb
+++ b/apps/save-editor/lib/l10n/app_de.arb
@@ -333,7 +333,7 @@
   "yes": "ja",
   "no": "nein",
   "aboutVersion": "Version {version} ({sha})",
-  "aboutCopyright": "© 2026 goresave-Mitwirkende",
+  "aboutCopyright": "© 2026 GORE-Mitwirkende",
   "aboutLicense": "Lizenziert unter der MIT-Lizenz.",
   "difficultyTitle": "Schwierigkeit — {profile}",
   "difficultyNoProfile": "Kein Profil",

--- a/apps/save-editor/lib/l10n/app_en.arb
+++ b/apps/save-editor/lib/l10n/app_en.arb
@@ -636,7 +636,7 @@
       }
     }
   },
-  "aboutCopyright": "© 2026 goresave contributors",
+  "aboutCopyright": "© 2026 GORE contributors",
   "aboutLicense": "Licensed under the MIT License.",
   "difficultyTitle": "Difficulty — {profile}",
   "@difficultyTitle": {

--- a/apps/save-editor/lib/l10n/app_es.arb
+++ b/apps/save-editor/lib/l10n/app_es.arb
@@ -320,7 +320,7 @@
   "yes": "sí",
   "no": "no",
   "aboutVersion": "Versión {version} ({sha})",
-  "aboutCopyright": "© 2026 colaboradores de goresave",
+  "aboutCopyright": "© 2026 colaboradores de GORE",
   "aboutLicense": "Distribuido bajo la licencia MIT.",
   "difficultyTitle": "Dificultad — {profile}",
   "difficultyNoProfile": "Sin perfil",

--- a/apps/save-editor/lib/l10n/app_fr.arb
+++ b/apps/save-editor/lib/l10n/app_fr.arb
@@ -320,7 +320,7 @@
   "yes": "oui",
   "no": "non",
   "aboutVersion": "Version {version} ({sha})",
-  "aboutCopyright": "© 2026 contributeurs de goresave",
+  "aboutCopyright": "© 2026 contributeurs de GORE",
   "aboutLicense": "Sous licence MIT.",
   "difficultyTitle": "Difficulté — {profile}",
   "difficultyNoProfile": "Aucun profil",

--- a/apps/save-editor/lib/l10n/app_it.arb
+++ b/apps/save-editor/lib/l10n/app_it.arb
@@ -320,7 +320,7 @@
   "yes": "sì",
   "no": "no",
   "aboutVersion": "Versione {version} ({sha})",
-  "aboutCopyright": "© 2026 collaboratori di goresave",
+  "aboutCopyright": "© 2026 collaboratori di GORE",
   "aboutLicense": "Concesso in licenza secondo la licenza MIT.",
   "difficultyTitle": "Difficoltà — {profile}",
   "difficultyNoProfile": "Nessun profilo",

--- a/apps/save-editor/lib/l10n/app_ja.arb
+++ b/apps/save-editor/lib/l10n/app_ja.arb
@@ -320,7 +320,7 @@
   "yes": "はい",
   "no": "いいえ",
   "aboutVersion": "バージョン {version}（{sha}）",
-  "aboutCopyright": "© 2026 goresave コントリビューター",
+  "aboutCopyright": "© 2026 GORE コントリビューター",
   "aboutLicense": "MIT ライセンスの下で提供されています。",
   "difficultyTitle": "難易度 — {profile}",
   "difficultyNoProfile": "プロファイルなし",

--- a/apps/save-editor/lib/l10n/app_localizations.dart
+++ b/apps/save-editor/lib/l10n/app_localizations.dart
@@ -2075,7 +2075,7 @@ abstract class AppLocalizations {
   /// No description provided for @aboutCopyright.
   ///
   /// In en, this message translates to:
-  /// **'© 2026 goresave contributors'**
+  /// **'© 2026 GORE contributors'**
   String get aboutCopyright;
 
   /// No description provided for @aboutLicense.

--- a/apps/save-editor/lib/l10n/app_localizations_de.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_de.dart
@@ -1145,7 +1145,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 goresave-Mitwirkende';
+  String get aboutCopyright => '© 2026 GORE-Mitwirkende';
 
   @override
   String get aboutLicense => 'Lizenziert unter der MIT-Lizenz.';

--- a/apps/save-editor/lib/l10n/app_localizations_en.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_en.dart
@@ -1136,7 +1136,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 goresave contributors';
+  String get aboutCopyright => '© 2026 GORE contributors';
 
   @override
   String get aboutLicense => 'Licensed under the MIT License.';

--- a/apps/save-editor/lib/l10n/app_localizations_es.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_es.dart
@@ -1146,7 +1146,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 colaboradores de goresave';
+  String get aboutCopyright => '© 2026 colaboradores de GORE';
 
   @override
   String get aboutLicense => 'Distribuido bajo la licencia MIT.';

--- a/apps/save-editor/lib/l10n/app_localizations_fr.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_fr.dart
@@ -1149,7 +1149,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 contributeurs de goresave';
+  String get aboutCopyright => '© 2026 contributeurs de GORE';
 
   @override
   String get aboutLicense => 'Sous licence MIT.';

--- a/apps/save-editor/lib/l10n/app_localizations_it.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_it.dart
@@ -1147,7 +1147,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 collaboratori di goresave';
+  String get aboutCopyright => '© 2026 collaboratori di GORE';
 
   @override
   String get aboutLicense => 'Concesso in licenza secondo la licenza MIT.';

--- a/apps/save-editor/lib/l10n/app_localizations_ja.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ja.dart
@@ -1121,7 +1121,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 goresave コントリビューター';
+  String get aboutCopyright => '© 2026 GORE コントリビューター';
 
   @override
   String get aboutLicense => 'MIT ライセンスの下で提供されています。';

--- a/apps/save-editor/lib/l10n/app_localizations_pl.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pl.dart
@@ -1156,7 +1156,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 współtwórcy goresave';
+  String get aboutCopyright => '© 2026 współtwórcy GORE';
 
   @override
   String get aboutLicense => 'Udostępniane na licencji MIT.';

--- a/apps/save-editor/lib/l10n/app_localizations_pt.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pt.dart
@@ -1143,7 +1143,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 colaboradores do goresave';
+  String get aboutCopyright => '© 2026 colaboradores do GORE';
 
   @override
   String get aboutLicense => 'Licenciado sob a Licença MIT.';
@@ -2436,7 +2436,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   }
 
   @override
-  String get aboutCopyright => '© 2026 colaboradores do goresave';
+  String get aboutCopyright => '© 2026 colaboradores do GORE';
 
   @override
   String get aboutLicense => 'Licenciado sob a Licença MIT.';

--- a/apps/save-editor/lib/l10n/app_localizations_ru.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ru.dart
@@ -1153,7 +1153,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 участники проекта goresave';
+  String get aboutCopyright => '© 2026 участники проекта GORE';
 
   @override
   String get aboutLicense => 'Распространяется по лицензии MIT.';

--- a/apps/save-editor/lib/l10n/app_localizations_zh.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_zh.dart
@@ -1105,7 +1105,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get aboutCopyright => '© 2026 goresave 贡献者';
+  String get aboutCopyright => '© 2026 GORE 贡献者';
 
   @override
   String get aboutLicense => '基于 MIT 许可证授权。';
@@ -2355,7 +2355,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   }
 
   @override
-  String get aboutCopyright => '© 2026 goresave 贡献者';
+  String get aboutCopyright => '© 2026 GORE 贡献者';
 
   @override
   String get aboutLicense => '基于 MIT 许可证授权。';

--- a/apps/save-editor/lib/l10n/app_pl.arb
+++ b/apps/save-editor/lib/l10n/app_pl.arb
@@ -320,7 +320,7 @@
   "yes": "tak",
   "no": "nie",
   "aboutVersion": "Wersja {version} ({sha})",
-  "aboutCopyright": "© 2026 współtwórcy goresave",
+  "aboutCopyright": "© 2026 współtwórcy GORE",
   "aboutLicense": "Udostępniane na licencji MIT.",
   "difficultyTitle": "Poziom trudności — {profile}",
   "difficultyNoProfile": "Brak profilu",

--- a/apps/save-editor/lib/l10n/app_pt.arb
+++ b/apps/save-editor/lib/l10n/app_pt.arb
@@ -320,7 +320,7 @@
   "yes": "sim",
   "no": "não",
   "aboutVersion": "Versão {version} ({sha})",
-  "aboutCopyright": "© 2026 colaboradores do goresave",
+  "aboutCopyright": "© 2026 colaboradores do GORE",
   "aboutLicense": "Licenciado sob a Licença MIT.",
   "difficultyTitle": "Dificuldade — {profile}",
   "difficultyNoProfile": "Nenhum perfil",

--- a/apps/save-editor/lib/l10n/app_pt_BR.arb
+++ b/apps/save-editor/lib/l10n/app_pt_BR.arb
@@ -320,7 +320,7 @@
   "yes": "sim",
   "no": "não",
   "aboutVersion": "Versão {version} ({sha})",
-  "aboutCopyright": "© 2026 colaboradores do goresave",
+  "aboutCopyright": "© 2026 colaboradores do GORE",
   "aboutLicense": "Licenciado sob a Licença MIT.",
   "difficultyTitle": "Dificuldade — {profile}",
   "difficultyNoProfile": "Nenhum perfil",

--- a/apps/save-editor/lib/l10n/app_ru.arb
+++ b/apps/save-editor/lib/l10n/app_ru.arb
@@ -320,7 +320,7 @@
   "yes": "да",
   "no": "нет",
   "aboutVersion": "Версия {version} ({sha})",
-  "aboutCopyright": "© 2026 участники проекта goresave",
+  "aboutCopyright": "© 2026 участники проекта GORE",
   "aboutLicense": "Распространяется по лицензии MIT.",
   "difficultyTitle": "Сложность — {profile}",
   "difficultyNoProfile": "Нет профиля",

--- a/apps/save-editor/lib/l10n/app_zh.arb
+++ b/apps/save-editor/lib/l10n/app_zh.arb
@@ -320,7 +320,7 @@
   "yes": "是",
   "no": "否",
   "aboutVersion": "版本 {version}（{sha}）",
-  "aboutCopyright": "© 2026 goresave 贡献者",
+  "aboutCopyright": "© 2026 GORE 贡献者",
   "aboutLicense": "基于 MIT 许可证授权。",
   "difficultyTitle": "难度 — {profile}",
   "difficultyNoProfile": "无存档配置",

--- a/apps/save-editor/lib/l10n/app_zh_Hans.arb
+++ b/apps/save-editor/lib/l10n/app_zh_Hans.arb
@@ -320,7 +320,7 @@
   "yes": "是",
   "no": "否",
   "aboutVersion": "版本 {version}（{sha}）",
-  "aboutCopyright": "© 2026 goresave 贡献者",
+  "aboutCopyright": "© 2026 GORE 贡献者",
   "aboutLicense": "基于 MIT 许可证授权。",
   "difficultyTitle": "难度 — {profile}",
   "difficultyNoProfile": "无存档配置",

--- a/apps/save-editor/pubspec.yaml
+++ b/apps/save-editor/pubspec.yaml
@@ -1,7 +1,7 @@
 name: goresave
 description: "goresave: Gothic Remake Savegame-Editor"
 publish_to: "none"
-version: 0.4.0
+version: 1.0.0
 
 environment:
   sdk: ^3.12.0

--- a/crates/gore/src/cmd/deploy_shared.rs
+++ b/crates/gore/src/cmd/deploy_shared.rs
@@ -1,5 +1,5 @@
 //! `gore-cli deploy-shared` — copy the gore-lua shared/ tree into the game's
-//! `ue4ss/Mods/shared/`, so mods can `require("gorelib")`.
+//! `ue4ss/Mods/shared/`, so mods can `require("gore-lua")`.
 
 use anyhow::{bail, Context, Result};
 use std::{fs, path::Path, path::PathBuf};
@@ -51,7 +51,7 @@ pub fn run(src: Option<PathBuf>, game: PathBuf) -> Result<()> {
         );
     }
     // `Mods/shared` is a namespace shared by multiple mods, so we must NOT wipe it — only the
-    // top-level entries the SDK actually provides (currently `gorelib/`). Stage the full copy
+    // top-level entries the SDK actually provides (currently `gore-lua/`). Stage the full copy
     // in a sibling temp first (atomic: a failed copy leaves the old SDK intact), then for each
     // SDK-provided top-level entry replace just that entry under dest_root, leaving unrelated
     // libraries other mods stored there untouched.
@@ -112,7 +112,7 @@ fn resolve_default_src() -> Result<PathBuf> {
 }
 
 fn copy_dir(src: &Path, dest: &Path) -> Result<usize> {
-    // A pre-existing symlinked destination (anywhere in the tree, e.g. Mods/shared/gorelib ->
+    // A pre-existing symlinked destination (anywhere in the tree, e.g. Mods/shared/gore-lua ->
     // /tmp/elsewhere) would be FOLLOWED by create_dir_all / copy, writing outside Mods. Refuse
     // it; this runs at every recursion level, so nested links are caught too.
     if let Ok(meta) = fs::symlink_metadata(dest) {

--- a/crates/gore/src/cmd/scaffold.rs
+++ b/crates/gore/src/cmd/scaffold.rs
@@ -32,11 +32,11 @@ pub fn run(mod_name: String, mods_dir: PathBuf) -> Result<()> {
 -- Use `gore-cli stubs` to generate LuaLS type stubs for autocomplete.
 -- Require stubs: (add to your .luarc.json: {{ "workspace.library": ["path/to/stubs"] }})
 
--- gore-lua SDK loader (require + robust loadfile fallback)
-local ok, gore = pcall(require, "gorelib")
+-- gore-lua helper loader (require + robust loadfile fallback)
+local ok, gore = pcall(require, "gore-lua")
 if not ok then gore = nil end -- a failed pcall leaves the error string in `gore`; clear it
 if not gore then
-    local f = loadfile("ue4ss/Mods/shared/gorelib/gorelib.lua")
+    local f = loadfile("ue4ss/Mods/shared/gore-lua/gore-lua.lua")
     if f then
         -- run the chunk under pcall: a load-time error in the SDK must not abort the mod
         local ok2, res = pcall(f)

--- a/crates/gore/tests/integration/deploy_shared_test.rs
+++ b/crates/gore/tests/integration/deploy_shared_test.rs
@@ -6,8 +6,8 @@ use tempfile::tempdir;
 fn deploy_shared_copies_tree_into_mods_shared() {
     let src = tempdir().unwrap();
     // a fake lua/shared/ tree
-    fs::create_dir_all(src.path().join("gorelib")).unwrap();
-    fs::write(src.path().join("gorelib/gorelib.lua"), "return {}\n").unwrap();
+    fs::create_dir_all(src.path().join("gore-lua")).unwrap();
+    fs::write(src.path().join("gore-lua/gore-lua.lua"), "return {}\n").unwrap();
 
     let game = tempdir().unwrap();
     let mods = game.path().join("ue4ss/Mods");
@@ -25,7 +25,7 @@ fn deploy_shared_copies_tree_into_mods_shared() {
         .assert()
         .success();
 
-    let dest = mods.join("shared/gorelib/gorelib.lua");
-    assert!(dest.exists(), "gorelib.lua should be copied to Mods/shared/");
+    let dest = mods.join("shared/gore-lua/gore-lua.lua");
+    assert!(dest.exists(), "gore-lua.lua should be copied to Mods/shared/");
     assert_eq!(fs::read_to_string(dest).unwrap(), "return {}\n");
 }

--- a/crates/gore/tests/integration/scaffold_test.rs
+++ b/crates/gore/tests/integration/scaffold_test.rs
@@ -28,7 +28,7 @@ fn scaffold_creates_mod_structure() {
 }
 
 #[test]
-fn scaffold_main_lua_wires_gorelib_loader() {
+fn scaffold_main_lua_wires_gore_lua_loader() {
     let dir = TempDir::new().unwrap();
     Command::cargo_bin("gore")
         .unwrap()
@@ -37,8 +37,8 @@ fn scaffold_main_lua_wires_gorelib_loader() {
         .success();
     let main = std::fs::read_to_string(dir.path().join("MyMod/Scripts/main.lua")).unwrap();
     assert!(
-        main.contains(r#"require("gorelib")"#) || main.contains(r#"require, "gorelib")"#),
-        "should require gorelib"
+        main.contains(r#"require("gore-lua")"#) || main.contains(r#"require, "gore-lua")"#),
+        "should require gore-lua"
     );
     assert!(main.contains("loadfile"), "should have a loadfile fallback");
 }

--- a/lua/README.md
+++ b/lua/README.md
@@ -1,4 +1,4 @@
-# gore-lua — shared UE4SS modding SDK
+# gore-lua — shared UE4SS helper library
 
 Common helpers for Gothic 1 Remake UE4SS mods. This README is the API reference;
 `gore.help.list([filter])` returns the same registry programmatically.
@@ -6,7 +6,7 @@ Common helpers for Gothic 1 Remake UE4SS mods. This README is the API reference;
 ## Use it
 Deploy with `gore-cli deploy-shared`, then in a mod:
 ```lua
-local ok, gore = pcall(require, "gorelib")
+local ok, gore = pcall(require, "gore-lua")
 ```
 New mods scaffolded with `gore-cli scaffold <name>` get this loader wired in automatically.
 

--- a/lua/shared/gore-lua/gore-lua.lua
+++ b/lua/shared/gore-lua/gore-lua.lua
@@ -1,5 +1,5 @@
--- gorelib.lua — shared UE4SS modding SDK for Gothic 1 Remake.  Load with:
---   local ok, gore = pcall(require, "gorelib")
+-- gore-lua.lua — shared UE4SS helper library for Gothic 1 Remake.  Load with:
+--   local ok, gore = pcall(require, "gore-lua")
 -- Every helper pcall-guards its reflection and returns nil/false on failure (never throws).
 -- `gore.selftest()` probes every namespace.  See the README for the full API.
 

--- a/mods/example/Scripts/main.lua
+++ b/mods/example/Scripts/main.lua
@@ -1,15 +1,15 @@
--- gorelib example mod: loads the SDK and registers `goretest` (runs gore.selftest)
+-- gore-lua example mod: loads the helpers and registers `goretest` (runs gore.selftest)
 -- and `goresay <msg>` (on-screen text). Proves deploy + load + API end-to-end.
 
-local ok, gore = pcall(require, "gorelib")
+local ok, gore = pcall(require, "gore-lua")
 if not ok then gore = nil end -- a failed pcall leaves the error string in `gore`; clear it
 if not gore then
     -- robust fallback: load directly from the shared folder (require can be finicky)
-    local base = [[\ue4ss\Mods\shared\gorelib\gorelib.lua]]
-    for _, root in ipairs({ "ue4ss/Mods/shared/gorelib/gorelib.lua", "." .. base }) do
+    local base = [[\ue4ss\Mods\shared\gore-lua\gore-lua.lua]]
+    for _, root in ipairs({ "ue4ss/Mods/shared/gore-lua/gore-lua.lua", "." .. base }) do
         local f = loadfile(root)
         if f then
-            -- run the chunk under pcall: a load-time error in the SDK must not abort the mod
+            -- run the chunk under pcall: a load-time error in the helpers must not abort the mod
             local ok2, res = pcall(f)
             if ok2 then gore = res; break end
         end
@@ -17,19 +17,19 @@ if not gore then
 end
 
 if not gore then
-    print("[gorelib-example] FAILED to load gorelib\n")
+    print("[gore-lua-example] FAILED to load gore-lua\n")
     return
 end
 
-gore.ui.log("example mod loaded; gore SDK " .. gore._VERSION)
+gore.ui.log("example mod loaded; gore-lua " .. gore._VERSION)
 
 gore.cmd.command("goretest", function()
     gore.selftest()
 end)
 
 gore.cmd.command("goresay", function(params)
-    local msg = (params and #params > 0) and table.concat(params, " ") or "hello from gorelib"
+    local msg = (params and #params > 0) and table.concat(params, " ") or "hello from gore-lua"
     gore.ui.text(msg)
 end)
 
-print("[gorelib-example] ready. Console: goretest | goresay <msg>\n")
+print("[gore-lua-example] ready. Console: goretest | goresay <msg>\n")

--- a/scripts/appcast.py
+++ b/scripts/appcast.py
@@ -34,7 +34,7 @@ from datetime import datetime, timezone
 from email.utils import format_datetime
 from pathlib import Path
 
-REPO_DOWNLOAD_BASE = "https://github.com/dh0er/goresave/releases/download"
+REPO_DOWNLOAD_BASE = "https://github.com/dh0er/gore/releases/download"
 
 
 def sign_dsa(installer: Path) -> str:


### PR DESCRIPTION
## Summary

Branding + version polish across the suite, one bounded rename, and updater/repo-URL prep for the planned `goresave` → `gore` GitHub repo rename.

- **save-editor → 1.0.0** (`pubspec.yaml`). Changelog gets a `1.0.0` entry: NPC stats/inventory editing, armor in inventory, faction-crime clearing, NPC revive, inventory reset, game-time setting, all talents editable; UI navigation rework; performance.
- **README status markers**: save-editor + CLI ready (CLI = *experimental*), mod-studio + mod-manager marked 🚧 work in progress.
- **`gorelib` → `gore-lua`** (full rename; no existing mods depend on the old name): module + folder + file, `require("gore-lua")`, `scaffold`/`deploy-shared`, example mod, integration tests, and the README section retitled **GORE Lua Helper Library**. Demoted from "SDK" to "helper library".
- **`goresave` codename — visible surfaces only**: user-facing copyright now reads `© 2026 GORE contributors` (12 locales × save-editor + mod-manager), plus README/CHANGELOG prose. **Left intact** (load-bearing identity): Dart package name, `goresave_execute/free` FFI symbols, `goresave.exe`/installer, `goresave_backups/` on-disk folder, updater feed continuity.
- **Repo-URL prep**: updater feeds, appcast download base, and doc links now point at `github.com/dh0er/gore`.
- **`.gitignore`**: stale `apps/goresave/` paths → `apps/*/windows/flutter/ephemeral/`.

## ⚠️ Ordering note for whoever ships this

`github.com/dh0er/gore` does not exist yet. **Rename the GitHub repo `goresave` → `gore` before shipping any build from this branch**, or new builds' updaters hit a 404 (no reverse redirect for a not-yet-existing name). Already-shipped `goresave` builds keep working via GitHub's forward redirect after the rename — so **never re-create a repo named `goresave`** under this owner.

## Verification

- `cargo test -p gore --test scaffold_test --test deploy_shared_test` → **4 passed** (covers the `gore-lua` rename).
- l10n change is a literal string swap kept in sync across `.arb` + generated `app_localizations*.dart`; no `flutter analyze` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updater and release URLs break if shipped before the GitHub repo rename; gore-lua is a breaking rename for custom Lua mods using gorelib.
> 
> **Overview**
> Rebrands the suite toward **GORE**, bumps **save-editor to 1.0.0**, renames the shared Lua module from **gorelib** to **gore-lua**, and points docs/updaters at **`github.com/dh0er/gore`**.
> 
> **Save editor:** `pubspec.yaml` goes to **1.0.0**; **CHANGELOG** adds a **1.0.0** section (NPC editing, armor, faction crimes, revive, inventory reset, game time, full talents, UI navigation rework). README release links use the new repo.
> 
> **Branding & docs:** Root **README** adds readiness markers (CLI experimental, save-editor ready, mod-studio/mod-manager/gore-lua WIP), retitles the Lua section as a helper library, and replaces **goresave** release URLs with **gore**. About/copyright strings in **save-editor** and **mod-manager** (all locales) become **© 2026 GORE contributors**; GitHub links in about dialogs and **scripts/appcast.py** use **dh0er/gore**. WinSparkle appcast URLs in all three Flutter apps target the **gore** repo (save-editor `releases/latest`, mod-studio/mod-manager fixed appcast releases).
> 
> **gorelib → gore-lua:** CLI **scaffold** / **deploy-shared**, integration tests, **lua/README**, example mod, and comments now use **`require("gore-lua")`** and deploy paths under **`shared/gore-lua/`** (breaking for anyone still on the old module name).
> 
> **Misc:** **`.gitignore`** ignores **`apps/*/windows/flutter/ephemeral/`** instead of save-editor-only paths.
> 
> **Ship note:** Builds from this branch expect the GitHub repo to be renamed to **gore** before release, or updaters and new download links 404.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f997ae41292e44ce60e7d4df32259c21d86ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->