### PR TITLE
fix(manager): bind deployment status

### DIFF
--- a/apps/mod-manager/lib/home_page.dart
+++ b/apps/mod-manager/lib/home_page.dart
@@ -399,12 +399,17 @@ class _ModsTab extends ConsumerWidget {
 
     // Apply is enabled when the enabled loadout differs from what's deployed —
     // including the first-ever deploy (nothing_deployed + >=1 enabled mod).
+    final statusForCurrentRoot = status.statusRoot == gameRoot
+        ? status.status
+        : null;
+    final studioActiveForCurrentRoot =
+        status.gameRoot == gameRoot && status.studioActive;
     final applyEnabled = canApply(
-      status.status,
+      statusForCurrentRoot,
       library,
       gameRoot != null,
       status.busy,
-      status.studioActive,
+      studioActiveForCurrentRoot,
       statusError: status.error,
     );
 
@@ -458,6 +463,7 @@ class _ModsTab extends ConsumerWidget {
               const SizedBox(width: 12),
               _StatusChip(
                 state: status,
+                currentRoot: gameRoot,
                 onStudioTap: operationsBusy || gameRoot == null
                     ? null
                     : () => _promptTakeOver(context, ref),
@@ -616,11 +622,13 @@ enum _OverflowAction { refresh, undeployAll }
 class _StatusChip extends StatelessWidget {
   const _StatusChip({
     required this.state,
+    required this.currentRoot,
     required this.onStudioTap,
     required this.onRecoveryTap,
   });
 
   final StatusState state;
+  final String? currentRoot;
   final VoidCallback? onStudioTap;
   final VoidCallback? onRecoveryTap;
 
@@ -628,12 +636,16 @@ class _StatusChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final scheme = Theme.of(context).colorScheme;
-    final status = state.status;
+    // Even before the path-change listener starts a refresh, never display
+    // authority that belongs to another game installation.
+    final rootMatches = state.statusRoot == currentRoot;
+    final status = rootMatches ? state.status : null;
 
     // studioActive (from a blocked apply) also surfaces the studio chip even
     // if mgr_status hasn't been re-read as studio_deploy_active yet.
     final isStudio =
-        status is ManagerStatusStudioDeployActive || state.studioActive;
+        status is ManagerStatusStudioDeployActive ||
+        (state.gameRoot == currentRoot && state.studioActive);
 
     final (String label, Color bg, Color fg, IconData icon) = switch (status) {
       ManagerStatusInSync() => (
@@ -679,10 +691,10 @@ class _StatusChip extends StatelessWidget {
         Icons.lock_outline,
       ),
       _ => (
-        l10n.statusNothingDeployed,
+        l10n.statusUnknown,
         scheme.surfaceContainerHighest,
         scheme.onSurfaceVariant,
-        Icons.circle_outlined,
+        Icons.help_outline,
       ),
     };
 

--- a/apps/mod-manager/lib/l10n/app_de.arb
+++ b/apps/mod-manager/lib/l10n/app_de.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "de",
+  "statusUnknown": "Unbekannt",
   "recoveryAction": "Wiederherstellen",
   "recoveryRequiredConfirm": "Unterbrochene Bereitstellung wiederherstellen und alle teilweise bereitgestellten Dateien entfernen?",
   "statusRecoveryRequired": "Wiederherstellung erforderlich",

--- a/apps/mod-manager/lib/l10n/app_en.arb
+++ b/apps/mod-manager/lib/l10n/app_en.arb
@@ -1,5 +1,9 @@
 {
   "@@locale": "en",
+  "statusUnknown": "Unknown",
+  "@statusUnknown": {
+    "description": "Deployment status is unavailable or uses an unsupported future state."
+  },
   "recoveryAction": "Recover",
   "recoveryRequiredConfirm": "Recover the interrupted deployment and remove any partially deployed files?",
   "statusRecoveryRequired": "Recovery required",

--- a/apps/mod-manager/lib/l10n/app_es.arb
+++ b/apps/mod-manager/lib/l10n/app_es.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "es",
+  "statusUnknown": "Desconocido",
   "recoveryAction": "Recuperar",
   "recoveryRequiredConfirm": "¿Recuperar el despliegue interrumpido y eliminar los archivos desplegados parcialmente?",
   "statusRecoveryRequired": "Recuperación necesaria",

--- a/apps/mod-manager/lib/l10n/app_fr.arb
+++ b/apps/mod-manager/lib/l10n/app_fr.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "fr",
+  "statusUnknown": "Inconnu",
   "recoveryAction": "Récupérer",
   "recoveryRequiredConfirm": "Récupérer le déploiement interrompu et supprimer les fichiers partiellement déployés ?",
   "statusRecoveryRequired": "Récupération requise",

--- a/apps/mod-manager/lib/l10n/app_it.arb
+++ b/apps/mod-manager/lib/l10n/app_it.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "it",
+  "statusUnknown": "Sconosciuto",
   "recoveryAction": "Ripristina",
   "recoveryRequiredConfirm": "Ripristinare la distribuzione interrotta e rimuovere i file distribuiti parzialmente?",
   "statusRecoveryRequired": "Ripristino necessario",

--- a/apps/mod-manager/lib/l10n/app_ja.arb
+++ b/apps/mod-manager/lib/l10n/app_ja.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "ja",
+  "statusUnknown": "不明",
   "recoveryAction": "復旧",
   "recoveryRequiredConfirm": "中断されたデプロイを復旧し、部分的にデプロイされたファイルを削除しますか？",
   "statusRecoveryRequired": "復旧が必要",

--- a/apps/mod-manager/lib/l10n/app_localizations.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations.dart
@@ -116,6 +116,12 @@ abstract class AppLocalizations {
     Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'),
   ];
 
+  /// Deployment status is unavailable or uses an unsupported future state.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get statusUnknown;
+
   /// No description provided for @recoveryAction.
   ///
   /// In en, this message translates to:

--- a/apps/mod-manager/lib/l10n/app_localizations_de.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_de.dart
@@ -9,6 +9,9 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get statusUnknown => 'Unbekannt';
+
+  @override
   String get recoveryAction => 'Wiederherstellen';
 
   @override

--- a/apps/mod-manager/lib/l10n/app_localizations_en.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_en.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get statusUnknown => 'Unknown';
+
+  @override
   String get recoveryAction => 'Recover';
 
   @override

--- a/apps/mod-manager/lib/l10n/app_localizations_es.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_es.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get statusUnknown => 'Desconocido';
+
+  @override
   String get recoveryAction => 'Recuperar';
 
   @override

--- a/apps/mod-manager/lib/l10n/app_localizations_fr.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_fr.dart
@@ -9,6 +9,9 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get statusUnknown => 'Inconnu';
+
+  @override
   String get recoveryAction => 'Récupérer';
 
   @override

--- a/apps/mod-manager/lib/l10n/app_localizations_it.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_it.dart
@@ -9,6 +9,9 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get statusUnknown => 'Sconosciuto';
+
+  @override
   String get recoveryAction => 'Ripristina';
 
   @override

--- a/apps/mod-manager/lib/l10n/app_localizations_ja.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_ja.dart
@@ -9,6 +9,9 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
+  String get statusUnknown => '不明';
+
+  @override
   String get recoveryAction => '復旧';
 
   @override

--- a/apps/mod-manager/lib/l10n/app_localizations_pl.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_pl.dart
@@ -9,6 +9,9 @@ class AppLocalizationsPl extends AppLocalizations {
   AppLocalizationsPl([String locale = 'pl']) : super(locale);
 
   @override
+  String get statusUnknown => 'Nieznany';
+
+  @override
   String get recoveryAction => 'Odzyskaj';
 
   @override

--- a/apps/mod-manager/lib/l10n/app_localizations_pt.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_pt.dart
@@ -9,6 +9,9 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String get statusUnknown => 'Desconhecido';
+
+  @override
   String get recoveryAction => 'Recuperar';
 
   @override
@@ -257,6 +260,9 @@ class AppLocalizationsPt extends AppLocalizations {
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).
 class AppLocalizationsPtBr extends AppLocalizationsPt {
   AppLocalizationsPtBr() : super('pt_BR');
+
+  @override
+  String get statusUnknown => 'Desconhecido';
 
   @override
   String get recoveryAction => 'Recuperar';

--- a/apps/mod-manager/lib/l10n/app_localizations_ru.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_ru.dart
@@ -9,6 +9,9 @@ class AppLocalizationsRu extends AppLocalizations {
   AppLocalizationsRu([String locale = 'ru']) : super(locale);
 
   @override
+  String get statusUnknown => 'Неизвестно';
+
+  @override
   String get recoveryAction => 'Восстановить';
 
   @override

--- a/apps/mod-manager/lib/l10n/app_localizations_zh.dart
+++ b/apps/mod-manager/lib/l10n/app_localizations_zh.dart
@@ -9,6 +9,9 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get statusUnknown => '未知';
+
+  @override
   String get recoveryAction => '恢复';
 
   @override
@@ -250,6 +253,9 @@ class AppLocalizationsZh extends AppLocalizations {
 /// The translations for Chinese, using the Han script (`zh_Hans`).
 class AppLocalizationsZhHans extends AppLocalizationsZh {
   AppLocalizationsZhHans() : super('zh_Hans');
+
+  @override
+  String get statusUnknown => '未知';
 
   @override
   String get recoveryAction => '恢复';

--- a/apps/mod-manager/lib/l10n/app_pl.arb
+++ b/apps/mod-manager/lib/l10n/app_pl.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "pl",
+  "statusUnknown": "Nieznany",
   "recoveryAction": "Odzyskaj",
   "recoveryRequiredConfirm": "Odzyskać przerwane wdrożenie i usunąć częściowo wdrożone pliki?",
   "statusRecoveryRequired": "Wymagane odzyskiwanie",

--- a/apps/mod-manager/lib/l10n/app_pt.arb
+++ b/apps/mod-manager/lib/l10n/app_pt.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "pt",
+  "statusUnknown": "Desconhecido",
   "recoveryAction": "Recuperar",
   "recoveryRequiredConfirm": "Recuperar a implantação interrompida e remover os arquivos parcialmente implantados?",
   "statusRecoveryRequired": "Recuperação necessária",

--- a/apps/mod-manager/lib/l10n/app_pt_BR.arb
+++ b/apps/mod-manager/lib/l10n/app_pt_BR.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "pt_BR",
+  "statusUnknown": "Desconhecido",
   "recoveryAction": "Recuperar",
   "recoveryRequiredConfirm": "Recuperar a implantação interrompida e remover os arquivos parcialmente implantados?",
   "statusRecoveryRequired": "Recuperação necessária",

--- a/apps/mod-manager/lib/l10n/app_ru.arb
+++ b/apps/mod-manager/lib/l10n/app_ru.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "ru",
+  "statusUnknown": "Неизвестно",
   "recoveryAction": "Восстановить",
   "recoveryRequiredConfirm": "Восстановить прерванное развёртывание и удалить частично развёрнутые файлы?",
   "statusRecoveryRequired": "Требуется восстановление",

--- a/apps/mod-manager/lib/l10n/app_zh.arb
+++ b/apps/mod-manager/lib/l10n/app_zh.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "zh",
+  "statusUnknown": "未知",
   "recoveryAction": "恢复",
   "recoveryRequiredConfirm": "恢复中断的部署并移除已部分部署的文件吗？",
   "statusRecoveryRequired": "需要恢复",

--- a/apps/mod-manager/lib/l10n/app_zh_Hans.arb
+++ b/apps/mod-manager/lib/l10n/app_zh_Hans.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "zh_Hans",
+  "statusUnknown": "未知",
   "recoveryAction": "恢复",
   "recoveryRequiredConfirm": "恢复中断的部署并移除已部分部署的文件吗？",
   "statusRecoveryRequired": "需要恢复",

--- a/apps/mod-manager/lib/status/domain/status_notifier.dart
+++ b/apps/mod-manager/lib/status/domain/status_notifier.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/legacy.dart';
 
 import '../../core/mgr_ffi.dart';
@@ -9,16 +11,27 @@ import '../../library/domain/models.dart';
 class StatusState {
   const StatusState({
     this.status,
+    this.statusRoot,
+    this.gameRoot,
     this.busy = false,
     this.error,
     this.lastReport,
     this.studioActive = false,
   });
 
-  /// The parsed `mgr_status`, or null before the first successful refresh.
+  /// The parsed `mgr_status`, or null without current status authority.
   final ManagerStatusView? status;
 
-  /// True while an FFI call is in flight.
+  /// Exact game root for which [status] is authoritative.
+  ///
+  /// This is null whenever a refresh fails or a different root is selected.
+  final String? statusRoot;
+
+  /// Root selected for root-bound reports and transient operation evidence.
+  /// Unlike [statusRoot], this can remain set when status authority is absent.
+  final String? gameRoot;
+
+  /// True while any physical status read or the exclusive mutation is in flight.
   final bool busy;
 
   /// Message of the last failure (including "no game path"), or null.
@@ -27,12 +40,15 @@ class StatusState {
   /// Report from the last successful [StatusNotifier.apply].
   final ApplyReportView? lastReport;
 
-  /// True when the last apply was blocked by an active studio deployment
-  /// (FFI code `STUDIO_DEPLOY_ACTIVE`). Drives the take-over prompt.
+  /// True when a blocked apply or recognized status established Studio
+  /// ownership and current authority has not established a known non-studio
+  /// state. Drives the fail-closed take-over fallback.
   final bool studioActive;
 
   StatusState copyWith({
     ManagerStatusView? status,
+    String? statusRoot,
+    String? gameRoot,
     bool? busy,
     String? error,
     ApplyReportView? lastReport,
@@ -40,9 +56,13 @@ class StatusState {
     bool clearError = false,
     bool clearReport = false,
     bool clearStatus = false,
+    bool clearStatusRoot = false,
+    bool clearGameRoot = false,
   }) {
     return StatusState(
       status: clearStatus ? null : status ?? this.status,
+      statusRoot: clearStatusRoot ? null : statusRoot ?? this.statusRoot,
+      gameRoot: clearGameRoot ? null : gameRoot ?? this.gameRoot,
       busy: busy ?? this.busy,
       error: clearError ? null : error ?? this.error,
       lastReport: clearReport ? null : lastReport ?? this.lastReport,
@@ -51,96 +71,257 @@ class StatusState {
   }
 }
 
-/// Owns the deployment status and the apply/undeploy actions.
+class _QueuedRefresh {
+  _QueuedRefresh(this.gameRoot);
+
+  String? gameRoot;
+  final waiters = <Completer<void>>[];
+}
+
+/// Owns deployment status and the exclusive apply/undeploy mutation lane.
 class StatusNotifier extends StateNotifier<StatusState> {
   StatusNotifier(this._mgr) : super(const StatusState());
 
   final MgrFfi _mgr;
+  int _statusGeneration = 0;
+  String? _selectedRoot;
+  int _activeStatusReads = 0;
+  bool _mutationInFlight = false;
+  _QueuedRefresh? _queuedRefresh;
 
   /// Sentinel error set when refresh/apply is attempted without a game path.
   /// The UI maps it to the localized `errorSetGamePath`.
   static const noGamePath = 'NO_GAME_PATH';
 
-  /// Refresh `mgr_status`. A null [gameRoot] means the user hasn't set the
-  /// game path yet; that parks [noGamePath] in the error rather than calling
-  /// the FFI.
-  Future<void> refresh(String? gameRoot) async {
-    if (gameRoot == null) {
-      // Drop any prior status too, so the chip can't keep showing a stale
-      // "In sync" while the banner asks the user to set the game path.
-      state = state.copyWith(error: noGamePath, clearStatus: true);
-      return;
+  /// Refresh `mgr_status` for [gameRoot].
+  ///
+  /// Reads may overlap; only the newest generation for the currently selected
+  /// root can publish. During a native write, refreshes are coalesced behind
+  /// that write so a status read never observes a partial mutation.
+  Future<void> refresh(String? gameRoot) {
+    _selectRoot(gameRoot);
+    if (_mutationInFlight) {
+      _invalidateStatusReads();
+      if (gameRoot == null) {
+        state = state.copyWith(
+          error: noGamePath,
+          clearStatus: true,
+          clearStatusRoot: true,
+        );
+      } else {
+        state = state.copyWith(clearError: true);
+      }
+      _syncBusy();
+
+      final waiter = Completer<void>();
+      final queued = _queuedRefresh ??= _QueuedRefresh(gameRoot);
+      queued.gameRoot = gameRoot;
+      queued.waiters.add(waiter);
+      return waiter.future;
     }
-    await _run(() async {
-      final status = await _mgr.status(gameRoot);
-      // The fresh status is authoritative for whether a studio deploy is active
-      // (the `StudioDeployActive` variant drives the take-over chip). Clear the
-      // transient [studioActive] flag left by an earlier blocked apply so a
-      // later "no studio deploy" refresh can't keep the take-over prompt armed.
-      state = state.copyWith(status: status, studioActive: false);
-    });
+    return _runStatusRefresh(gameRoot);
   }
 
-  /// Apply the current loadout to [gameRoot], record the report, then refresh
-  /// status. If the apply is blocked by an active studio deployment, set
-  /// [StatusState.studioActive] instead of surfacing a raw error.
-  Future<void> apply(String gameRoot) async {
+  /// Apply the current loadout and establish status again before settling.
+  /// A second physical mutation is refused while this exclusive lane is busy.
+  Future<void> apply(String gameRoot) => _runMutation(
+    gameRoot,
+    clearStudioAtStart: true,
+    command: () => _mgr.apply(gameRoot),
+  );
+
+  /// Remove everything the manager deployed and establish status again before
+  /// settling. Shares the same exclusive physical mutation lane as [apply].
+  Future<void> undeployAll(String gameRoot) => _runMutation(
+    gameRoot,
+    command: () async {
+      await _mgr.undeployAll(gameRoot);
+      return null;
+    },
+  );
+
+  Future<void> _runStatusRefresh(
+    String? gameRoot, {
+    bool preserveExistingError = false,
+  }) async {
+    _selectRoot(gameRoot);
+    final generation = ++_statusGeneration;
+    if (gameRoot == null) {
+      state = state.copyWith(
+        error: noGamePath,
+        clearStatus: true,
+        clearStatusRoot: true,
+      );
+      _syncBusy();
+      return;
+    }
+
+    _activeStatusReads++;
+    final keepError = preserveExistingError && state.error != null;
+    state = state.copyWith(busy: true, clearError: !keepError);
+    try {
+      final status = await _mgr.status(gameRoot);
+      if (!_ownsStatusRead(generation, gameRoot)) return;
+      state = state.copyWith(
+        status: status,
+        statusRoot: gameRoot,
+        // Remember recognized Studio ownership across later unknown future
+        // states. Only a known non-studio state or root switch disproves it.
+        studioActive: switch (status) {
+          ManagerStatusStudioDeployActive() => true,
+          ManagerStatusUnknown() => state.studioActive,
+          _ => false,
+        },
+        clearError: !keepError,
+      );
+    } on Object catch (error) {
+      if (!_ownsStatusRead(generation, gameRoot)) return;
+      state = state.copyWith(
+        error: keepError ? null : _message(error),
+        clearStatus: true,
+        clearStatusRoot: true,
+      );
+    } finally {
+      _activeStatusReads--;
+      // Publication is generation-bound; the physical-read count is not. An
+      // older ignored read still blocks native writes until it settles.
+      _syncBusy();
+    }
+  }
+
+  Future<void> _runMutation(
+    String gameRoot, {
+    required Future<ApplyReportView?> Function() command,
+    bool clearStudioAtStart = false,
+  }) async {
+    // UI gates these calls already. This guard makes the native safety rule
+    // hold for direct/provider calls too: no overlapping physical writes, and
+    // no write starts while a status read is inspecting the install.
+    if (_mutationInFlight || _activeStatusReads > 0) return;
+
+    _selectRoot(gameRoot);
+    _invalidateStatusReads();
+    _mutationInFlight = true;
     state = state.copyWith(
       busy: true,
       clearError: true,
-      studioActive: false,
-      // Drop the previous apply's report up front: if this attempt fails, the
-      // banner must not keep showing a stale "Applied N mods" next to the error.
       clearReport: true,
+      clearStatus: true,
+      clearStatusRoot: true,
+      studioActive: clearStudioAtStart ? false : state.studioActive,
     );
+
+    ApplyReportView? report;
+    Object? commandError;
     try {
-      final report = await _mgr.apply(gameRoot);
-      state = state.copyWith(lastReport: report);
-      final status = await _mgr.status(gameRoot);
-      state = state.copyWith(status: status);
-    } on MgrFfiException catch (e) {
-      if (e.code == 'STUDIO_DEPLOY_ACTIVE') {
-        state = state.copyWith(studioActive: true, error: e.message);
-        // The install really has a studio deploy — re-query so `status` reflects
-        // StudioDeployActive (drives the chip + disables Apply) instead of a
-        // stale e.g. changes_pending that would keep Apply enabled.
-        try {
-          final status = await _mgr.status(gameRoot);
-          state = state.copyWith(status: status);
-        } on MgrFfiException {
-          // Best-effort; the studioActive flag still gates Apply.
-        }
-      } else {
-        state = state.copyWith(error: e.message);
+      report = await command();
+    } on Object catch (error) {
+      commandError = error;
+    }
+
+    // A native write can fail after touching disk. Always inspect the exact
+    // mutation root afterward; the command error remains the user-facing
+    // priority if this best-effort postflight also fails.
+    ManagerStatusView? postflightStatus;
+    Object? postflightError;
+    try {
+      postflightStatus = await _mgr.status(gameRoot);
+    } on Object catch (error) {
+      postflightError = error;
+    }
+
+    final queued = _queuedRefresh;
+    final stillSelected = _selectedRoot == gameRoot;
+    final studioBlocked =
+        commandError is MgrFfiException &&
+        commandError.code == 'STUDIO_DEPLOY_ACTIVE';
+    final unresolvedStudioEvidence = studioBlocked || state.studioActive;
+    final studioEvidenceAfterPostflight = switch (postflightStatus) {
+      ManagerStatusStudioDeployActive() => true,
+      ManagerStatusUnknown() ||
+      null => commandError != null && unresolvedStudioEvidence,
+      _ => false,
+    };
+
+    if (stillSelected) {
+      if (report != null && commandError == null) {
+        state = state.copyWith(lastReport: report);
       }
-    } finally {
-      state = state.copyWith(busy: false);
+
+      final priorityError = commandError ?? postflightError;
+      state = state.copyWith(
+        error: priorityError == null ? null : _message(priorityError),
+        clearError: priorityError == null,
+        studioActive: studioEvidenceAfterPostflight,
+      );
+
+      // A refresh explicitly requested during the write owns the next
+      // publication. Otherwise the mutation postflight establishes authority.
+      if (queued == null) {
+        if (postflightStatus == null) {
+          state = state.copyWith(clearStatus: true, clearStatusRoot: true);
+        } else {
+          state = state.copyWith(
+            status: postflightStatus,
+            statusRoot: gameRoot,
+          );
+        }
+      }
     }
-  }
 
-  /// Remove everything the manager deployed from [gameRoot], then refresh.
-  Future<void> undeployAll(String gameRoot) async {
-    await _run(() async {
-      await _mgr.undeployAll(gameRoot);
-      final status = await _mgr.status(gameRoot);
-      // Nothing is deployed anymore, so a prior "Applied N mods" report is stale.
-      state = state.copyWith(status: status, studioActive: false, clearReport: true);
-    });
-  }
+    _mutationInFlight = false;
+    if (queued == null) {
+      _syncBusy();
+      return;
+    }
 
-  Future<void> _run(Future<void> Function() body) async {
-    state = state.copyWith(busy: true, clearError: true);
+    _queuedRefresh = null;
     try {
-      await body();
-    } on MgrFfiException catch (e) {
-      state = state.copyWith(error: e.message);
+      await _runStatusRefresh(
+        queued.gameRoot,
+        preserveExistingError:
+            queued.gameRoot == gameRoot && commandError != null,
+      );
     } finally {
-      state = state.copyWith(busy: false);
+      for (final waiter in queued.waiters) {
+        if (!waiter.isCompleted) waiter.complete();
+      }
     }
   }
+
+  void _selectRoot(String? gameRoot) {
+    if (_selectedRoot == gameRoot) return;
+    _selectedRoot = gameRoot;
+    // Status, reports, and the transient studio flag are installation-bound.
+    state = state.copyWith(
+      clearStatus: true,
+      clearStatusRoot: true,
+      clearReport: true,
+      clearError: true,
+      studioActive: false,
+      gameRoot: gameRoot,
+      clearGameRoot: gameRoot == null,
+    );
+  }
+
+  void _invalidateStatusReads() {
+    _statusGeneration++;
+  }
+
+  bool _ownsStatusRead(int generation, String gameRoot) =>
+      generation == _statusGeneration && _selectedRoot == gameRoot;
+
+  void _syncBusy() {
+    final busy = _mutationInFlight || _activeStatusReads > 0;
+    if (state.busy != busy) state = state.copyWith(busy: busy);
+  }
+
+  String _message(Object error) =>
+      error is MgrFfiException ? error.message : error.toString();
 }
 
-final statusProvider =
-    StateNotifierProvider<StatusNotifier, StatusState>((ref) {
+final statusProvider = StateNotifierProvider<StatusNotifier, StatusState>((
+  ref,
+) {
   return StatusNotifier(ref.watch(mgrFfiProvider));
 });

--- a/apps/mod-manager/test/library/widgets_test.dart
+++ b/apps/mod-manager/test/library/widgets_test.dart
@@ -567,6 +567,10 @@ void main() {
       container.read(statusProvider).error,
       contains('status refresh failed'),
     );
+    expect(container.read(statusProvider).status, isNull);
+    expect(container.read(statusProvider).statusRoot, isNull);
+    expect(find.text(l10n.statusUnknown), findsOneWidget);
+    expect(find.text(l10n.statusNothingDeployed), findsNothing);
     expect(applyButton().onPressed, isNull);
     expect(
       core.calls.where((call) => call.command == 'mgr_status').length,
@@ -917,6 +921,74 @@ void main() {
       find.widgetWithText(FilledButton, l10n.actionApply),
     );
     expect(applyBtn.onPressed, isNotNull); // enabled
+  });
+
+  testWidgets('future deployment state is shown as Unknown and cannot Apply', (
+    tester,
+  ) async {
+    final exe = _makeGameExe();
+    final fake = FakeGoreCoreFfiService(
+      responses: {
+        'mgr_library_list': _libraryList(),
+        'mgr_analyze': {'ok': true, 'conflicts': []},
+        'mgr_status': {
+          'ok': true,
+          'status': {'state': 'future_manager_state'},
+        },
+      },
+    );
+    await tester.pumpWidget(_appWith(fake, exePath: exe));
+    await tester.pumpAndSettle();
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(l10n.statusUnknown), findsOneWidget);
+    expect(find.text(l10n.statusNothingDeployed), findsNothing);
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, l10n.actionApply),
+          )
+          .onPressed,
+      isNull,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('known non-studio postflight does not offer stale takeover', (
+    tester,
+  ) async {
+    final exe = _makeGameExe();
+    final fake = FakeGoreCoreFfiService(
+      responses: {
+        'mgr_library_list': _libraryList(),
+        'mgr_analyze': {'ok': true, 'conflicts': []},
+        'mgr_status': {
+          'ok': true,
+          'status': {'state': 'nothing_deployed'},
+        },
+        'mgr_apply': {
+          'ok': false,
+          'error': {
+            'code': 'STUDIO_DEPLOY_ACTIVE',
+            'message': 'studio owned the install during apply',
+          },
+        },
+      },
+    );
+    await tester.pumpWidget(_appWith(fake, exePath: exe));
+    await tester.pumpAndSettle();
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    await tester.tap(find.widgetWithText(FilledButton, l10n.actionApply));
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(HomePage)),
+    );
+    expect(container.read(statusProvider).studioActive, isFalse);
+    expect(find.text(l10n.statusNothingDeployed), findsOneWidget);
+    expect(find.text(l10n.statusStudioDeploy), findsNothing);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('conflict panel groups by target and bolds the winner', (

--- a/apps/mod-manager/test/status/status_notifier_test.dart
+++ b/apps/mod-manager/test/status/status_notifier_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gore_manager/core/core_service.dart';
 import 'package:gore_manager/core/mgr_ffi.dart';
@@ -7,21 +9,64 @@ import 'package:gore_manager/status/domain/status_notifier.dart';
 StatusNotifier _notifier(FakeGoreCoreFfiService fake) =>
     StatusNotifier(MgrFfi(fake));
 
+class _ControlledCore implements GoreCoreFfiService {
+  final requests =
+      <
+        ({
+          String command,
+          Map<String, Object?> payload,
+          Completer<Map<String, Object?>> response,
+        })
+      >[];
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  String get description => 'controlled-status-test';
+
+  @override
+  Future<Map<String, Object?>> execute(
+    String command, {
+    Map<String, Object?> payload = const {},
+  }) {
+    final response = Completer<Map<String, Object?>>();
+    requests.add((command: command, payload: payload, response: response));
+    return response.future;
+  }
+}
+
+Map<String, Object?> _statusResponse(String state) => {
+  'ok': true,
+  'status': {'state': state},
+};
+
+Map<String, Object?> _errorResponse(String message) => {
+  'ok': false,
+  'error': {'code': 'IO', 'message': message},
+};
+
+Future<void> _waitForRequests(_ControlledCore core, int count) async {
+  while (core.requests.length < count) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
 void main() {
   group('StatusNotifier.refresh', () {
-    test('null gameRoot records the set-path sentinel without calling FFI',
-        () async {
-      final fake = FakeGoreCoreFfiService(responses: const {});
-      final n = _notifier(fake);
-      await n.refresh(null);
-      expect(n.state.error, StatusNotifier.noGamePath);
-      expect(fake.calls, isEmpty);
-    });
+    test(
+      'null gameRoot records the set-path sentinel without calling FFI',
+      () async {
+        final fake = FakeGoreCoreFfiService(responses: const {});
+        final n = _notifier(fake);
+        await n.refresh(null);
+        expect(n.state.error, StatusNotifier.noGamePath);
+        expect(fake.calls, isEmpty);
+      },
+    );
 
     test('maps each state to its status variant', () async {
-      Future<ManagerStatusView?> statusFor(
-        Map<String, Object?> status,
-      ) async {
+      Future<ManagerStatusView?> statusFor(Map<String, Object?> status) async {
         final fake = FakeGoreCoreFfiService(
           responses: {
             'mgr_status': {'ok': true, 'status': status},
@@ -59,27 +104,57 @@ void main() {
     });
 
     test('a successful refresh clears a stale studioActive flag', () async {
-      final fake = FakeGoreCoreFfiService(
-        responses: {
-          'mgr_apply': {
-            'ok': false,
-            'error': {'code': 'STUDIO_DEPLOY_ACTIVE', 'message': 'studio'},
-          },
-          'mgr_status': {
-            'ok': true,
-            'status': {'state': 'nothing_deployed'},
-          },
-        },
-      );
-      final n = _notifier(fake);
-      // A blocked apply arms studioActive.
-      await n.apply('C:/game');
+      final core = _ControlledCore();
+      final n = StatusNotifier(MgrFfi(core));
+
+      final apply = n.apply('C:/game');
+      core.requests.single.response.complete({
+        'ok': false,
+        'error': {'code': 'STUDIO_DEPLOY_ACTIVE', 'message': 'studio'},
+      });
+      await _waitForRequests(core, 2);
+      core.requests[1].response.complete(_errorResponse('status unavailable'));
+      await apply;
+      // A blocked apply with no usable postflight needs the transient fallback.
       expect(n.state.studioActive, isTrue);
+
       // A later refresh where the install has no studio deploy must disarm it,
       // or the take-over prompt stays wrongly available.
-      await n.refresh('C:/game');
+      final refresh = n.refresh('C:/game');
+      core.requests[2].response.complete(_statusResponse('nothing_deployed'));
+      await refresh;
       expect(n.state.studioActive, isFalse);
       expect(n.state.status, isA<ManagerStatusNothingDeployed>());
+    });
+
+    test('an unknown refresh preserves unresolved studio ownership', () async {
+      final core = _ControlledCore();
+      final n = StatusNotifier(MgrFfi(core));
+
+      final apply = n.apply('C:/game');
+      core.requests.single.response.complete({
+        'ok': false,
+        'error': {'code': 'STUDIO_DEPLOY_ACTIVE', 'message': 'studio'},
+      });
+      await _waitForRequests(core, 2);
+      core.requests[1].response.complete(_errorResponse('status unavailable'));
+      await apply;
+      expect(n.state.studioActive, isTrue);
+
+      final confirmedRefresh = n.refresh('C:/game');
+      core.requests[2].response.complete({
+        'ok': true,
+        'status': {'state': 'studio_deploy_active', 'mod_name': 'Studio mod'},
+      });
+      await confirmedRefresh;
+      expect(n.state.studioActive, isTrue);
+
+      final unknownRefresh = n.refresh('C:/game');
+      core.requests[3].response.complete(_statusResponse('future_state'));
+      await unknownRefresh;
+
+      expect(n.state.status, isA<ManagerStatusUnknown>());
+      expect(n.state.studioActive, isTrue);
     });
 
     test('a null-root refresh clears a previously shown status', () async {
@@ -99,6 +174,93 @@ void main() {
       await n.refresh(null);
       expect(n.state.status, isNull);
       expect(n.state.error, StatusNotifier.noGamePath);
+    });
+
+    test(
+      'newer root wins when overlapping reads finish out of order',
+      () async {
+        final core = _ControlledCore();
+        final n = StatusNotifier(MgrFfi(core));
+
+        final first = n.refresh('C:/game-a');
+        final second = n.refresh('C:/game-b');
+        expect(core.requests, hasLength(2));
+
+        core.requests[1].response.complete(_statusResponse('changes_pending'));
+        await second;
+        expect(n.state.status, isA<ManagerStatusChangesPending>());
+        expect(n.state.statusRoot, 'C:/game-b');
+        expect(n.state.busy, isTrue);
+
+        // The old read is ignored for publication, but it is still physically
+        // inspecting native state and therefore blocks a write.
+        await n.apply('C:/game-b');
+        expect(core.requests, hasLength(2));
+
+        core.requests[0].response.complete(_statusResponse('in_sync'));
+        await first;
+        expect(n.state.status, isA<ManagerStatusChangesPending>());
+        expect(n.state.statusRoot, 'C:/game-b');
+        expect(n.state.error, isNull);
+        expect(n.state.busy, isFalse);
+      },
+    );
+
+    test('newer same-root read survives an older late failure', () async {
+      final core = _ControlledCore();
+      final n = StatusNotifier(MgrFfi(core));
+
+      final first = n.refresh('C:/game');
+      final second = n.refresh('C:/game');
+      core.requests[1].response.complete(_statusResponse('in_sync'));
+      await second;
+      expect(n.state.busy, isTrue);
+
+      core.requests[0].response.complete(_errorResponse('old failure'));
+      await first;
+      expect(n.state.status, isA<ManagerStatusInSync>());
+      expect(n.state.statusRoot, 'C:/game');
+      expect(n.state.error, isNull);
+      expect(n.state.busy, isFalse);
+    });
+
+    test('null root invalidates a still-pending response', () async {
+      final core = _ControlledCore();
+      final n = StatusNotifier(MgrFfi(core));
+
+      final pending = n.refresh('C:/game');
+      await n.refresh(null);
+      expect(n.state.status, isNull);
+      expect(n.state.statusRoot, isNull);
+      expect(n.state.error, StatusNotifier.noGamePath);
+      expect(n.state.busy, isTrue);
+
+      core.requests.single.response.complete(_statusResponse('in_sync'));
+      await pending;
+      expect(n.state.status, isNull);
+      expect(n.state.statusRoot, isNull);
+      expect(n.state.error, StatusNotifier.noGamePath);
+      expect(n.state.busy, isFalse);
+    });
+
+    test('failed refresh clears prior status authority', () async {
+      final core = _ControlledCore();
+      final n = StatusNotifier(MgrFfi(core));
+
+      final initial = n.refresh('C:/game');
+      core.requests.single.response.complete(
+        _statusResponse('changes_pending'),
+      );
+      await initial;
+      expect(n.state.statusRoot, 'C:/game');
+
+      final failed = n.refresh('C:/game');
+      core.requests[1].response.complete(_errorResponse('cannot inspect'));
+      await failed;
+      expect(n.state.status, isNull);
+      expect(n.state.statusRoot, isNull);
+      expect(n.state.error, contains('cannot inspect'));
+      expect(n.state.busy, isFalse);
     });
   });
 
@@ -134,8 +296,7 @@ void main() {
       expect(n.state.busy, isFalse);
     });
 
-    test('STUDIO_DEPLOY_ACTIVE sets the flag and re-queries studio status',
-        () async {
+    test('STUDIO_DEPLOY_ACTIVE re-queries and uses studio status', () async {
       final fake = FakeGoreCoreFfiService(
         responses: {
           'mgr_apply': {
@@ -155,11 +316,92 @@ void main() {
       );
       final n = _notifier(fake);
       await n.apply('C:/game');
+      // Preserve the explicit blocked-apply evidence even though this known
+      // status currently drives the same take-over action. A later Unknown
+      // refresh cannot otherwise retain that fail-closed fallback.
       expect(n.state.studioActive, isTrue);
       expect(n.state.error, contains('studio mod'));
       expect(n.state.status, isA<ManagerStatusStudioDeployActive>());
       expect(n.state.busy, isFalse);
     });
+
+    test(
+      'unknown refresh cannot erase a confirmed studio postflight',
+      () async {
+        final core = _ControlledCore();
+        final n = StatusNotifier(MgrFfi(core));
+
+        final apply = n.apply('C:/game');
+        core.requests.single.response.complete({
+          'ok': false,
+          'error': {'code': 'STUDIO_DEPLOY_ACTIVE', 'message': 'studio'},
+        });
+        await _waitForRequests(core, 2);
+        core.requests[1].response.complete({
+          'ok': true,
+          'status': {'state': 'studio_deploy_active', 'mod_name': 'Studio mod'},
+        });
+        await apply;
+        expect(n.state.studioActive, isTrue);
+
+        final refresh = n.refresh('C:/game');
+        core.requests[2].response.complete(_statusResponse('future_state'));
+        await refresh;
+
+        expect(n.state.status, isA<ManagerStatusUnknown>());
+        expect(n.state.statusRoot, 'C:/game');
+        expect(n.state.studioActive, isTrue);
+        expect(n.state.error, isNull);
+      },
+    );
+
+    test('known non-studio postflight clears transient studio block', () async {
+      final fake = FakeGoreCoreFfiService(
+        responses: {
+          'mgr_apply': {
+            'ok': false,
+            'error': {
+              'code': 'STUDIO_DEPLOY_ACTIVE',
+              'message': 'studio owned the install during apply',
+            },
+          },
+          'mgr_status': _statusResponse('nothing_deployed'),
+        },
+      );
+      final n = _notifier(fake);
+      await n.apply('C:/game');
+
+      expect(n.state.status, isA<ManagerStatusNothingDeployed>());
+      expect(n.state.statusRoot, 'C:/game');
+      expect(n.state.studioActive, isFalse);
+      expect(n.state.error, contains('studio owned'));
+    });
+
+    test(
+      'studio block remains root-bound when postflight status fails',
+      () async {
+        final fake = FakeGoreCoreFfiService(
+          responses: {
+            'mgr_apply': {
+              'ok': false,
+              'error': {
+                'code': 'STUDIO_DEPLOY_ACTIVE',
+                'message': 'studio still owns this install',
+              },
+            },
+            'mgr_status': _errorResponse('postflight unavailable'),
+          },
+        );
+        final n = _notifier(fake);
+        await n.apply('C:/game');
+
+        expect(n.state.gameRoot, 'C:/game');
+        expect(n.state.status, isNull);
+        expect(n.state.statusRoot, isNull);
+        expect(n.state.studioActive, isTrue);
+        expect(n.state.error, contains('studio still owns'));
+      },
+    );
 
     test('a non-studio error surfaces without the studio flag', () async {
       final fake = FakeGoreCoreFfiService(
@@ -176,10 +418,205 @@ void main() {
       expect(n.state.error, contains('disk full'));
       // A failed apply must not leave a stale success report behind.
       expect(n.state.lastReport, isNull);
+      expect(
+        fake.calls.map((call) => call.command),
+        containsAllInOrder(['mgr_apply', 'mgr_status']),
+      );
+    });
+
+    test(
+      'root switches coalesce behind apply and latest root wins publication',
+      () async {
+        final core = _ControlledCore();
+        final n = StatusNotifier(MgrFfi(core));
+
+        final apply = n.apply('C:/game-a');
+        expect(core.requests.single.command, 'mgr_apply');
+
+        final switchedToB = n.refresh('C:/game-b');
+        final switchedToC = n.refresh('C:/game-c');
+        // Both reads are held behind the physical write and coalesce to C.
+        expect(core.requests, hasLength(1));
+        expect(n.state.status, isNull);
+        expect(n.state.statusRoot, isNull);
+        expect(n.state.busy, isTrue);
+
+        core.requests[0].response.complete({
+          'ok': true,
+          'report': {
+            'applied': ['A'],
+            'warnings': <String>[],
+          },
+        });
+        await _waitForRequests(core, 2);
+        expect(core.requests[1].command, 'mgr_status');
+        expect(core.requests[1].payload['game_root'], 'C:/game-a');
+        core.requests[1].response.complete(_statusResponse('in_sync'));
+
+        await _waitForRequests(core, 3);
+        expect(core.requests[2].command, 'mgr_status');
+        expect(core.requests[2].payload['game_root'], 'C:/game-c');
+        core.requests[2].response.complete(_statusResponse('changes_pending'));
+        await Future.wait([apply, switchedToB, switchedToC]);
+
+        expect(n.state.status, isA<ManagerStatusChangesPending>());
+        expect(n.state.statusRoot, 'C:/game-c');
+        expect(n.state.lastReport, isNull);
+        expect(n.state.error, isNull);
+        expect(n.state.busy, isFalse);
+      },
+    );
+
+    test(
+      'queued unknown refresh preserves a known studio postflight fallback',
+      () async {
+        final core = _ControlledCore();
+        final n = StatusNotifier(MgrFfi(core));
+
+        final apply = n.apply('C:/game');
+        final queuedRefresh = n.refresh('C:/game');
+        core.requests.single.response.complete({
+          'ok': false,
+          'error': {'code': 'STUDIO_DEPLOY_ACTIVE', 'message': 'studio'},
+        });
+        await _waitForRequests(core, 2);
+        core.requests[1].response.complete({
+          'ok': true,
+          'status': {'state': 'studio_deploy_active', 'mod_name': 'Studio mod'},
+        });
+        await _waitForRequests(core, 3);
+        core.requests[2].response.complete(_statusResponse('future_state'));
+        await Future.wait([apply, queuedRefresh]);
+
+        expect(n.state.status, isA<ManagerStatusUnknown>());
+        expect(n.state.statusRoot, 'C:/game');
+        expect(n.state.studioActive, isTrue);
+        expect(n.state.error, contains('studio'));
+        expect(n.state.busy, isFalse);
+      },
+    );
+
+    test('apply and undeploy cannot overlap physical writes', () async {
+      final core = _ControlledCore();
+      final n = StatusNotifier(MgrFfi(core));
+
+      final apply = n.apply('C:/game');
+      await n.undeployAll('C:/game');
+      expect(
+        core.requests.where(
+          (request) =>
+              request.command == 'mgr_apply' ||
+              request.command == 'mgr_undeploy_all',
+        ),
+        hasLength(1),
+      );
+
+      core.requests.single.response.complete({
+        'ok': true,
+        'report': {'applied': <String>[], 'warnings': <String>[]},
+      });
+      await _waitForRequests(core, 2);
+      core.requests[1].response.complete(_statusResponse('in_sync'));
+      await apply;
+      expect(n.state.busy, isFalse);
+    });
+
+    test('successful apply with failed postflight clears authority', () async {
+      final fake = FakeGoreCoreFfiService(
+        responses: {
+          'mgr_apply': {
+            'ok': true,
+            'report': {
+              'applied': ['A'],
+              'warnings': <String>[],
+            },
+          },
+          'mgr_status': _errorResponse('postflight unavailable'),
+        },
+      );
+      final n = _notifier(fake);
+      await n.apply('C:/game');
+
+      expect(n.state.lastReport?.applied, ['A']);
+      expect(n.state.status, isNull);
+      expect(n.state.statusRoot, isNull);
+      expect(n.state.error, contains('postflight unavailable'));
+      expect(n.state.busy, isFalse);
     });
   });
 
   group('StatusNotifier.undeployAll', () {
+    test(
+      'failure still runs postflight and keeps command error priority',
+      () async {
+        final fake = FakeGoreCoreFfiService(
+          responses: {
+            'mgr_undeploy_all': _errorResponse('undeploy command failed'),
+            'mgr_status': _statusResponse('recovery_required'),
+          },
+        );
+        final n = _notifier(fake);
+        await n.undeployAll('C:/game');
+
+        expect(
+          fake.calls.map((call) => call.command),
+          containsAllInOrder(['mgr_undeploy_all', 'mgr_status']),
+        );
+        expect(n.state.error, contains('undeploy command failed'));
+        expect(n.state.status, isA<ManagerStatusRecoveryRequired>());
+        expect(n.state.statusRoot, 'C:/game');
+        expect(n.state.busy, isFalse);
+      },
+    );
+
+    for (final postflightState in ['studio_deploy_active', 'future_state']) {
+      test(
+        'failed undeploy preserves studio evidence through $postflightState',
+        () async {
+          final core = _ControlledCore();
+          final n = StatusNotifier(MgrFfi(core));
+
+          final initialRefresh = n.refresh('C:/game');
+          core.requests.single.response.complete({
+            'ok': true,
+            'status': {
+              'state': 'studio_deploy_active',
+              'mod_name': 'Studio mod',
+            },
+          });
+          await initialRefresh;
+          expect(n.state.studioActive, isTrue);
+
+          final undeploy = n.undeployAll('C:/game');
+          core.requests[1].response.complete(
+            _errorResponse('undeploy command failed'),
+          );
+          await _waitForRequests(core, 3);
+          core.requests[2].response.complete(
+            postflightState == 'studio_deploy_active'
+                ? {
+                    'ok': true,
+                    'status': {
+                      'state': postflightState,
+                      'mod_name': 'Studio mod',
+                    },
+                  }
+                : _statusResponse(postflightState),
+          );
+          await undeploy;
+
+          expect(n.state.studioActive, isTrue);
+          expect(n.state.error, contains('undeploy command failed'));
+
+          final unknownRefresh = n.refresh('C:/game');
+          core.requests[3].response.complete(_statusResponse('later_future'));
+          await unknownRefresh;
+          expect(n.state.status, isA<ManagerStatusUnknown>());
+          expect(n.state.studioActive, isTrue);
+        },
+      );
+    }
+
     test('undeploys then refreshes and clears the studio flag', () async {
       final fake = FakeGoreCoreFfiService(
         responses: {
@@ -205,7 +642,10 @@ void main() {
         responses: {
           'mgr_apply': {
             'ok': true,
-            'report': {'applied': ['A'], 'warnings': <String>[]},
+            'report': {
+              'applied': ['A'],
+              'warnings': <String>[],
+            },
           },
           'mgr_undeploy_all': {'ok': true, 'removed': 1},
           'mgr_status': {


### PR DESCRIPTION
## Summary
- bind `mgr_status` facts to the exact game root and discard stale generations
- serialize Apply/Undeploy and coalesce refreshes behind native writes
- recheck status after mutation errors and fail closed when current authority is unknown
- render future/null status as localized Unknown and preserve Studio takeover evidence until disproved

## Safety
- no real game operations were performed by tests
- Apply requires exact-root status plus the current authoritative library gates
- this slice changes only the Flutter Mod Manager

## Validation
- focused status tests: 24/24
- full Mod Manager suite: 115/115
- Flutter analyze clean
- Dart format check clean
- all 12 ARBs have 74-key parity
- four independent reviews clean on the frozen diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Apply/Undeploy and status reads are coordinated around native game installs; mistakes could enable wrong deploys or stale chips, though the design is fail-closed and heavily tested in the Flutter layer only.
> 
> **Overview**
> **Deployment status is now tied to the selected game install**, so Apply, the status chip, and Studio takeover no longer trust stale `mgr_status` from another path or an in-flight refresh.
> 
> `StatusNotifier` tracks **`statusRoot`** (authoritative status) and **`gameRoot`** (selected install), ignores out-of-order refresh generations, **serializes Apply/Undeploy**, **queues refreshes during native writes**, and always **postflights `mgr_status` after mutations**—clearing authority when reads fail. **Studio takeover evidence** (`studioActive`) is kept across unknown/future states until a known non-studio status or a root switch disproves it.
> 
> The home UI only uses status when **`statusRoot` matches the current game root**; missing or mismatched authority shows localized **Unknown** (not “Nothing deployed”) and **disables Apply**. New **`statusUnknown`** strings were added across locales, with expanded unit and widget tests for these races and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8acd1b784e069862d475242bebe5c5d5ad77bc3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->