### PR TITLE
feat: gore config command + shared game path; rename gore-tools→gore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "aes",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "winreg",
 ]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ Get the binary by building it (`cargo build --release -p gore` →
 that contains `G1R/`). The exact `--game`/path each subcommand expects is always
 in `gore <cmd> --help`.
 
+Set the game path once and skip `--game` everywhere:
+
+```sh
+gore config set game-path "$GAME"   # an install root or the game .exe
+gore config detect                  # …or auto-detect a Steam install & save it
+gore config list                    # show the stored value + resolved root
+```
+
+Every command that needs the game (`deploy-shared`, `mod`, `mgr`, `texture`,
+`loc`) then resolves it automatically. Precedence is an explicit `--game` (or
+`--lcache` for `loc`) > the configured path > Steam auto-detect. The path is
+stored in a shared `config.json` (`gore config path`) that the GUI apps read
+too, so you configure the install in one place.
+
 Each domain produces a mod a different way:
 
 | Domain | Mechanism | Touches |
@@ -221,7 +235,7 @@ This is the same engine [`mod-studio`](#gore-mod-studio) drives. Other helpers:
 
 ```sh
 gore scaffold MyMod -o "$GAME/.../Mods"   # empty hand-written gore-lua mod skeleton
-gore deploy-shared --game "$GAME/.../Win64"   # install the gore-lua helpers (for custom Lua mods)
+gore deploy-shared --game "$GAME"         # install the gore-lua helpers (for custom Lua mods)
 gore package mod_dir/ -o MyMod.zip        # zip a Lua mod for sharing
 ```
 
@@ -231,6 +245,7 @@ Every subcommand of the `gore` binary:
 
 | Command | Action(s) | Purpose |
 |---------|-----------|---------|
+| `config` | `set` · `get` · `unset` · `list` · `path` · `detect` | Persist shared settings (the game path) so other commands can omit `--game`. |
 | `gen` | — | Compile `overrides.toml` → a UE4SS Lua override mod. |
 | `mod` | `build` · `deploy` · `undeploy` | Build/deploy/undeploy a unified bundle (overrides + loc + audio + textures + scripts). |
 | `mgr` | `import` · `list` · `enable` · `disable` · `order` · `analyze` · `apply` · `status` · `reset` · `remove` | Multi-mod manager: library, load order, conflict analysis, composed deploy (the CLI behind mod-manager). |
@@ -358,7 +373,7 @@ custom mods.
 How a mod uses it:
 
 ```sh
-gore deploy-shared --game "$GAME/.../Win64"   # copy gore-lua into ue4ss/Mods/shared (once)
+gore deploy-shared --game "$GAME"             # copy gore-lua into ue4ss/Mods/shared (once)
 gore scaffold MyMod -o "$GAME/.../Mods"       # new mod with the loader wired in
 ```
 

--- a/apps/mod-manager/installer/setup.iss
+++ b/apps/mod-manager/installer/setup.iss
@@ -43,10 +43,10 @@ SetupIconFile=..\windows\runner\resources\app_icon.ico
 LicenseFile=..\..\..\LICENSE
 
 [UninstallDelete]
-; Active settings live under the shared gore-tools umbrella
-; (%LOCALAPPDATA%\gore-tools\gore-manager\). Remove only gore-manager's own
-; subfolder so gore-save / gore-mod / gore-cli data under gore-tools survives.
-Type: filesandordirs; Name: "{localappdata}\gore-tools\gore-manager"
+; Active settings live under the shared gore umbrella
+; (%LOCALAPPDATA%\gore\gore-manager\). Remove only gore-manager's own
+; subfolder so gore-save / gore-mod / gore-cli data under gore survives.
+Type: filesandordirs; Name: "{localappdata}\gore\gore-manager"
 
 [Files]
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/apps/mod-manager/lib/app/domain/shared_config.dart
+++ b/apps/mod-manager/lib/app/domain/shared_config.dart
@@ -38,7 +38,9 @@ class SharedConfig {
 
   String? gamePath() {
     final v = _read()['game_path'];
-    return (v is String && v.isNotEmpty) ? v : null;
+    // Trim so a blank/whitespace-only value reads as unset, matching the Rust
+    // side (gore_loc::config) — else CLI and GUI disagree on whether it's set.
+    return (v is String && v.trim().isNotEmpty) ? v : null;
   }
 
   void setGamePath(String path) {

--- a/apps/mod-manager/lib/app/domain/shared_config.dart
+++ b/apps/mod-manager/lib/app/domain/shared_config.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'ui_settings.dart' show sharedDataDir;
+
+/// Read/write the shared per-user `config.json` — the SAME file the `gore` CLI
+/// and the other apps use. The contract is a flat JSON object; the only key
+/// this app uses is `game_path` (snake_case, matching the Rust `Config`).
+/// Unknown keys are preserved on write for forward-compatibility.
+class SharedConfig {
+  SharedConfig(this.file);
+
+  /// The real config at `<shared>/config.json`.
+  factory SharedConfig.defaultForPlatform({Map<String, String>? environment}) {
+    final env = environment ?? Platform.environment;
+    return SharedConfig(File(p.join(sharedDataDir(env), 'config.json')));
+  }
+
+  final File file;
+
+  Map<String, Object?> _read() {
+    try {
+      if (!file.existsSync()) return {};
+      final decoded = jsonDecode(file.readAsStringSync());
+      return decoded is Map ? decoded.cast<String, Object?>() : {};
+    } catch (_) {
+      return {};
+    }
+  }
+
+  void _write(Map<String, Object?> json) {
+    file.parent.createSync(recursive: true);
+    const encoder = JsonEncoder.withIndent('  ');
+    file.writeAsStringSync('${encoder.convert(json)}\n');
+  }
+
+  String? gamePath() {
+    final v = _read()['game_path'];
+    return (v is String && v.isNotEmpty) ? v : null;
+  }
+
+  void setGamePath(String path) {
+    final json = _read();
+    json['game_path'] = path;
+    _write(json);
+  }
+
+  void clearGamePath() {
+    final json = _read();
+    json.remove('game_path');
+    _write(json);
+  }
+}

--- a/apps/mod-manager/lib/app/domain/ui_settings.dart
+++ b/apps/mod-manager/lib/app/domain/ui_settings.dart
@@ -175,8 +175,11 @@ final uiSettingsStoreProvider = Provider<UiSettingsStore>((ref) {
 /// The shared `config.json` the `gore` CLI and other apps also read/write.
 final sharedConfigProvider = Provider<SharedConfig>((ref) {
   if (Platform.environment.containsKey('FLUTTER_TEST')) {
-    // Widget tests must not touch the real shared config.
-    return SharedConfig(File(p.join(Directory.systemTemp.path, 'gore-test', 'config.json')));
+    // Widget tests must not touch the real shared config. Use a UNIQUE temp file
+    // per container so tests never leak persisted game-path state into one
+    // another via a shared fixed path; each starts from a clean default.
+    final dir = Directory.systemTemp.createTempSync('gore_test_cfg');
+    return SharedConfig(File(p.join(dir.path, 'config.json')));
   }
   return SharedConfig.defaultForPlatform();
 });

--- a/apps/mod-manager/lib/app/domain/ui_settings.dart
+++ b/apps/mod-manager/lib/app/domain/ui_settings.dart
@@ -115,11 +115,11 @@ class NoopUiSettingsStore implements UiSettingsStore {
   void write(UiSettings settings) {}
 }
 
-/// Resolves the shared `gore-tools` umbrella data directory, matching the Rust
+/// Resolves the shared `gore` umbrella data directory, matching the Rust
 /// side (`gore_loc::paths::shared_data_dir`) exactly:
-/// - Windows: `%LOCALAPPDATA%` (fallback `%APPDATA%`) then `\gore-tools`
-/// - macOS:   `$HOME/Library/Application Support/gore-tools`
-/// - Linux:   `$XDG_DATA_HOME/gore-tools` else `$HOME/.local/share/gore-tools`
+/// - Windows: `%LOCALAPPDATA%` (fallback `%APPDATA%`) then `\gore`
+/// - macOS:   `$HOME/Library/Application Support/gore`
+/// - Linux:   `$XDG_DATA_HOME/gore` else `$HOME/.local/share/gore`
 String sharedDataDir(Map<String, String> env) {
   final String base;
   if (Platform.isWindows) {
@@ -138,7 +138,7 @@ String sharedDataDir(Map<String, String> env) {
               ? Directory.current.path
               : p.join(home, '.local', 'share'));
   }
-  return p.join(base, 'gore-tools');
+  return p.join(base, 'gore');
 }
 
 class JsonFileUiSettingsStore implements UiSettingsStore {

--- a/apps/mod-manager/lib/app/domain/ui_settings.dart
+++ b/apps/mod-manager/lib/app/domain/ui_settings.dart
@@ -6,9 +6,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:path/path.dart' as p;
 
+import 'shared_config.dart';
+
 class UiSettings {
   const UiSettings({
-    this.gameExePath,
     this.appLocale = 'en',
     this.themeMode = ThemeMode.light,
     this.uiScale = 1.0,
@@ -18,10 +19,6 @@ class UiSettings {
 
   factory UiSettings.fromJson(Map<String, Object?> json) {
     return UiSettings(
-      gameExePath: switch (json['gameExePath']) {
-        final String path when path.isNotEmpty => path,
-        _ => null,
-      },
       appLocale: switch (json['appLocale']) {
         // Trim so a stored " de " still matches kGameLangs (else the picker
         // would silently fall back to English).
@@ -46,10 +43,6 @@ class UiSettings {
     );
   }
 
-  /// Path to the game's executable (.exe). Used to derive the game root that
-  /// mods are deployed into; null until set by the user.
-  final String? gameExePath;
-
   /// Selected app/game language code (one of [kGameLangs]); drives the
   /// MaterialApp locale.
   final String appLocale;
@@ -65,8 +58,6 @@ class UiSettings {
   final bool windowMaximized;
 
   UiSettings copyWith({
-    String? gameExePath,
-    bool clearGameExePath = false,
     String? appLocale,
     ThemeMode? themeMode,
     double? uiScale,
@@ -74,7 +65,6 @@ class UiSettings {
     bool? windowMaximized,
   }) {
     return UiSettings(
-      gameExePath: clearGameExePath ? null : gameExePath ?? this.gameExePath,
       appLocale: appLocale ?? this.appLocale,
       themeMode: themeMode ?? this.themeMode,
       uiScale: uiScale ?? this.uiScale,
@@ -84,7 +74,6 @@ class UiSettings {
   }
 
   Map<String, Object?> toJson() => {
-    if (gameExePath != null) 'gameExePath': gameExePath,
     'appLocale': appLocale,
     'themeMode': switch (themeMode) {
       ThemeMode.dark => 'dark',
@@ -183,26 +172,36 @@ final uiSettingsStoreProvider = Provider<UiSettingsStore>((ref) {
   return JsonFileUiSettingsStore.defaultForPlatform();
 });
 
+/// The shared `config.json` the `gore` CLI and other apps also read/write.
+final sharedConfigProvider = Provider<SharedConfig>((ref) {
+  if (Platform.environment.containsKey('FLUTTER_TEST')) {
+    // Widget tests must not touch the real shared config.
+    return SharedConfig(File(p.join(Directory.systemTemp.path, 'gore-test', 'config.json')));
+  }
+  return SharedConfig.defaultForPlatform();
+});
+
 /// Path to the game's executable (.exe), or null if unset. Used to derive the
-/// game root for deploys. Persisted so the choice survives restarts.
+/// game root for deploys. Persisted (in the shared `config.json`) so the
+/// choice survives restarts and is shared with the `gore` CLI and other apps.
 final gameExePathProvider =
     StateNotifierProvider<GameExePathNotifier, String?>((ref) {
-  return GameExePathNotifier(ref.watch(uiSettingsStoreProvider));
+  return GameExePathNotifier(ref.watch(sharedConfigProvider));
 });
 
 class GameExePathNotifier extends StateNotifier<String?> {
-  GameExePathNotifier(this._store) : super(_store.read().gameExePath);
+  GameExePathNotifier(this._config) : super(_config.gamePath());
 
-  final UiSettingsStore _store;
+  final SharedConfig _config;
 
   void set(String path) {
     state = path;
-    _store.write(_store.read().copyWith(gameExePath: path));
+    _config.setGamePath(path);
   }
 
   void clear() {
     state = null;
-    _store.write(_store.read().copyWith(clearGameExePath: true));
+    _config.clearGamePath();
   }
 }
 

--- a/apps/mod-manager/lib/app/game_paths.dart
+++ b/apps/mod-manager/lib/app/game_paths.dart
@@ -1,12 +1,18 @@
 import 'dart:io';
 import 'package:path/path.dart' as p;
 
-/// Derive the game root (the folder containing `G1R/`) from the configured exe path.
-/// The exe lives at `<root>/G1R/Binaries/Win64/G1R-Win64-Shipping.exe`.
-String? gameRootFromExe(String? exePath) {
-  if (exePath == null || exePath.isEmpty) return null;
-  var dir = p.dirname(exePath);
-  for (var i = 0; i < 8; i++) {
+/// Derive the game root (the folder containing `G1R/`) from the configured path.
+///
+/// That path may be the install **root** itself — the shared `game_path` set by
+/// `gore config set game-path`/`detect` (and by another gore app) is the install
+/// root, not an exe — OR the game **.exe** at
+/// `<root>/G1R/Binaries/Win64/G1R-Win64-Shipping.exe`. The walk starts at the
+/// path itself and climbs to the nearest ancestor holding a `G1R/` child, so a
+/// root resolves to itself and an exe resolves to its root.
+String? gameRootFromExe(String? path) {
+  if (path == null || path.isEmpty) return null;
+  var dir = path;
+  for (var i = 0; i < 9; i++) {
     if (Directory(p.join(dir, 'G1R')).existsSync()) return dir;
     if (p.basename(dir) == 'G1R') return p.dirname(dir);
     final parent = p.dirname(dir);

--- a/apps/mod-manager/test/app/game_paths_test.dart
+++ b/apps/mod-manager/test/app/game_paths_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gore_manager/app/game_paths.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('gameRootFromExe', () {
+    test('resolves an install root (a dir holding G1R/) to itself', () {
+      // The shared game_path from `gore config set game-path`/`detect` is the
+      // install root, not an exe. It must resolve to itself, not its parent.
+      final dir = Directory.systemTemp.createTempSync('gore_root');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      Directory(p.join(dir.path, 'G1R')).createSync();
+
+      expect(gameRootFromExe(dir.path), dir.path);
+    });
+
+    test('resolves the game .exe to its install root', () {
+      final dir = Directory.systemTemp.createTempSync('gore_root');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final exe = p.join(
+        dir.path,
+        'G1R',
+        'Binaries',
+        'Win64',
+        'G1R-Win64-Shipping.exe',
+      );
+      Directory(p.dirname(exe)).createSync(recursive: true);
+      File(exe).writeAsStringSync('x');
+
+      expect(gameRootFromExe(exe), dir.path);
+    });
+
+    test('returns null for null or empty', () {
+      expect(gameRootFromExe(null), isNull);
+      expect(gameRootFromExe(''), isNull);
+    });
+  });
+}

--- a/apps/mod-manager/test/home_page_game_path_status_test.dart
+++ b/apps/mod-manager/test/home_page_game_path_status_test.dart
@@ -1,7 +1,10 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gore_manager/app/domain/shared_config.dart';
 import 'package:gore_manager/app/domain/ui_settings.dart';
 import 'package:gore_manager/app/game_paths.dart';
 import 'package:gore_manager/core/core_service.dart';
@@ -9,10 +12,10 @@ import 'package:gore_manager/core/providers.dart';
 import 'package:gore_manager/home_page.dart';
 import 'package:gore_manager/l10n/app_localizations.dart';
 import 'package:gore_manager/library/domain/library_notifier.dart';
+import 'package:path/path.dart' as p;
 
-/// A settings store that starts with no game path so the startup status runs
-/// against a null root (the set-path sentinel), letting the test isolate the
-/// mgr_status call triggered by the *path change*.
+/// A settings store that starts empty; only theme/locale/scale live here now
+/// (the game path moved to the shared config, see [_freshSharedConfig]).
 class _EmptySettingsStore implements UiSettingsStore {
   UiSettings _current = const UiSettings();
 
@@ -23,11 +26,26 @@ class _EmptySettingsStore implements UiSettingsStore {
   void write(UiSettings settings) => _current = settings;
 }
 
-Widget _app(FakeGoreCoreFfiService fake, UiSettingsStore store) {
+/// A shared config backed by its own temp file, optionally pre-seeded with a
+/// game path. Isolated per call (fresh temp dir) so tests never observe state
+/// left over by another test or a previous run — unlike the app's default
+/// FLUTTER_TEST shared-config stub, which points at one fixed temp path.
+SharedConfig _freshSharedConfig({String? gamePath}) {
+  final dir = Directory.systemTemp.createTempSync('gm_status_test_cfg');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final config = SharedConfig(File(p.join(dir.path, 'config.json')));
+  if (gamePath != null) config.setGamePath(gamePath);
+  return config;
+}
+
+Widget _app(FakeGoreCoreFfiService fake, UiSettingsStore store, SharedConfig config) {
   return ProviderScope(
     overrides: [
       coreServiceProvider.overrideWithValue(fake),
       uiSettingsStoreProvider.overrideWithValue(store),
+      sharedConfigProvider.overrideWithValue(config),
     ],
     child: MaterialApp(
       localizationsDelegates: const [
@@ -102,11 +120,13 @@ class _StatefulFake implements GoreCoreFfiService {
   }
 }
 
-Widget _appService(GoreCoreFfiService svc, UiSettingsStore store) {
+Widget _appService(
+    GoreCoreFfiService svc, UiSettingsStore store, SharedConfig config) {
   return ProviderScope(
     overrides: [
       coreServiceProvider.overrideWithValue(svc),
       uiSettingsStoreProvider.overrideWithValue(store),
+      sharedConfigProvider.overrideWithValue(config),
     ],
     child: MaterialApp(
       localizationsDelegates: const [
@@ -124,14 +144,14 @@ Widget _appService(GoreCoreFfiService svc, UiSettingsStore store) {
 void main() {
   testWidgets('a loadout edit re-queries deployment status', (tester) async {
     // Start with the game path already set so status refreshes hit the FFI.
-    final store = _EmptySettingsStore()
-      ..write(const UiSettings().copyWith(
-        gameExePath: 'C:/games/gothic/G1R/Binaries/Win64/G1R-Win64-Shipping.exe',
-      ));
+    final store = _EmptySettingsStore();
+    final config = _freshSharedConfig(
+      gamePath: 'C:/games/gothic/G1R/Binaries/Win64/G1R-Win64-Shipping.exe',
+    );
     final fake = _StatefulFake([
       {'id': 'm1', 'enabled': false},
     ]);
-    await tester.pumpWidget(_appService(fake, store));
+    await tester.pumpWidget(_appService(fake, store, config));
     await tester.pumpAndSettle();
 
     final before = fake.calls.where((c) => c.command == 'mgr_status').length;
@@ -166,7 +186,8 @@ void main() {
         },
       },
     );
-    await tester.pumpWidget(_app(fake, _EmptySettingsStore()));
+    await tester.pumpWidget(
+        _app(fake, _EmptySettingsStore(), _freshSharedConfig()));
     await tester.pumpAndSettle();
 
     // Startup ran mgr_status with a null root -> the sentinel, no FFI call.

--- a/apps/mod-manager/test/library/widgets_test.dart
+++ b/apps/mod-manager/test/library/widgets_test.dart
@@ -4,7 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gore_manager/app/domain/ui_settings.dart';
+import 'package:gore_manager/app/domain/shared_config.dart';
+import 'package:gore_manager/app/domain/ui_settings.dart' show sharedConfigProvider;
 import 'package:gore_manager/conflicts/ui/conflict_panel.dart';
 import 'package:gore_manager/core/core_service.dart';
 import 'package:gore_manager/core/providers.dart';
@@ -64,14 +65,16 @@ Map<String, Object?> _oneHardConflict() => {
       ],
     };
 
-/// A settings store that reports a fixed exe path so the game root resolves.
-class _FixedSettingsStore implements UiSettingsStore {
-  _FixedSettingsStore(this.exePath);
-  final String exePath;
-  @override
-  UiSettings read() => UiSettings(gameExePath: exePath);
-  @override
-  void write(UiSettings settings) {}
+/// A shared config, backed by its own temp file, seeded with a fixed exe path
+/// so the game root resolves. Isolated per call so tests don't share state.
+SharedConfig _fixedSharedConfig(String exePath) {
+  final dir = Directory.systemTemp.createTempSync('gm_widget_test_cfg');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final config = SharedConfig(File(p.join(dir.path, 'config.json')));
+  config.setGamePath(exePath);
+  return config;
 }
 
 /// Create a temp game tree whose exe path resolves via gameRootFromExe (it
@@ -91,8 +94,7 @@ Widget _appWith(FakeGoreCoreFfiService fake, {String? exePath}) {
     overrides: [
       coreServiceProvider.overrideWithValue(fake),
       if (exePath != null)
-        uiSettingsStoreProvider
-            .overrideWithValue(_FixedSettingsStore(exePath)),
+        sharedConfigProvider.overrideWithValue(_fixedSharedConfig(exePath)),
     ],
     child: MaterialApp(
       localizationsDelegates: const [

--- a/apps/mod-manager/test/shared_config_test.dart
+++ b/apps/mod-manager/test/shared_config_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:gore_manager/app/domain/shared_config.dart';
+
+void main() {
+  test('write then read round-trips game_path', () {
+    final dir = Directory.systemTemp.createTempSync('gore_cfg');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final file = File(p.join(dir.path, 'config.json'));
+
+    final cfg = SharedConfig(file);
+    cfg.setGamePath('D:/Games/G1R');
+
+    expect(cfg.gamePath(), 'D:/Games/G1R');
+    // Stored under the snake_case key the Rust side uses.
+    final json = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+    expect(json['game_path'], 'D:/Games/G1R');
+  });
+
+  test('missing file reads null', () {
+    final dir = Directory.systemTemp.createTempSync('gore_cfg');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final cfg = SharedConfig(File(p.join(dir.path, 'config.json')));
+    expect(cfg.gamePath(), isNull);
+  });
+
+  test('unknown keys are preserved on write', () {
+    final dir = Directory.systemTemp.createTempSync('gore_cfg');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final file = File(p.join(dir.path, 'config.json'))
+      ..writeAsStringSync('{"game_path":"x","future":1}');
+    SharedConfig(file).setGamePath('y');
+    final json = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+    expect(json['game_path'], 'y');
+    expect(json['future'], 1); // forward-compat: don't drop unknown keys
+  });
+}

--- a/apps/mod-studio/installer/setup.iss
+++ b/apps/mod-studio/installer/setup.iss
@@ -42,10 +42,10 @@ SetupIconFile=..\windows\runner\resources\app_icon.ico
 LicenseFile=..\..\..\LICENSE
 
 [UninstallDelete]
-; Active settings live under the shared gore-tools umbrella
-; (%LOCALAPPDATA%\gore-tools\gore-mod\ui_settings.json). Remove only gore-mod's
-; own subfolder so gore-save / gore-cli data under gore-tools survives.
-Type: filesandordirs; Name: "{localappdata}\gore-tools\gore-mod"
+; Active settings live under the shared gore umbrella
+; (%LOCALAPPDATA%\gore\gore-mod\ui_settings.json). Remove only gore-mod's
+; own subfolder so gore-save / gore-cli data under gore survives.
+Type: filesandordirs; Name: "{localappdata}\gore\gore-mod"
 ; Legacy per-app config dir (%APPDATA%\gore-mod), kept only as the one-time
 ; settings migration source; drop it too.
 Type: filesandordirs; Name: "{userappdata}\gore-mod"

--- a/apps/mod-studio/lib/app/domain/shared_config.dart
+++ b/apps/mod-studio/lib/app/domain/shared_config.dart
@@ -37,7 +37,9 @@ class SharedConfig {
 
   String? gamePath() {
     final v = _read()['game_path'];
-    return (v is String && v.isNotEmpty) ? v : null;
+    // Trim so a blank/whitespace-only value reads as unset, matching the Rust
+    // side (gore_loc::config) — else CLI and GUI disagree on whether it's set.
+    return (v is String && v.trim().isNotEmpty) ? v : null;
   }
 
   void setGamePath(String path) {

--- a/apps/mod-studio/lib/app/domain/shared_config.dart
+++ b/apps/mod-studio/lib/app/domain/shared_config.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'ui_settings.dart' show sharedDataDir;
+
+/// Read/write the shared per-user `config.json` — the SAME file the `gore` CLI
+/// and the other apps use. The contract is a flat JSON object; the only key
+/// this app uses is `game_path` (snake_case, matching the Rust `Config`).
+/// Unknown keys are preserved on write for forward-compatibility.
+class SharedConfig {
+  SharedConfig(this.file);
+
+  factory SharedConfig.defaultForPlatform({Map<String, String>? environment}) {
+    final env = environment ?? Platform.environment;
+    return SharedConfig(File(p.join(sharedDataDir(env), 'config.json')));
+  }
+
+  final File file;
+
+  Map<String, Object?> _read() {
+    try {
+      if (!file.existsSync()) return {};
+      final decoded = jsonDecode(file.readAsStringSync());
+      return decoded is Map ? decoded.cast<String, Object?>() : {};
+    } catch (_) {
+      return {};
+    }
+  }
+
+  void _write(Map<String, Object?> json) {
+    file.parent.createSync(recursive: true);
+    const encoder = JsonEncoder.withIndent('  ');
+    file.writeAsStringSync('${encoder.convert(json)}\n');
+  }
+
+  String? gamePath() {
+    final v = _read()['game_path'];
+    return (v is String && v.isNotEmpty) ? v : null;
+  }
+
+  void setGamePath(String path) {
+    final json = _read();
+    json['game_path'] = path;
+    _write(json);
+  }
+
+  void clearGamePath() {
+    final json = _read();
+    json.remove('game_path');
+    _write(json);
+  }
+}

--- a/apps/mod-studio/lib/app/domain/ui_settings.dart
+++ b/apps/mod-studio/lib/app/domain/ui_settings.dart
@@ -6,6 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:path/path.dart' as p;
 
+import 'shared_config.dart';
+
 class UiSettings {
   const UiSettings({
     this.themeMode = ThemeMode.light,
@@ -13,7 +15,6 @@ class UiSettings {
     this.windowSize,
     this.windowMaximized = false,
     this.dumpPath,
-    this.gameExePath,
     this.locExtractPrompted = false,
     this.appLocale = 'en',
   });
@@ -45,10 +46,6 @@ class UiSettings {
         final String path when path.isNotEmpty => path,
         _ => null,
       },
-      gameExePath: switch (json['gameExePath']) {
-        final String path when path.isNotEmpty => path,
-        _ => null,
-      },
       locExtractPrompted: json['locExtractPrompted'] == true,
     );
   }
@@ -63,10 +60,6 @@ class UiSettings {
   /// Path to a user-loaded game-data dump that overrides the bundled model;
   /// null means use the bundled assets.
   final String? dumpPath;
-
-  /// Path to the game's executable (.exe). Used as the hint when auto-detecting
-  /// localized text and the game install; null until set by the user.
-  final String? gameExePath;
 
   /// Whether the first-run localized-text extraction prompt has been shown.
   /// Persisted so the optional auto-prompt only fires once.
@@ -83,8 +76,6 @@ class UiSettings {
     bool? windowMaximized,
     String? dumpPath,
     bool clearDumpPath = false,
-    String? gameExePath,
-    bool clearGameExePath = false,
     bool? locExtractPrompted,
     String? appLocale,
   }) {
@@ -94,7 +85,6 @@ class UiSettings {
       windowSize: windowSize ?? this.windowSize,
       windowMaximized: windowMaximized ?? this.windowMaximized,
       dumpPath: clearDumpPath ? null : dumpPath ?? this.dumpPath,
-      gameExePath: clearGameExePath ? null : gameExePath ?? this.gameExePath,
       locExtractPrompted: locExtractPrompted ?? this.locExtractPrompted,
       appLocale: appLocale ?? this.appLocale,
     );
@@ -113,7 +103,6 @@ class UiSettings {
     },
     'windowMaximized': windowMaximized,
     if (dumpPath != null) 'dumpPath': dumpPath,
-    if (gameExePath != null) 'gameExePath': gameExePath,
     'locExtractPrompted': locExtractPrompted,
     'appLocale': appLocale,
   };
@@ -243,6 +232,15 @@ final uiSettingsStoreProvider = Provider<UiSettingsStore>((ref) {
   return JsonFileUiSettingsStore.defaultForPlatform();
 });
 
+/// The shared `config.json` the `gore` CLI and other apps also read/write.
+final sharedConfigProvider = Provider<SharedConfig>((ref) {
+  if (Platform.environment.containsKey('FLUTTER_TEST')) {
+    // Widget tests must not touch the real shared config.
+    return SharedConfig(File(p.join(Directory.systemTemp.path, 'gore-test', 'config.json')));
+  }
+  return SharedConfig.defaultForPlatform();
+});
+
 final themeModeProvider = StateNotifierProvider<ThemeModeNotifier, ThemeMode>((
   ref,
 ) {
@@ -308,26 +306,27 @@ class DumpPathNotifier extends StateNotifier<String?> {
 }
 
 /// Path to the game's executable (.exe), or null if unset. Used as the hint for
-/// localized-text auto-detection and game-install discovery. Persisted so the
-/// choice survives restarts.
+/// localized-text auto-detection and game-install discovery. Persisted (in the
+/// shared `config.json`) so the choice survives restarts and is shared with the
+/// `gore` CLI and other apps.
 final gameExePathProvider =
     StateNotifierProvider<GameExePathNotifier, String?>((ref) {
-  return GameExePathNotifier(ref.watch(uiSettingsStoreProvider));
+  return GameExePathNotifier(ref.watch(sharedConfigProvider));
 });
 
 class GameExePathNotifier extends StateNotifier<String?> {
-  GameExePathNotifier(this._store) : super(_store.read().gameExePath);
+  GameExePathNotifier(this._config) : super(_config.gamePath());
 
-  final UiSettingsStore _store;
+  final SharedConfig _config;
 
   void set(String path) {
     state = path;
-    _store.write(_store.read().copyWith(gameExePath: path));
+    _config.setGamePath(path);
   }
 
   void clear() {
     state = null;
-    _store.write(_store.read().copyWith(clearGameExePath: true));
+    _config.clearGamePath();
   }
 }
 

--- a/apps/mod-studio/lib/app/domain/ui_settings.dart
+++ b/apps/mod-studio/lib/app/domain/ui_settings.dart
@@ -235,8 +235,11 @@ final uiSettingsStoreProvider = Provider<UiSettingsStore>((ref) {
 /// The shared `config.json` the `gore` CLI and other apps also read/write.
 final sharedConfigProvider = Provider<SharedConfig>((ref) {
   if (Platform.environment.containsKey('FLUTTER_TEST')) {
-    // Widget tests must not touch the real shared config.
-    return SharedConfig(File(p.join(Directory.systemTemp.path, 'gore-test', 'config.json')));
+    // Widget tests must not touch the real shared config. Use a UNIQUE temp file
+    // per container so tests never leak persisted game-path state into one
+    // another via a shared fixed path; each starts from a clean default.
+    final dir = Directory.systemTemp.createTempSync('gore_test_cfg');
+    return SharedConfig(File(p.join(dir.path, 'config.json')));
   }
   return SharedConfig.defaultForPlatform();
 });

--- a/apps/mod-studio/lib/app/domain/ui_settings.dart
+++ b/apps/mod-studio/lib/app/domain/ui_settings.dart
@@ -134,11 +134,11 @@ class NoopUiSettingsStore implements UiSettingsStore {
   void write(UiSettings settings) {}
 }
 
-/// Resolves the shared `gore-tools` umbrella data directory, matching the Rust
+/// Resolves the shared `gore` umbrella data directory, matching the Rust
 /// side (`gore_loc::paths::shared_data_dir`) exactly:
-/// - Windows: `%LOCALAPPDATA%` (fallback `%APPDATA%`) then `\gore-tools`
-/// - macOS:   `$HOME/Library/Application Support/gore-tools`
-/// - Linux:   `$XDG_DATA_HOME/gore-tools` else `$HOME/.local/share/gore-tools`
+/// - Windows: `%LOCALAPPDATA%` (fallback `%APPDATA%`) then `\gore`
+/// - macOS:   `$HOME/Library/Application Support/gore`
+/// - Linux:   `$XDG_DATA_HOME/gore` else `$HOME/.local/share/gore`
 String sharedDataDir(Map<String, String> env) {
   final String base;
   if (Platform.isWindows) {
@@ -157,7 +157,7 @@ String sharedDataDir(Map<String, String> env) {
               ? Directory.current.path
               : p.join(home, '.local', 'share'));
   }
-  return p.join(base, 'gore-tools');
+  return p.join(base, 'gore');
 }
 
 /// The previous per-app config directory (`<config>/gore-mod`), kept only so a

--- a/apps/mod-studio/lib/app/game_paths.dart
+++ b/apps/mod-studio/lib/app/game_paths.dart
@@ -1,12 +1,18 @@
 import 'dart:io';
 import 'package:path/path.dart' as p;
 
-/// Derive the game root (the folder containing `G1R/`) from the configured exe path.
-/// The exe lives at `<root>/G1R/Binaries/Win64/G1R-Win64-Shipping.exe`.
-String? gameRootFromExe(String? exePath) {
-  if (exePath == null || exePath.isEmpty) return null;
-  var dir = p.dirname(exePath);
-  for (var i = 0; i < 8; i++) {
+/// Derive the game root (the folder containing `G1R/`) from the configured path.
+///
+/// That path may be the install **root** itself — the shared `game_path` set by
+/// `gore config set game-path`/`detect` (and by another gore app) is the install
+/// root, not an exe — OR the game **.exe** at
+/// `<root>/G1R/Binaries/Win64/G1R-Win64-Shipping.exe`. The walk starts at the
+/// path itself and climbs to the nearest ancestor holding a `G1R/` child, so a
+/// root resolves to itself and an exe resolves to its root.
+String? gameRootFromExe(String? path) {
+  if (path == null || path.isEmpty) return null;
+  var dir = path;
+  for (var i = 0; i < 9; i++) {
     if (Directory(p.join(dir, 'G1R')).existsSync()) return dir;
     if (p.basename(dir) == 'G1R') return p.dirname(dir);
     final parent = p.dirname(dir);

--- a/apps/mod-studio/test/app/game_path_scope_test.dart
+++ b/apps/mod-studio/test/app/game_path_scope_test.dart
@@ -9,8 +9,9 @@ void main() {
   testWidgets(
     'game path change resets scoped tab state; tab switching alone keeps it',
     (tester) async {
-      // gameExePathProvider is backed by NoopUiSettingsStore under
-      // FLUTTER_TEST, so driving the real notifier is side-effect free.
+      // gameExePathProvider is backed by a SharedConfig pointed at a
+      // <systemTemp>/gore-test/config.json file under FLUTTER_TEST (never the
+      // real shared config), so driving the real notifier here is safe.
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(

--- a/apps/mod-studio/test/app/game_paths_test.dart
+++ b/apps/mod-studio/test/app/game_paths_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gore_mod/app/game_paths.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('gameRootFromExe', () {
+    test('resolves an install root (a dir holding G1R/) to itself', () {
+      // The shared game_path from `gore config set game-path`/`detect` is the
+      // install root, not an exe. It must resolve to itself, not its parent.
+      final dir = Directory.systemTemp.createTempSync('gore_root');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      Directory(p.join(dir.path, 'G1R')).createSync();
+
+      expect(gameRootFromExe(dir.path), dir.path);
+    });
+
+    test('resolves the game .exe to its install root', () {
+      final dir = Directory.systemTemp.createTempSync('gore_root');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final exe = p.join(
+        dir.path,
+        'G1R',
+        'Binaries',
+        'Win64',
+        'G1R-Win64-Shipping.exe',
+      );
+      Directory(p.dirname(exe)).createSync(recursive: true);
+      File(exe).writeAsStringSync('x');
+
+      expect(gameRootFromExe(exe), dir.path);
+    });
+
+    test('returns null for null or empty', () {
+      expect(gameRootFromExe(null), isNull);
+      expect(gameRootFromExe(''), isNull);
+    });
+  });
+}

--- a/apps/mod-studio/test/audio/audio_tab_widget_test.dart
+++ b/apps/mod-studio/test/audio/audio_tab_widget_test.dart
@@ -3,7 +3,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gore_mod/app/domain/ui_settings.dart';
+import 'package:gore_mod/app/domain/shared_config.dart';
+import 'package:gore_mod/app/domain/ui_settings.dart' show sharedConfigProvider;
 import 'package:gore_mod/audio/domain/audio_replacements_notifier.dart';
 import 'package:gore_mod/audio/domain/audio_samples_provider.dart';
 import 'package:gore_mod/audio/ui/audio_tab.dart';
@@ -22,16 +23,17 @@ final String _fakeGameExePath = p.join(
   'G1R-Win64-Shipping.exe',
 );
 
-/// In-memory settings store so the test never touches the real settings file.
-class _MemUiSettingsStore implements UiSettingsStore {
-  _MemUiSettingsStore(this._settings);
-  UiSettings _settings;
-
-  @override
-  UiSettings read() => _settings;
-
-  @override
-  void write(UiSettings settings) => _settings = settings;
+/// A shared config, backed by its own temp file, seeded with the fake exe
+/// path so AudioTab resolves an FMOD dir. Isolated per call so tests don't
+/// share state.
+SharedConfig _fixedSharedConfig() {
+  final dir = Directory.systemTemp.createTempSync('gore_audio_widget_cfg');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final config = SharedConfig(File(p.join(dir.path, 'config.json')));
+  config.setGamePath(_fakeGameExePath);
+  return config;
 }
 
 AudioSampleInfo _sample(String name) => AudioSampleInfo(
@@ -52,11 +54,7 @@ Future<void> _pumpAudioTab(
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
-        uiSettingsStoreProvider.overrideWith(
-          (ref) => _MemUiSettingsStore(
-            UiSettings(gameExePath: _fakeGameExePath),
-          ),
-        ),
+        sharedConfigProvider.overrideWithValue(_fixedSharedConfig()),
         audioSamplesProvider.overrideWith(
           (ref, bankFullPath) async =>
               samplesByBank[bankFullPath.split(RegExp(r'[\\/]')).last] ??

--- a/apps/mod-studio/test/shared_config_test.dart
+++ b/apps/mod-studio/test/shared_config_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:gore_mod/app/domain/shared_config.dart';
+
+void main() {
+  test('write then read round-trips game_path', () {
+    final dir = Directory.systemTemp.createTempSync('gore_cfg');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final file = File(p.join(dir.path, 'config.json'));
+    final cfg = SharedConfig(file);
+    cfg.setGamePath('D:/Games/G1R');
+    expect(cfg.gamePath(), 'D:/Games/G1R');
+    final json = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+    expect(json['game_path'], 'D:/Games/G1R');
+  });
+
+  test('missing file reads null', () {
+    final dir = Directory.systemTemp.createTempSync('gore_cfg');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final cfg = SharedConfig(File(p.join(dir.path, 'config.json')));
+    expect(cfg.gamePath(), isNull);
+  });
+
+  test('unknown keys are preserved on write', () {
+    final dir = Directory.systemTemp.createTempSync('gore_cfg');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final file = File(p.join(dir.path, 'config.json'))
+      ..writeAsStringSync('{"game_path":"x","future":1}');
+    SharedConfig(file).setGamePath('y');
+    final json = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+    expect(json['game_path'], 'y');
+    expect(json['future'], 1);
+  });
+}

--- a/apps/mod-studio/test/textures/texture_tab_staged_filter_test.dart
+++ b/apps/mod-studio/test/textures/texture_tab_staged_filter_test.dart
@@ -1,24 +1,29 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gore_mod/app/domain/ui_settings.dart';
+import 'package:gore_mod/app/domain/shared_config.dart';
+import 'package:gore_mod/app/domain/ui_settings.dart' show sharedConfigProvider;
 import 'package:gore_mod/app/ui/path_tree.dart';
 import 'package:gore_mod/textures/domain/texture_index_provider.dart';
 import 'package:gore_mod/textures/domain/texture_replacements_notifier.dart';
 import 'package:gore_mod/textures/ui/texture_tab.dart';
+import 'package:path/path.dart' as p;
 
-/// Settings store with a game exe path set so TextureTab proceeds past the
-/// "set the game path" hint. The path doesn't exist on disk, so the game root
-/// resolves to null and no FFI preview/extract is ever attempted.
-class _ExeStore implements UiSettingsStore {
-  const _ExeStore();
-
-  @override
-  UiSettings read() =>
-      const UiSettings(gameExePath: r'C:\gore-test-nonexistent\G1R.exe');
-
-  @override
-  void write(UiSettings settings) {}
+/// A shared config, backed by its own temp file, seeded with a fixed
+/// nonexistent exe path so TextureTab proceeds past the "set the game path"
+/// hint. The path doesn't exist on disk, so the game root resolves to null
+/// and no FFI preview/extract is ever attempted. Isolated per call so tests
+/// don't share state.
+SharedConfig _fixedSharedConfig() {
+  final dir = Directory.systemTemp.createTempSync('gore_texture_filter_cfg');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final config = SharedConfig(File(p.join(dir.path, 'config.json')));
+  config.setGamePath(r'C:\gore-test-nonexistent\G1R.exe');
+  return config;
 }
 
 const Map<String, String> _fakeIndex = {
@@ -30,7 +35,7 @@ const Map<String, String> _fakeIndex = {
 Widget _app({required bool onlyStaged}) {
   return ProviderScope(
     overrides: [
-      uiSettingsStoreProvider.overrideWithValue(const _ExeStore()),
+      sharedConfigProvider.overrideWithValue(_fixedSharedConfig()),
       textureIndexProvider.overrideWith((ref) async => _fakeIndex),
     ],
     child: MaterialApp(

--- a/apps/mod-studio/test/textures/texture_tab_staged_preview_test.dart
+++ b/apps/mod-studio/test/textures/texture_tab_staged_preview_test.dart
@@ -4,25 +4,28 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gore_mod/app/domain/ui_settings.dart';
+import 'package:gore_mod/app/domain/shared_config.dart';
+import 'package:gore_mod/app/domain/ui_settings.dart' show sharedConfigProvider;
 import 'package:gore_mod/textures/domain/texture_index_provider.dart';
 import 'package:gore_mod/textures/domain/texture_replacements_notifier.dart';
 import 'package:gore_mod/textures/ui/texture_tab.dart';
+import 'package:path/path.dart' as p;
 
-/// Settings store with a game exe path set so TextureTab proceeds past the
-/// "set the game path" hint. The path doesn't exist on disk, so the game root
-/// resolves to null and no FFI preview/extract is ever attempted — the
-/// original-preview branch stays on its "Preview to see…" placeholder, making
-/// the staged-vs-original branch switch directly observable.
-class _ExeStore implements UiSettingsStore {
-  const _ExeStore();
-
-  @override
-  UiSettings read() =>
-      const UiSettings(gameExePath: r'C:\gore-test-nonexistent\G1R.exe');
-
-  @override
-  void write(UiSettings settings) {}
+/// A shared config, backed by its own temp file, seeded with a fixed
+/// nonexistent exe path so TextureTab proceeds past the "set the game path"
+/// hint. The path doesn't exist on disk, so the game root resolves to null
+/// and no FFI preview/extract is ever attempted — the original-preview branch
+/// stays on its "Preview to see…" placeholder, making the staged-vs-original
+/// branch switch directly observable. Isolated per call so tests don't share
+/// state.
+SharedConfig _fixedSharedConfig() {
+  final dir = Directory.systemTemp.createTempSync('gore_texture_preview_cfg');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final config = SharedConfig(File(p.join(dir.path, 'config.json')));
+  config.setGamePath(r'C:\gore-test-nonexistent\G1R.exe');
+  return config;
 }
 
 const _asset = 'Game/Textures/A';
@@ -40,7 +43,7 @@ final Uint8List _onePixelPng = Uint8List.fromList(const [
 
 Widget _app() => ProviderScope(
   overrides: [
-    uiSettingsStoreProvider.overrideWithValue(const _ExeStore()),
+    sharedConfigProvider.overrideWithValue(_fixedSharedConfig()),
     textureIndexProvider.overrideWith((ref) async => _fakeIndex),
   ],
   child: const MaterialApp(home: Scaffold(body: TextureTab())),

--- a/apps/save-editor/README.md
+++ b/apps/save-editor/README.md
@@ -2,7 +2,7 @@
 
 `gore-save` is the savegame editor for Gothic Remake. It
 provides a Flutter interface backed by a Rust savegame core. It is one project
-in the [gore-tools](../../README.md) monorepo.
+in the [gore](../../README.md) monorepo.
 
 ## Features
 

--- a/apps/save-editor/lib/features/app/domain/ui_settings.dart
+++ b/apps/save-editor/lib/features/app/domain/ui_settings.dart
@@ -135,7 +135,7 @@ class JsonFileUiSettingsStore implements UiSettingsStore {
   }
 
   /// Previous per-app config location used before settings moved under the
-  /// shared `gore-tools` umbrella. Kept only to migrate old files once.
+  /// shared `gore` umbrella. Kept only to migrate old files once.
   static File _legacyFile(Map<String, String> env, String fileName) {
     final String root;
     if (Platform.isWindows) {

--- a/apps/save-editor/lib/features/editor/domain/editor_settings_store.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_settings_store.dart
@@ -52,7 +52,7 @@ class JsonFileEditorSettingsStore implements EditorSettingsStore {
   }
 
   /// Previous per-app config location used before settings moved under the
-  /// shared `gore-tools` umbrella. Kept only to migrate old files once.
+  /// shared `gore` umbrella. Kept only to migrate old files once.
   static File _legacyFile(Map<String, String> env, String fileName) {
     final root =
         env['APPDATA'] ?? env['LOCALAPPDATA'] ?? Directory.current.path;

--- a/apps/save-editor/lib/features/localization/domain/localization_controller.dart
+++ b/apps/save-editor/lib/features/localization/domain/localization_controller.dart
@@ -124,10 +124,12 @@ class LocalizationController extends StateNotifier<LocalizationState> {
         final error = (response['error'] as Map?)?.cast<String, Object?>();
         final code = error?['code'] as String?;
         final message = error?['message'] as String? ?? 'Unknown core error';
-        // INVALID_REQUEST is raised when the .lcache wasn't found (e.g. Steam
-        // auto-detect came up empty); treat that as the file-picker fallback
-        // signal rather than a hard error.
-        final notFound = code == 'INVALID_REQUEST' && lcacheHint == null;
+        // INVALID_REQUEST is raised when the .lcache wasn't found — whether we
+        // were auto-detecting (no hint) or resolving from a hint that pointed at
+        // no cache. Signal it regardless of the hint so the caller can tell a
+        // "no cache here, try elsewhere" outcome (retry auto-detect / pick a
+        // file) apart from a real read/decode failure of a cache that WAS found.
+        final notFound = code == 'INVALID_REQUEST';
         if (notFound) {
           // Expected case: auto-detect came up empty and the caller will open
           // the file picker. Stay idle and clear the message so cancelling the

--- a/apps/save-editor/lib/features/localization/ui/localization_flow.dart
+++ b/apps/save-editor/lib/features/localization/ui/localization_flow.dart
@@ -11,11 +11,12 @@ import 'package:goresave/providers/data_providers.dart';
 ///
 /// 1. Attempts extraction using the configured `game_path` (shared
 ///    `config.json`, e.g. set via `gore config` or another gore-suite app) as
-///    an authoritative hint when present; otherwise auto-detects via Steam.
-/// 2. On a not-found auto-detect failure (no hint at all), opens a `.lcache`
-///    file picker and retries with the picked path; if the user cancels,
-///    aborts gracefully.
-/// 3. Reports success/failure via a SnackBar.
+///    a preferred hint when present; otherwise auto-detects via Steam.
+/// 2. If that configured hint fails to resolve a `.lcache`, falls back to Steam
+///    auto-detect so a stale/wrong configured path never dead-ends the GUI.
+/// 3. On a not-found auto-detect failure, opens a `.lcache` file picker and
+///    retries with the picked path; if the user cancels, aborts gracefully.
+/// 4. Reports success/failure via a SnackBar.
 ///
 /// [context] must come from a widget that is still mounted; the function checks
 /// `context.mounted` after each await before touching the UI.
@@ -29,6 +30,15 @@ Future<void> runLocalizationExtractFlow(
   // (matches the `gore` CLI's own precedence: configured path > auto-detect).
   final configuredGamePath = ref.read(sharedConfigProvider).gamePath();
   var result = await controller.extract(lcacheHint: configuredGamePath);
+
+  // A configured game_path is only a preferred hint here — the GUI must stay
+  // recoverable. If it fails to resolve a .lcache, fall back to Steam
+  // auto-detect (called with no hint), which sets `notFound` and opens the
+  // picker below when it too finds nothing. Without this, a stale/wrong
+  // configured path would surface only an error with no way to proceed.
+  if (!result.success && configuredGamePath != null) {
+    result = await controller.extract(lcacheHint: null);
+  }
 
   if (result.notFound) {
     if (!context.mounted) return;

--- a/apps/save-editor/lib/features/localization/ui/localization_flow.dart
+++ b/apps/save-editor/lib/features/localization/ui/localization_flow.dart
@@ -4,13 +4,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:goresave/features/localization/domain/localization_controller.dart';
 import 'package:goresave/l10n/app_localizations.dart';
 import 'package:goresave/loc/loc_catalog_provider.dart';
+import 'package:goresave/providers/data_providers.dart';
 
 /// Runs the shared "extract localized game text" flow used by both the
 /// first-run confirmation and the manual Settings button.
 ///
-/// 1. Attempts auto-detect extraction (no hint).
-/// 2. On a not-found auto-detect failure, opens a `.lcache` file picker and
-///    retries with the picked path; if the user cancels, aborts gracefully.
+/// 1. Attempts extraction using the configured `game_path` (shared
+///    `config.json`, e.g. set via `gore config` or another gore-suite app) as
+///    an authoritative hint when present; otherwise auto-detects via Steam.
+/// 2. On a not-found auto-detect failure (no hint at all), opens a `.lcache`
+///    file picker and retries with the picked path; if the user cancels,
+///    aborts gracefully.
 /// 3. Reports success/failure via a SnackBar.
 ///
 /// [context] must come from a widget that is still mounted; the function checks
@@ -21,7 +25,10 @@ Future<void> runLocalizationExtractFlow(
 ) async {
   final controller = ref.read(localizationControllerProvider.notifier);
 
-  var result = await controller.extract();
+  // An explicitly-configured game install is preferred over Steam auto-detect
+  // (matches the `gore` CLI's own precedence: configured path > auto-detect).
+  final configuredGamePath = ref.read(sharedConfigProvider).gamePath();
+  var result = await controller.extract(lcacheHint: configuredGamePath);
 
   if (result.notFound) {
     if (!context.mounted) return;

--- a/apps/save-editor/lib/features/localization/ui/localization_flow.dart
+++ b/apps/save-editor/lib/features/localization/ui/localization_flow.dart
@@ -32,11 +32,12 @@ Future<void> runLocalizationExtractFlow(
   var result = await controller.extract(lcacheHint: configuredGamePath);
 
   // A configured game_path is only a preferred hint here — the GUI must stay
-  // recoverable. If it fails to resolve a .lcache, fall back to Steam
-  // auto-detect (called with no hint), which sets `notFound` and opens the
-  // picker below when it too finds nothing. Without this, a stale/wrong
-  // configured path would surface only an error with no way to proceed.
-  if (!result.success && configuredGamePath != null) {
+  // recoverable. If it resolved NO .lcache (notFound), fall back to Steam
+  // auto-detect (no hint), which sets `notFound` and opens the picker below when
+  // it too finds nothing. Retry only on not-found: a hint that found a cache but
+  // failed to read/decode it must surface that error, not silently fall back to
+  // a possibly-different install's catalog.
+  if (result.notFound && configuredGamePath != null) {
     result = await controller.extract(lcacheHint: null);
   }
 

--- a/apps/save-editor/lib/providers/data_providers.dart
+++ b/apps/save-editor/lib/providers/data_providers.dart
@@ -1,9 +1,13 @@
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:goresave/features/app/ui/router.dart';
 import 'package:goresave/features/editor/domain/core_service.dart';
 import 'package:goresave/features/editor/domain/editor_notifier.dart';
 import 'package:goresave/features/editor/domain/editor_settings_store.dart';
+import 'package:goresave/utils/shared_config.dart';
+import 'package:path/path.dart' as p;
 
 final coreServiceProvider = Provider<GoresaveCoreService>((ref) {
   return NativeGoresaveCoreService.tryCreate() ?? MissingGoresaveCoreService();
@@ -11,6 +15,19 @@ final coreServiceProvider = Provider<GoresaveCoreService>((ref) {
 
 final editorSettingsStoreProvider = Provider<EditorSettingsStore>((ref) {
   return JsonFileEditorSettingsStore.defaultForPlatform();
+});
+
+/// The shared cross-tool `config.json` (currently just `game_path`). Widget
+/// tests get an isolated, almost-certainly-absent file under the temp dir
+/// instead of the real per-user config, matching [uiSettingsStoreProvider]'s
+/// FLUTTER_TEST guard.
+final sharedConfigProvider = Provider<SharedConfig>((ref) {
+  if (Platform.environment.containsKey('FLUTTER_TEST')) {
+    return SharedConfig(
+      File(p.join(Directory.systemTemp.path, 'gore-test', 'config.json')),
+    );
+  }
+  return SharedConfig.defaultForPlatform();
 });
 
 final editorProvider = StateNotifierProvider<EditorNotifier, EditorState>((

--- a/apps/save-editor/lib/providers/data_providers.dart
+++ b/apps/save-editor/lib/providers/data_providers.dart
@@ -23,9 +23,10 @@ final editorSettingsStoreProvider = Provider<EditorSettingsStore>((ref) {
 /// FLUTTER_TEST guard.
 final sharedConfigProvider = Provider<SharedConfig>((ref) {
   if (Platform.environment.containsKey('FLUTTER_TEST')) {
-    return SharedConfig(
-      File(p.join(Directory.systemTemp.path, 'gore-test', 'config.json')),
-    );
+    // Unique temp file per container so tests never leak persisted game-path
+    // state into one another via a shared fixed path.
+    final dir = Directory.systemTemp.createTempSync('gore_test_cfg');
+    return SharedConfig(File(p.join(dir.path, 'config.json')));
   }
   return SharedConfig.defaultForPlatform();
 });

--- a/apps/save-editor/lib/utils/gore_tools_paths.dart
+++ b/apps/save-editor/lib/utils/gore_tools_paths.dart
@@ -2,19 +2,19 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-/// Shared on-disk locations for the gore-tools suite.
+/// Shared on-disk locations for the gore suite.
 ///
 /// All tools (gore-cli, gore-save, gore-mod) keep their per-user data under ONE
-/// shared directory named `gore-tools` so a single localization extraction
+/// shared directory named `gore` so a single localization extraction
 /// serves every tool. This app's persisted JSON lives in the `gore-save`
-/// subfolder; the loc catalog stays directly in `gore-tools`.
+/// subfolder; the loc catalog stays directly in `gore`.
 ///
 /// The base-dir resolution mirrors the Rust side (`gore_loc::paths`) exactly:
-/// - Windows: `%LOCALAPPDATA%` (falls back to `%APPDATA%`) then `\gore-tools`
-/// - macOS:   `$HOME/Library/Application Support/gore-tools`
-/// - Linux:   `$XDG_DATA_HOME/gore-tools` (if set) else `$HOME/.local/share/gore-tools`
+/// - Windows: `%LOCALAPPDATA%` (falls back to `%APPDATA%`) then `\gore`
+/// - macOS:   `$HOME/Library/Application Support/gore`
+/// - Linux:   `$XDG_DATA_HOME/gore` (if set) else `$HOME/.local/share/gore`
 
-/// The shared `gore-tools` data directory root.
+/// The shared `gore` data directory root.
 String goreToolsDir({Map<String, String>? environment}) {
   final env = environment ?? Platform.environment;
   final String base;
@@ -34,10 +34,10 @@ String goreToolsDir({Map<String, String>? environment}) {
               ? Directory.current.path
               : p.join(home, '.local', 'share'));
   }
-  return p.join(base, 'gore-tools');
+  return p.join(base, 'gore');
 }
 
-/// This app's settings folder under the shared umbrella: `<gore-tools>/gore-save`.
+/// This app's settings folder under the shared umbrella: `<gore>/gore-save`.
 String goreSaveSettingsDir({Map<String, String>? environment}) {
   return p.join(goreToolsDir(environment: environment), 'gore-save');
 }

--- a/apps/save-editor/lib/utils/shared_config.dart
+++ b/apps/save-editor/lib/utils/shared_config.dart
@@ -37,7 +37,9 @@ class SharedConfig {
 
   String? gamePath() {
     final v = _read()['game_path'];
-    return (v is String && v.isNotEmpty) ? v : null;
+    // Trim so a blank/whitespace-only value reads as unset, matching the Rust
+    // side (gore_loc::config) — else CLI and GUI disagree on whether it's set.
+    return (v is String && v.trim().isNotEmpty) ? v : null;
   }
 
   void setGamePath(String path) {

--- a/apps/save-editor/lib/utils/shared_config.dart
+++ b/apps/save-editor/lib/utils/shared_config.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'gore_tools_paths.dart' show goreToolsDir;
+
+/// Read/write the shared per-user `config.json` — the SAME file the `gore` CLI
+/// and the other apps use. Flat JSON object; the only key this app uses is
+/// `game_path` (snake_case, matching the Rust `Config`). Unknown keys preserved
+/// on write for forward-compatibility.
+class SharedConfig {
+  SharedConfig(this.file);
+
+  factory SharedConfig.defaultForPlatform({Map<String, String>? environment}) {
+    final env = environment ?? Platform.environment;
+    return SharedConfig(File(p.join(goreToolsDir(environment: env), 'config.json')));
+  }
+
+  final File file;
+
+  Map<String, Object?> _read() {
+    try {
+      if (!file.existsSync()) return {};
+      final decoded = jsonDecode(file.readAsStringSync());
+      return decoded is Map ? decoded.cast<String, Object?>() : {};
+    } catch (_) {
+      return {};
+    }
+  }
+
+  void _write(Map<String, Object?> json) {
+    file.parent.createSync(recursive: true);
+    const encoder = JsonEncoder.withIndent('  ');
+    file.writeAsStringSync('${encoder.convert(json)}\n');
+  }
+
+  String? gamePath() {
+    final v = _read()['game_path'];
+    return (v is String && v.isNotEmpty) ? v : null;
+  }
+
+  void setGamePath(String path) {
+    final json = _read();
+    json['game_path'] = path;
+    _write(json);
+  }
+
+  void clearGamePath() {
+    final json = _read();
+    json.remove('game_path');
+    _write(json);
+  }
+}

--- a/apps/save-editor/test/shared_config_test.dart
+++ b/apps/save-editor/test/shared_config_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:goresave/utils/shared_config.dart';
+
+void main() {
+  test('write then read round-trips game_path', () {
+    final dir = Directory.systemTemp.createTempSync('gore_cfg');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final file = File(p.join(dir.path, 'config.json'));
+    final cfg = SharedConfig(file);
+    cfg.setGamePath('D:/Games/G1R');
+    expect(cfg.gamePath(), 'D:/Games/G1R');
+    final json = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+    expect(json['game_path'], 'D:/Games/G1R');
+  });
+
+  test('missing file reads null', () {
+    final dir = Directory.systemTemp.createTempSync('gore_cfg');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final cfg = SharedConfig(File(p.join(dir.path, 'config.json')));
+    expect(cfg.gamePath(), isNull);
+  });
+
+  test('unknown keys are preserved on write', () {
+    final dir = Directory.systemTemp.createTempSync('gore_cfg');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final file = File(p.join(dir.path, 'config.json'))
+      ..writeAsStringSync('{"game_path":"x","future":1}');
+    SharedConfig(file).setGamePath('y');
+    final json = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+    expect(json['game_path'], 'y');
+    expect(json['future'], 1);
+  });
+}

--- a/build.py
+++ b/build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""gore-tools monorepo build orchestrator.
+"""gore monorepo build orchestrator.
 
 One entry point for every releasable product in the flat layout (Flutter apps
 under apps/, the gore CLI under crates/gore). Wraps the per-project build logic

--- a/crates/gore-as/Cargo.toml
+++ b/crates/gore-as/Cargo.toml
@@ -3,7 +3,7 @@ name = "gore-as"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "AngelScript precompiled-cache decoder + tooling for Gothic 1 Remake (gore-tools)."
+description = "AngelScript precompiled-cache decoder + tooling for Gothic 1 Remake (gore)."
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/gore-catalog/Cargo.toml
+++ b/crates/gore-catalog/Cargo.toml
@@ -3,7 +3,7 @@ name = "gore-catalog"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Item/knowledge catalog model + prefix→category mapping for gore-tools."
+description = "Item/knowledge catalog model + prefix→category mapping for gore."
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/gore-ffi/src/lib.rs
+++ b/crates/gore-ffi/src/lib.rs
@@ -763,7 +763,7 @@ mod tests {
     fn loc_status_reports_shared_catalog_path() {
         let v: Value = serde_json::from_str(&execute_json(r#"{"command":"loc_status"}"#)).unwrap();
         assert_eq!(v["ok"], true);
-        assert!(v["catalog_path"].as_str().unwrap().contains("gore-tools"));
+        assert!(v["catalog_path"].as_str().unwrap().contains("gore"));
         assert!(v.get("present").is_some());
     }
 

--- a/crates/gore-loc/Cargo.toml
+++ b/crates/gore-loc/Cargo.toml
@@ -16,3 +16,6 @@ aes = "0.8"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/gore-loc/Cargo.toml
+++ b/crates/gore-loc/Cargo.toml
@@ -3,7 +3,7 @@ name = "gore-loc"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Localization cache decrypt + discovery/paths/store for gore-tools."
+description = "Localization cache decrypt + discovery/paths/store for gore."
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/gore-loc/src/config.rs
+++ b/crates/gore-loc/src/config.rs
@@ -73,11 +73,22 @@ pub enum ConfigError {
 /// The winning path is normalized (an `.exe` or a descendant walks up to the
 /// `G1R/` parent). Returns [`ConfigError::Unresolved`] when nothing resolves.
 pub fn game_root(explicit: Option<PathBuf>) -> Result<PathBuf, ConfigError> {
-    let configured = load().game_path.map(PathBuf::from);
+    let configured = configured_game_path(&load());
     let detected = if autodetect_disabled() { None } else { discover::find_game_root() };
     resolve_root(explicit, configured, detected)
         .map(|p| normalize_root(&p))
         .ok_or(ConfigError::Unresolved)
+}
+
+/// The configured `game_path` as an `Option`, treating an empty/whitespace-only
+/// string as **unset** — parity with the Dart apps' `SharedConfig.gamePath()`,
+/// so the same `config.json` never leaves the CLI stuck on a blank value (and
+/// blocking auto-detect) while the GUI behaves as if nothing is configured.
+fn configured_game_path(cfg: &Config) -> Option<PathBuf> {
+    cfg.game_path
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .map(PathBuf::from)
 }
 
 /// Test / power-user seam: when `GORE_DISABLE_GAME_AUTODETECT` is set to a
@@ -195,6 +206,22 @@ mod tests {
     #[test]
     fn resolve_none_when_all_absent() {
         assert_eq!(resolve_root(None, None, None), None);
+    }
+
+    #[test]
+    fn empty_configured_game_path_is_unset() {
+        // Parity with Dart's SharedConfig.gamePath(): "" / whitespace = unset,
+        // so it never wins over Steam auto-detect in resolve_root.
+        let mut cfg = Config::default();
+        cfg.game_path = Some(String::new());
+        assert_eq!(configured_game_path(&cfg), None);
+        cfg.game_path = Some("   ".to_string());
+        assert_eq!(configured_game_path(&cfg), None);
+        cfg.game_path = Some("D:/Games/G1R".to_string());
+        assert_eq!(
+            configured_game_path(&cfg),
+            Some(PathBuf::from("D:/Games/G1R"))
+        );
     }
 
     #[test]

--- a/crates/gore-loc/src/config.rs
+++ b/crates/gore-loc/src/config.rs
@@ -74,10 +74,19 @@ pub enum ConfigError {
 /// `G1R/` parent). Returns [`ConfigError::Unresolved`] when nothing resolves.
 pub fn game_root(explicit: Option<PathBuf>) -> Result<PathBuf, ConfigError> {
     let configured = load().game_path.map(PathBuf::from);
-    let detected = discover::find_game_root();
+    let detected = if autodetect_disabled() { None } else { discover::find_game_root() };
     resolve_root(explicit, configured, detected)
         .map(|p| normalize_root(&p))
         .ok_or(ConfigError::Unresolved)
+}
+
+/// Test / power-user seam: when `GORE_DISABLE_GAME_AUTODETECT` is set to a
+/// non-empty value, skip Steam auto-detection so resolution relies solely on an
+/// explicit arg or the configured `game_path`.
+fn autodetect_disabled() -> bool {
+    std::env::var_os("GORE_DISABLE_GAME_AUTODETECT")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
 }
 
 /// Pure precedence selection (no IO): explicit > configured > detected.

--- a/crates/gore-loc/src/config.rs
+++ b/crates/gore-loc/src/config.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::discover;
 use crate::paths;
 
 /// Persisted per-user settings. All fields optional and additive so old files
@@ -57,6 +58,47 @@ pub fn save_to(path: &Path, cfg: &Config) -> std::io::Result<()> {
     }
     let bytes = serde_json::to_vec_pretty(cfg)?;
     crate::loc_store::write_atomic(path, &bytes)
+}
+
+/// Error resolving the game path.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("no game path set — run 'gore config set game-path <path>' or pass --game")]
+    Unresolved,
+}
+
+/// Resolve the game install ROOT (the folder containing `G1R/`).
+///
+/// Precedence: explicit CLI arg > configured `game_path` > Steam auto-detect.
+/// The winning path is normalized (an `.exe` or a descendant walks up to the
+/// `G1R/` parent). Returns [`ConfigError::Unresolved`] when nothing resolves.
+pub fn game_root(explicit: Option<PathBuf>) -> Result<PathBuf, ConfigError> {
+    let configured = load().game_path.map(PathBuf::from);
+    let detected = discover::find_game_root();
+    resolve_root(explicit, configured, detected)
+        .map(|p| normalize_root(&p))
+        .ok_or(ConfigError::Unresolved)
+}
+
+/// Pure precedence selection (no IO): explicit > configured > detected.
+fn resolve_root(
+    explicit: Option<PathBuf>,
+    configured: Option<PathBuf>,
+    detected: Option<PathBuf>,
+) -> Option<PathBuf> {
+    explicit.or(configured).or(detected)
+}
+
+/// Normalize any game path to the install root: the nearest ancestor (including
+/// `p` itself) that holds a `G1R/` child. Best-effort — returns `p` unchanged
+/// when no such ancestor exists (unusual layout / path not on disk).
+fn normalize_root(p: &Path) -> PathBuf {
+    for anc in p.ancestors() {
+        if anc.join("G1R").is_dir() {
+            return anc.to_path_buf();
+        }
+    }
+    p.to_path_buf()
 }
 
 #[cfg(test)]
@@ -116,5 +158,56 @@ mod tests {
         let path = dir.path().join("config.json");
         std::fs::write(&path, b"not json at all").unwrap();
         assert_eq!(load_from(&path).game_path, None);
+    }
+
+    #[test]
+    fn resolve_precedence_explicit_wins() {
+        let got = resolve_root(
+            Some(PathBuf::from("/explicit")),
+            Some(PathBuf::from("/configured")),
+            Some(PathBuf::from("/detected")),
+        );
+        assert_eq!(got, Some(PathBuf::from("/explicit")));
+    }
+
+    #[test]
+    fn resolve_precedence_config_over_detected() {
+        let got = resolve_root(None, Some(PathBuf::from("/configured")), Some(PathBuf::from("/detected")));
+        assert_eq!(got, Some(PathBuf::from("/configured")));
+    }
+
+    #[test]
+    fn resolve_precedence_detected_last() {
+        let got = resolve_root(None, None, Some(PathBuf::from("/detected")));
+        assert_eq!(got, Some(PathBuf::from("/detected")));
+    }
+
+    #[test]
+    fn resolve_none_when_all_absent() {
+        assert_eq!(resolve_root(None, None, None), None);
+    }
+
+    #[test]
+    fn normalize_walks_exe_up_to_g1r_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("G1R")).unwrap();
+        let exe = root.join("G1R").join("Binaries").join("Win64").join("G1R-Win64-Shipping.exe");
+        std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        std::fs::write(&exe, b"x").unwrap();
+        assert_eq!(normalize_root(&exe), root.to_path_buf());
+    }
+
+    #[test]
+    fn normalize_returns_root_unchanged_when_it_holds_g1r() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("G1R")).unwrap();
+        assert_eq!(normalize_root(root), root.to_path_buf());
+    }
+
+    #[test]
+    fn normalize_best_effort_when_no_g1r() {
+        assert_eq!(normalize_root(Path::new("/no/such/place")), PathBuf::from("/no/such/place"));
     }
 }

--- a/crates/gore-loc/src/config.rs
+++ b/crates/gore-loc/src/config.rs
@@ -73,11 +73,17 @@ pub enum ConfigError {
 /// The winning path is normalized (an `.exe` or a descendant walks up to the
 /// `G1R/` parent). Returns [`ConfigError::Unresolved`] when nothing resolves.
 pub fn game_root(explicit: Option<PathBuf>) -> Result<PathBuf, ConfigError> {
-    let configured = configured_game_path(&load());
-    let detected = if autodetect_disabled() { None } else { discover::find_game_root() };
-    resolve_root(explicit, configured, detected)
-        .map(|p| normalize_root(&p))
-        .ok_or(ConfigError::Unresolved)
+    // Steam auto-detect is deferred (it probes the registry + filesystem): it
+    // runs only when neither an explicit arg nor a configured path resolves.
+    resolve_root(explicit, configured_game_path(&load()), || {
+        if autodetect_disabled() {
+            None
+        } else {
+            discover::find_game_root()
+        }
+    })
+    .map(|p| normalize_root(&p))
+    .ok_or(ConfigError::Unresolved)
 }
 
 /// The configured `game_path` as an `Option`, treating an empty/whitespace-only
@@ -101,13 +107,15 @@ pub fn autodetect_disabled() -> bool {
         .unwrap_or(false)
 }
 
-/// Pure precedence selection (no IO): explicit > configured > detected.
+/// Precedence selection: explicit > configured > detected. `detect` is a closure
+/// so Steam auto-detection is invoked only when neither an explicit arg nor a
+/// configured path is present (it does a registry + filesystem probe).
 fn resolve_root(
     explicit: Option<PathBuf>,
     configured: Option<PathBuf>,
-    detected: Option<PathBuf>,
+    detect: impl FnOnce() -> Option<PathBuf>,
 ) -> Option<PathBuf> {
-    explicit.or(configured).or(detected)
+    explicit.or(configured).or_else(detect)
 }
 
 /// Normalize any game path to the install root: the nearest ancestor (including
@@ -186,26 +194,41 @@ mod tests {
         let got = resolve_root(
             Some(PathBuf::from("/explicit")),
             Some(PathBuf::from("/configured")),
-            Some(PathBuf::from("/detected")),
+            || Some(PathBuf::from("/detected")),
         );
         assert_eq!(got, Some(PathBuf::from("/explicit")));
     }
 
     #[test]
     fn resolve_precedence_config_over_detected() {
-        let got = resolve_root(None, Some(PathBuf::from("/configured")), Some(PathBuf::from("/detected")));
+        let got = resolve_root(None, Some(PathBuf::from("/configured")), || {
+            Some(PathBuf::from("/detected"))
+        });
         assert_eq!(got, Some(PathBuf::from("/configured")));
     }
 
     #[test]
     fn resolve_precedence_detected_last() {
-        let got = resolve_root(None, None, Some(PathBuf::from("/detected")));
+        let got = resolve_root(None, None, || Some(PathBuf::from("/detected")));
         assert_eq!(got, Some(PathBuf::from("/detected")));
     }
 
     #[test]
     fn resolve_none_when_all_absent() {
-        assert_eq!(resolve_root(None, None, None), None);
+        assert_eq!(resolve_root(None, None, || None), None);
+    }
+
+    #[test]
+    fn resolve_does_not_detect_when_a_path_is_present() {
+        // Steam auto-detect must be deferred: the closure is not called when an
+        // explicit (or configured) path already resolves.
+        let mut detected = false;
+        let got = resolve_root(Some(PathBuf::from("/x")), None, || {
+            detected = true;
+            Some(PathBuf::from("/steam"))
+        });
+        assert_eq!(got, Some(PathBuf::from("/x")));
+        assert!(!detected, "detect closure ran despite an explicit path");
     }
 
     #[test]

--- a/crates/gore-loc/src/config.rs
+++ b/crates/gore-loc/src/config.rs
@@ -1,0 +1,94 @@
+//! Shared, extensible per-user configuration for the gore tools.
+//!
+//! Stored as JSON at `<shared>/config.json` (see [`crate::paths::config_path`])
+//! so the CLI and every app read the same file. Currently holds the game
+//! install path; the struct is designed so new keys are additive.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::paths;
+
+/// Persisted per-user settings. All fields optional and additive so old files
+/// keep loading as new keys appear. Serialized as snake_case JSON.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    /// Game install path exactly as the user set it (an install root or the
+    /// `.exe`). Consumers normalize to the root via [`game_root`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub game_path: Option<String>,
+}
+
+/// Absolute path of the shared `config.json`.
+pub fn config_path() -> PathBuf {
+    paths::config_path()
+}
+
+/// Load the shared config. A missing, unreadable, or corrupt file yields
+/// [`Config::default`] — config is best-effort, never a hard error on read.
+pub fn load() -> Config {
+    load_from(&config_path())
+}
+
+/// Persist the shared config (creates the shared dir; atomic write).
+pub fn save(cfg: &Config) -> std::io::Result<()> {
+    save_to(&config_path(), cfg)
+}
+
+/// [`load`] against an explicit path (test seam).
+pub fn load_from(path: &Path) -> Config {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+        Err(_) => Config::default(),
+    }
+}
+
+/// [`save`] against an explicit path (test seam).
+pub fn save_to(path: &Path, cfg: &Config) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let bytes = serde_json::to_vec_pretty(cfg)?;
+    crate::loc_store::write_atomic(path, &bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_file_loads_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = load_from(&dir.path().join("config.json"));
+        assert_eq!(cfg.game_path, None);
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let cfg = Config { game_path: Some("D:/Games/G1R".to_string()) };
+        save_to(&path, &cfg).unwrap();
+        let read = load_from(&path);
+        assert_eq!(read.game_path.as_deref(), Some("D:/Games/G1R"));
+    }
+
+    #[test]
+    fn unknown_keys_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, br#"{"game_path":"x","future_key":42}"#).unwrap();
+        let cfg = load_from(&path);
+        assert_eq!(cfg.game_path.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn corrupt_file_loads_default_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, b"not json at all").unwrap();
+        assert_eq!(load_from(&path).game_path, None);
+    }
+}

--- a/crates/gore-loc/src/config.rs
+++ b/crates/gore-loc/src/config.rs
@@ -82,8 +82,9 @@ pub fn game_root(explicit: Option<PathBuf>) -> Result<PathBuf, ConfigError> {
 
 /// Test / power-user seam: when `GORE_DISABLE_GAME_AUTODETECT` is set to a
 /// non-empty value, skip Steam auto-detection so resolution relies solely on an
-/// explicit arg or the configured `game_path`.
-fn autodetect_disabled() -> bool {
+/// explicit arg or the configured `game_path`. Public so other Steam-scanning
+/// entry points (e.g. `loc extract`'s cache fallback) honor the same switch.
+pub fn autodetect_disabled() -> bool {
     std::env::var_os("GORE_DISABLE_GAME_AUTODETECT")
         .map(|v| !v.is_empty())
         .unwrap_or(false)

--- a/crates/gore-loc/src/config.rs
+++ b/crates/gore-loc/src/config.rs
@@ -19,6 +19,11 @@ pub struct Config {
     /// `.exe`). Consumers normalize to the root via [`game_root`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub game_path: Option<String>,
+
+    /// Unknown/future keys written by a newer tool version. Preserved verbatim
+    /// on save so an older tool never clobbers a newer one's settings.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 /// Absolute path of the shared `config.json`.
@@ -69,10 +74,31 @@ mod tests {
     fn save_then_load_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.json");
-        let cfg = Config { game_path: Some("D:/Games/G1R".to_string()) };
+        let cfg = Config { game_path: Some("D:/Games/G1R".to_string()), ..Default::default() };
         save_to(&path, &cfg).unwrap();
         let read = load_from(&path);
         assert_eq!(read.game_path.as_deref(), Some("D:/Games/G1R"));
+    }
+
+    #[test]
+    fn save_preserves_unknown_keys_and_creates_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        // Parent "nested/" does NOT exist -> save_to must create it.
+        let path = dir.path().join("nested").join("config.json");
+
+        // Seed a config file that carries an unmodeled key.
+        let mut seed = Config::default();
+        seed.extra.insert("future_key".to_string(), serde_json::json!(42));
+        seed.game_path = Some("x".to_string());
+        save_to(&path, &seed).unwrap(); // also proves parent-dir creation
+
+        let mut cfg = load_from(&path);
+        cfg.game_path = Some("y".to_string());
+        save_to(&path, &cfg).unwrap();
+
+        let reread = load_from(&path);
+        assert_eq!(reread.game_path.as_deref(), Some("y"));
+        assert_eq!(reread.extra.get("future_key"), Some(&serde_json::json!(42)));
     }
 
     #[test]

--- a/crates/gore-loc/src/lib.rs
+++ b/crates/gore-loc/src/lib.rs
@@ -1,5 +1,5 @@
 //! Localization cache (`.lcache`) decrypt/flatten plus discovery, paths, and
-//! the shared catalog store for gore-tools.
+//! the shared catalog store for gore.
 
 pub mod config;
 pub mod discover;

--- a/crates/gore-loc/src/lib.rs
+++ b/crates/gore-loc/src/lib.rs
@@ -1,6 +1,7 @@
 //! Localization cache (`.lcache`) decrypt/flatten plus discovery, paths, and
 //! the shared catalog store for gore-tools.
 
+pub mod config;
 pub mod discover;
 pub mod loc;
 pub mod loc_store;

--- a/crates/gore-loc/src/loc_store.rs
+++ b/crates/gore-loc/src/loc_store.rs
@@ -1,4 +1,4 @@
-//! Extract the game's localization into the shared `gore-tools` directory.
+//! Extract the game's localization into the shared `gore` directory.
 //!
 //! Ties together [`crate::discover`] (find the `.lcache`), [`crate::loc`] (decrypt
 //! + flatten), and [`crate::paths`] (where the shared catalog lives). All three
@@ -75,7 +75,7 @@ pub fn catalog_present() -> bool {
 }
 
 /// Decrypt the `.lcache` (resolved from `hint` or Steam), flatten it, and write
-/// `loc_catalog.json` + `loc_meta.json` into the shared `gore-tools` dir.
+/// `loc_catalog.json` + `loc_meta.json` into the shared `gore` dir.
 pub fn extract(hint: Option<&Path>) -> Result<LocMeta, LocStoreError> {
     let lcache = resolve_lcache(hint).ok_or(LocStoreError::NotFound)?;
     let enc = fs::read(&lcache).map_err(|source| LocStoreError::Read {

--- a/crates/gore-loc/src/paths.rs
+++ b/crates/gore-loc/src/paths.rs
@@ -1,19 +1,19 @@
-//! Shared on-disk locations for the gore-tools suite.
+//! Shared on-disk locations for the gore tool suite.
 //!
 //! All three tools (gore-cli, gore-save, gore-mod) read and write the extracted
-//! localization catalog from ONE shared per-user directory named `gore-tools`,
+//! localization catalog from ONE shared per-user directory named `gore`,
 //! so a single extraction serves every tool. The directory lives under the
 //! platform's local-app-data root and is never part of the repo.
 
 use std::path::PathBuf;
 
-/// The shared `gore-tools` data directory:
-/// - Windows: `%LOCALAPPDATA%\gore-tools` (falls back to `%APPDATA%`)
-/// - macOS:   `~/Library/Application Support/gore-tools`
-/// - Linux:   `$XDG_DATA_HOME/gore-tools` or `~/.local/share/gore-tools`
+/// The shared `gore` data directory:
+/// - Windows: `%LOCALAPPDATA%\gore` (falls back to `%APPDATA%`)
+/// - macOS:   `~/Library/Application Support/gore`
+/// - Linux:   `$XDG_DATA_HOME/gore` or `~/.local/share/gore`
 pub fn shared_data_dir() -> PathBuf {
     let base = local_app_data_root();
-    base.join("gore-tools")
+    base.join("gore")
 }
 
 /// The shared localized-text catalog (`{id:{language:value}}`).
@@ -26,8 +26,7 @@ pub fn loc_meta_path() -> PathBuf {
     shared_data_dir().join("loc_meta.json")
 }
 
-/// The shared per-user `config.json` (see [`crate::config`]).
-// TODO: a later task formalizes/tests this alongside the rest of `paths.rs`.
+/// The shared, extensible tool configuration (`{ "game_path": ... }`).
 pub fn config_path() -> PathBuf {
     shared_data_dir().join("config.json")
 }
@@ -64,14 +63,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn catalog_and_meta_live_in_the_shared_gore_tools_dir() {
+    fn catalog_meta_config_live_in_the_shared_gore_dir() {
         let dir = shared_data_dir();
-        assert!(dir.ends_with("gore-tools"));
+        assert!(dir.ends_with("gore"));
         assert_eq!(loc_catalog_path().parent().unwrap(), dir);
         assert_eq!(loc_meta_path().parent().unwrap(), dir);
-        assert_eq!(
-            loc_catalog_path().file_name().unwrap(),
-            "loc_catalog.json"
-        );
+        assert_eq!(config_path().parent().unwrap(), dir);
+        assert_eq!(loc_catalog_path().file_name().unwrap(), "loc_catalog.json");
+        assert_eq!(config_path().file_name().unwrap(), "config.json");
     }
 }

--- a/crates/gore-loc/src/paths.rs
+++ b/crates/gore-loc/src/paths.rs
@@ -26,6 +26,12 @@ pub fn loc_meta_path() -> PathBuf {
     shared_data_dir().join("loc_meta.json")
 }
 
+/// The shared per-user `config.json` (see [`crate::config`]).
+// TODO: a later task formalizes/tests this alongside the rest of `paths.rs`.
+pub fn config_path() -> PathBuf {
+    shared_data_dir().join("config.json")
+}
+
 #[cfg(windows)]
 fn local_app_data_root() -> PathBuf {
     std::env::var_os("LOCALAPPDATA")

--- a/crates/gore-mod/src/mgr/paths.rs
+++ b/crates/gore-mod/src/mgr/paths.rs
@@ -1,9 +1,9 @@
-//! Shared on-disk layout for the mod manager, under the per-user `gore-tools` data dir
+//! Shared on-disk layout for the mod manager, under the per-user `gore` data dir
 //! (see `gore_loc::paths::shared_data_dir`) so every tool sees the same library/loadout.
 
 use std::path::PathBuf;
 
-/// Root of all manager state: `<gore-tools>/mod-manager`.
+/// Root of all manager state: `<gore>/mod-manager`.
 pub fn manager_root() -> PathBuf {
     gore_loc::paths::shared_data_dir().join("mod-manager")
 }

--- a/crates/gore-modgen/Cargo.toml
+++ b/crates/gore-modgen/Cargo.toml
@@ -3,7 +3,7 @@ name = "gore-modgen"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Config→Lua mod-generation engine + field-level validation for gore-tools."
+description = "Config→Lua mod-generation engine + field-level validation for gore."
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/gore-modgen/src/lib.rs
+++ b/crates/gore-modgen/src/lib.rs
@@ -1,4 +1,4 @@
-//! Config→Lua mod-generation engine + field-level validation for gore-tools.
+//! Config→Lua mod-generation engine + field-level validation for gore.
 
 pub mod gen;
 pub mod validate;

--- a/crates/gore-reflect/Cargo.toml
+++ b/crates/gore-reflect/Cargo.toml
@@ -3,7 +3,7 @@ name = "gore-reflect"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "UE reflection model + UE4SS SDK dump parser for gore-tools."
+description = "UE reflection model + UE4SS SDK dump parser for gore."
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/gore-reflect/src/lib.rs
+++ b/crates/gore-reflect/src/lib.rs
@@ -1,4 +1,4 @@
-//! UE reflection model (parsed from UE4SS SDK dumps) for gore-tools.
+//! UE reflection model (parsed from UE4SS SDK dumps) for gore.
 
 pub mod model;
 pub mod parser;

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -536,7 +536,7 @@ fn execute_json_inner(input: &str) -> Result<Value, CoreError> {
             Ok(write_difficulty_internal(&req, &targets, backup)?)
         }
         // Localized game text: extracted offline from the encrypted .lcache into
-        // the shared `gore-tools` dir (see gore_loc::loc_store). User-local only.
+        // the shared `gore` dir (see gore_loc::loc_store). User-local only.
         "loc_status" => {
             let present = gore_loc::loc_store::catalog_present();
             // Only report metadata while the catalog file is present, so stale

--- a/crates/gore-tex/src/index.rs
+++ b/crates/gore-tex/src/index.rs
@@ -15,7 +15,7 @@ use retoc::{Config, EIoChunkType, FIoChunkId};
 use crate::error::Result;
 
 /// Maps each Texture2D asset path to its IoStore package id (u64). Built once per game
-/// build (a full container scan); cached to the shared gore-tools dir.
+/// build (a full container scan); cached to the shared gore dir.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TextureIndex {
     /// Identifies the game build the index was built against (the .usmap filename), so a

--- a/crates/gore-tex/src/paths.rs
+++ b/crates/gore-tex/src/paths.rs
@@ -82,7 +82,7 @@ pub fn content_mount_rel(asset: &str) -> Option<String> {
     }
 }
 
-/// The shared gore-tools cache path for the texture index (next to loc_catalog.json).
+/// The shared gore cache path for the texture index (next to loc_catalog.json).
 pub fn texture_index_path() -> PathBuf {
     gore_loc::paths::shared_data_dir().join("texture_index.json")
 }

--- a/crates/gore/Cargo.toml
+++ b/crates/gore/Cargo.toml
@@ -71,3 +71,7 @@ path = "tests/integration/as_cache_test.rs"
 [[test]]
 name = "mgr"
 path = "tests/integration/mgr.rs"
+
+[[test]]
+name = "config_test"
+path = "tests/integration/config_test.rs"

--- a/crates/gore/src/cmd/config.rs
+++ b/crates/gore/src/cmd/config.rs
@@ -73,7 +73,13 @@ pub fn run(action: ConfigAction) -> Result<()> {
             println!("game-path = {raw}");
             match config::game_root(None) {
                 Ok(root) => {
-                    let source = if cfg.game_path.is_some() { "config" } else { "auto-detect" };
+                    // Match game_root's own view: a blank/whitespace game_path is
+                    // treated as unset, so the root came from auto-detect, not config.
+                    let from_config = cfg
+                        .game_path
+                        .as_deref()
+                        .is_some_and(|s| !s.trim().is_empty());
+                    let source = if from_config { "config" } else { "auto-detect" };
                     println!("resolved game root = {} (source: {source})", root.display());
                 }
                 Err(_) => println!("resolved game root = (unresolved)"),

--- a/crates/gore/src/cmd/config.rs
+++ b/crates/gore/src/cmd/config.rs
@@ -4,6 +4,7 @@
 use anyhow::{bail, Result};
 use clap::{Subcommand, ValueEnum};
 use gore_loc::config::{self, Config};
+use std::path::PathBuf;
 
 #[derive(Subcommand)]
 pub enum ConfigAction {
@@ -33,11 +34,18 @@ pub fn run(action: ConfigAction) -> Result<()> {
     match action {
         ConfigAction::Set { key, value } => {
             let mut cfg = config::load();
-            match key {
-                ConfigKey::GamePath => cfg.game_path = Some(value.clone()),
-            }
+            let stored = match key {
+                // Persist an absolute path: a relative value (e.g. `.`) would
+                // otherwise be re-resolved against whatever directory a later
+                // command happens to run from.
+                ConfigKey::GamePath => {
+                    let s = absolutize(&value);
+                    cfg.game_path = Some(s.clone());
+                    s
+                }
+            };
             config::save(&cfg)?;
-            println!("set game-path = {value}");
+            println!("set game-path = {stored}");
             Ok(())
         }
         ConfigAction::Get { key } => {
@@ -97,4 +105,19 @@ fn value_of(cfg: &Config, key: ConfigKey) -> Option<String> {
     match key {
         ConfigKey::GamePath => cfg.game_path.clone(),
     }
+}
+
+/// Resolve a possibly-relative user path to an absolute one (joined against the
+/// current directory) so a stored config value doesn't depend on the cwd of a
+/// later command. Kept lexical — no symlink / `..` resolution — to avoid the
+/// Windows `\\?\` verbatim prefix that `canonicalize` produces, which some
+/// downstream tooling mishandles.
+fn absolutize(value: &str) -> String {
+    let raw = PathBuf::from(value);
+    let abs = if raw.is_absolute() {
+        raw
+    } else {
+        std::env::current_dir().map(|d| d.join(&raw)).unwrap_or(raw)
+    };
+    abs.to_string_lossy().into_owned()
 }

--- a/crates/gore/src/cmd/config.rs
+++ b/crates/gore/src/cmd/config.rs
@@ -1,0 +1,100 @@
+//! `gore config` — read/write the shared, per-user tool configuration
+//! (`<shared>/config.json`). Currently the game install path.
+
+use anyhow::{bail, Result};
+use clap::{Subcommand, ValueEnum};
+use gore_loc::config::{self, Config};
+
+#[derive(Subcommand)]
+pub enum ConfigAction {
+    /// Set a config value
+    Set { key: ConfigKey, value: String },
+    /// Print a single config value (exit non-zero if unset)
+    Get { key: ConfigKey },
+    /// Clear a single config value
+    Unset { key: ConfigKey },
+    /// Print all config values and, for the game path, the resolved root + source
+    List,
+    /// Print the path of the config.json file
+    Path,
+    /// Auto-detect the game via Steam and save it as game-path
+    Detect,
+}
+
+/// The known, validated config keys. Add a variant here + a `Config` field to
+/// extend the config surface.
+#[derive(Clone, Copy, ValueEnum)]
+pub enum ConfigKey {
+    /// Game install path (an install root or the .exe)
+    GamePath,
+}
+
+pub fn run(action: ConfigAction) -> Result<()> {
+    match action {
+        ConfigAction::Set { key, value } => {
+            let mut cfg = config::load();
+            match key {
+                ConfigKey::GamePath => cfg.game_path = Some(value.clone()),
+            }
+            config::save(&cfg)?;
+            println!("set game-path = {value}");
+            Ok(())
+        }
+        ConfigAction::Get { key } => {
+            let cfg = config::load();
+            match value_of(&cfg, key) {
+                Some(v) => {
+                    println!("{v}");
+                    Ok(())
+                }
+                None => bail!("game-path is not set"),
+            }
+        }
+        ConfigAction::Unset { key } => {
+            let mut cfg = config::load();
+            match key {
+                ConfigKey::GamePath => cfg.game_path = None,
+            }
+            config::save(&cfg)?;
+            println!("unset game-path");
+            Ok(())
+        }
+        ConfigAction::List => {
+            let cfg = config::load();
+            let raw = cfg.game_path.clone().unwrap_or_else(|| "(unset)".into());
+            println!("game-path = {raw}");
+            match config::game_root(None) {
+                Ok(root) => {
+                    let source = if cfg.game_path.is_some() { "config" } else { "auto-detect" };
+                    println!("resolved game root = {} (source: {source})", root.display());
+                }
+                Err(_) => println!("resolved game root = (unresolved)"),
+            }
+            println!("config file = {}", config::config_path().display());
+            Ok(())
+        }
+        ConfigAction::Path => {
+            println!("{}", config::config_path().display());
+            Ok(())
+        }
+        ConfigAction::Detect => {
+            match gore_loc::discover::find_game_root() {
+                Some(root) => {
+                    let mut cfg: Config = config::load();
+                    let val = root.display().to_string();
+                    cfg.game_path = Some(val.clone());
+                    config::save(&cfg)?;
+                    println!("detected and saved game-path = {val}");
+                    Ok(())
+                }
+                None => bail!("could not auto-detect a Steam install; set it manually with 'gore config set game-path <path>'"),
+            }
+        }
+    }
+}
+
+fn value_of(cfg: &Config, key: ConfigKey) -> Option<String> {
+    match key {
+        ConfigKey::GamePath => cfg.game_path.clone(),
+    }
+}

--- a/crates/gore/src/cmd/deploy_shared.rs
+++ b/crates/gore/src/cmd/deploy_shared.rs
@@ -13,7 +13,12 @@ pub fn run(src: Option<PathBuf>, game: Option<PathBuf>) -> Result<()> {
     if !src.is_dir() {
         bail!("source '{}' is not a directory", src.display());
     }
-    let mods = game.join("ue4ss").join("Mods");
+    let mods = game
+        .join("G1R")
+        .join("Binaries")
+        .join("Win64")
+        .join("ue4ss")
+        .join("Mods");
     if !mods.is_dir() {
         bail!(
             "'{}' does not look like a game dir (no ue4ss/Mods)",

--- a/crates/gore/src/cmd/deploy_shared.rs
+++ b/crates/gore/src/cmd/deploy_shared.rs
@@ -4,7 +4,8 @@
 use anyhow::{bail, Context, Result};
 use std::{fs, path::Path, path::PathBuf};
 
-pub fn run(src: Option<PathBuf>, game: PathBuf) -> Result<()> {
+pub fn run(src: Option<PathBuf>, game: Option<PathBuf>) -> Result<()> {
+    let game = gore_loc::config::game_root(game)?;
     let src = match src {
         Some(s) => s,
         None => resolve_default_src()?,

--- a/crates/gore/src/cmd/loc.rs
+++ b/crates/gore/src/cmd/loc.rs
@@ -18,12 +18,7 @@ type LocMap = BTreeMap<String, BTreeMap<String, String>>;
 /// Auto-detect (or use `--lcache`) the game's localization cache and write the
 /// shared `gore/loc_catalog.json`. Prompts for confirmation unless `--yes`.
 pub fn extract(lcache: Option<PathBuf>, yes: bool) -> Result<()> {
-    // Resolution precedence: explicit --lcache > the configured game path
-    // (discover walks it to the .lcache) > Steam auto-detect. A configured path
-    // is used authoritatively (like an explicit hint), so `loc` reads text from
-    // YOUR configured install rather than a possibly-different Steam one.
-    let hint = lcache.or_else(|| config::load().game_path.map(PathBuf::from));
-    let resolved = loc_store::resolve_lcache(hint.as_deref())
+    let resolved = resolve_extract_lcache(lcache)
         .ok_or_else(|| anyhow::anyhow!(
             "no AlkimiaLocalization .lcache found (tried --lcache, the configured \
              game path, then Steam auto-detect). Pass --lcache <path-to-.lcache or game dir>."
@@ -50,6 +45,30 @@ pub fn extract(lcache: Option<PathBuf>, yes: bool) -> Result<()> {
         meta.catalog_path
     );
     Ok(())
+}
+
+/// Resolve the `.lcache` for `extract`, mirroring every other command's game-path
+/// precedence: explicit `--lcache` > the configured `game_path` > Steam
+/// auto-detect. The configured path is normalized to the install root via
+/// [`config::game_root`] (so an exe / `Win64` / intermediate path resolves the
+/// same as it does for `mod`/`mgr`/`texture`), and each level falls back to the
+/// next when it can't resolve a cache — so a stale configured path never blocks
+/// extraction, it just yields to Steam auto-detect.
+fn resolve_extract_lcache(lcache: Option<PathBuf>) -> Option<PathBuf> {
+    // 1. An explicit --lcache is authoritative: the user pointed us at it.
+    if let Some(hint) = lcache {
+        return loc_store::resolve_lcache(Some(&hint));
+    }
+    // 2. The configured game path (else Steam), normalized to the G1R-containing
+    //    root exactly like the other commands, then find the cache under it.
+    if let Ok(root) = config::game_root(None) {
+        if let Some(found) = loc_store::resolve_lcache(Some(&root)) {
+            return Some(found);
+        }
+    }
+    // 3. Fall back to a direct Steam `.lcache` scan (covers a stale configured
+    //    path, or an install whose root normalization missed but discover finds).
+    loc_store::resolve_lcache(None)
 }
 
 /// Print whether a shared catalog exists and its provenance.

--- a/crates/gore/src/cmd/loc.rs
+++ b/crates/gore/src/cmd/loc.rs
@@ -67,7 +67,12 @@ fn resolve_extract_lcache(lcache: Option<PathBuf>) -> Option<PathBuf> {
         }
     }
     // 3. Fall back to a direct Steam `.lcache` scan (covers a stale configured
-    //    path, or an install whose root normalization missed but discover finds).
+    //    path, or an install whose root normalization missed but discover finds)
+    //    — but honor the autodetect-disable seam, so a caller that excluded Steam
+    //    (tests / power users) never has `loc` reach an install behind their back.
+    if config::autodetect_disabled() {
+        return None;
+    }
     loc_store::resolve_lcache(None)
 }
 

--- a/crates/gore/src/cmd/loc.rs
+++ b/crates/gore/src/cmd/loc.rs
@@ -9,7 +9,7 @@
 
 use anyhow::{Context, Result};
 use gore_loc::loc::Lcache;
-use gore_loc::{loc_store, paths};
+use gore_loc::{config, loc_store, paths};
 use std::io::Write as _;
 use std::{collections::BTreeMap, fs, path::PathBuf};
 
@@ -18,10 +18,15 @@ type LocMap = BTreeMap<String, BTreeMap<String, String>>;
 /// Auto-detect (or use `--lcache`) the game's localization cache and write the
 /// shared `gore-tools/loc_catalog.json`. Prompts for confirmation unless `--yes`.
 pub fn extract(lcache: Option<PathBuf>, yes: bool) -> Result<()> {
-    let resolved = loc_store::resolve_lcache(lcache.as_deref())
+    // Resolution precedence: explicit --lcache > the configured game path
+    // (discover walks it to the .lcache) > Steam auto-detect. A configured path
+    // is used authoritatively (like an explicit hint), so `loc` reads text from
+    // YOUR configured install rather than a possibly-different Steam one.
+    let hint = lcache.or_else(|| config::load().game_path.map(PathBuf::from));
+    let resolved = loc_store::resolve_lcache(hint.as_deref())
         .ok_or_else(|| anyhow::anyhow!(
-            "no AlkimiaLocalization .lcache found (Steam auto-detect failed). \
-             Pass --lcache <path-to-.lcache or game dir>."
+            "no AlkimiaLocalization .lcache found (tried --lcache, the configured \
+             game path, then Steam auto-detect). Pass --lcache <path-to-.lcache or game dir>."
         ))?;
 
     if !yes {

--- a/crates/gore/src/cmd/loc.rs
+++ b/crates/gore/src/cmd/loc.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, fs, path::PathBuf};
 type LocMap = BTreeMap<String, BTreeMap<String, String>>;
 
 /// Auto-detect (or use `--lcache`) the game's localization cache and write the
-/// shared `gore-tools/loc_catalog.json`. Prompts for confirmation unless `--yes`.
+/// shared `gore/loc_catalog.json`. Prompts for confirmation unless `--yes`.
 pub fn extract(lcache: Option<PathBuf>, yes: bool) -> Result<()> {
     // Resolution precedence: explicit --lcache > the configured game path
     // (discover walks it to the .lcache) > Steam auto-detect. A configured path

--- a/crates/gore/src/cmd/mgr.rs
+++ b/crates/gore/src/cmd/mgr.rs
@@ -90,7 +90,7 @@ pub enum MgrAction {
     Apply {
         /// Game root (the folder containing G1R/)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
         #[arg(long)]
         library: Option<PathBuf>,
         #[arg(long)]
@@ -100,7 +100,7 @@ pub enum MgrAction {
     Status {
         /// Game root (the folder containing G1R/)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
         #[arg(long)]
         library: Option<PathBuf>,
         #[arg(long)]
@@ -110,7 +110,7 @@ pub enum MgrAction {
     Reset {
         /// Game root (the folder containing G1R/)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
     },
 }
 
@@ -255,6 +255,7 @@ pub fn run(action: MgrAction) -> Result<()> {
         }
 
         MgrAction::Apply { game, library, loadout } => {
+            let game = gore_loc::config::game_root(game)?;
             let lib = library_of(library);
             let ld_path = loadout_of(loadout);
 
@@ -292,6 +293,7 @@ pub fn run(action: MgrAction) -> Result<()> {
         }
 
         MgrAction::Status { game, library, loadout } => {
+            let game = gore_loc::config::game_root(game)?;
             let lib = library_of(library);
             let ld_path = loadout_of(loadout);
             let ld = loadout::load(&ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -301,6 +303,7 @@ pub fn run(action: MgrAction) -> Result<()> {
         }
 
         MgrAction::Reset { game } => {
+            let game = gore_loc::config::game_root(game)?;
             let removed = undeploy_all(&game).map_err(|e| anyhow::anyhow!("{e}"))?;
             if removed {
                 println!("reset: undeployed the active manager deployment");

--- a/crates/gore/src/cmd/mod.rs
+++ b/crates/gore/src/cmd/mod.rs
@@ -1,6 +1,7 @@
 pub mod as_cache;
 pub mod audio;
 pub mod catalog;
+pub mod config;
 pub mod deploy_shared;
 pub mod dump;
 pub mod dump_mod;

--- a/crates/gore/src/cmd/modcmd.rs
+++ b/crates/gore/src/cmd/modcmd.rs
@@ -22,14 +22,16 @@ pub fn build(spec: PathBuf, out: PathBuf) -> Result<()> {
 }
 
 /// `gore mod deploy --bundle DIR --game ROOT` → apply to the game install.
-pub fn deploy(bundle: PathBuf, game: PathBuf) -> Result<()> {
+pub fn deploy(bundle: PathBuf, game: Option<PathBuf>) -> Result<()> {
+    let game = gore_loc::config::game_root(game)?;
     let rec = gore_mod::deploy(&bundle, &game).map_err(|e| anyhow::anyhow!("{e}"))?;
     println!("deployed '{}' ({} backup(s))", rec.mod_name, rec.backups.len());
     Ok(())
 }
 
 /// `gore mod undeploy --game ROOT` → restore the active mod's backups.
-pub fn undeploy(game: PathBuf) -> Result<()> {
+pub fn undeploy(game: Option<PathBuf>) -> Result<()> {
+    let game = gore_loc::config::game_root(game)?;
     match gore_mod::undeploy(&game).map_err(|e| anyhow::anyhow!("{e}"))? {
         Some(rec) => println!("undeployed '{}' ({} restored)", rec.mod_name, rec.backups.len()),
         None => println!("nothing deployed"),

--- a/crates/gore/src/cmd/texture.rs
+++ b/crates/gore/src/cmd/texture.rs
@@ -11,7 +11,7 @@ pub enum TextureAction {
     List {
         /// Path to the game install dir (contains G1R/Content/Paks/…)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
         /// Keep only asset paths containing this substring
         #[arg(long)]
         filter: Option<String>,
@@ -20,7 +20,7 @@ pub enum TextureAction {
     Extract {
         /// Path to the game install dir (contains G1R/Content/Paks/…)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
         /// Cooked asset path, e.g. /Game/UI/Textures/Common/T_HardwareCursor
         asset: String,
         /// Output PNG path
@@ -31,7 +31,7 @@ pub enum TextureAction {
     Replace {
         /// Path to the game install dir (contains G1R/Content/Paks/…)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
         /// Cooked asset path, e.g. /Game/UI/Textures/Common/T_HardwareCursor
         asset: String,
         /// Replacement PNG (RGBA8 / RGB8); dims need not match the original
@@ -45,7 +45,7 @@ pub enum TextureAction {
     Pack {
         /// Path to the game install dir (needed for the global script-objects store)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
         /// Mod dir laid out under its mount path (from `texture replace`)
         #[arg(long)]
         mod_dir: PathBuf,
@@ -66,7 +66,7 @@ pub enum TextureAction {
     Deploy {
         /// Path to the game install dir (contains G1R/Content/Paks/…)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
         /// Dir holding <name>.{utoc,ucas,pak} (the `texture pack` output dir)
         #[arg(long)]
         triplet_dir: PathBuf,
@@ -77,7 +77,7 @@ pub enum TextureAction {
     /// Build the texture index (asset->package_id) and cache it to the shared dir
     Index {
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
         /// Output path (defaults to the shared gore-tools texture_index.json)
         #[arg(short = 'o', long)]
         out: Option<PathBuf>,
@@ -86,7 +86,7 @@ pub enum TextureAction {
     Undeploy {
         /// Path to the game install dir (contains G1R/Content/Paks/…)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
         /// Base name of the deployed triplet, e.g. zzz_MyMod_P
         #[arg(long)]
         name: String,
@@ -127,6 +127,7 @@ fn validate_triplet_name(name: &str) -> Result<()> {
 pub fn run(action: TextureAction) -> Result<()> {
     match action {
         TextureAction::List { game, filter } => {
+            let game = gore_loc::config::game_root(game)?;
             let utoc = gore_tex::paths::main_container(&game)?;
             let usmap = gore_tex::paths::usmap(&game)?;
             eprintln!(
@@ -138,6 +139,7 @@ pub fn run(action: TextureAction) -> Result<()> {
             Ok(())
         }
         TextureAction::Extract { game, asset, out } => {
+            let game = gore_loc::config::game_root(game)?;
             let utoc = gore_tex::paths::main_container(&game)?;
             let usmap = gore_tex::paths::usmap(&game)?;
 
@@ -207,6 +209,7 @@ pub fn run(action: TextureAction) -> Result<()> {
             image: image_path,
             mod_dir,
         } => {
+            let game = gore_loc::config::game_root(game)?;
             let utoc = gore_tex::paths::main_container(&game)?;
             let usmap = gore_tex::paths::usmap(&game)?;
 
@@ -302,6 +305,7 @@ pub fn run(action: TextureAction) -> Result<()> {
             out,
             compress,
         } => {
+            let game = gore_loc::config::game_root(game)?;
             validate_triplet_name(&name)?;
             let triplet = gore_tex::container::repack_to_zen(&mod_dir, &name, &out, &game, compress)
                 .with_context(|| format!("packing {} into {name}", mod_dir.display()))?;
@@ -316,6 +320,7 @@ pub fn run(action: TextureAction) -> Result<()> {
             triplet_dir,
             name,
         } => {
+            let game = gore_loc::config::game_root(game)?;
             validate_triplet_name(&name)?;
             let triplet = [
                 triplet_dir.join(format!("{name}.utoc")),
@@ -334,6 +339,7 @@ pub fn run(action: TextureAction) -> Result<()> {
             Ok(())
         }
         TextureAction::Index { game, out } => {
+            let game = gore_loc::config::game_root(game)?;
             let utoc = gore_tex::paths::main_container(&game)?;
             let usmap = gore_tex::paths::usmap(&game)?;
             let build_id = gore_tex::index::build_id_for(&utoc, &usmap);
@@ -345,6 +351,7 @@ pub fn run(action: TextureAction) -> Result<()> {
             Ok(())
         }
         TextureAction::Undeploy { game, name } => {
+            let game = gore_loc::config::game_root(game)?;
             validate_triplet_name(&name)?;
             gore_tex::container::undeploy(&game, &name)
                 .with_context(|| format!("undeploying {name}"))?;

--- a/crates/gore/src/cmd/texture.rs
+++ b/crates/gore/src/cmd/texture.rs
@@ -78,7 +78,7 @@ pub enum TextureAction {
     Index {
         #[arg(long)]
         game: Option<PathBuf>,
-        /// Output path (defaults to the shared gore-tools texture_index.json)
+        /// Output path (defaults to the shared gore texture_index.json)
         #[arg(short = 'o', long)]
         out: Option<PathBuf>,
     },

--- a/crates/gore/src/main.rs
+++ b/crates/gore/src/main.rs
@@ -259,7 +259,7 @@ enum AudioAction {
 #[derive(Subcommand)]
 enum LocAction {
     /// Auto-detect (or --lcache) the game's .lcache and write the shared
-    /// gore-tools/loc_catalog.json (used by gore-save and gore-mod too)
+    /// gore/loc_catalog.json (used by gore-save and gore-mod too)
     Extract {
         /// Path to the .lcache, the game dir, or a Steam library (else auto-detect)
         #[arg(long)]

--- a/crates/gore/src/main.rs
+++ b/crates/gore/src/main.rs
@@ -110,9 +110,10 @@ enum Commands {
         /// executable (cwd-independent); pass this when running from an unusual layout.
         #[arg(long)]
         src: Option<std::path::PathBuf>,
-        /// Game dir containing ue4ss/Mods.
+        /// Game dir containing ue4ss/Mods. Defaults to the configured game path or
+        /// Steam auto-detect when omitted (see `gore config`).
         #[arg(long)]
-        game: std::path::PathBuf,
+        game: Option<std::path::PathBuf>,
     },
     /// AngelScript precompiled-cache tooling (decode/emit/splice/decompile).
     As {
@@ -172,13 +173,13 @@ enum ModAction {
         bundle: PathBuf,
         /// Game root (the folder containing G1R/)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
     },
     /// Undeploy the active mod (restore backups)
     Undeploy {
         /// Game root (the folder containing G1R/)
         #[arg(long)]
-        game: PathBuf,
+        game: Option<PathBuf>,
     },
 }
 

--- a/crates/gore/src/main.rs
+++ b/crates/gore/src/main.rs
@@ -147,6 +147,11 @@ enum Commands {
         #[command(subcommand)]
         action: cmd::mgr::MgrAction,
     },
+    /// Read/write the shared per-user config (game path, …)
+    Config {
+        #[command(subcommand)]
+        action: cmd::config::ConfigAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -325,6 +330,7 @@ fn main() {
         },
         Commands::Texture { action } => cmd::texture::run(action),
         Commands::Mgr { action } => cmd::mgr::run(action),
+        Commands::Config { action } => cmd::config::run(action),
     };
     if let Err(e) = result {
         eprintln!("error: {e:#}");

--- a/crates/gore/src/main.rs
+++ b/crates/gore/src/main.rs
@@ -110,8 +110,8 @@ enum Commands {
         /// executable (cwd-independent); pass this when running from an unusual layout.
         #[arg(long)]
         src: Option<std::path::PathBuf>,
-        /// Game dir containing ue4ss/Mods. Defaults to the configured game path or
-        /// Steam auto-detect when omitted (see `gore config`).
+        /// Game install root (the folder containing G1R/). Falls back to the
+        /// configured game path, then Steam auto-detect.
         #[arg(long)]
         game: Option<std::path::PathBuf>,
     },

--- a/crates/gore/tests/integration/config_test.rs
+++ b/crates/gore/tests/integration/config_test.rs
@@ -1,0 +1,52 @@
+//! Integration tests for `gore config`. Each run isolates the shared dir by
+//! pointing LOCALAPPDATA/APPDATA (Windows), HOME (macOS), and XDG_DATA_HOME/HOME
+//! (Linux) at a TempDir, so tests never touch the real user config.
+
+use assert_cmd::Command;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// A `gore` command with the shared dir redirected into `home`.
+fn gore(home: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("gore").unwrap();
+    cmd.env("LOCALAPPDATA", home)
+        .env("APPDATA", home)
+        .env("XDG_DATA_HOME", home)
+        .env("HOME", home);
+    cmd
+}
+
+#[test]
+fn set_then_get_round_trips_game_path() {
+    let tmp = TempDir::new().unwrap();
+    gore(tmp.path())
+        .args(["config", "set", "game-path", "D:/Games/G1R"])
+        .assert()
+        .success();
+    gore(tmp.path())
+        .args(["config", "get", "game-path"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("D:/Games/G1R"));
+}
+
+#[test]
+fn config_path_prints_config_json_under_gore() {
+    let tmp = TempDir::new().unwrap();
+    gore(tmp.path())
+        .args(["config", "path"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("config.json"));
+}
+
+#[test]
+fn unset_clears_the_value() {
+    let tmp = TempDir::new().unwrap();
+    gore(tmp.path()).args(["config", "set", "game-path", "X"]).assert().success();
+    gore(tmp.path()).args(["config", "unset", "game-path"]).assert().success();
+    gore(tmp.path())
+        .args(["config", "get", "game-path"])
+        .assert()
+        .failure(); // unset key exits non-zero
+}

--- a/crates/gore/tests/integration/config_test.rs
+++ b/crates/gore/tests/integration/config_test.rs
@@ -82,3 +82,21 @@ fn mgr_status_errors_helpfully_when_unset() {
         .failure()
         .stderr(predicates::str::contains("no game path set"));
 }
+
+#[test]
+fn loc_extract_honors_disabled_autodetect() {
+    let tmp = TempDir::new().unwrap();
+    // No configured game-path and autodetect disabled (the `gore` helper sets
+    // GORE_DISABLE_GAME_AUTODETECT=1): `loc extract` must NOT fall through to a
+    // Steam scan and reach an install the caller excluded. It must fail cleanly
+    // with the not-found message. (On a machine WITH the game installed, an
+    // ungated Steam fallback would instead succeed — so asserting `.failure()`
+    // is a real guard on the seam.)
+    gore(tmp.path())
+        .args(["loc", "extract", "-y"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "no AlkimiaLocalization .lcache found",
+        ));
+}

--- a/crates/gore/tests/integration/config_test.rs
+++ b/crates/gore/tests/integration/config_test.rs
@@ -3,16 +3,19 @@
 //! (Linux) at a TempDir, so tests never touch the real user config.
 
 use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt; // `.not()`
 use std::path::Path;
 use tempfile::TempDir;
 
-/// A `gore` command with the shared dir redirected into `home`.
+/// A `gore` command with the shared dir redirected into `home` and Steam
+/// auto-detect disabled, so resolution depends only on explicit/configured paths.
 fn gore(home: &Path) -> Command {
     let mut cmd = Command::cargo_bin("gore").unwrap();
     cmd.env("LOCALAPPDATA", home)
         .env("APPDATA", home)
         .env("XDG_DATA_HOME", home)
-        .env("HOME", home);
+        .env("HOME", home)
+        .env("GORE_DISABLE_GAME_AUTODETECT", "1");
     cmd
 }
 
@@ -49,4 +52,33 @@ fn unset_clears_the_value() {
         .args(["config", "get", "game-path"])
         .assert()
         .failure(); // unset key exits non-zero
+}
+
+#[test]
+fn mgr_status_uses_configured_game_path() {
+    let tmp = TempDir::new().unwrap();
+    // A fake game root so normalize_root resolves and the command reaches its
+    // own logic instead of erroring on an unresolved path.
+    let game = tmp.path().join("Game");
+    std::fs::create_dir_all(game.join("G1R")).unwrap();
+    gore(tmp.path())
+        .args(["config", "set", "game-path", game.to_str().unwrap()])
+        .assert()
+        .success();
+    // `mgr status` with NO --game must not fail with the "no game path" error.
+    gore(tmp.path())
+        .args(["mgr", "status"])
+        .assert()
+        .stderr(predicates::str::contains("no game path set").not());
+}
+
+#[test]
+fn mgr_status_errors_helpfully_when_unset() {
+    let tmp = TempDir::new().unwrap();
+    // No config, and auto-detect disabled -> nothing resolves.
+    gore(tmp.path())
+        .args(["mgr", "status"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("no game path set"));
 }

--- a/crates/gore/tests/integration/config_test.rs
+++ b/crates/gore/tests/integration/config_test.rs
@@ -100,3 +100,28 @@ fn loc_extract_honors_disabled_autodetect() {
             "no AlkimiaLocalization .lcache found",
         ));
 }
+
+#[test]
+fn set_stores_relative_game_path_as_absolute() {
+    let tmp = TempDir::new().unwrap();
+    // `set game-path .` run from cwd=tmp must persist an ABSOLUTE path, not the
+    // literal ".", so a later command run from any other directory resolves the
+    // same install rather than a stray ./G1R relative to its own cwd.
+    gore(tmp.path())
+        .current_dir(tmp.path())
+        .args(["config", "set", "game-path", "."])
+        .assert()
+        .success();
+    let out = gore(tmp.path())
+        .args(["config", "get", "game-path"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let got = String::from_utf8(out).unwrap();
+    assert!(
+        std::path::Path::new(got.trim()).is_absolute(),
+        "stored game-path is not absolute: {got:?}"
+    );
+}

--- a/crates/gore/tests/integration/deploy_shared_test.rs
+++ b/crates/gore/tests/integration/deploy_shared_test.rs
@@ -10,13 +10,10 @@ fn deploy_shared_copies_tree_into_mods_shared() {
     fs::write(src.path().join("gore-lua/gore-lua.lua"), "return {}\n").unwrap();
 
     let game = tempdir().unwrap();
-    // `--game` now resolves through `gore_loc::config::game_root`, which normalizes
-    // any resolved path (explicit args included) by walking up to the nearest
-    // ancestor holding a `G1R/` child. Give the fixture its own `G1R/` marker so it
-    // normalizes to itself instead of an unrelated ancestor further up the shared OS
-    // temp root (e.g. a stray leftover `G1R` dir from other tooling).
-    fs::create_dir_all(game.path().join("G1R")).unwrap();
-    let mods = game.path().join("ue4ss/Mods");
+    // deploy-shared derives the UE4SS Mods dir from the install root:
+    // <root>/G1R/Binaries/Win64/ue4ss/Mods. Creating it also gives the fixture
+    // its `G1R/` child, so game_root's normalize resolves `game` to itself.
+    let mods = game.path().join("G1R/Binaries/Win64/ue4ss/Mods");
     fs::create_dir_all(&mods).unwrap();
 
     Command::cargo_bin("gore")

--- a/crates/gore/tests/integration/deploy_shared_test.rs
+++ b/crates/gore/tests/integration/deploy_shared_test.rs
@@ -10,6 +10,12 @@ fn deploy_shared_copies_tree_into_mods_shared() {
     fs::write(src.path().join("gore-lua/gore-lua.lua"), "return {}\n").unwrap();
 
     let game = tempdir().unwrap();
+    // `--game` now resolves through `gore_loc::config::game_root`, which normalizes
+    // any resolved path (explicit args included) by walking up to the nearest
+    // ancestor holding a `G1R/` child. Give the fixture its own `G1R/` marker so it
+    // normalizes to itself instead of an unrelated ancestor further up the shared OS
+    // temp root (e.g. a stray leftover `G1R` dir from other tooling).
+    fs::create_dir_all(game.path().join("G1R")).unwrap();
     let mods = game.path().join("ue4ss/Mods");
     fs::create_dir_all(&mods).unwrap();
 

--- a/scripts/appcast.py
+++ b/scripts/appcast.py
@@ -1,4 +1,4 @@
-"""Generate and DSA-sign a WinSparkle appcast for a gore-tools release.
+"""Generate and DSA-sign a WinSparkle appcast for a gore release.
 
 Shared by every WinSparkle-updated app in the monorepo (gore-save, gore-mod).
 The appcast is uploaded as a GitHub release asset; the app polls a stable


### PR DESCRIPTION
## Summary

Adds a `gore config` command that persists shared settings (the game path first) to a per-user `config.json`, read by the CLI **and** all three Flutter apps. Every command that needs the game install now resolves it automatically, so `--game`/`game` is optional. Also renames the shared per-user dir `gore-tools` → `gore`.

Set the game path once instead of passing `--game` to every command and re-picking it in every app.

## What changed

- **`gore_loc::config`** — typed, extensible `Config` (JSON at `<shared>/config.json`, `game_path` key, unknown keys preserved via `#[serde(flatten)]`) + a `game_root()` resolver. Precedence: explicit `--game` > configured path > Steam auto-detect > actionable error.
- **`gore config`** subcommand — `set` / `get` / `unset` / `list` / `path` / `detect` (validated key enum, extensible).
- **`--game`/`game` is now optional** on `deploy-shared`, `mod deploy/undeploy`, `texture` (all 7 subcommands), and `mgr apply/status/reset` — each resolves through the config. `loc extract` prefers the configured path before Steam auto-detect.
- **Fix:** `deploy-shared` now derives `…/G1R/Binaries/Win64/ue4ss/Mods` from the install root (it previously took the `…/Win64` dir as `--game`, inconsistent with every other command). Surfaced while unifying on one resolved path.
- **Rename** shared dir `gore-tools` → `gore` (Rust resolver + 3 Dart resolvers + 2 installers + prose sweep). No migration — the umbrella was unreleased. save-editor's legacy `%APPDATA%\goresave` → umbrella migration is preserved, now retargeted to `gore`.
- **All 3 apps** (mod-manager, mod-studio, save-editor) read/write the same shared `config.json` via a small Dart `SharedConfig` that mirrors the Rust JSON contract. mod-manager/mod-studio back their game-path picker with it (single source of truth); save-editor prefers it as the localization detection hint.
- README documents `gore config` + the now-optional `--game`.

## Testing

- **Rust:** `gore-loc` 24/24, `gore` 66/66 (incl. the new `config_test`), `gore-ffi` 15/15, `gore-mod` 89/89.
- **Flutter:** mod-manager / mod-studio / save-editor suites green; each app gains `shared_config` round-trip + unknown-key-preservation tests.
- **Cross-language contract** verified: Rust `#[serde(flatten)]` ↔ Dart read-modify-write; `game_path` snake_case on both sides; identical shared-dir resolution.
- Pre-existing `gore-as` / vendored `retoc` test failures are environmental (fixtures under gitignored `work/` and `vendor/retoc/tests/**` are absent in a worktree), unrelated to this change.

## Breaking

- Shared per-user directory renamed `gore-tools` → `gore` (unreleased; no migration needed).
- `gore deploy-shared --game` now expects the **install root** (folder containing `G1R/`), not the `…/Win64` dir.

## Review notes

Built task-by-task (spec + code-quality review after each). Design/plan under `docs/superpowers/` (local, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deploy/mod/mgr/texture/loc path resolution and changes `deploy-shared --game` semantics; wrong root could deploy to the wrong tree, but explicit `--game` and tests mitigate this.
> 
> **Overview**
> Introduces a **shared per-user `config.json`** (under `%LOCALAPPDATA%/gore` et al.) with **`game_path`**, managed by a new **`gore config`** subcommand (`set`/`get`/`unset`/`list`/`path`/`detect`). Rust **`gore_loc::config`** loads/saves it and **`game_root()`** resolves the install root with precedence **explicit `--game` > configured path > Steam auto-detect**.
> 
> **CLI:** `--game` is now **optional** on `deploy-shared`, `mod deploy/undeploy`, all `texture` actions, and `mgr apply/status/reset`; **`loc extract`** tries the configured path before Steam. **`deploy-shared`** now expects the **install root** and copies into **`G1R/Binaries/Win64/ue4ss/Mods`** (previously assumed a `Win64`-style `--game`).
> 
> **Flutter (mod-manager, mod-studio, save-editor):** game path moves out of per-app UI settings into **`SharedConfig`** reading the same **`game_path`** key; **`gameRootFromExe`** accepts install root or exe. Save-editor’s loc extract flow prefers configured path with Steam/file-picker fallback; **`INVALID_REQUEST`** from loc always signals “cache not found” when a hint was used.
> 
> **Rename:** shared data dir **`gore-tools` → `gore`** across Rust paths, Dart, installers, and docs (no migration for the old umbrella name).
> 
> Tests added/updated for shared config, game-root resolution, CLI config integration, and widget tests using isolated temp `config.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7391e78f8a798fe0b94b2fb91019535a4275f2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->