### PR TITLE
fix(studio): reflect exact DataAssets preview status

### DIFF
--- a/apps/mod-studio/lib/home_page.dart
+++ b/apps/mod-studio/lib/home_page.dart
@@ -2176,6 +2176,8 @@ class _ManagedRevision3ProjectViewState
   late Revision3ProjectCompilerCheckController _projectCompilerController;
   late Revision3ProjectProblemsController _projectProblemsController;
   late Revision3VoiceBuildReadinessController _voiceBuildReadinessController;
+  late Revision3ProjectBuildPlanDataAssetsController
+  _projectBuildPlanDataAssetsController;
   late Revision3ScopedContentBrowserController _scopedContentBrowserController;
   late Revision3ProjectGlobalUndoCoordinator _globalUndoCoordinator;
   late FocusNode _globalSearchQueryFocusNode;
@@ -2680,6 +2682,8 @@ class _ManagedRevision3ProjectViewState
     );
     _projectProblemsController = Revision3ProjectProblemsController();
     _voiceBuildReadinessController = Revision3VoiceBuildReadinessController();
+    _projectBuildPlanDataAssetsController =
+        Revision3ProjectBuildPlanDataAssetsController();
     _scopedContentBrowserController = Revision3ScopedContentBrowserController(
       projectIdentity: (project.root.path, project.projectId),
     );
@@ -2747,6 +2751,7 @@ class _ManagedRevision3ProjectViewState
     _projectCompilerController.dispose();
     _projectProblemsController.dispose();
     _voiceBuildReadinessController.dispose();
+    _projectBuildPlanDataAssetsController.dispose();
     _dataAssetStagePanelController = Revision3DataAssetStagePanelController();
     _projectCompilerController = Revision3ProjectCompilerCheckController(
       checkpoint: _projectCompilerCheckpoint,
@@ -2755,6 +2760,8 @@ class _ManagedRevision3ProjectViewState
     );
     _projectProblemsController = Revision3ProjectProblemsController();
     _voiceBuildReadinessController = Revision3VoiceBuildReadinessController();
+    _projectBuildPlanDataAssetsController =
+        Revision3ProjectBuildPlanDataAssetsController();
     _scopedContentBrowserController.dispose();
     _scopedContentBrowserController = Revision3ScopedContentBrowserController(
       projectIdentity: (project.root.path, project.projectId),
@@ -2863,6 +2870,7 @@ class _ManagedRevision3ProjectViewState
     _projectCompilerController.dispose();
     _projectProblemsController.dispose();
     _voiceBuildReadinessController.dispose();
+    _projectBuildPlanDataAssetsController.dispose();
     _scopedContentBrowserController.dispose();
     _globalUndoCoordinator.dispose();
     _globalSearchQueryFocusNode.dispose();
@@ -4642,6 +4650,7 @@ class _ManagedRevision3ProjectViewState
         _projectCompilerController,
         _projectProblemsController,
         _voiceBuildReadinessController,
+        _projectBuildPlanDataAssetsController,
       ]),
       builder: (context, _) => Revision3TestReleaseWorkspace(
         projectId: checkpoint.projectId,
@@ -4711,11 +4720,8 @@ class _ManagedRevision3ProjectViewState
             secondary: 'voice',
           ),
         ),
-        dataAssets: Revision3TestReleaseCheck(
-          state: Revision3TestReleaseCheckState.notEvaluated,
-          title: l10n.managedTestReleaseDataAssetsTitle,
-          description: l10n.managedTestReleaseDataAssetsDescription,
-          actionLabel: l10n.managedTestReleaseDataAssetsAction,
+        dataAssets: _dataAssetsBuildPreviewCheck(
+          l10n,
           onPressed: () => navigate(
             Revision3ProjectWorkspaceSection.content,
             secondary: Revision3ContentWorkspaceView.dataAssets.secondaryRoute,
@@ -4723,11 +4729,13 @@ class _ManagedRevision3ProjectViewState
         ),
         buildPreviewBuilder: (_) => Revision3ProjectBuildPlanPanel(
           checkpoint: Revision3ProjectBuildPlanCheckpoint(
+            projectRoot: buildPreviewProjectRoot,
             projectId: checkpoint.projectId,
             projectRevision: checkpoint.projectRevision,
             checkpointIdentity: checkpoint.checkpointIdentity,
           ),
           load: planProjectBuild,
+          dataAssetsController: _projectBuildPlanDataAssetsController,
           openVoiceDetails: () {
             final current = currentManagedProject;
             if (!context.mounted ||
@@ -4893,6 +4901,66 @@ class _ManagedRevision3ProjectViewState
       description: l10n.managedTestReleaseVoiceDescription,
       evidence: evidence,
       actionLabel: l10n.managedTestReleaseVoiceAction,
+      onPressed: onPressed,
+    );
+  }
+
+  Revision3TestReleaseCheck _dataAssetsBuildPreviewCheck(
+    AppLocalizations l10n, {
+    required VoidCallback onPressed,
+  }) {
+    final expected = Revision3ProjectBuildPlanCheckpoint(
+      projectRoot: project.root.path,
+      projectId: project.projectId,
+      projectRevision: project.projectRevision,
+      checkpointIdentity: project.head.canonicalJson,
+    );
+    final snapshot = _projectBuildPlanDataAssetsController.snapshot;
+    var state = project.requiresReopen
+        ? Revision3TestReleaseCheckState.unavailable
+        : Revision3TestReleaseCheckState.checking;
+    Revision3TestReleaseEvidence? evidence;
+
+    if (!project.requiresReopen && snapshot.belongsTo(expected)) {
+      switch (snapshot.state) {
+        case Revision3ProjectBuildPlanDataAssetsLoadState.detached ||
+            Revision3ProjectBuildPlanDataAssetsLoadState.loading:
+          state = Revision3TestReleaseCheckState.checking;
+        case Revision3ProjectBuildPlanDataAssetsLoadState.unavailable:
+          state = Revision3TestReleaseCheckState.unavailable;
+        case Revision3ProjectBuildPlanDataAssetsLoadState.ready:
+          final dataAssets = snapshot.dataAssets;
+          if (dataAssets == null ||
+              dataAssets.domain !=
+                  AuthoringRevision3ProjectBuildDomain.dataAssets) {
+            state = Revision3TestReleaseCheckState.unavailable;
+            break;
+          }
+          state = switch (dataAssets.status) {
+            AuthoringRevision3ProjectBuildDomainStatus.notPresent ||
+            AuthoringRevision3ProjectBuildDomainStatus.ready =>
+              Revision3TestReleaseCheckState.passed,
+            AuthoringRevision3ProjectBuildDomainStatus.blocked =>
+              Revision3TestReleaseCheckState.needsAttention,
+          };
+          evidence = Revision3TestReleaseEvidence(
+            projectId: expected.projectId,
+            projectRevision: expected.projectRevision,
+            checkpointIdentity: expected.checkpointIdentity,
+            scope: Revision3TestReleaseEvidenceScope.dataAssets,
+            summary:
+                '${l10n.managedTestReleaseDataAssetsTitle}: '
+                '${state == Revision3TestReleaseCheckState.passed ? l10n.managedTestReleaseStatusChecked : l10n.managedTestReleaseStatusNeedsAttention}',
+          );
+      }
+    }
+
+    return Revision3TestReleaseCheck(
+      state: state,
+      title: l10n.managedTestReleaseDataAssetsTitle,
+      description: l10n.managedTestReleaseDataAssetsDescription,
+      evidence: evidence,
+      actionLabel: l10n.managedTestReleaseDataAssetsAction,
       onPressed: onPressed,
     );
   }

--- a/apps/mod-studio/lib/l10n/app_de.arb
+++ b/apps/mod-studio/lib/l10n/app_de.arb
@@ -1101,7 +1101,7 @@
   "managedTestReleaseVoiceDescription": "Prüft nur den exakten aktuellen Plan für ein Voice-Bundle aus vorhandenen Archiveinträgen. Text- oder Übersetzungsabdeckung, Wiedergabe, Build-Ausgabe, Bereitstellung und Laufzeit werden nicht geprüft.",
   "managedTestReleaseVoiceAction": "Voice-Bundle prüfen",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "Vorgemerkte DataAssets erscheinen in der Problemliste, aber es gibt noch keinen vollständigen projektweiten Build-Nachweis.",
+  "managedTestReleaseDataAssetsDescription": "Prüft nur den exakten aktuellen Bereich bereits vorgemerkter DataAssets, den die Projekt-Bauvorschau verifiziert hat. Neue oder strukturelle Assets, spielbare Dateien, Installation, Bereitstellung, Spiel- oder Spielstandsänderungen, Laufzeitverhalten und Weltinhalte sind nicht abgedeckt.",
   "managedTestReleaseDataAssetsAction": "DataAssets prüfen",
   "managedTestReleasePlayableBuildTitle": "Spielbare Dateien",
   "managedTestReleasePlayableBuildDescription": "Erstelle aus genau dieser gespeicherten Projektversion einen geprüften spielbaren Build.",

--- a/apps/mod-studio/lib/l10n/app_en.arb
+++ b/apps/mod-studio/lib/l10n/app_en.arb
@@ -1284,7 +1284,7 @@
   "managedTestReleaseVoiceDescription": "Checks only the exact current existing-member Voice bundle plan. It does not check text or translation coverage, playback, build output, deployment, or runtime.",
   "managedTestReleaseVoiceAction": "Open Voice bundle check",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "Staged DataAssets are visible in Problems, but no complete project-wide build evidence exists yet.",
+  "managedTestReleaseDataAssetsDescription": "Checks only the exact current staged DataAssets domain already verified by Project build preview. It does not cover new or structural assets, playable files, installation, deployment, game or save changes, runtime behavior, or World content.",
   "managedTestReleaseDataAssetsAction": "Review DataAssets",
   "managedTestReleasePlayableBuildTitle": "Playable files",
   "managedTestReleasePlayableBuildDescription": "Create a checked playable build from this exact saved project version.",

--- a/apps/mod-studio/lib/l10n/app_es.arb
+++ b/apps/mod-studio/lib/l10n/app_es.arb
@@ -442,7 +442,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "Aquí solo se comprueba el plan; crear el paquete de voces sin conexión sigue siendo una acción independiente.",
   "managedVoiceBuildReadinessConfigureGameGuidance": "El plan exacto del paquete de voces está comprobado. Aún se debe configurar una instalación del juego para que esté disponible la acción independiente del paquete sin conexión.",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "Los DataAssets preparados aparecen en Problemas, pero todavía no existe evidencia de una compilación completa del proyecto.",
+  "managedTestReleaseDataAssetsDescription": "Comprueba solo el dominio exacto actual de DataAssets preparados que ya verificó la vista previa de compilación del proyecto. No cubre recursos nuevos o estructurales, archivos jugables, instalación, despliegue, cambios en el juego o partidas guardadas, comportamiento en ejecución ni contenido del mundo.",
   "managedTestReleaseDataAssetsAction": "Revisar DataAssets",
   "managedTestReleasePlayableBuildTitle": "Archivos jugables",
   "managedTestReleasePlayableBuildDescription": "Crea una compilación jugable comprobada a partir de esta versión guardada exacta del proyecto.",

--- a/apps/mod-studio/lib/l10n/app_fr.arb
+++ b/apps/mod-studio/lib/l10n/app_fr.arb
@@ -442,7 +442,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "Seul le plan est vérifié ici ; la création du bundle vocal hors ligne reste une action distincte.",
   "managedVoiceBuildReadinessConfigureGameGuidance": "Le plan exact du bundle vocal est vérifié. Une installation du jeu doit encore être configurée pour rendre disponible l’action distincte du bundle hors ligne.",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "Les DataAssets préparés apparaissent dans les problèmes, mais aucune preuve de build complet du projet n’existe encore.",
+  "managedTestReleaseDataAssetsDescription": "Vérifie uniquement le domaine exact et actuel des DataAssets préparés, déjà validé par l’aperçu de build du projet. Cela ne couvre pas les ressources nouvelles ou structurelles, les fichiers jouables, l’installation, le déploiement, les modifications du jeu ou des fichiers de sauvegarde, le comportement à l’exécution ni le contenu du monde.",
   "managedTestReleaseDataAssetsAction": "Examiner les DataAssets",
   "managedTestReleasePlayableBuildTitle": "Fichiers jouables",
   "managedTestReleasePlayableBuildDescription": "Créez un build jouable vérifié à partir de cette version enregistrée précise du projet.",

--- a/apps/mod-studio/lib/l10n/app_it.arb
+++ b/apps/mod-studio/lib/l10n/app_it.arb
@@ -442,7 +442,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "Qui viene controllato solo il piano; la creazione del bundle vocale offline rimane un’azione separata.",
   "managedVoiceBuildReadinessConfigureGameGuidance": "Il piano esatto del bundle vocale è stato controllato. Per rendere disponibile l’azione separata del bundle offline è ancora necessaria un’installazione del gioco configurata.",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "I DataAsset preparati sono visibili nei Problemi, ma non esiste ancora un’evidenza completa della build dell’intero progetto.",
+  "managedTestReleaseDataAssetsDescription": "Controlla solo il dominio esatto e corrente dei DataAsset preparati, già verificato dall'anteprima build del progetto. Non copre asset nuovi o strutturali, file giocabili, installazione, distribuzione, modifiche al gioco o ai file di salvataggio, comportamento in esecuzione o contenuti del mondo.",
   "managedTestReleaseDataAssetsAction": "Esamina i DataAsset",
   "managedTestReleasePlayableBuildTitle": "File giocabili",
   "managedTestReleasePlayableBuildDescription": "Crea una build giocabile verificata da questa esatta versione salvata del progetto.",

--- a/apps/mod-studio/lib/l10n/app_ja.arb
+++ b/apps/mod-studio/lib/l10n/app_ja.arb
@@ -442,7 +442,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "ここではプランだけを確認します。オフライン Voice バンドルの作成は別の操作です。",
   "managedVoiceBuildReadinessConfigureGameGuidance": "Voice バンドルの正確なプランは確認済みです。別のオフラインバンドル操作を使用するには、ゲームのインストールを設定する必要があります。",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "準備された DataAsset は問題一覧に表示されますが、プロジェクト全体の完全なビルド根拠はまだありません。",
+  "managedTestReleaseDataAssetsDescription": "プロジェクトのビルドプレビューで検証済みの、現在の正確なステージ済み DataAssets ドメインだけを確認します。新規または構造的なアセット、プレイ可能ファイル、インストール、デプロイ、ゲームやセーブの変更、実行時の挙動、World コンテンツは対象外です。",
   "managedTestReleaseDataAssetsAction": "DataAsset を確認",
   "managedTestReleasePlayableBuildTitle": "プレイ可能なファイル",
   "managedTestReleasePlayableBuildDescription": "この保存済みプロジェクトバージョンから、確認済みのプレイ可能なビルドを作成します。",

--- a/apps/mod-studio/lib/l10n/app_localizations.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations.dart
@@ -6147,7 +6147,7 @@ abstract class AppLocalizations {
   /// No description provided for @managedTestReleaseDataAssetsDescription.
   ///
   /// In en, this message translates to:
-  /// **'Staged DataAssets are visible in Problems, but no complete project-wide build evidence exists yet.'**
+  /// **'Checks only the exact current staged DataAssets domain already verified by Project build preview. It does not cover new or structural assets, playable files, installation, deployment, game or save changes, runtime behavior, or World content.'**
   String get managedTestReleaseDataAssetsDescription;
 
   /// No description provided for @managedTestReleaseDataAssetsAction.

--- a/apps/mod-studio/lib/l10n/app_localizations_de.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_de.dart
@@ -3727,7 +3727,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      'Vorgemerkte DataAssets erscheinen in der Problemliste, aber es gibt noch keinen vollständigen projektweiten Build-Nachweis.';
+      'Prüft nur den exakten aktuellen Bereich bereits vorgemerkter DataAssets, den die Projekt-Bauvorschau verifiziert hat. Neue oder strukturelle Assets, spielbare Dateien, Installation, Bereitstellung, Spiel- oder Spielstandsänderungen, Laufzeitverhalten und Weltinhalte sind nicht abgedeckt.';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'DataAssets prüfen';

--- a/apps/mod-studio/lib/l10n/app_localizations_en.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_en.dart
@@ -3679,7 +3679,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      'Staged DataAssets are visible in Problems, but no complete project-wide build evidence exists yet.';
+      'Checks only the exact current staged DataAssets domain already verified by Project build preview. It does not cover new or structural assets, playable files, installation, deployment, game or save changes, runtime behavior, or World content.';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'Review DataAssets';

--- a/apps/mod-studio/lib/l10n/app_localizations_es.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_es.dart
@@ -3710,7 +3710,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      'Los DataAssets preparados aparecen en Problemas, pero todavía no existe evidencia de una compilación completa del proyecto.';
+      'Comprueba solo el dominio exacto actual de DataAssets preparados que ya verificó la vista previa de compilación del proyecto. No cubre recursos nuevos o estructurales, archivos jugables, instalación, despliegue, cambios en el juego o partidas guardadas, comportamiento en ejecución ni contenido del mundo.';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'Revisar DataAssets';

--- a/apps/mod-studio/lib/l10n/app_localizations_fr.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_fr.dart
@@ -3712,7 +3712,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      'Les DataAssets préparés apparaissent dans les problèmes, mais aucune preuve de build complet du projet n’existe encore.';
+      'Vérifie uniquement le domaine exact et actuel des DataAssets préparés, déjà validé par l’aperçu de build du projet. Cela ne couvre pas les ressources nouvelles ou structurelles, les fichiers jouables, l’installation, le déploiement, les modifications du jeu ou des fichiers de sauvegarde, le comportement à l’exécution ni le contenu du monde.';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'Examiner les DataAssets';

--- a/apps/mod-studio/lib/l10n/app_localizations_it.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_it.dart
@@ -3710,7 +3710,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      'I DataAsset preparati sono visibili nei Problemi, ma non esiste ancora un’evidenza completa della build dell’intero progetto.';
+      'Controlla solo il dominio esatto e corrente dei DataAsset preparati, già verificato dall\'anteprima build del progetto. Non copre asset nuovi o strutturali, file giocabili, installazione, distribuzione, modifiche al gioco o ai file di salvataggio, comportamento in esecuzione o contenuti del mondo.';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'Esamina i DataAsset';

--- a/apps/mod-studio/lib/l10n/app_localizations_ja.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_ja.dart
@@ -3642,7 +3642,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      '準備された DataAsset は問題一覧に表示されますが、プロジェクト全体の完全なビルド根拠はまだありません。';
+      'プロジェクトのビルドプレビューで検証済みの、現在の正確なステージ済み DataAssets ドメインだけを確認します。新規または構造的なアセット、プレイ可能ファイル、インストール、デプロイ、ゲームやセーブの変更、実行時の挙動、World コンテンツは対象外です。';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'DataAsset を確認';

--- a/apps/mod-studio/lib/l10n/app_localizations_pl.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_pl.dart
@@ -3698,7 +3698,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      'Przygotowane DataAssety są widoczne w Problemach, ale nie ma jeszcze pełnego dowodu kompilacji całego projektu.';
+      'Sprawdza wyłącznie dokładny, bieżący obszar przygotowanych zasobów DataAssets, który został już zweryfikowany przez podgląd kompilacji projektu. Nie obejmuje nowych ani strukturalnych zasobów, plików grywalnych, instalacji, wdrażania, zmian w grze lub zapisach, działania w czasie wykonywania ani zawartości świata.';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'Przejrzyj DataAssety';

--- a/apps/mod-studio/lib/l10n/app_localizations_pt.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_pt.dart
@@ -3699,7 +3699,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      'Os DataAssets preparados aparecem nos Problemas, mas ainda não existe evidência de uma compilação completa do projeto.';
+      'Verifica apenas o domínio DataAssets preparado, exato e atual, já validado pela pré-visualização da compilação do projeto. Não abrange recursos novos ou estruturais, ficheiros jogáveis, instalação, distribuição, alterações ao jogo ou aos ficheiros guardados, comportamento em execução nem conteúdo do mundo.';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'Rever DataAssets';
@@ -5273,7 +5273,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      'Os DataAssets preparados aparecem em Problemas, mas ainda não há evidência de uma compilação completa do projeto.';
+      'Verifica somente o domínio DataAssets preparado, exato e atual, já validado pela prévia da compilação do projeto. Não abrange assets novos ou estruturais, arquivos jogáveis, instalação, implantação, alterações no jogo ou em saves, comportamento em execução nem conteúdo de mundo.';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'Revisar DataAssets';

--- a/apps/mod-studio/lib/l10n/app_localizations_ru.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_ru.dart
@@ -3699,7 +3699,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      'Подготовленные DataAsset отображаются в списке проблем, но полного подтверждения сборки всего проекта ещё нет.';
+      'Проверяет только точный текущий домен подготовленных DataAssets, уже подтверждённый предварительным просмотром сборки проекта. Проверка не охватывает новые или структурные ресурсы, игровые файлы, установку, развёртывание, изменения игры или сохранений, поведение во время выполнения и содержимое мира.';
 
   @override
   String get managedTestReleaseDataAssetsAction => 'Просмотреть DataAsset';

--- a/apps/mod-studio/lib/l10n/app_localizations_zh.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_zh.dart
@@ -3613,7 +3613,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      '僅檢查已由專案建置預覽驗證的精確目前暫存 DataAssets 領域。不涵蓋新增或結構性資產、可遊玩檔案、安裝、部署、遊戲或存檔變更、執行階段行為或世界內容。';
+      '仅检查已由项目构建预览验证的精确当前暂存 DataAssets 领域。不涵盖新增或结构性资产、可游玩文件、安装、部署、游戏或存档更改、运行时行为或世界内容。';
 
   @override
   String get managedTestReleaseDataAssetsAction => '查看 DataAsset';

--- a/apps/mod-studio/lib/l10n/app_localizations_zh.dart
+++ b/apps/mod-studio/lib/l10n/app_localizations_zh.dart
@@ -3613,7 +3613,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      '已准备的 DataAsset 会显示在问题列表中，但尚无完整的全项目构建证据。';
+      '僅檢查已由專案建置預覽驗證的精確目前暫存 DataAssets 領域。不涵蓋新增或結構性資產、可遊玩檔案、安裝、部署、遊戲或存檔變更、執行階段行為或世界內容。';
 
   @override
   String get managedTestReleaseDataAssetsAction => '查看 DataAsset';
@@ -5101,7 +5101,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get managedTestReleaseDataAssetsDescription =>
-      '已准备的 DataAsset 会显示在问题列表中，但尚无完整的全项目构建证据。';
+      '仅检查已由项目构建预览验证的精确当前暂存 DataAssets 领域。不涵盖新增或结构性资产、可游玩文件、安装、部署、游戏或存档更改、运行时行为或世界内容。';
 
   @override
   String get managedTestReleaseDataAssetsAction => '查看 DataAsset';

--- a/apps/mod-studio/lib/l10n/app_pl.arb
+++ b/apps/mod-studio/lib/l10n/app_pl.arb
@@ -442,7 +442,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "Tutaj sprawdzany jest tylko plan; utworzenie pakietu głosowego offline pozostaje osobną czynnością.",
   "managedVoiceBuildReadinessConfigureGameGuidance": "Dokładny plan pakietu głosowego został sprawdzony. Aby udostępnić osobną czynność tworzenia pakietu offline, nadal trzeba skonfigurować instalację gry.",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "Przygotowane DataAssety są widoczne w Problemach, ale nie ma jeszcze pełnego dowodu kompilacji całego projektu.",
+  "managedTestReleaseDataAssetsDescription": "Sprawdza wyłącznie dokładny, bieżący obszar przygotowanych zasobów DataAssets, który został już zweryfikowany przez podgląd kompilacji projektu. Nie obejmuje nowych ani strukturalnych zasobów, plików grywalnych, instalacji, wdrażania, zmian w grze lub zapisach, działania w czasie wykonywania ani zawartości świata.",
   "managedTestReleaseDataAssetsAction": "Przejrzyj DataAssety",
   "managedTestReleasePlayableBuildTitle": "Grywalne pliki",
   "managedTestReleasePlayableBuildDescription": "Utwórz sprawdzoną grywalną kompilację z tej dokładnej zapisanej wersji projektu.",

--- a/apps/mod-studio/lib/l10n/app_pt.arb
+++ b/apps/mod-studio/lib/l10n/app_pt.arb
@@ -442,7 +442,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "Aqui é verificado apenas o plano; criar o pacote de vozes offline continua a ser uma ação separada.",
   "managedVoiceBuildReadinessConfigureGameGuidance": "O plano exato do pacote de vozes foi verificado. Ainda é necessário configurar uma instalação do jogo para disponibilizar a ação separada do pacote offline.",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "Os DataAssets preparados aparecem nos Problemas, mas ainda não existe evidência de uma compilação completa do projeto.",
+  "managedTestReleaseDataAssetsDescription": "Verifica apenas o domínio DataAssets preparado, exato e atual, já validado pela pré-visualização da compilação do projeto. Não abrange recursos novos ou estruturais, ficheiros jogáveis, instalação, distribuição, alterações ao jogo ou aos ficheiros guardados, comportamento em execução nem conteúdo do mundo.",
   "managedTestReleaseDataAssetsAction": "Rever DataAssets",
   "managedTestReleasePlayableBuildTitle": "Ficheiros jogáveis",
   "managedTestReleasePlayableBuildDescription": "Crie uma compilação jogável verificada a partir desta versão exata guardada do projeto.",

--- a/apps/mod-studio/lib/l10n/app_pt_BR.arb
+++ b/apps/mod-studio/lib/l10n/app_pt_BR.arb
@@ -427,7 +427,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "Aqui, apenas o plano é verificado; criar o pacote de vozes offline continua sendo uma ação separada.",
   "managedVoiceBuildReadinessConfigureGameGuidance": "O plano exato do pacote de vozes foi verificado. Ainda é necessário configurar uma instalação do jogo para disponibilizar a ação separada do pacote offline.",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "Os DataAssets preparados aparecem em Problemas, mas ainda não há evidência de uma compilação completa do projeto.",
+  "managedTestReleaseDataAssetsDescription": "Verifica somente o domínio DataAssets preparado, exato e atual, já validado pela prévia da compilação do projeto. Não abrange assets novos ou estruturais, arquivos jogáveis, instalação, implantação, alterações no jogo ou em saves, comportamento em execução nem conteúdo de mundo.",
   "managedTestReleaseDataAssetsAction": "Revisar DataAssets",
   "managedTestReleasePlayableBuildTitle": "Arquivos jogáveis",
   "managedTestReleasePlayableBuildDescription": "Crie uma compilação jogável verificada a partir desta versão exata salva do projeto.",

--- a/apps/mod-studio/lib/l10n/app_ru.arb
+++ b/apps/mod-studio/lib/l10n/app_ru.arb
@@ -442,7 +442,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "Здесь проверяется только план; создание автономного голосового пакета остаётся отдельным действием.",
   "managedVoiceBuildReadinessConfigureGameGuidance": "Точный план голосового пакета проверен. Чтобы стало доступно отдельное действие создания автономного пакета, по-прежнему требуется настроенная установка игры.",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "Подготовленные DataAsset отображаются в списке проблем, но полного подтверждения сборки всего проекта ещё нет.",
+  "managedTestReleaseDataAssetsDescription": "Проверяет только точный текущий домен подготовленных DataAssets, уже подтверждённый предварительным просмотром сборки проекта. Проверка не охватывает новые или структурные ресурсы, игровые файлы, установку, развёртывание, изменения игры или сохранений, поведение во время выполнения и содержимое мира.",
   "managedTestReleaseDataAssetsAction": "Просмотреть DataAsset",
   "managedTestReleasePlayableBuildTitle": "Игровые файлы",
   "managedTestReleasePlayableBuildDescription": "Создайте проверенную игровую сборку из этой точной сохранённой версии проекта.",

--- a/apps/mod-studio/lib/l10n/app_zh.arb
+++ b/apps/mod-studio/lib/l10n/app_zh.arb
@@ -442,7 +442,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "这里只检查计划；创建离线语音包仍是单独的操作。",
   "managedVoiceBuildReadinessConfigureGameGuidance": "精确的语音包计划已检查。要使用单独的离线语音包操作，仍需配置游戏安装。",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "已准备的 DataAsset 会显示在问题列表中，但尚无完整的全项目构建证据。",
+  "managedTestReleaseDataAssetsDescription": "僅檢查已由專案建置預覽驗證的精確目前暫存 DataAssets 領域。不涵蓋新增或結構性資產、可遊玩檔案、安裝、部署、遊戲或存檔變更、執行階段行為或世界內容。",
   "managedTestReleaseDataAssetsAction": "查看 DataAsset",
   "managedTestReleasePlayableBuildTitle": "可游玩文件",
   "managedTestReleasePlayableBuildDescription": "从当前这一确切的已保存项目版本创建经过检查的可游玩构建。",

--- a/apps/mod-studio/lib/l10n/app_zh.arb
+++ b/apps/mod-studio/lib/l10n/app_zh.arb
@@ -442,7 +442,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "这里只检查计划；创建离线语音包仍是单独的操作。",
   "managedVoiceBuildReadinessConfigureGameGuidance": "精确的语音包计划已检查。要使用单独的离线语音包操作，仍需配置游戏安装。",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "僅檢查已由專案建置預覽驗證的精確目前暫存 DataAssets 領域。不涵蓋新增或結構性資產、可遊玩檔案、安裝、部署、遊戲或存檔變更、執行階段行為或世界內容。",
+  "managedTestReleaseDataAssetsDescription": "仅检查已由项目构建预览验证的精确当前暂存 DataAssets 领域。不涵盖新增或结构性资产、可游玩文件、安装、部署、游戏或存档更改、运行时行为或世界内容。",
   "managedTestReleaseDataAssetsAction": "查看 DataAsset",
   "managedTestReleasePlayableBuildTitle": "可游玩文件",
   "managedTestReleasePlayableBuildDescription": "从当前这一确切的已保存项目版本创建经过检查的可游玩构建。",

--- a/apps/mod-studio/lib/l10n/app_zh_Hans.arb
+++ b/apps/mod-studio/lib/l10n/app_zh_Hans.arb
@@ -427,7 +427,7 @@
   "managedVoiceBuildReadinessBuildReleaseGuidance": "这里只检查计划；创建离线语音包仍是单独的操作。",
   "managedVoiceBuildReadinessConfigureGameGuidance": "精确的语音包计划已检查。要使用单独的离线语音包操作，仍需配置游戏安装。",
   "managedTestReleaseDataAssetsTitle": "DataAssets",
-  "managedTestReleaseDataAssetsDescription": "已准备的 DataAsset 会显示在问题列表中，但尚无完整的全项目构建证据。",
+  "managedTestReleaseDataAssetsDescription": "仅检查已由项目构建预览验证的精确当前暂存 DataAssets 领域。不涵盖新增或结构性资产、可游玩文件、安装、部署、游戏或存档更改、运行时行为或世界内容。",
   "managedTestReleaseDataAssetsAction": "查看 DataAsset",
   "managedTestReleasePlayableBuildTitle": "可游玩文件",
   "managedTestReleasePlayableBuildDescription": "从当前这一确切的已保存项目版本创建经过检查的可游玩构建。",

--- a/apps/mod-studio/lib/project/revision3_project_build_plan_panel.dart
+++ b/apps/mod-studio/lib/project/revision3_project_build_plan_panel.dart
@@ -26,10 +26,12 @@ typedef Revision3ProjectBuildPlanReasonCopy =
 @immutable
 final class Revision3ProjectBuildPlanCheckpoint {
   Revision3ProjectBuildPlanCheckpoint({
+    required String projectRoot,
     required String projectId,
     required this.projectRevision,
     required String checkpointIdentity,
-  }) : projectId = _requiredBuildPlanText(projectId, 'projectId'),
+  }) : projectRoot = _requiredBuildPlanText(projectRoot, 'projectRoot'),
+       projectId = _requiredBuildPlanText(projectId, 'projectId'),
        checkpointIdentity = _requiredBuildPlanText(
          checkpointIdentity,
          'checkpointIdentity',
@@ -39,6 +41,7 @@ final class Revision3ProjectBuildPlanCheckpoint {
     }
   }
 
+  final String projectRoot;
   final String projectId;
   final int projectRevision;
   final String checkpointIdentity;
@@ -46,13 +49,14 @@ final class Revision3ProjectBuildPlanCheckpoint {
   @override
   bool operator ==(Object other) =>
       other is Revision3ProjectBuildPlanCheckpoint &&
+      other.projectRoot == projectRoot &&
       other.projectId == projectId &&
       other.projectRevision == projectRevision &&
       other.checkpointIdentity == checkpointIdentity;
 
   @override
   int get hashCode =>
-      Object.hash(projectId, projectRevision, checkpointIdentity);
+      Object.hash(projectRoot, projectId, projectRevision, checkpointIdentity);
 }
 
 enum Revision3ProjectBuildPlanLoadState { loading, ready, failed }
@@ -152,6 +156,143 @@ final class Revision3ProjectBuildPlanController extends ChangeNotifier {
   void dispose() {
     _disposed = true;
     _generation++;
+    super.dispose();
+  }
+}
+
+/// Publication state of the DataAssets domain observed from one mounted
+/// project build preview.
+enum Revision3ProjectBuildPlanDataAssetsLoadState {
+  detached,
+  loading,
+  ready,
+  unavailable,
+}
+
+/// Narrow DataAssets-only output from the exact preview already loaded by the
+/// panel.
+///
+/// This deliberately excludes the aggregate plan outcome, blocker targets,
+/// every other domain, build output, deployment, game/save writes, runtime,
+/// and World evidence.
+@immutable
+final class Revision3ProjectBuildPlanDataAssetsSnapshot {
+  const Revision3ProjectBuildPlanDataAssetsSnapshot._({
+    required this.state,
+    this.checkpoint,
+    this.dataAssets,
+  }) : assert(
+         state == Revision3ProjectBuildPlanDataAssetsLoadState.detached
+             ? checkpoint == null && dataAssets == null
+             : checkpoint != null,
+       ),
+       assert(
+         state == Revision3ProjectBuildPlanDataAssetsLoadState.ready
+             ? dataAssets != null
+             : dataAssets == null,
+       );
+
+  const Revision3ProjectBuildPlanDataAssetsSnapshot._detached()
+    : this._(state: Revision3ProjectBuildPlanDataAssetsLoadState.detached);
+
+  factory Revision3ProjectBuildPlanDataAssetsSnapshot._loading(
+    Revision3ProjectBuildPlanCheckpoint checkpoint,
+  ) => Revision3ProjectBuildPlanDataAssetsSnapshot._(
+    state: Revision3ProjectBuildPlanDataAssetsLoadState.loading,
+    checkpoint: checkpoint,
+  );
+
+  factory Revision3ProjectBuildPlanDataAssetsSnapshot._unavailable(
+    Revision3ProjectBuildPlanCheckpoint checkpoint,
+  ) => Revision3ProjectBuildPlanDataAssetsSnapshot._(
+    state: Revision3ProjectBuildPlanDataAssetsLoadState.unavailable,
+    checkpoint: checkpoint,
+  );
+
+  factory Revision3ProjectBuildPlanDataAssetsSnapshot._ready(
+    Revision3ProjectBuildPlanCheckpoint checkpoint,
+    AuthoringRevision3ProjectBuildPlanResult result,
+  ) {
+    final dataAssets = result.plan.domain(
+      AuthoringRevision3ProjectBuildDomain.dataAssets,
+    );
+    if (dataAssets.domain != AuthoringRevision3ProjectBuildDomain.dataAssets) {
+      throw const FormatException(
+        'Project build preview returned the wrong DataAssets domain.',
+      );
+    }
+    return Revision3ProjectBuildPlanDataAssetsSnapshot._(
+      state: Revision3ProjectBuildPlanDataAssetsLoadState.ready,
+      checkpoint: checkpoint,
+      dataAssets: dataAssets,
+    );
+  }
+
+  final Revision3ProjectBuildPlanDataAssetsLoadState state;
+  final Revision3ProjectBuildPlanCheckpoint? checkpoint;
+  final AuthoringRevision3ProjectBuildDomainSummary? dataAssets;
+
+  bool belongsTo(Revision3ProjectBuildPlanCheckpoint expected) =>
+      checkpoint == expected;
+}
+
+/// Observes one mounted project build preview without owning or rerunning its
+/// native planner.
+///
+/// Attachment identity prevents a replaced or disposed preview from
+/// publishing stale DataAssets evidence into Test & Release.
+final class Revision3ProjectBuildPlanDataAssetsController
+    extends ChangeNotifier {
+  Object? _attachment;
+  Revision3ProjectBuildPlanDataAssetsSnapshot _snapshot =
+      const Revision3ProjectBuildPlanDataAssetsSnapshot._detached();
+  int _attachmentGeneration = 0;
+  bool _disposed = false;
+
+  Revision3ProjectBuildPlanDataAssetsSnapshot get snapshot => _snapshot;
+
+  void _attach(Object attachment) {
+    if (_disposed) {
+      throw StateError(
+        'A disposed project build DataAssets controller cannot attach.',
+      );
+    }
+    _attachment = attachment;
+    _attachmentGeneration++;
+    _snapshot = const Revision3ProjectBuildPlanDataAssetsSnapshot._detached();
+  }
+
+  void _publish(
+    Object attachment,
+    Revision3ProjectBuildPlanDataAssetsSnapshot snapshot,
+  ) {
+    if (_disposed || !identical(_attachment, attachment)) return;
+    _snapshot = snapshot;
+    _notifyAfterBuild(_attachmentGeneration);
+  }
+
+  void _detach(Object attachment) {
+    if (!identical(_attachment, attachment)) return;
+    _attachment = null;
+    final generation = ++_attachmentGeneration;
+    _snapshot = const Revision3ProjectBuildPlanDataAssetsSnapshot._detached();
+    _notifyAfterBuild(generation);
+  }
+
+  void _notifyAfterBuild(int generation) {
+    scheduleMicrotask(() {
+      if (_disposed || generation != _attachmentGeneration) return;
+      notifyListeners();
+    });
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _attachment = null;
+    _attachmentGeneration++;
+    _snapshot = const Revision3ProjectBuildPlanDataAssetsSnapshot._detached();
     super.dispose();
   }
 }
@@ -347,6 +488,7 @@ class Revision3ProjectBuildPlanPanel extends StatefulWidget {
     required this.load,
     this.openVoiceDetails,
     this.openDataAssetDetails,
+    this.dataAssetsController,
     this.copy = const Revision3ProjectBuildPlanCopy.english(),
     super.key,
   });
@@ -355,6 +497,7 @@ class Revision3ProjectBuildPlanPanel extends StatefulWidget {
   final Revision3ProjectBuildPlanLoader load;
   final Revision3ProjectBuildPlanOpenVoiceDetails? openVoiceDetails;
   final Revision3ProjectBuildPlanOpenDataAssetDetails? openDataAssetDetails;
+  final Revision3ProjectBuildPlanDataAssetsController? dataAssetsController;
   final Revision3ProjectBuildPlanCopy copy;
 
   @override
@@ -374,29 +517,67 @@ class _Revision3ProjectBuildPlanPanelState
   @override
   void initState() {
     super.initState();
+    widget.dataAssetsController?._attach(this);
     _controller = Revision3ProjectBuildPlanController(
       checkpoint: widget.checkpoint,
       loader: widget.load,
     );
+    _controller.addListener(_publishCurrentDataAssetsSnapshot);
     unawaited(_controller.refresh());
   }
 
   @override
   void didUpdateWidget(covariant Revision3ProjectBuildPlanPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
+    final dataAssetsControllerChanged =
+        oldWidget.dataAssetsController != widget.dataAssetsController;
+    if (dataAssetsControllerChanged) {
+      oldWidget.dataAssetsController?._detach(this);
+      widget.dataAssetsController?._attach(this);
+    }
     if (oldWidget.checkpoint != widget.checkpoint) {
       _actionEpoch++;
       _openingDetails = null;
       _actionError = null;
     }
     _controller.synchronize(checkpoint: widget.checkpoint, load: widget.load);
+    if (dataAssetsControllerChanged &&
+        oldWidget.checkpoint == widget.checkpoint) {
+      _publishCurrentDataAssetsSnapshot();
+    }
   }
 
   @override
   void dispose() {
     _actionEpoch++;
+    _controller.removeListener(_publishCurrentDataAssetsSnapshot);
+    widget.dataAssetsController?._detach(this);
     _controller.dispose();
     super.dispose();
+  }
+
+  void _publishCurrentDataAssetsSnapshot() {
+    final snapshot = _controller.snapshot;
+    final dataAssetsSnapshot = switch (snapshot.state) {
+      Revision3ProjectBuildPlanLoadState.loading =>
+        Revision3ProjectBuildPlanDataAssetsSnapshot._loading(
+          snapshot.checkpoint,
+        ),
+      Revision3ProjectBuildPlanLoadState.failed =>
+        Revision3ProjectBuildPlanDataAssetsSnapshot._unavailable(
+          snapshot.checkpoint,
+        ),
+      Revision3ProjectBuildPlanLoadState.ready when snapshot.result != null =>
+        Revision3ProjectBuildPlanDataAssetsSnapshot._ready(
+          snapshot.checkpoint,
+          snapshot.result!,
+        ),
+      Revision3ProjectBuildPlanLoadState.ready =>
+        Revision3ProjectBuildPlanDataAssetsSnapshot._unavailable(
+          snapshot.checkpoint,
+        ),
+    };
+    widget.dataAssetsController?._publish(this, dataAssetsSnapshot);
   }
 
   Future<void> _refresh() async {

--- a/apps/mod-studio/test/app/home_current_project_integration_test.dart
+++ b/apps/mod-studio/test/app/home_current_project_integration_test.dart
@@ -5796,6 +5796,22 @@ void main() {
       final workspace = tester.widget<Revision3TestReleaseWorkspace>(
         find.byType(Revision3TestReleaseWorkspace),
       );
+      expect(workspace.dataAssets.state, Revision3TestReleaseCheckState.passed);
+      expect(
+        workspace.dataAssets.evidence?.scope,
+        Revision3TestReleaseEvidenceScope.dataAssets,
+      );
+      expect(workspace.dataAssets.evidence?.projectId, managed.projectId);
+      expect(workspace.dataAssets.evidence?.projectRevision, 3);
+      expect(
+        workspace.dataAssets.evidence?.checkpointIdentity,
+        managed.head.canonicalJson,
+      );
+      expect(workspace.dataAssets.evidence?.summary, 'DataAssets: Checked');
+      expect(
+        workspace.dataAssets.description,
+        contains('exact current staged DataAssets domain'),
+      );
       expect(workspace.playableBuild.evidence, isNull);
       expect(workspace.playableBuild.onPressed, isNull);
       expect(workspace.deployment.evidence, isNull);
@@ -5816,6 +5832,293 @@ void main() {
       expect(managed.projectBuildPlanCalls, 1);
     },
   );
+
+  testWidgets(
+    'DataAssets check mirrors loading then the mounted ready domain once',
+    (tester) async {
+      await _setDesktopTestSurface(tester);
+      final fixture = revision3ProjectProblemsRetainedDataAssetFixture(
+        projectRevision: 8,
+      );
+      final planned = Completer<AuthoringRevision3ProjectBuildPlanResult>();
+      final managed = _FakeProjectBuildPlanManagedLease(
+        root: Directory(r'C:\mods\dataassets-status-ready'),
+        projectId: fixture.projectId,
+        projectRevision: fixture.projectRevision,
+        head: _head(fixture.projectRevision),
+        contentIndexBuilder: (_) => fixture.contentIndex,
+        onDataAssetList: (_) => fixture.dataAssetStages,
+        onProjectBuildPlan: (_) => planned.future,
+      );
+      final coordinator = CurrentProjectCoordinator(
+        openManagedRevision3: (_) async => managed,
+      );
+      await coordinator.openManagedRevision3(managed.root);
+      final container = _container(
+        coordinator: coordinator,
+        pickManaged: (_) async => null,
+      );
+      addTearDown(container.dispose);
+
+      await _pumpApp(tester, container);
+      await tester.pumpAndSettle();
+      final destination = find.byKey(
+        const Key('revision3-project-workspace-tab-test-release'),
+      );
+      await tester.ensureVisible(destination);
+      await tester.tap(destination);
+      await tester.pump();
+
+      var workspace = tester.widget<Revision3TestReleaseWorkspace>(
+        find.byType(Revision3TestReleaseWorkspace),
+      );
+      expect(
+        workspace.dataAssets.state,
+        Revision3TestReleaseCheckState.checking,
+      );
+      expect(workspace.dataAssets.evidence, isNull);
+      expect(managed.projectBuildPlanCalls, 1);
+
+      planned.complete(
+        _readyDataAssetProjectBuildPlanResult(
+          head: managed.head,
+          fixture: fixture,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      workspace = tester.widget<Revision3TestReleaseWorkspace>(
+        find.byType(Revision3TestReleaseWorkspace),
+      );
+      expect(workspace.dataAssets.state, Revision3TestReleaseCheckState.passed);
+      expect(
+        workspace.dataAssets.evidence?.scope,
+        Revision3TestReleaseEvidenceScope.dataAssets,
+      );
+      expect(workspace.dataAssets.evidence?.projectId, fixture.projectId);
+      expect(
+        workspace.dataAssets.evidence?.projectRevision,
+        fixture.projectRevision,
+      );
+      expect(
+        workspace.dataAssets.evidence?.checkpointIdentity,
+        managed.head.canonicalJson,
+      );
+      expect(workspace.dataAssets.evidence?.summary, 'DataAssets: Checked');
+      expect(managed.projectBuildPlanCalls, 1);
+      expect(workspace.playableBuild.evidence, isNull);
+      expect(workspace.deployment.evidence, isNull);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('DataAssets check makes a mismatched plan unavailable', (
+    tester,
+  ) async {
+    await _setDesktopTestSurface(tester);
+    final fixture = revision3ProjectProblemsRetainedDataAssetFixture(
+      projectRevision: 8,
+    );
+    final managed = _FakeProjectBuildPlanManagedLease(
+      root: Directory(r'C:\mods\dataassets-status-mismatch'),
+      projectId: fixture.projectId,
+      projectRevision: fixture.projectRevision,
+      head: _head(fixture.projectRevision),
+      contentIndexBuilder: (_) => fixture.contentIndex,
+      onDataAssetList: (_) => fixture.dataAssetStages,
+      onProjectBuildPlan: (_) => _readyDataAssetProjectBuildPlanResult(
+        head: _head(fixture.projectRevision + 1),
+        fixture: fixture,
+      ),
+    );
+    final coordinator = CurrentProjectCoordinator(
+      openManagedRevision3: (_) async => managed,
+    );
+    await coordinator.openManagedRevision3(managed.root);
+    final container = _container(
+      coordinator: coordinator,
+      pickManaged: (_) async => null,
+    );
+    addTearDown(container.dispose);
+
+    await _pumpApp(tester, container);
+    await tester.pumpAndSettle();
+    await _navigateManagedTestRelease(tester);
+
+    final workspace = tester.widget<Revision3TestReleaseWorkspace>(
+      find.byType(Revision3TestReleaseWorkspace),
+    );
+    expect(
+      workspace.dataAssets.state,
+      Revision3TestReleaseCheckState.unavailable,
+    );
+    expect(workspace.dataAssets.evidence, isNull);
+    expect(managed.projectBuildPlanCalls, 1);
+    expect(workspace.playableBuild.evidence, isNull);
+    expect(workspace.deployment.evidence, isNull);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'DataAssets check clears evidence across same-revision head drift',
+    (tester) async {
+      await _setDesktopTestSurface(tester);
+      final fixture = revision3ProjectProblemsRetainedDataAssetFixture(
+        projectRevision: 8,
+      );
+      final replacementLoad =
+          Completer<AuthoringRevision3ProjectBuildPlanResult>();
+      var delayReplacement = false;
+      final managed = _FakeProjectBuildPlanManagedLease(
+        root: Directory(r'C:\mods\dataassets-status-head-drift'),
+        projectId: fixture.projectId,
+        projectRevision: fixture.projectRevision,
+        head: _head(fixture.projectRevision),
+        contentIndexBuilder: (_) => fixture.contentIndex,
+        onDataAssetList: (_) => fixture.dataAssetStages,
+        onProjectBuildPlan: (lease) => delayReplacement
+            ? replacementLoad.future
+            : _readyDataAssetProjectBuildPlanResult(
+                head: lease.head,
+                fixture: fixture,
+              ),
+      );
+      final coordinator = CurrentProjectCoordinator(
+        openManagedRevision3: (_) async => managed,
+      );
+      await coordinator.openManagedRevision3(managed.root);
+      final container = _container(
+        coordinator: coordinator,
+        pickManaged: (_) async => null,
+      );
+      addTearDown(container.dispose);
+
+      await _pumpApp(tester, container);
+      await tester.pumpAndSettle();
+      await _navigateManagedTestRelease(tester);
+      var workspace = tester.widget<Revision3TestReleaseWorkspace>(
+        find.byType(Revision3TestReleaseWorkspace),
+      );
+      expect(workspace.dataAssets.state, Revision3TestReleaseCheckState.passed);
+      expect(managed.projectBuildPlanCalls, 1);
+
+      delayReplacement = true;
+      final replacementHead = _head(fixture.projectRevision + 1);
+      managed.head = replacementHead;
+      (coordinator as dynamic).state = ManagedRevision3CurrentProjectState(
+        root: managed.root,
+        projectId: managed.projectId,
+        projectRevision: managed.projectRevision,
+        head: replacementHead,
+        requiresReopen: false,
+      );
+      await tester.pump();
+      await tester.pump();
+
+      workspace = tester.widget<Revision3TestReleaseWorkspace>(
+        find.byType(Revision3TestReleaseWorkspace),
+      );
+      expect(
+        workspace.dataAssets.state,
+        Revision3TestReleaseCheckState.checking,
+      );
+      expect(workspace.dataAssets.evidence, isNull);
+      expect(managed.projectBuildPlanCalls, 2);
+
+      replacementLoad.complete(
+        _readyDataAssetProjectBuildPlanResult(
+          head: replacementHead,
+          fixture: fixture,
+        ),
+      );
+      await tester.pumpAndSettle();
+      workspace = tester.widget<Revision3TestReleaseWorkspace>(
+        find.byType(Revision3TestReleaseWorkspace),
+      );
+      expect(workspace.dataAssets.state, Revision3TestReleaseCheckState.passed);
+      expect(
+        workspace.dataAssets.evidence?.checkpointIdentity,
+        replacementHead.canonicalJson,
+      );
+      expect(managed.projectBuildPlanCalls, 2);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('DataAssets check replans after requires-reopen recovery', (
+    tester,
+  ) async {
+    await _setDesktopTestSurface(tester);
+    final fixture = revision3ProjectProblemsRetainedDataAssetFixture(
+      projectRevision: 8,
+    );
+    final managed = _FakeProjectBuildPlanManagedLease(
+      root: Directory(r'C:\mods\dataassets-status-reopen'),
+      projectId: fixture.projectId,
+      projectRevision: fixture.projectRevision,
+      head: _head(fixture.projectRevision),
+      contentIndexBuilder: (_) => fixture.contentIndex,
+      onDataAssetList: (_) => fixture.dataAssetStages,
+      onProjectBuildPlan: (lease) => _readyDataAssetProjectBuildPlanResult(
+        head: lease.head,
+        fixture: fixture,
+      ),
+    );
+    final coordinator = CurrentProjectCoordinator(
+      openManagedRevision3: (_) async => managed,
+    );
+    await coordinator.openManagedRevision3(managed.root);
+    final container = _container(
+      coordinator: coordinator,
+      pickManaged: (_) async => null,
+    );
+    addTearDown(container.dispose);
+
+    await _pumpApp(tester, container);
+    await tester.pumpAndSettle();
+    await _navigateManagedTestRelease(tester);
+    var workspace = tester.widget<Revision3TestReleaseWorkspace>(
+      find.byType(Revision3TestReleaseWorkspace),
+    );
+    expect(workspace.dataAssets.state, Revision3TestReleaseCheckState.passed);
+    expect(managed.projectBuildPlanCalls, 1);
+
+    managed.requiresReopenValue = true;
+    (coordinator as dynamic).state = ManagedRevision3CurrentProjectState(
+      root: managed.root,
+      projectId: managed.projectId,
+      projectRevision: managed.projectRevision,
+      head: managed.head,
+      requiresReopen: true,
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(Revision3TestReleaseWorkspace), findsNothing);
+    expect(managed.projectBuildPlanCalls, 1);
+
+    managed.requiresReopenValue = false;
+    (coordinator as dynamic).state = ManagedRevision3CurrentProjectState(
+      root: managed.root,
+      projectId: managed.projectId,
+      projectRevision: managed.projectRevision,
+      head: managed.head,
+      requiresReopen: false,
+    );
+    await tester.pumpAndSettle();
+    if (find.byType(Revision3TestReleaseWorkspace).evaluate().isEmpty) {
+      await _navigateManagedTestRelease(tester);
+    }
+    workspace = tester.widget<Revision3TestReleaseWorkspace>(
+      find.byType(Revision3TestReleaseWorkspace),
+    );
+    expect(workspace.dataAssets.state, Revision3TestReleaseCheckState.passed);
+    expect(
+      workspace.dataAssets.evidence?.scope,
+      Revision3TestReleaseEvidenceScope.dataAssets,
+    );
+    expect(managed.projectBuildPlanCalls, 2);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets(
     'build preview opens exact Voice problems without enabling release authority',
@@ -5946,6 +6249,25 @@ void main() {
     await tester.pumpAndSettle();
     await _navigateManagedTestRelease(tester);
     await tester.pumpAndSettle();
+
+    final statusWorkspace = tester.widget<Revision3TestReleaseWorkspace>(
+      find.byType(Revision3TestReleaseWorkspace),
+    );
+    expect(
+      statusWorkspace.dataAssets.state,
+      Revision3TestReleaseCheckState.needsAttention,
+    );
+    expect(
+      statusWorkspace.dataAssets.evidence?.scope,
+      Revision3TestReleaseEvidenceScope.dataAssets,
+    );
+    expect(
+      statusWorkspace.dataAssets.evidence?.summary,
+      'DataAssets: Needs attention',
+    );
+    expect(managed.projectBuildPlanCalls, 1);
+    expect(statusWorkspace.playableBuild.evidence, isNull);
+    expect(statusWorkspace.deployment.evidence, isNull);
 
     final panel = tester.widget<Revision3ProjectBuildPlanPanel>(
       find.byType(Revision3ProjectBuildPlanPanel),
@@ -19487,6 +19809,22 @@ AuthoringRevision3ProjectBuildPlanResult
 _blockedDataAssetProjectBuildPlanResult({
   required AuthoringWorkingHead head,
   required Revision3ProjectProblemsFixture fixture,
+}) => _dataAssetProjectBuildPlanResult(
+  head: head,
+  fixture: fixture,
+  ready: false,
+);
+
+AuthoringRevision3ProjectBuildPlanResult _readyDataAssetProjectBuildPlanResult({
+  required AuthoringWorkingHead head,
+  required Revision3ProjectProblemsFixture fixture,
+}) =>
+    _dataAssetProjectBuildPlanResult(head: head, fixture: fixture, ready: true);
+
+AuthoringRevision3ProjectBuildPlanResult _dataAssetProjectBuildPlanResult({
+  required AuthoringWorkingHead head,
+  required Revision3ProjectProblemsFixture fixture,
+  required bool ready,
 }) {
   final stage = fixture.dataAssetStage!;
   final projectJson = jsonEncode(<String, Object?>{
@@ -19548,26 +19886,32 @@ _blockedDataAssetProjectBuildPlanResult({
     ])
       <String, Object?>{
         'domain': domain,
-        'status': domain == 'data_assets' ? 'blocked' : 'not_present',
+        'status': domain == 'data_assets'
+            ? ready
+                  ? 'ready'
+                  : 'blocked'
+            : 'not_present',
         'content_count': domain == 'data_assets' ? 1 : 0,
-        'ready_count': 0,
-        'blocked_count': domain == 'data_assets' ? 1 : 0,
+        'ready_count': domain == 'data_assets' && ready ? 1 : 0,
+        'blocked_count': domain == 'data_assets' && !ready ? 1 : 0,
       },
   ];
-  final blockers = <Object?>[
-    <String, Object?>{
-      'category': 'author_project',
-      'domain': 'data_assets',
-      'reason': 'data_asset_selector_mismatch',
-      'affected_count': 1,
-    },
-  ];
+  final blockers = ready
+      ? <Object?>[]
+      : <Object?>[
+          <String, Object?>{
+            'category': 'author_project',
+            'domain': 'data_assets',
+            'reason': 'data_asset_selector_mismatch',
+            'affected_count': 1,
+          },
+        ];
   final projection = <String, Object?>{
     'format': 'gore.authoring.revision3-project-build-plan.v1',
     'schema_revision': 1,
     'project_id': fixture.projectId,
     'project_revision': fixture.projectRevision,
-    'outcome': 'blocked',
+    'outcome': ready ? 'coverage_complete' : 'blocked',
     'production_content_count': 1,
     'input_seal': inputSeal,
     'domains': domains,
@@ -19587,7 +19931,7 @@ _blockedDataAssetProjectBuildPlanResult({
         'schema_revision': 1,
         'project_id': fixture.projectId,
         'project_revision': fixture.projectRevision,
-        'outcome': 'blocked',
+        'outcome': ready ? 'coverage_complete' : 'blocked',
         'production_content_count': 1,
         'input_seal': inputSeal,
         'plan_seal': seal(utf8.encode(jsonEncode(projection))),

--- a/apps/mod-studio/test/l10n/revision3_test_release_localizations_test.dart
+++ b/apps/mod-studio/test/l10n/revision3_test_release_localizations_test.dart
@@ -193,10 +193,13 @@ const _dataAssetsBoundaryMarkers = <String, List<String>>{
     'изменения игры или сохранений, поведение во время выполнения и содержимое '
         'мира.',
   ],
+  // The generic `zh` locale carries Simplified, the same as `zh-Hans` and as every neighbouring
+  // string in app_zh.arb. It briefly carried Traditional here, which made this one row read
+  // differently from the rest of the screen for anyone whose locale resolves to plain `zh`.
   'zh': <String>[
-    '僅檢查已由專案建置預覽驗證的精確目前暫存 DataAssets 領域。',
-    '不涵蓋新增或結構性資產、可遊玩檔案、安裝、部署',
-    '遊戲或存檔變更、執行階段行為或世界內容。',
+    '仅检查已由项目构建预览验证的精确当前暂存 DataAssets 领域。',
+    '不涵盖新增或结构性资产、可游玩文件、安装、部署',
+    '游戏或存档更改、运行时行为或世界内容。',
   ],
   'zh-Hans': <String>[
     '仅检查已由项目构建预览验证的精确当前暂存 DataAssets 领域。',

--- a/apps/mod-studio/test/l10n/revision3_test_release_localizations_test.dart
+++ b/apps/mod-studio/test/l10n/revision3_test_release_localizations_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/widgets.dart' show Locale;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gore_mod/l10n/app_localizations.dart';
 import 'package:gore_mod/l10n/app_localizations_de.dart';
@@ -114,6 +115,96 @@ const _requiredKeys = <String>{
   'managedProjectCommandBarBusyDisabledReason',
 };
 
+const _dataAssetsBoundaryMarkers = <String, List<String>>{
+  'de': <String>[
+    'Prüft nur den exakten aktuellen Bereich bereits vorgemerkter DataAssets, '
+        'den die Projekt-Bauvorschau verifiziert hat.',
+    'Neue oder strukturelle Assets, spielbare Dateien, Installation, '
+        'Bereitstellung',
+    'Spiel- oder Spielstandsänderungen, Laufzeitverhalten und Weltinhalte sind '
+        'nicht abgedeckt.',
+  ],
+  'en': <String>[
+    'Checks only the exact current staged DataAssets domain already verified '
+        'by Project build preview.',
+    'It does not cover new or structural assets, playable files, installation, '
+        'deployment',
+    'game or save changes, runtime behavior, or World content.',
+  ],
+  'es': <String>[
+    'Comprueba solo el dominio exacto actual de DataAssets preparados que ya '
+        'verificó la vista previa de compilación del proyecto.',
+    'No cubre recursos nuevos o estructurales, archivos jugables, instalación, '
+        'despliegue',
+    'cambios en el juego o partidas guardadas, comportamiento en ejecución ni '
+        'contenido del mundo.',
+  ],
+  'fr': <String>[
+    'Vérifie uniquement le domaine exact et actuel des DataAssets préparés, '
+        'déjà validé par l’aperçu de build du projet.',
+    'Cela ne couvre pas les ressources nouvelles ou structurelles, les fichiers '
+        'jouables, l’installation, le déploiement',
+    'les modifications du jeu ou des fichiers de sauvegarde, le comportement '
+        'à l’exécution ni le contenu du monde.',
+  ],
+  'it': <String>[
+    'Controlla solo il dominio esatto e corrente dei DataAsset preparati, già '
+        "verificato dall'anteprima build del progetto.",
+    'Non copre asset nuovi o strutturali, file giocabili, installazione, '
+        'distribuzione',
+    'modifiche al gioco o ai file di salvataggio, comportamento in esecuzione '
+        'o contenuti del mondo.',
+  ],
+  'ja': <String>[
+    'プロジェクトのビルドプレビューで検証済みの、現在の正確なステージ済み DataAssets ドメインだけを確認します。',
+    '新規または構造的なアセット、プレイ可能ファイル、インストール、デプロイ',
+    'ゲームやセーブの変更、実行時の挙動、World コンテンツは対象外です。',
+  ],
+  'pl': <String>[
+    'Sprawdza wyłącznie dokładny, bieżący obszar przygotowanych zasobów '
+        'DataAssets, który został już zweryfikowany przez podgląd kompilacji '
+        'projektu.',
+    'Nie obejmuje nowych ani strukturalnych zasobów, plików grywalnych, '
+        'instalacji, wdrażania',
+    'zmian w grze lub zapisach, działania w czasie wykonywania ani zawartości '
+        'świata.',
+  ],
+  'pt': <String>[
+    'Verifica apenas o domínio DataAssets preparado, exato e atual, já validado '
+        'pela pré-visualização da compilação do projeto.',
+    'Não abrange recursos novos ou estruturais, ficheiros jogáveis, instalação, '
+        'distribuição',
+    'alterações ao jogo ou aos ficheiros guardados, comportamento em execução '
+        'nem conteúdo do mundo.',
+  ],
+  'pt-BR': <String>[
+    'Verifica somente o domínio DataAssets preparado, exato e atual, já '
+        'validado pela prévia da compilação do projeto.',
+    'Não abrange assets novos ou estruturais, arquivos jogáveis, instalação, '
+        'implantação',
+    'alterações no jogo ou em saves, comportamento em execução nem conteúdo de '
+        'mundo.',
+  ],
+  'ru': <String>[
+    'Проверяет только точный текущий домен подготовленных DataAssets, уже '
+        'подтверждённый предварительным просмотром сборки проекта.',
+    'Проверка не охватывает новые или структурные ресурсы, игровые файлы, '
+        'установку, развёртывание',
+    'изменения игры или сохранений, поведение во время выполнения и содержимое '
+        'мира.',
+  ],
+  'zh': <String>[
+    '僅檢查已由專案建置預覽驗證的精確目前暫存 DataAssets 領域。',
+    '不涵蓋新增或結構性資產、可遊玩檔案、安裝、部署',
+    '遊戲或存檔變更、執行階段行為或世界內容。',
+  ],
+  'zh-Hans': <String>[
+    '仅检查已由项目构建预览验证的精确当前暂存 DataAssets 领域。',
+    '不涵盖新增或结构性资产、可游玩文件、安装、部署',
+    '游戏或存档更改、运行时行为或世界内容。',
+  ],
+};
+
 void main() {
   test(
     'every shipped locale owns the complete Test & Release copy contract',
@@ -158,7 +249,11 @@ void main() {
   test(
     'generated localizations expose the complete contract for every locale',
     () {
-      expect(AppLocalizations.supportedLocales, hasLength(_arbFiles.length));
+      final localeTags = AppLocalizations.supportedLocales
+          .map((locale) => locale.toLanguageTag())
+          .toList(growable: false);
+      expect(localeTags, unorderedEquals(_dataAssetsBoundaryMarkers.keys));
+      expect(localeTags.map(_arbFileForLocaleTag), unorderedEquals(_arbFiles));
 
       for (final locale in AppLocalizations.supportedLocales) {
         final l10n = lookupAppLocalizations(locale);
@@ -175,7 +270,50 @@ void main() {
           allOf(contains('My Mod'), contains('Story')),
           reason: '$locale: orientation substitutions',
         );
+        final localeTag = locale.toLanguageTag();
+        final markers = _dataAssetsBoundaryMarkers[localeTag];
+        expect(markers, isNotNull, reason: '$locale: boundary markers');
+        final arb =
+            (jsonDecode(
+                      File(
+                        'lib/l10n/${_arbFileForLocaleTag(localeTag)}',
+                      ).readAsStringSync(),
+                    )
+                    as Map)
+                .cast<String, Object?>();
+        final generatedDescription =
+            l10n.managedTestReleaseDataAssetsDescription;
+        expect(
+          generatedDescription,
+          arb['managedTestReleaseDataAssetsDescription'],
+          reason: '$localeTag: generated/ARB drift',
+        );
+        for (final marker in markers!) {
+          expect(
+            generatedDescription,
+            contains(marker),
+            reason: '$localeTag: DataAssets boundary marker "$marker"',
+          );
+        }
       }
+
+      expect(
+        lookupAppLocalizations(const Locale('pt', 'BR')).localeName,
+        'pt_BR',
+      );
+      expect(lookupAppLocalizations(const Locale('pt', 'PT')).localeName, 'pt');
+      expect(
+        lookupAppLocalizations(
+          const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'),
+        ).localeName,
+        'zh_Hans',
+      );
+      expect(
+        lookupAppLocalizations(
+          const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
+        ).localeName,
+        'zh',
+      );
     },
   );
 
@@ -277,6 +415,60 @@ void main() {
       ),
     );
   });
+
+  test('DataAssets row copy bounds only the exact staged preview domain', () {
+    final english = AppLocalizationsEn();
+    expect(
+      english.managedTestReleaseDataAssetsDescription,
+      allOf(
+        allOf(
+          contains('exact current staged DataAssets domain'),
+          contains('Project build preview'),
+          contains('new or structural assets'),
+          contains('playable files'),
+          contains('installation'),
+          contains('deployment'),
+        ),
+        allOf(
+          contains('game or save changes'),
+          contains('runtime behavior'),
+          contains('World content'),
+          isNot(contains('visible in Problems')),
+          isNot(contains('complete project-wide build evidence')),
+        ),
+      ),
+    );
+
+    final german = AppLocalizationsDe();
+    expect(
+      german.managedTestReleaseDataAssetsDescription,
+      allOf(
+        allOf(
+          contains('exakten aktuellen Bereich'),
+          contains('Projekt-Bauvorschau'),
+          contains('Neue oder strukturelle Assets'),
+          contains('spielbare Dateien'),
+          contains('Installation'),
+          contains('Bereitstellung'),
+        ),
+        allOf(
+          contains('Spiel- oder Spielstandsänderungen'),
+          contains('Laufzeitverhalten'),
+          contains('Weltinhalte'),
+          isNot(contains('Problemliste')),
+          isNot(contains('vollständigen projektweiten Build-Nachweis')),
+        ),
+      ),
+    );
+  });
+}
+
+String _arbFileForLocaleTag(String localeTag) {
+  return switch (localeTag) {
+    'pt-BR' => 'app_pt_BR.arb',
+    'zh-Hans' => 'app_zh_Hans.arb',
+    _ => 'app_$localeTag.arb',
+  };
 }
 
 List<String> _testReleaseStrings(AppLocalizations l10n) => <String>[

--- a/apps/mod-studio/test/project/revision3_project_build_plan_panel_test.dart
+++ b/apps/mod-studio/test/project/revision3_project_build_plan_panel_test.dart
@@ -10,6 +10,7 @@ import 'package:gore_mod/project/revision3_project_build_plan_panel.dart';
 import '../support/revision3_voice_fixture.dart';
 
 const _otherProjectId = '11111111111111111111111111111111';
+const _projectRoot = r'C:\managed\project-build-preview';
 const _stageMediaType =
     'application/vnd.gore.dataasset-fixed-leaf-stage+json;version=1';
 
@@ -62,6 +63,238 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(calls, 2);
+  });
+
+  testWidgets(
+    'publishes only the exact DataAssets domain without a second load',
+    (tester) async {
+      final fixture = _dataAssetBlockedFixture(readyCount: 1);
+      final completion = Completer<AuthoringRevision3ProjectBuildPlanResult>();
+      final controller = Revision3ProjectBuildPlanDataAssetsController();
+      addTearDown(controller.dispose);
+      var calls = 0;
+
+      await _pumpPanel(
+        tester,
+        fixture: fixture,
+        load: () {
+          calls++;
+          return completion.future;
+        },
+        dataAssetsController: controller,
+      );
+      await tester.pump();
+
+      expect(calls, 1);
+      expect(
+        controller.snapshot.state,
+        Revision3ProjectBuildPlanDataAssetsLoadState.loading,
+      );
+      expect(controller.snapshot.checkpoint, fixture.checkpoint);
+      expect(controller.snapshot.dataAssets, isNull);
+
+      completion.complete(fixture.result);
+      await tester.pumpAndSettle();
+
+      final dataAssets = controller.snapshot.dataAssets;
+      expect(calls, 1);
+      expect(
+        controller.snapshot.state,
+        Revision3ProjectBuildPlanDataAssetsLoadState.ready,
+      );
+      expect(
+        dataAssets?.domain,
+        AuthoringRevision3ProjectBuildDomain.dataAssets,
+      );
+      expect(
+        dataAssets?.status,
+        AuthoringRevision3ProjectBuildDomainStatus.ready,
+      );
+      expect(dataAssets?.contentCount, 1);
+      expect(dataAssets?.readyCount, 1);
+      expect(dataAssets?.blockedCount, 0);
+    },
+  );
+
+  testWidgets('refresh clears DataAssets evidence before failure and retry', (
+    tester,
+  ) async {
+    final fixture = _dataAssetBlockedFixture();
+    final failedRefresh = Completer<AuthoringRevision3ProjectBuildPlanResult>();
+    final controller = Revision3ProjectBuildPlanDataAssetsController();
+    addTearDown(controller.dispose);
+    var calls = 0;
+
+    await _pumpPanel(
+      tester,
+      fixture: fixture,
+      dataAssetsController: controller,
+      load: () {
+        calls++;
+        return switch (calls) {
+          1 || 3 => Future.value(fixture.result),
+          _ => failedRefresh.future,
+        };
+      },
+    );
+    await tester.pumpAndSettle();
+    expect(
+      controller.snapshot.state,
+      Revision3ProjectBuildPlanDataAssetsLoadState.ready,
+    );
+
+    await tester.tap(
+      find.byKey(const Key('revision3-project-build-plan-refresh')),
+    );
+    await tester.pump();
+    expect(calls, 2);
+    expect(
+      controller.snapshot.state,
+      Revision3ProjectBuildPlanDataAssetsLoadState.loading,
+    );
+    expect(controller.snapshot.dataAssets, isNull);
+
+    failedRefresh.completeError(StateError(r'C:\private\dataassets'));
+    await tester.pumpAndSettle();
+    expect(
+      controller.snapshot.state,
+      Revision3ProjectBuildPlanDataAssetsLoadState.unavailable,
+    );
+    expect(controller.snapshot.dataAssets, isNull);
+
+    await tester.tap(
+      find.byKey(const Key('revision3-project-build-plan-retry')),
+    );
+    await tester.pumpAndSettle();
+    expect(calls, 3);
+    expect(
+      controller.snapshot.state,
+      Revision3ProjectBuildPlanDataAssetsLoadState.ready,
+    );
+  });
+
+  testWidgets(
+    'observer replacement transfers current output without reloading',
+    (tester) async {
+      final fixture = _emptyFixture();
+      final first = Revision3ProjectBuildPlanDataAssetsController();
+      final second = Revision3ProjectBuildPlanDataAssetsController();
+      addTearDown(first.dispose);
+      addTearDown(second.dispose);
+      var observer = first;
+      var calls = 0;
+      late StateSetter updateHost;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                updateHost = setState;
+                return SingleChildScrollView(
+                  child: Revision3ProjectBuildPlanPanel(
+                    checkpoint: fixture.checkpoint,
+                    load: () async {
+                      calls++;
+                      return fixture.result;
+                    },
+                    dataAssetsController: observer,
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(calls, 1);
+      expect(
+        first.snapshot.state,
+        Revision3ProjectBuildPlanDataAssetsLoadState.ready,
+      );
+
+      updateHost(() => observer = second);
+      await tester.pumpAndSettle();
+
+      expect(calls, 1);
+      expect(
+        first.snapshot.state,
+        Revision3ProjectBuildPlanDataAssetsLoadState.detached,
+      );
+      expect(
+        second.snapshot.state,
+        Revision3ProjectBuildPlanDataAssetsLoadState.ready,
+      );
+      expect(second.snapshot.checkpoint, fixture.checkpoint);
+    },
+  );
+
+  testWidgets('root drift disposal and late completions fail closed', (
+    tester,
+  ) async {
+    final first = _emptyFixture(projectRoot: r'C:\managed\first');
+    final second = _emptyFixture(projectRoot: r'C:\managed\second');
+    final firstLoad = Completer<AuthoringRevision3ProjectBuildPlanResult>();
+    final secondLoad = Completer<AuthoringRevision3ProjectBuildPlanResult>();
+    final controller = Revision3ProjectBuildPlanDataAssetsController();
+    addTearDown(controller.dispose);
+    var current = first;
+    var calls = 0;
+    late StateSetter updateHost;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              updateHost = setState;
+              return Revision3ProjectBuildPlanPanel(
+                checkpoint: current.checkpoint,
+                load: () {
+                  calls++;
+                  return calls == 1 ? firstLoad.future : secondLoad.future;
+                },
+                dataAssetsController: controller,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(calls, 1);
+
+    updateHost(() => current = second);
+    await tester.pump();
+    expect(calls, 2);
+    expect(controller.snapshot.checkpoint?.projectRoot, r'C:\managed\second');
+    expect(
+      controller.snapshot.state,
+      Revision3ProjectBuildPlanDataAssetsLoadState.loading,
+    );
+
+    firstLoad.complete(first.result);
+    await tester.pump();
+    expect(
+      controller.snapshot.state,
+      Revision3ProjectBuildPlanDataAssetsLoadState.loading,
+    );
+    expect(controller.snapshot.checkpoint, second.checkpoint);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    expect(
+      controller.snapshot.state,
+      Revision3ProjectBuildPlanDataAssetsLoadState.detached,
+    );
+
+    secondLoad.complete(second.result);
+    await tester.pump();
+    expect(
+      controller.snapshot.state,
+      Revision3ProjectBuildPlanDataAssetsLoadState.detached,
+    );
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('groups author blockers separately from toolkit gaps', (
@@ -579,7 +812,10 @@ void main() {
 
   testWidgets('rejects a result for another exact checkpoint', (tester) async {
     final fixture = _emptyFixture();
+    final controller = Revision3ProjectBuildPlanDataAssetsController();
+    addTearDown(controller.dispose);
     final wrongCheckpoint = Revision3ProjectBuildPlanCheckpoint(
+      projectRoot: fixture.checkpoint.projectRoot,
       projectId: _otherProjectId,
       projectRevision: 8,
       checkpointIdentity: fixture.head.canonicalJson,
@@ -590,6 +826,7 @@ void main() {
           body: Revision3ProjectBuildPlanPanel(
             checkpoint: wrongCheckpoint,
             load: () async => fixture.result,
+            dataAssetsController: controller,
           ),
         ),
       ),
@@ -601,6 +838,11 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('No production content yet'), findsNothing);
+    expect(
+      controller.snapshot.state,
+      Revision3ProjectBuildPlanDataAssetsLoadState.unavailable,
+    );
+    expect(controller.snapshot.dataAssets, isNull);
   });
 
   testWidgets('compact German panel is overflow-safe at 200 percent text', (
@@ -690,6 +932,7 @@ Future<void> _pumpPanel(
   required Revision3ProjectBuildPlanLoader load,
   Revision3ProjectBuildPlanOpenVoiceDetails? openVoiceDetails,
   Revision3ProjectBuildPlanOpenDataAssetDetails? openDataAssetDetails,
+  Revision3ProjectBuildPlanDataAssetsController? dataAssetsController,
 }) => tester.pumpWidget(
   MaterialApp(
     home: Scaffold(
@@ -699,6 +942,7 @@ Future<void> _pumpPanel(
           load: load,
           openVoiceDetails: openVoiceDetails,
           openDataAssetDetails: openDataAssetDetails,
+          dataAssetsController: dataAssetsController,
         ),
       ),
     ),
@@ -707,11 +951,13 @@ Future<void> _pumpPanel(
 
 final class _BuildPlanFixture {
   const _BuildPlanFixture({
+    required this.projectRoot,
     required this.projectJson,
     required this.head,
     required this.result,
   });
 
+  final String projectRoot;
   final String projectJson;
   final AuthoringWorkingHead head;
   final AuthoringRevision3ProjectBuildPlanResult result;
@@ -719,6 +965,7 @@ final class _BuildPlanFixture {
   Revision3ProjectBuildPlanCheckpoint get checkpoint {
     final project = (jsonDecode(projectJson) as Map).cast<String, Object?>();
     return Revision3ProjectBuildPlanCheckpoint(
+      projectRoot: projectRoot,
       projectId: project['project_id']! as String,
       projectRevision: project['revision']! as int,
       checkpointIdentity: head.canonicalJson,
@@ -726,10 +973,11 @@ final class _BuildPlanFixture {
   }
 }
 
-_BuildPlanFixture _emptyFixture() {
+_BuildPlanFixture _emptyFixture({String projectRoot = _projectRoot}) {
   final projectJson = revision3VoiceFixtureProjectJson();
   return _fixture(
     projectJson: projectJson,
+    projectRoot: projectRoot,
     domainCounts: const <String, ({int ready, int blocked})>{},
     blockers: const <Map<String, Object?>>[],
   );
@@ -886,7 +1134,7 @@ _BuildPlanFixture _dataAssetBlockedFixture({
   if (toolkitBlocker && stageCount != 1) {
     throw ArgumentError.value(stageCount, 'stageCount');
   }
-  if (readyCount < 0 || readyCount >= stageCount) {
+  if (readyCount < 0 || readyCount > stageCount) {
     throw ArgumentError.value(readyCount, 'readyCount');
   }
   final blockedCount = stageCount - readyCount;
@@ -901,7 +1149,9 @@ _BuildPlanFixture _dataAssetBlockedFixture({
     };
   }
   project['asset_store'] = <String, Object?>{'assets': assets};
-  final blockers = toolkitBlocker
+  final blockers = blockedCount == 0
+      ? const <Map<String, Object?>>[]
+      : toolkitBlocker
       ? const <Map<String, Object?>>[
           <String, Object?>{
             'category': 'toolkit_support',
@@ -938,6 +1188,7 @@ _BuildPlanFixture _fixture({
   required String projectJson,
   required Map<String, ({int ready, int blocked})> domainCounts,
   required List<Map<String, Object?>> blockers,
+  String projectRoot = _projectRoot,
 }) {
   final project = (jsonDecode(projectJson) as Map).cast<String, Object?>();
   final assetStore = (project['asset_store']! as Map).cast<String, Object?>();
@@ -1046,6 +1297,7 @@ _BuildPlanFixture _fixture({
     },
   };
   return _BuildPlanFixture(
+    projectRoot: projectRoot,
     projectJson: projectJson,
     head: head,
     result: AuthoringRevision3ProjectBuildPlanResult.fromJson(


### PR DESCRIPTION
## Summary

- Reflect the exact current DataAssets domain from the already-mounted Project build preview in Test & Release.
- Reuse the existing planner output through a narrow immutable observer; no second planning pass is introduced.
- Bind observations to root, project, revision, and head, and clear stale evidence across loading, refresh, replacement, recovery, drift, failure, and disposal.
- Map ready/not-present to checked, blocked to needs attention, and mismatched or unavailable output fail-closed.
- Harden boundary copy across all 12 locales, including generated-getter/ARB consistency and pt/zh fallback coverage.

## Evidence boundary

The row proves only the exact staged DataAssets domain already verified by Project build preview. Its evidence scope is DataAssets only.

It does not grant or imply authority or qualification for new or structural assets, playable files, build output, installation, deployment, game or save changes, runtime behavior, or World content. No game, save, installation, deployment, or runtime action is performed.

## Validation

- Full post-rebase Flutter suite: 2,364 passed, 1 expected environment-gated skip, 0 failed
- Home integration suite: 149 passed
- Build-plan panel and localization suites: 25 passed
- Test & Release workspace suite: 7 passed
- Final 12-locale contract suite after copy corrections: 5 passed
- flutter analyze --no-pub: no issues
- git diff --check: clean
- Independent architecture review and final commit audit: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and readiness signaling only; no build, deploy, or game/save mutations. Risk is mainly showing wrong check state if observer binding regresses—covered by new integration and panel tests.
> 
> **Overview**
> **Test & Release** now drives the **DataAssets** row from the same **Project build preview** planner output as the build-preview panel, instead of a static “not evaluated” placeholder.
> 
> A **`Revision3ProjectBuildPlanDataAssetsController`** observes the mounted **`Revision3ProjectBuildPlanPanel`** (no second plan load) and publishes a narrow DataAssets snapshot. **`Revision3ProjectBuildPlanCheckpoint`** gains **`projectRoot`** so evidence stays tied to root, project, revision, and head; stale output is cleared on load, refresh, detach, and checkpoint drift. Status maps to **passed** / **needs attention** / **checking** / **unavailable** with optional **`Revision3TestReleaseEvidence`** for the DataAssets scope.
> 
> **`managedTestReleaseDataAssetsDescription`** is updated in all shipped locales to state the bounded preview-only scope. Integration, panel, and localization tests cover the new behavior and copy contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a611ff52db128cf771efa3fa1dae19fbea27577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->