### PR TITLE
feat(manager): add read-only preflight

### DIFF
--- a/crates/gore-ffi/src/lib.rs
+++ b/crates/gore-ffi/src/lib.rs
@@ -188,6 +188,10 @@
 //! - `script_compile_install_state_v1` is a bounded, strictly read-only native preflight for the
 //!   shipping-game process and every known compile/recovery artifact. It returns display-only
 //!   paths and never creates, removes, renames, repairs, launches, or writes anything.
+//! - `mgr_preflight_v1` accepts one explicit game root plus optional native Manager path
+//!   overrides and returns seven fixed-order, bounded first-run findings. It never falls back to
+//!   config/Steam discovery, reconciles imports, probes by writing, repairs recovery state, or
+//!   claims that Apply is ready; all returned paths are display-only evidence.
 //! - `authoring_store_inspect_revision3_installed_dataasset_v1` accepts only one exact managed
 //!   revision-3 head, installed package-snapshot seals, game/Store roots, and a candidate ordinal.
 //!   It rebuilds every native authority and returns bounded whole-package fixed-leaf inspection
@@ -245,6 +249,7 @@ mod authoring_voice_take_remove_revision3;
 mod authoring_voice_take_status_revision3;
 mod authoring_voice_target_revision3;
 mod dataasset;
+mod mgr_preflight;
 mod script_compile_report;
 mod texture_preview;
 mod transport;
@@ -349,6 +354,7 @@ const CORE_COMMANDS: &[&str] = &[
     "mgr_apply",
     "mgr_import",
     "mgr_library_list",
+    mgr_preflight::COMMAND,
     "mgr_remove",
     "mgr_set_loadout",
     "mgr_status",
@@ -442,7 +448,7 @@ enum DispatchProbeError {
 
 /// Finds the top-level command without allocating attacker-sized JSON keys or payload values.
 ///
-/// Raw Store routes must see their original wire under their command-local cap before a generic
+/// Strict raw routes must see their original wire under their command-local cap before a generic
 /// `Value` tree exists. A command spelling is the only allocation here, and even its maximally
 /// escaped wire form is capped before decoding. Unknown values are skipped with a fixed-depth
 /// byte scanner. Once a raw command is found, its closed duplicate-safe parser owns all remaining
@@ -487,7 +493,7 @@ fn probe_dispatch_command(input: &str) -> Result<Option<String>, DispatchProbeEr
             if command.len() > MAX_DISPATCH_COMMAND_BYTES {
                 return Err(DispatchProbeError::CommandTooLong);
             }
-            if revision3_store_raw_route(&command).is_some() {
+            if command == mgr_preflight::COMMAND || revision3_store_raw_route(&command).is_some() {
                 return Ok(Some(command));
             }
             last_command = Some(command);
@@ -809,6 +815,9 @@ fn dispatch(input: &str) -> Value {
             return err("BAD_REQUEST", "invalid request json");
         }
     };
+    if command == mgr_preflight::COMMAND {
+        return mgr_preflight::mgr_preflight_v1_raw(input);
+    }
     // These security-sensitive Store routes see the original wire before any generic
     // payload `Value` exists. Route-local parsers enforce their smaller envelope caps before
     // decoding nested strings.
@@ -2028,6 +2037,7 @@ mod tests {
                     "mgr_apply",
                     "mgr_import",
                     "mgr_library_list",
+                    "mgr_preflight_v1",
                     "mgr_remove",
                     "mgr_set_loadout",
                     "mgr_status",

--- a/crates/gore-ffi/src/mgr_preflight.rs
+++ b/crates/gore-ffi/src/mgr_preflight.rs
@@ -1,0 +1,287 @@
+//! Strict raw FFI adapter for Mod Manager V1's read-only first-run evidence.
+
+use std::path::{Path, PathBuf};
+
+use gore_mod::mgr::preflight::ManagerPreflightV1;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::err;
+
+pub(super) const COMMAND: &str = "mgr_preflight_v1";
+
+const MAX_PATH_BYTES: usize = 32 * 1024;
+// Three path strings may each expand to six JSON bytes per input byte (`\u00XX`). This route sees
+// the untouched wire and rejects it before serde allocates a generic request tree.
+const MAX_WIRE_BYTES: usize = MAX_PATH_BYTES * 18 + 4 * 1024;
+const MAX_RESPONSE_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExactRequest {
+    command: String,
+    payload: Payload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Payload {
+    game_root: String,
+    #[serde(default)]
+    library_dir: Option<String>,
+    #[serde(default)]
+    loadout_path: Option<String>,
+}
+
+pub(super) fn mgr_preflight_v1_raw(input: &str) -> Value {
+    let payload = match parse_request(input) {
+        Ok(payload) => payload,
+        Err(message) => return err("MGR_PREFLIGHT_BAD_REQUEST", message),
+    };
+    let library_dir = payload
+        .library_dir
+        .map(PathBuf::from)
+        .unwrap_or_else(gore_mod::mgr::paths::library_dir);
+    let loadout_path = payload
+        .loadout_path
+        .map(PathBuf::from)
+        .unwrap_or_else(gore_mod::mgr::paths::loadout_path);
+    let preflight = run_preflight(Path::new(&payload.game_root), &library_dir, &loadout_path);
+    bounded_response(preflight)
+}
+
+#[cfg(not(test))]
+fn run_preflight(game_root: &Path, library: &Path, loadout: &Path) -> ManagerPreflightV1 {
+    gore_mod::mgr::preflight::preflight_v1(game_root, library, loadout)
+}
+
+#[cfg(test)]
+fn run_preflight(game_root: &Path, library: &Path, loadout: &Path) -> ManagerPreflightV1 {
+    gore_mod::mgr::preflight::preflight_v1_with_stated_game_process(
+        game_root,
+        library,
+        loadout,
+        || Ok(false),
+    )
+}
+
+fn parse_request(input: &str) -> Result<Payload, &'static str> {
+    if input.len() > MAX_WIRE_BYTES {
+        return Err("manager preflight request exceeds its bounded wire limit");
+    }
+    let request: ExactRequest = serde_json::from_str(input)
+        .map_err(|_| "manager preflight request has an invalid schema")?;
+    if request.command != COMMAND {
+        return Err("manager preflight request command does not match this route");
+    }
+    validate_path(&request.payload.game_root, "game_root")?;
+    if let Some(path) = request.payload.library_dir.as_deref() {
+        validate_path(path, "library_dir")?;
+    }
+    if let Some(path) = request.payload.loadout_path.as_deref() {
+        validate_path(path, "loadout_path")?;
+    }
+    Ok(request.payload)
+}
+
+fn validate_path(path: &str, _field: &'static str) -> Result<(), &'static str> {
+    if path.is_empty() || path.len() > MAX_PATH_BYTES || path.contains('\0') {
+        return Err("a path is empty, contains NUL, or exceeds its bounded length");
+    }
+    Ok(())
+}
+
+fn bounded_response(preflight: ManagerPreflightV1) -> Value {
+    let response = json!({"ok": true, "preflight": preflight});
+    if serde_json::to_vec(&response).is_ok_and(|wire| wire.len() <= MAX_RESPONSE_BYTES) {
+        response
+    } else {
+        err(
+            "MGR_PREFLIGHT_OUTPUT_LIMIT",
+            "manager preflight response exceeds its bounded output limit",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use gore_mod::mgr::preflight::{PreflightCheckIdV1, PreflightCheckV1, PreflightStateV1};
+
+    use super::*;
+
+    fn execute(input: Value) -> Value {
+        mgr_preflight_v1_raw(&input.to_string())
+    }
+
+    fn install_fixture() -> tempfile::TempDir {
+        let root = tempfile::tempdir().unwrap();
+        for directory in [
+            "G1R/Binaries/Win64",
+            "G1R/Content/Paks",
+            "G1R/Story/Cache",
+            "G1R/Script",
+        ] {
+            fs::create_dir_all(root.path().join(directory)).unwrap();
+        }
+        fs::write(
+            root.path()
+                .join("G1R/Binaries/Win64/G1R-Win64-Shipping.exe"),
+            b"exe",
+        )
+        .unwrap();
+        root
+    }
+
+    #[test]
+    fn exact_request_returns_environmental_findings_as_ok() {
+        let install = install_fixture();
+        let response = execute(json!({
+            "command": COMMAND,
+            "payload": {
+                "game_root": install.path(),
+                "library_dir": install.path().join("library"),
+                "loadout_path": install.path().join("loadout.json"),
+            }
+        }));
+        assert_eq!(response["ok"], true);
+        assert_eq!(response["preflight"]["format"], 1);
+        assert_eq!(response["preflight"]["checks"].as_array().unwrap().len(), 7);
+        assert_eq!(response["preflight"]["checks"][6]["state"], "unverified");
+        assert_eq!(
+            response["preflight"]["checks"][6]["code"],
+            "unverified_read_only"
+        );
+        assert!(response["preflight"].get("ready").is_none());
+        assert!(response["preflight"].get("can_apply").is_none());
+        assert!(response.get("ready").is_none());
+        assert!(response.get("can_apply").is_none());
+
+        let missing_root = install.path().join("not-installed");
+        let response = execute(json!({
+            "command": COMMAND,
+            "payload": {
+                "game_root": missing_root,
+                "library_dir": install.path().join("library"),
+                "loadout_path": install.path().join("loadout.json"),
+            }
+        }));
+        assert_eq!(response["ok"], true);
+        assert_eq!(response["preflight"]["checks"][0]["state"], "problem");
+        assert_eq!(
+            response["preflight"]["checks"][0]["code"],
+            "game_root_not_found"
+        );
+    }
+
+    #[test]
+    fn omitted_manager_paths_are_accepted_but_game_root_is_required() {
+        let payload = parse_request(&format!(
+            r#"{{"command":"{COMMAND}","payload":{{"game_root":"C:/explicit-game"}}}}"#
+        ))
+        .unwrap();
+        assert_eq!(payload.game_root, "C:/explicit-game");
+        assert!(payload.library_dir.is_none());
+        assert!(payload.loadout_path.is_none());
+
+        let missing = mgr_preflight_v1_raw(&format!(r#"{{"command":"{COMMAND}","payload":{{}}}}"#));
+        assert_eq!(missing["ok"], false);
+        assert_eq!(missing["error"]["code"], "MGR_PREFLIGHT_BAD_REQUEST");
+    }
+
+    #[test]
+    fn unknown_duplicate_and_missing_outer_fields_are_rejected() {
+        for input in [
+            format!(r#"{{"command":"{COMMAND}","payload":{{"game_root":"x"}},"extra":true}}"#),
+            format!(
+                r#"{{"command":"{COMMAND}","command":"{COMMAND}","payload":{{"game_root":"x"}}}}"#
+            ),
+            format!(r#"{{"command":"{COMMAND}"}}"#),
+            r#"{"payload":{"game_root":"x"}}"#.to_owned(),
+            format!(
+                r#"{{"command":"{COMMAND}","payload":{{"game_root":"x"}},"payload":{{"game_root":"y"}}}}"#
+            ),
+        ] {
+            let response = mgr_preflight_v1_raw(&input);
+            assert_eq!(response["ok"], false, "input: {input}");
+            assert_eq!(
+                response["error"]["code"], "MGR_PREFLIGHT_BAD_REQUEST",
+                "input: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn public_dispatch_keeps_duplicate_commands_inside_the_strict_raw_parser() {
+        for input in [
+            format!(
+                r#"{{"command":"{COMMAND}","payload":{{"game_root":"x"}},"command":"core_info"}}"#
+            ),
+            format!(
+                r#"{{"command":"core_info","command":"{COMMAND}","payload":{{"game_root":"x"}}}}"#
+            ),
+        ] {
+            let response = crate::dispatch(&input);
+            assert_eq!(response["ok"], false, "input: {input}");
+            assert_eq!(response["error"]["code"], "MGR_PREFLIGHT_BAD_REQUEST");
+        }
+    }
+
+    #[test]
+    fn unknown_duplicate_and_wrongly_typed_payload_fields_are_rejected() {
+        for input in [
+            format!(r#"{{"command":"{COMMAND}","payload":{{"game_root":"x","extra":true}}}}"#),
+            format!(r#"{{"command":"{COMMAND}","payload":{{"game_root":"x","game_root":"y"}}}}"#),
+            format!(r#"{{"command":"{COMMAND}","payload":{{"game_root":42}}}}"#),
+        ] {
+            let response = mgr_preflight_v1_raw(&input);
+            assert_eq!(response["ok"], false, "input: {input}");
+            assert_eq!(response["error"]["code"], "MGR_PREFLIGHT_BAD_REQUEST");
+        }
+    }
+
+    #[test]
+    fn wrong_command_empty_nul_and_oversized_paths_are_rejected() {
+        for input in [
+            json!({"command":"mgr_status", "payload":{"game_root":"x"}}).to_string(),
+            json!({"command":COMMAND, "payload":{"game_root":""}}).to_string(),
+            json!({"command":COMMAND, "payload":{"game_root":"x\u{0}"}}).to_string(),
+            json!({
+                "command":COMMAND,
+                "payload":{"game_root":"x", "library_dir":"x".repeat(MAX_PATH_BYTES + 1)}
+            })
+            .to_string(),
+        ] {
+            let response = mgr_preflight_v1_raw(&input);
+            assert_eq!(response["ok"], false, "input length: {}", input.len());
+            assert_eq!(response["error"]["code"], "MGR_PREFLIGHT_BAD_REQUEST");
+        }
+    }
+
+    #[test]
+    fn oversized_raw_wire_is_rejected_before_decode() {
+        let response = mgr_preflight_v1_raw(&"x".repeat(MAX_WIRE_BYTES + 1));
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"]["code"], "MGR_PREFLIGHT_BAD_REQUEST");
+    }
+
+    #[test]
+    fn output_cap_fails_closed_without_partial_snapshot() {
+        let oversized = PreflightCheckV1 {
+            id: PreflightCheckIdV1::GameRoot,
+            state: PreflightStateV1::Unknown,
+            code: "injected_test",
+            action: "none",
+            detail: "x".repeat(MAX_RESPONSE_BYTES),
+            items: Vec::new(),
+        };
+        let response = bounded_response(ManagerPreflightV1 {
+            format: 1,
+            checks: std::array::from_fn(|_| oversized.clone()),
+        });
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"]["code"], "MGR_PREFLIGHT_OUTPUT_LIMIT");
+        assert!(response.get("preflight").is_none());
+    }
+}

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -14125,10 +14125,7 @@ mod tests {
                 prior_live.display().to_string(),
                 content_hash(b"prior-modded"),
             )]),
-            backup_hashes: BTreeMap::from([(
-                prior_backup.display().to_string(),
-                noncanonical,
-            )]),
+            backup_hashes: BTreeMap::from([(prior_backup.display().to_string(), noncanonical)]),
             ..Default::default()
         };
         let record_path = record_path(&game);

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -3309,6 +3309,11 @@ fn update_content_hash(hash: &mut u64, bytes: &[u8]) {
 /// Hash a file with a fixed-size buffer. Voice archives can be many GiB, so drift checks must not
 /// materialize the live ZIP merely to compare it with the hash persisted in the deploy record.
 fn content_hash_file(path: &Path) -> std::io::Result<String> {
+    let mut remaining = u64::MAX;
+    content_hash_file_bounded(path, &mut remaining)
+}
+
+fn content_hash_file_bounded(path: &Path, remaining: &mut u64) -> std::io::Result<String> {
     let metadata = std::fs::symlink_metadata(path)?;
     if metadata_is_link(&metadata) || !metadata.is_file() {
         return Err(std::io::Error::new(
@@ -3316,24 +3321,42 @@ fn content_hash_file(path: &Path) -> std::io::Result<String> {
             format!("not a regular non-link file: {}", path.display()),
         ));
     }
-    let mut file = std::io::BufReader::new(std::fs::File::open(path)?);
+    let mut file = std::fs::File::open(path)?;
+    let opened = file.metadata()?;
+    if opened.len() > *remaining {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "file exceeds the remaining {remaining}-byte hashing budget: {}",
+                path.display()
+            ),
+        ));
+    }
+    *remaining -= opened.len();
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     // Keep the streaming buffer off the caller's stack. Windows console binaries reserve only
     // 1 MiB by default, so an equally-sized local array can overflow before the first read.
     let mut buffer = vec![0u8; 1024 * 1024];
     let mut read_total = 0u64;
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
+    {
+        let mut limited = std::io::Read::by_ref(&mut file).take(opened.len().saturating_add(1));
+        loop {
+            let read = limited.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            update_content_hash(&mut hash, &buffer[..read]);
+            read_total = read_total.checked_add(read as u64).ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "file length overflow")
+            })?;
         }
-        update_content_hash(&mut hash, &buffer[..read]);
-        read_total = read_total.checked_add(read as u64).ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::InvalidData, "file length overflow")
-        })?;
     }
     // If a Steam update races the hash, do not accept a digest of a partial/mixed generation.
-    if read_total != metadata.len() || std::fs::metadata(path)?.len() != metadata.len() {
+    if read_total != opened.len()
+        || file.metadata()?.len() != opened.len()
+        || metadata.len() != opened.len()
+        || std::fs::metadata(path)?.len() != opened.len()
+    {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("file changed while hashing: {}", path.display()),
@@ -3343,6 +3366,11 @@ fn content_hash_file(path: &Path) -> std::io::Result<String> {
 }
 
 fn sha256_file(path: &Path) -> Result<String> {
+    let mut remaining = u64::MAX;
+    sha256_file_bounded(path, &mut remaining)
+}
+
+pub(crate) fn sha256_file_bounded(path: &Path, remaining: &mut u64) -> Result<String> {
     let metadata = std::fs::symlink_metadata(path).map_err(io(&format!(
         "reading SHA-256 source metadata {}",
         path.display()
@@ -3358,21 +3386,31 @@ fn sha256_file(path: &Path) -> Result<String> {
     let opened = file
         .metadata()
         .map_err(io("reading opened SHA-256 source metadata"))?;
+    if opened.len() > *remaining {
+        return Err(ModError::Other(format!(
+            "SHA-256 source exceeds the remaining {remaining}-byte hashing budget: {}",
+            path.display()
+        )));
+    }
+    *remaining -= opened.len();
     let mut hasher = Sha256::new();
     // This helper is used during deploy preflight on the CLI's 1 MiB Windows main stack.
     let mut buffer = vec![0u8; 1024 * 1024];
     let mut total = 0u64;
-    loop {
-        let read = file
-            .read(&mut buffer)
-            .map_err(io("hashing SHA-256 source"))?;
-        if read == 0 {
-            break;
+    {
+        let mut limited = std::io::Read::by_ref(&mut file).take(opened.len().saturating_add(1));
+        loop {
+            let read = limited
+                .read(&mut buffer)
+                .map_err(io("hashing SHA-256 source"))?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+            total = total
+                .checked_add(read as u64)
+                .ok_or_else(|| ModError::Other("SHA-256 source length overflow".into()))?;
         }
-        hasher.update(&buffer[..read]);
-        total = total
-            .checked_add(read as u64)
-            .ok_or_else(|| ModError::Other("SHA-256 source length overflow".into()))?;
     }
     let after = file
         .metadata()
@@ -3391,6 +3429,15 @@ pub(crate) fn file_matches_recorded_hash(path: &Path, expected: &str) -> bool {
 }
 
 fn file_matches_recorded_hash_result(path: &Path, expected: &str) -> Result<bool> {
+    let mut remaining = u64::MAX;
+    file_matches_recorded_hash_bounded(path, expected, &mut remaining)
+}
+
+pub(crate) fn file_matches_recorded_hash_bounded(
+    path: &Path,
+    expected: &str,
+    remaining: &mut u64,
+) -> Result<bool> {
     if let Some(hex) = expected.strip_prefix("sha256:") {
         if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
             return Err(ModError::Other(format!(
@@ -3398,7 +3445,7 @@ fn file_matches_recorded_hash_result(path: &Path, expected: &str) -> Result<bool
                 path.display()
             )));
         }
-        sha256_file(path).map(|current| current == expected)
+        sha256_file_bounded(path, remaining).map(|current| current == expected)
     } else {
         if expected.len() != 16 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
             return Err(ModError::Other(format!(
@@ -3406,7 +3453,7 @@ fn file_matches_recorded_hash_result(path: &Path, expected: &str) -> Result<bool
                 path.display()
             )));
         }
-        content_hash_file(path)
+        content_hash_file_bounded(path, remaining)
             .map(|current| current == expected)
             .map_err(io(&format!("hashing deployed file {}", path.display())))
     }
@@ -3416,7 +3463,27 @@ fn tree_fingerprint(root: &Path) -> Result<String> {
     tree_fingerprint_with_prefix(root, None)
 }
 
+pub(crate) fn tree_fingerprint_bounded(
+    root: &Path,
+    remaining_bytes: &mut u64,
+    remaining_entries: &mut u64,
+) -> Result<String> {
+    tree_fingerprint_with_prefix_bounded(
+        root,
+        None,
+        Some((remaining_bytes, remaining_entries)),
+    )
+}
+
 fn tree_fingerprint_with_prefix(root: &Path, prefix: Option<&str>) -> Result<String> {
+    tree_fingerprint_with_prefix_bounded(root, prefix, None)
+}
+
+fn tree_fingerprint_with_prefix_bounded(
+    root: &Path,
+    prefix: Option<&str>,
+    mut budget: Option<(&mut u64, &mut u64)>,
+) -> Result<String> {
     let root_metadata = std::fs::symlink_metadata(root).map_err(io(&format!(
         "reading UE4SS tree metadata {}",
         root.display()
@@ -3454,6 +3521,14 @@ fn tree_fingerprint_with_prefix(root: &Path, prefix: Option<&str>) -> Result<Str
         )))?;
         for entry in read_dir {
             let entry = entry.map_err(io("reading UE4SS identity entry"))?;
+            if let Some((_, remaining_entries)) = budget.as_mut() {
+                if **remaining_entries == 0 {
+                    return Err(ModError::Other(
+                        "deployment inspection exhausted its tree-entry budget".into(),
+                    ));
+                }
+                **remaining_entries -= 1;
+            }
             let path = entry.path();
             let metadata = std::fs::symlink_metadata(&path)
                 .map_err(io("reading UE4SS identity entry metadata"))?;
@@ -3505,6 +3580,16 @@ fn tree_fingerprint_with_prefix(root: &Path, prefix: Option<&str>) -> Result<Str
                         path.display()
                     )));
                 }
+                if let Some((remaining_bytes, _)) = budget.as_mut() {
+                    if metadata.len() > **remaining_bytes {
+                        return Err(ModError::Other(format!(
+                            "UE4SS identity file exceeds the remaining {}-byte deployment inspection budget: {}",
+                            **remaining_bytes,
+                            path.display()
+                        )));
+                    }
+                    **remaining_bytes -= metadata.len();
+                }
                 total_bytes = total_bytes
                     .checked_add(metadata.len())
                     .ok_or_else(|| ModError::Other("UE4SS identity byte total overflow".into()))?;
@@ -3537,7 +3622,8 @@ fn tree_fingerprint_with_prefix(root: &Path, prefix: Option<&str>) -> Result<Str
         hasher.update(entry.relative.as_bytes());
         hasher.update(entry.len.to_le_bytes());
         if !entry.is_dir {
-            let expected = sha256_file(&entry.path)?;
+            let mut file_budget = entry.len;
+            let expected = sha256_file_bounded(&entry.path, &mut file_budget)?;
             hasher.update(expected.as_bytes());
         }
     }

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -57,6 +57,9 @@ pub enum ModError {
     Fmod(String),
     #[error("voice archive: {0}")]
     Voice(String),
+    /// A read-only aggregate inspection ceiling, not evidence that one input is unsupported.
+    #[error("inspection bound: {0}")]
+    InspectionBound(String),
     #[error("{0}")]
     Other(String),
 }
@@ -3313,6 +3316,24 @@ fn content_hash_file(path: &Path) -> std::io::Result<String> {
     content_hash_file_bounded(path, &mut remaining)
 }
 
+#[derive(Debug)]
+struct InspectionBoundIo(String);
+
+impl std::fmt::Display for InspectionBoundIo {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for InspectionBoundIo {}
+
+fn inspection_bound_from_io(error: &std::io::Error) -> Option<String> {
+    error
+        .get_ref()?
+        .downcast_ref::<InspectionBoundIo>()
+        .map(|bound| bound.0.clone())
+}
+
 fn content_hash_file_bounded(path: &Path, remaining: &mut u64) -> std::io::Result<String> {
     let metadata = std::fs::symlink_metadata(path)?;
     if metadata_is_link(&metadata) || !metadata.is_file() {
@@ -3326,10 +3347,10 @@ fn content_hash_file_bounded(path: &Path, remaining: &mut u64) -> std::io::Resul
     if opened.len() > *remaining {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!(
+            InspectionBoundIo(format!(
                 "file exceeds the remaining {remaining}-byte hashing budget: {}",
                 path.display()
-            ),
+            )),
         ));
     }
     *remaining -= opened.len();
@@ -3387,7 +3408,7 @@ pub(crate) fn sha256_file_bounded(path: &Path, remaining: &mut u64) -> Result<St
         .metadata()
         .map_err(io("reading opened SHA-256 source metadata"))?;
     if opened.len() > *remaining {
-        return Err(ModError::Other(format!(
+        return Err(ModError::InspectionBound(format!(
             "SHA-256 source exceeds the remaining {remaining}-byte hashing budget: {}",
             path.display()
         )));
@@ -3453,9 +3474,15 @@ pub(crate) fn file_matches_recorded_hash_bounded(
                 path.display()
             )));
         }
-        content_hash_file_bounded(path, remaining)
-            .map(|current| current == expected)
-            .map_err(io(&format!("hashing deployed file {}", path.display())))
+        match content_hash_file_bounded(path, remaining) {
+            Ok(current) => Ok(current == expected),
+            Err(error) => match inspection_bound_from_io(&error) {
+                Some(message) => Err(ModError::InspectionBound(message)),
+                None => Err(io(&format!("hashing deployed file {}", path.display()))(
+                    error,
+                )),
+            },
+        }
     }
 }
 
@@ -3521,9 +3548,14 @@ fn tree_fingerprint_with_prefix_bounded(
         )))?;
         for entry in read_dir {
             let entry = entry.map_err(io("reading UE4SS identity entry"))?;
+            if entries.len() as u64 >= MAX_UE4SS_TREE_ENTRIES {
+                return Err(ModError::Other(format!(
+                    "UE4SS identity tree exceeds the {MAX_UE4SS_TREE_ENTRIES}-entry limit"
+                )));
+            }
             if let Some((_, remaining_entries)) = budget.as_mut() {
                 if **remaining_entries == 0 {
-                    return Err(ModError::Other(
+                    return Err(ModError::InspectionBound(
                         "deployment inspection exhausted its tree-entry budget".into(),
                     ));
                 }
@@ -3560,11 +3592,6 @@ fn tree_fingerprint_with_prefix_bounded(
                     path.display()
                 )));
             }
-            if entries.len() as u64 >= MAX_UE4SS_TREE_ENTRIES {
-                return Err(ModError::Other(format!(
-                    "UE4SS identity tree exceeds the {MAX_UE4SS_TREE_ENTRIES}-entry limit"
-                )));
-            }
             if metadata.is_dir() {
                 pending.push(path.clone());
                 entries.push(Entry {
@@ -3580,16 +3607,6 @@ fn tree_fingerprint_with_prefix_bounded(
                         path.display()
                     )));
                 }
-                if let Some((remaining_bytes, _)) = budget.as_mut() {
-                    if metadata.len() > **remaining_bytes {
-                        return Err(ModError::Other(format!(
-                            "UE4SS identity file exceeds the remaining {}-byte deployment inspection budget: {}",
-                            **remaining_bytes,
-                            path.display()
-                        )));
-                    }
-                    **remaining_bytes -= metadata.len();
-                }
                 total_bytes = total_bytes
                     .checked_add(metadata.len())
                     .ok_or_else(|| ModError::Other("UE4SS identity byte total overflow".into()))?;
@@ -3597,6 +3614,16 @@ fn tree_fingerprint_with_prefix_bounded(
                     return Err(ModError::Other(format!(
                         "UE4SS identity tree exceeds the {MAX_UE4SS_TREE_BYTES}-byte total limit"
                     )));
+                }
+                if let Some((remaining_bytes, _)) = budget.as_mut() {
+                    if metadata.len() > **remaining_bytes {
+                        return Err(ModError::InspectionBound(format!(
+                            "UE4SS identity file exceeds the remaining {}-byte deployment inspection budget: {}",
+                            **remaining_bytes,
+                            path.display()
+                        )));
+                    }
+                    **remaining_bytes -= metadata.len();
                 }
                 entries.push(Entry {
                     relative,

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -4798,6 +4798,9 @@ fn commit_plan_guarded(
     let game_root = abs_root;
     let prior = prev.as_ref().map(|stored| &stored.record);
     let prev_record_bytes = prev.as_ref().map(|stored| stored.raw.as_slice());
+    if let Some(prior) = prior {
+        validate_record_identities(prior)?;
+    }
 
     // Reject a plan that would write the SAME destination twice (across in-place writes, UE4SS
     // dirs, texture triplets, and manager paks). Two components/mods targeting one path would race in
@@ -14089,6 +14092,77 @@ mod tests {
         );
         assert_eq!(std::fs::read(&dst).unwrap(), b"manual");
         assert!(!record_path(&game).exists());
+    }
+
+    #[test]
+    fn commit_rejects_noncanonical_prior_before_staging() {
+        let dir = tempfile::tempdir().unwrap();
+        let game = dir.path().join("game");
+        let prior_live = game.join("G1R/Story/VoiceOver/prior.zip");
+        let prior_backup = bak_path(&prior_live);
+        let target = game.join("G1R/Story/VoiceOver/target.zip");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&prior_live, b"prior-modded").unwrap();
+        std::fs::write(&prior_backup, b"prior-pristine").unwrap();
+        std::fs::write(&target, b"target-pristine").unwrap();
+        let canonical = sha256_file(&prior_backup).unwrap();
+        let noncanonical = format!(
+            "sha256:{}",
+            canonical
+                .strip_prefix("sha256:")
+                .unwrap()
+                .to_ascii_uppercase()
+        );
+        let prior_record = DeployRecord {
+            mod_name: "prior".into(),
+            owner: "manager".into(),
+            backups: vec![(
+                prior_live.display().to_string(),
+                prior_backup.display().to_string(),
+                true,
+            )],
+            deployed_hashes: BTreeMap::from([(
+                prior_live.display().to_string(),
+                content_hash(b"prior-modded"),
+            )]),
+            backup_hashes: BTreeMap::from([(
+                prior_backup.display().to_string(),
+                noncanonical,
+            )]),
+            ..Default::default()
+        };
+        let record_path = record_path(&game);
+        let record_bytes = serde_json::to_vec(&prior_record).unwrap();
+        std::fs::write(&record_path, &record_bytes).unwrap();
+        let prior = read_record(&game).unwrap().unwrap();
+
+        let error = commit_plan(
+            &resolve_game_paths(&game),
+            &game,
+            DeployPlan {
+                writes: vec![(target.clone(), b"new-deployment".to_vec())],
+                ..Default::default()
+            },
+            DeployRecord {
+                mod_name: "next".into(),
+                owner: "manager".into(),
+                ..Default::default()
+            },
+            Some(prior),
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid backup SHA-256 identity"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(std::fs::read(&prior_live).unwrap(), b"prior-modded");
+        assert_eq!(std::fs::read(&prior_backup).unwrap(), b"prior-pristine");
+        assert_eq!(std::fs::read(&target).unwrap(), b"target-pristine");
+        assert!(!bak_path(&target).exists());
+        assert_eq!(std::fs::read(&record_path).unwrap(), record_bytes);
     }
 
     #[test]

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -5077,6 +5077,7 @@ fn commit_plan_guarded(
 
 fn write_record_file(game_root: &Path, record: &DeployRecord) -> Result<()> {
     validate_record(game_root, record)?;
+    validate_record_identities(record)?;
     let bytes = serde_json::to_vec_pretty(record)?;
     if bytes.len() as u64 > MAX_DEPLOY_RECORD_BYTES {
         return Err(ModError::Other(format!(
@@ -7252,6 +7253,94 @@ fn path_exists_no_follow(path: &Path) -> bool {
 /// Whether `list` already contains a path referring to the same file as `p` (`same_path_s`).
 fn contains_same_path(list: &[String], p: &str) -> bool {
     list.iter().any(|x| same_path_s(x, p))
+}
+
+fn valid_sha256_identity(identity: &str) -> bool {
+    identity.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+fn valid_file_identity(identity: &str) -> bool {
+    valid_sha256_identity(identity)
+        || (identity.len() == 16
+            && identity
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)))
+}
+
+/// Require the exact lowercase identities GORE writes. This remains separate from structural
+/// record parsing so legacy public status can keep its read-only classification, while preflight
+/// and every attempted record publication fail closed before trusting noncanonical ownership.
+pub(crate) fn validate_record_identities(record: &DeployRecord) -> Result<()> {
+    for (path, identity) in &record.deployed_hashes {
+        if !valid_file_identity(identity) {
+            return Err(ModError::Other(format!(
+                "deploy record contains an invalid deployed file identity for {path}"
+            )));
+        }
+    }
+    for (path, identities) in &record.recovery_file_hashes {
+        if identities.is_empty()
+            || identities
+                .iter()
+                .any(|identity| !valid_file_identity(identity))
+        {
+            return Err(ModError::Other(format!(
+                "deploy record contains an invalid alternate file identity for {path}"
+            )));
+        }
+    }
+    for (path, identity) in &record.backup_hashes {
+        if !valid_sha256_identity(identity) {
+            return Err(ModError::Other(format!(
+                "deploy record contains an invalid backup SHA-256 identity for {path}"
+            )));
+        }
+    }
+    for (path, identity) in &record.ue4ss_tree_fingerprints {
+        if !valid_sha256_identity(identity) {
+            return Err(ModError::Other(format!(
+                "deploy record contains an invalid UE4SS tree identity for {path}"
+            )));
+        }
+    }
+    for (path, identities) in &record.recovery_tree_fingerprints {
+        if identities.is_empty()
+            || identities
+                .iter()
+                .any(|identity| !valid_sha256_identity(identity))
+        {
+            return Err(ModError::Other(format!(
+                "deploy record contains an invalid alternate UE4SS tree identity for {path}"
+            )));
+        }
+    }
+    for (source, claim) in &record.file_cleanup_claims {
+        if claim.expected_hashes.is_empty()
+            || claim
+                .expected_hashes
+                .iter()
+                .any(|identity| !valid_file_identity(identity))
+        {
+            return Err(ModError::Other(format!(
+                "deploy record contains an invalid cleanup file identity for {source}"
+            )));
+        }
+        if claim
+            .restore_hash
+            .as_deref()
+            .is_some_and(|identity| !valid_sha256_identity(identity))
+        {
+            return Err(ModError::Other(format!(
+                "deploy record contains an invalid cleanup restore identity for {source}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Clone, Copy)]
@@ -13001,6 +13090,90 @@ mod tests {
         assert_eq!(std::fs::read(&live).unwrap(), b"modded");
         assert_eq!(std::fs::read(&bak).unwrap(), b"pristine");
         assert_eq!(std::fs::read(&path).unwrap(), record_bytes);
+    }
+
+    #[test]
+    fn undeploy_rejects_noncanonical_ownership_before_recovery_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let game = dir.path().join("game");
+        let live = game.join("G1R/Story/VoiceOver/target.zip");
+        let backup = bak_path(&live);
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"modded").unwrap();
+        std::fs::write(&backup, b"pristine").unwrap();
+        let canonical = sha256_file(&backup).unwrap();
+        let noncanonical = format!(
+            "sha256:{}",
+            canonical
+                .strip_prefix("sha256:")
+                .unwrap()
+                .to_ascii_uppercase()
+        );
+        assert_ne!(noncanonical, canonical);
+        let record = DeployRecord {
+            backups: vec![(
+                live.display().to_string(),
+                backup.display().to_string(),
+                true,
+            )],
+            deployed_hashes: BTreeMap::from([(
+                live.display().to_string(),
+                content_hash(b"modded"),
+            )]),
+            backup_hashes: BTreeMap::from([(backup.display().to_string(), noncanonical)]),
+            ..Default::default()
+        };
+        let path = record_path(&game);
+        let record_bytes = serde_json::to_vec(&record).unwrap();
+        std::fs::write(&path, &record_bytes).unwrap();
+
+        let error = undeploy(&game).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("invalid backup SHA-256 identity"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(std::fs::read(&live).unwrap(), b"modded");
+        assert_eq!(std::fs::read(&backup).unwrap(), b"pristine");
+        assert_eq!(std::fs::read(&path).unwrap(), record_bytes);
+    }
+
+    #[test]
+    fn record_identity_validation_covers_cleanup_claims() {
+        let canonical_sha = format!("sha256:{}", "a".repeat(64));
+        let noncanonical_sha = format!("sha256:{}", "A".repeat(64));
+        let noncanonical_legacy = "A".repeat(16);
+        let cases = [
+            DeployRecord {
+                file_cleanup_claims: BTreeMap::from([(
+                    "source".into(),
+                    FileCleanupClaim {
+                        holder: "holder".into(),
+                        expected_hashes: vec![noncanonical_legacy],
+                        restore_from: None,
+                        restore_hash: None,
+                    },
+                )]),
+                ..Default::default()
+            },
+            DeployRecord {
+                file_cleanup_claims: BTreeMap::from([(
+                    "source".into(),
+                    FileCleanupClaim {
+                        holder: "holder".into(),
+                        expected_hashes: vec![canonical_sha],
+                        restore_from: Some("backup".into()),
+                        restore_hash: Some(noncanonical_sha),
+                    },
+                )]),
+                ..Default::default()
+            },
+        ];
+
+        for record in cases {
+            assert!(validate_record_identities(&record).is_err());
+        }
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -191,6 +191,76 @@ fn validate_payload_rel(rel: &str, label: &str, limits: ApplyLimits) -> crate::R
     Ok(())
 }
 
+/// Validate the sidecar-only component fields that the default apply path rejects before
+/// publication. Apply invokes this before reading that component's payload; preflight uses the
+/// same boundary so syntactically valid but undeployable enabled metadata never advertises Apply.
+pub(super) fn validate_component_descriptor_for_default_apply(
+    component: &ComponentInfo,
+) -> crate::Result<()> {
+    validate_component_descriptor(component, DEFAULT_APPLY_LIMITS)
+}
+
+fn validate_component_descriptor(
+    component: &ComponentInfo,
+    limits: ApplyLimits,
+) -> crate::Result<()> {
+    match component {
+        ComponentInfo::Ue4ssLua { name, rel, .. } => {
+            if !crate::is_safe_mod_name(name) {
+                return Err(ModError::Other(format!(
+                    "unsafe ue4ss component: name={name:?} rel={rel:?}"
+                )));
+            }
+            validate_payload_rel(rel, "ue4ss component", limits)
+        }
+        ComponentInfo::LocPatch { rel, .. } => {
+            validate_payload_rel(rel, "localization patch", limits)
+        }
+        ComponentInfo::AudioPatch { rel, .. } => {
+            validate_payload_rel(rel, "audio patch", limits)?;
+            validate_payload_rel(&format!("{rel}/manifest.json"), "audio manifest", limits)
+        }
+        ComponentInfo::TexturePatch { rel, .. } => {
+            validate_payload_rel(rel, "texture component", limits)
+        }
+        ComponentInfo::AngelScriptPatch { rel, .. } => {
+            validate_payload_rel(rel, "script patch", limits)?;
+            validate_payload_rel(&format!("{rel}/manifest.json"), "script manifest", limits)
+        }
+        ComponentInfo::FilePatch { rel, .. } => {
+            validate_payload_rel(rel, "loose file component", limits)?;
+            validate_payload_rel(
+                &format!("{rel}/manifest.json"),
+                "loose file manifest",
+                limits,
+            )
+        }
+        ComponentInfo::PakFilePatch { rel, .. } => {
+            validate_payload_rel(rel, "pak file component", limits)
+        }
+        ComponentInfo::VoiceArchivePatch { rel, .. } => {
+            validate_payload_rel(rel, "voice patch", limits)
+        }
+        ComponentInfo::Triplet { rel_base, .. } => {
+            validate_payload_rel(rel_base, "triplet", limits)?;
+            for ext in ["utoc", "ucas", "pak"] {
+                validate_payload_rel(&format!("{rel_base}.{ext}"), "triplet", limits)?;
+            }
+            Ok(())
+        }
+        ComponentInfo::LoosePak { rel, .. } => validate_payload_rel(rel, "loose pak", limits),
+        ComponentInfo::RawFile { rel, target_file } => {
+            validate_payload_rel(rel, "raw file", limits)?;
+            if let RawTarget::Bank { name } = target_file {
+                if name.len() > limits.max_payload_path_bytes || !crate::is_safe_filename(name) {
+                    return Err(ModError::Other(format!("unsafe bank name: {name:?}")));
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
 fn read_manifest_payload(
     payload: &PendingPayload,
     label: &str,
@@ -560,6 +630,7 @@ fn apply_loadout_with_limits(
     let mut shadow = crate::PakShadowIndex::new(&gp.root);
     for l in &loaded {
         for comp in &l.meta.components {
+            validate_component_descriptor(comp, limits)?;
             match comp {
                 ComponentInfo::Ue4ssLua { name, rel, .. } => {
                     if !crate::is_safe_mod_name(name) {

--- a/crates/gore-mod/src/mgr/mod.rs
+++ b/crates/gore-mod/src/mgr/mod.rs
@@ -12,6 +12,7 @@ pub mod import;
 pub mod loadout;
 pub mod model;
 pub mod paths;
+pub mod preflight;
 pub mod status;
 
 pub use loadout::{Loadout, LoadoutEntry};

--- a/crates/gore-mod/src/mgr/model.rs
+++ b/crates/gore-mod/src/mgr/model.rs
@@ -324,6 +324,25 @@ impl SecureDirectory {
     ) -> crate::Result<SecureNode> {
         validate_plain_component(name, label)?;
         let opened = open_child_node(&self.anchor, name, label)?;
+        self.secure_child_from_opened(opened, label)
+    }
+
+    fn open_optional_child(
+        &self,
+        name: &std::ffi::OsStr,
+        label: &str,
+    ) -> crate::Result<Option<SecureNode>> {
+        validate_plain_component(name, label)?;
+        open_optional_child_node(&self.anchor, name, label)?
+            .map(|opened| self.secure_child_from_opened(opened, label))
+            .transpose()
+    }
+
+    fn secure_child_from_opened(
+        &self,
+        opened: OpenedNode,
+        label: &str,
+    ) -> crate::Result<SecureNode> {
         if opened.metadata.is_dir() {
             let mut parents = self.parents.clone();
             parents.push(self.anchor.clone());
@@ -360,13 +379,10 @@ impl SecureDirectory {
         name: &std::ffi::OsStr,
         label: &str,
     ) -> crate::Result<Option<SecureDirectory>> {
-        validate_plain_component(name, label)?;
-        if !self.contains_child(name, label)? {
-            return Ok(None);
-        }
-        match self.open_child(name, label)? {
-            SecureNode::Directory(directory) => Ok(Some(directory)),
-            SecureNode::File(file) => Err(crate::ModError::Other(format!(
+        match self.open_optional_child(name, label)? {
+            None => Ok(None),
+            Some(SecureNode::Directory(directory)) => Ok(Some(directory)),
+            Some(SecureNode::File(file)) => Err(crate::ModError::Other(format!(
                 "{label} must be a real directory: {}",
                 file.path().display()
             ))),
@@ -954,18 +970,13 @@ fn inject_tree_entry_race(hook: impl FnOnce(&Path) + 'static) {
 }
 
 #[cfg(windows)]
-fn open_absolute_node(path: &Path, label: &str) -> crate::Result<OpenedNode> {
-    use std::os::windows::ffi::OsStringExt as _;
+fn open_windows_node_handle(path: &Path) -> std::io::Result<std::fs::File> {
     use std::os::windows::fs::OpenOptionsExt as _;
-    use std::os::windows::io::AsRawHandle as _;
     use windows_sys::Win32::Storage::FileSystem::{
-        FileAttributeTagInfo, FileIdInfo, GetFileInformationByHandleEx, GetFinalPathNameByHandleW,
-        FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS,
-        FILE_FLAG_OPEN_REPARSE_POINT, FILE_ID_INFO, FILE_NAME_NORMALIZED, FILE_SHARE_READ,
-        VOLUME_NAME_DOS,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
     };
 
-    let file = std::fs::OpenOptions::new()
+    std::fs::OpenOptions::new()
         .read(true)
         // Excluding FILE_SHARE_DELETE prevents a validated object from being renamed/replaced
         // while this handle (or a retained parent anchor) participates in traversal.
@@ -976,10 +987,31 @@ fn open_absolute_node(path: &Path, label: &str) -> crate::Result<OpenedNode> {
         .share_mode(FILE_SHARE_READ)
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)
         .open(path)
-        .map_err(crate::io(&format!(
-            "opening {label} without following reparse points {}",
-            path.display()
-        )))?;
+}
+
+#[cfg(windows)]
+fn open_absolute_node(path: &Path, label: &str) -> crate::Result<OpenedNode> {
+    let file = open_windows_node_handle(path).map_err(crate::io(&format!(
+        "opening {label} without following reparse points {}",
+        path.display()
+    )))?;
+    finish_opened_windows_node(path, label, file)
+}
+
+#[cfg(windows)]
+fn finish_opened_windows_node(
+    path: &Path,
+    label: &str,
+    file: std::fs::File,
+) -> crate::Result<OpenedNode> {
+    use std::os::windows::ffi::OsStringExt as _;
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileAttributeTagInfo, FileIdInfo, GetFileInformationByHandleEx, GetFinalPathNameByHandleW,
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_ID_INFO, FILE_NAME_NORMALIZED,
+        VOLUME_NAME_DOS,
+    };
+
     let handle = file.as_raw_handle();
     let mut attributes = FILE_ATTRIBUTE_TAG_INFO::default();
     let attribute_ok = unsafe {
@@ -1061,9 +1093,33 @@ fn open_child_node(
     name: &std::ffi::OsStr,
     label: &str,
 ) -> crate::Result<OpenedNode> {
+    open_optional_child_node(parent, name, label)?.ok_or_else(|| {
+        crate::ModError::Other(format!(
+            "required {label} child is missing from validated parent {}: {name:?}",
+            parent.final_path.display()
+        ))
+    })
+}
+
+#[cfg(windows)]
+fn open_optional_child_node(
+    parent: &DirectoryAnchor,
+    name: &std::ffi::OsStr,
+    label: &str,
+) -> crate::Result<Option<OpenedNode>> {
     let child = parent.final_path.join(name);
     run_open_child_race_hook(&child);
-    let opened = open_absolute_node(&child, label)?;
+    let file = match open_windows_node_handle(&child) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(crate::io(&format!(
+                "opening {label} without following reparse points {}",
+                child.display()
+            ))(error))
+        }
+    };
+    let opened = finish_opened_windows_node(&child, label, file)?;
     if !handle_path_is_direct_child(&parent.final_path, &opened.final_path) {
         return Err(crate::ModError::Other(format!(
             "opened {label} escaped its validated parent: {} -> {}",
@@ -1071,7 +1127,7 @@ fn open_child_node(
             opened.final_path.display()
         )));
     }
-    Ok(opened)
+    Ok(Some(opened))
 }
 
 #[cfg(windows)]
@@ -1109,7 +1165,7 @@ fn open_absolute_node(path: &Path, label: &str) -> crate::Result<OpenedNode> {
 
     let file = std::fs::OpenOptions::new()
         .read(true)
-        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK)
         .open(path)
         .map_err(crate::io(&format!(
             "opening {label} with O_NOFOLLOW {}",
@@ -1140,6 +1196,20 @@ fn open_child_node(
     name: &std::ffi::OsStr,
     label: &str,
 ) -> crate::Result<OpenedNode> {
+    open_optional_child_node(parent, name, label)?.ok_or_else(|| {
+        crate::ModError::Other(format!(
+            "required {label} child is missing from validated parent {}: {name:?}",
+            parent.final_path.display()
+        ))
+    })
+}
+
+#[cfg(unix)]
+fn open_optional_child_node(
+    parent: &DirectoryAnchor,
+    name: &std::ffi::OsStr,
+    label: &str,
+) -> crate::Result<Option<OpenedNode>> {
     use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
     use std::os::unix::fs::MetadataExt as _;
     use std::os::unix::io::{AsRawFd as _, FromRawFd as _};
@@ -1152,20 +1222,30 @@ fn open_child_node(
         libc::openat(
             parent.file.as_raw_fd(),
             c_name.as_ptr(),
-            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
         )
     };
     if fd < 0 {
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::NotFound {
+            return Ok(None);
+        }
+        if error.raw_os_error() == Some(libc::ELOOP) {
+            return Err(crate::ModError::Other(format!(
+                "{label} is a symbolic link: {}",
+                parent.final_path.join(name).display()
+            )));
+        }
         return Err(crate::io(&format!(
             "opening {label} relative to validated parent {}",
             parent.final_path.display()
-        ))(std::io::Error::last_os_error()));
+        ))(error));
     }
     let file = unsafe { std::fs::File::from_raw_fd(fd) };
     let metadata = file
         .metadata()
         .map_err(crate::io(&format!("reading opened {label} metadata")))?;
-    Ok(OpenedNode {
+    Ok(Some(OpenedNode {
         file,
         final_path: parent
             .final_path
@@ -1175,7 +1255,7 @@ fn open_child_node(
             inode: metadata.ino(),
         },
         metadata,
-    })
+    }))
 }
 
 #[cfg(unix)]
@@ -1516,10 +1596,10 @@ impl LibraryEntry {
                     "unsafe {label} path component in {rel_text:?}"
                 )));
             };
-            if !directory.contains_child(name, label)? {
+            let Some(node) = directory.open_optional_child(name, label)? else {
                 return Ok(None);
-            }
-            match directory.open_child(name, label)? {
+            };
+            match node {
                 SecureNode::File(file) if index + 1 == components.len() => {
                     return Ok(Some(file));
                 }
@@ -1580,29 +1660,6 @@ impl LibraryEntry {
     }
 
     fn open_required_payload_node(&self, rel: &Path, label: &str) -> crate::Result<SecureNode> {
-        let rel_text = rel.to_string_lossy();
-        if !crate::is_safe_rel_path(&rel_text) {
-            return Err(crate::ModError::Other(format!(
-                "unsafe {label} path in library entry {:?}: {rel_text:?}",
-                self.id
-            )));
-        }
-        let path = self.path().join(rel);
-        match std::fs::symlink_metadata(&path) {
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                return Err(crate::ModError::Other(format!(
-                    "required {label} is missing from library entry {:?}: {rel:?}",
-                    self.id
-                )))
-            }
-            Err(error) => {
-                return Err(crate::io(&format!(
-                    "inspecting required {label} in library entry {:?}",
-                    self.id
-                ))(error))
-            }
-            Ok(_) => {}
-        }
         self.open_payload_node(rel, label)
     }
 
@@ -2067,6 +2124,141 @@ mod tests {
             let error = result.unwrap_err().to_string();
             assert!(error.contains("content revision"), "{error}");
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn required_payload_validation_stays_bound_to_a_renamed_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let library_path = temp.path().join("library");
+        let entry_path = library_path.join("entry-a");
+        std::fs::create_dir_all(&entry_path).unwrap();
+        std::fs::write(entry_path.join("payload.bin"), b"payload").unwrap();
+        let library = LibraryRoot::open(&library_path).unwrap();
+        let entry = library.entry("entry-a").unwrap();
+
+        let moved = library_path.join("entry-moved");
+        std::fs::rename(&entry_path, &moved).unwrap();
+        std::fs::create_dir(&entry_path).unwrap();
+
+        entry
+            .validate_required_payload_file(Path::new("payload.bin"), "test payload")
+            .unwrap();
+        assert!(!entry_path.join("payload.bin").exists());
+        assert!(moved.join("payload.bin").is_file());
+    }
+
+    #[test]
+    fn required_payload_validation_classifies_missing_and_intermediate_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let library_path = temp.path().join("library");
+        let entry_path = library_path.join("entry-a");
+        std::fs::create_dir_all(&entry_path).unwrap();
+        std::fs::write(entry_path.join("blocking"), b"file").unwrap();
+        let library = LibraryRoot::open(&library_path).unwrap();
+        let entry = library.entry("entry-a").unwrap();
+
+        let missing = entry
+            .validate_required_payload_file(Path::new("missing.bin"), "test payload")
+            .unwrap_err();
+        assert!(matches!(missing, crate::ModError::Other(_)));
+        assert!(missing.to_string().contains("child is missing"));
+
+        let blocked = entry
+            .validate_required_payload_file(Path::new("blocking/payload.bin"), "test payload")
+            .unwrap_err();
+        assert!(matches!(blocked, crate::ModError::Other(_)));
+        assert!(blocked.to_string().contains("crosses a regular file"));
+    }
+
+    #[test]
+    fn optional_payload_open_observes_a_file_created_at_the_open_boundary() {
+        let temp = tempfile::tempdir().unwrap();
+        let library_path = temp.path().join("library");
+        let entry_path = library_path.join("entry-a");
+        std::fs::create_dir_all(&entry_path).unwrap();
+        let entry = LibraryRoot::open(&library_path)
+            .unwrap()
+            .entry("entry-a")
+            .unwrap();
+
+        inject_open_child_race(|opened_path| {
+            assert_eq!(
+                opened_path.file_name(),
+                Some(std::ffi::OsStr::new("optional.bin"))
+            );
+            std::fs::write(opened_path, b"created at open").unwrap();
+        });
+
+        assert!(entry
+            .open_optional_payload_file(Path::new("optional.bin"), "optional payload")
+            .unwrap()
+            .is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn required_payload_validation_rejects_a_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let temp = tempfile::tempdir().unwrap();
+        let library_path = temp.path().join("library");
+        let entry_path = library_path.join("entry-a");
+        std::fs::create_dir_all(&entry_path).unwrap();
+        let fifo = entry_path.join("payload.pipe");
+        let fifo_name = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = LibraryRoot::open(&library_path)
+                .and_then(|library| library.entry("entry-a"))
+                .and_then(|entry| {
+                    entry.validate_required_payload_file(Path::new("payload.pipe"), "test payload")
+                })
+                .map_err(|error| error.to_string());
+            let _ = sender.send(result);
+        });
+
+        let result = receiver
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("opening a FIFO must complete promptly")
+            .unwrap_err();
+        assert!(
+            result.contains("neither a regular file nor directory"),
+            "{result}"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[cfg_attr(
+        windows,
+        ignore = "requires Windows symbolic-link privilege; run explicitly on a privileged worker"
+    )]
+    #[test]
+    fn required_payload_validation_rejects_a_final_link_as_corruption() {
+        let temp = tempfile::tempdir().unwrap();
+        let library_path = temp.path().join("library");
+        let entry_path = library_path.join("entry-a");
+        std::fs::create_dir_all(&entry_path).unwrap();
+        let outside = temp.path().join("outside.bin");
+        std::fs::write(&outside, b"outside").unwrap();
+        assert!(
+            make_file_link(&outside, &entry_path.join("payload.bin")),
+            "test requires symbolic-link creation support"
+        );
+        let library = LibraryRoot::open(&library_path).unwrap();
+        let entry = library.entry("entry-a").unwrap();
+
+        let error = entry
+            .validate_required_payload_file(Path::new("payload.bin"), "test payload")
+            .unwrap_err();
+        assert!(matches!(error, crate::ModError::Other(_)));
+        assert!(
+            error.to_string().contains("symbolic link")
+                || error.to_string().contains("reparse point"),
+            "{error}"
+        );
     }
 
     #[cfg(any(unix, windows))]

--- a/crates/gore-mod/src/mgr/model.rs
+++ b/crates/gore-mod/src/mgr/model.rs
@@ -1340,10 +1340,19 @@ impl LibraryEntry {
     /// claimed id to identify this directory. On Windows the filesystem decides identity, so a
     /// harmless casing difference is accepted while a different sibling remains a mismatch.
     pub(crate) fn read_meta(&self) -> crate::Result<ModEntryMeta> {
-        let bytes = self.read_payload_bounded(
+        let mut budget = LIBRARY_META_MAX_BYTES;
+        self.read_meta_bounded(&mut budget)
+    }
+
+    /// Read metadata within a caller's remaining aggregate budget, charging the authoritative
+    /// opened-handle length before any allocation, read, or parsing work begins.
+    pub(crate) fn read_meta_bounded(&self, remaining: &mut u64) -> crate::Result<ModEntryMeta> {
+        let limit = (*remaining).min(LIBRARY_META_MAX_BYTES);
+        let bytes = self.read_payload_bounded_with(
             Path::new(META_FILE),
             "library sidecar",
-            LIBRARY_META_MAX_BYTES,
+            limit,
+            |expected| *remaining -= expected,
         )?;
         let meta: ModEntryMeta = serde_json::from_slice(&bytes).map_err(|error| {
             crate::ModError::Other(format!(
@@ -1357,7 +1366,7 @@ impl LibraryEntry {
     }
 
     /// Read one already-validated library payload through an opened file handle and a hard byte
-    /// ceiling.  The metadata snapshot, `limit + 1` read, and final handle/path metadata checks
+    /// ceiling.  The metadata snapshot, `expected + 1` read, and final handle/path metadata checks
     /// make truncation or growth during the read a hard error instead of accepting a partial or
     /// unexpectedly large allocation.
     pub(crate) fn read_payload_bounded(
@@ -1366,7 +1375,7 @@ impl LibraryEntry {
         label: &str,
         limit: u64,
     ) -> crate::Result<Vec<u8>> {
-        self.read_payload_bounded_with(rel, label, limit, || {})
+        self.read_payload_bounded_with(rel, label, limit, |_| {})
     }
 
     fn read_payload_bounded_with<F>(
@@ -1377,10 +1386,10 @@ impl LibraryEntry {
         after_metadata: F,
     ) -> crate::Result<Vec<u8>>
     where
-        F: FnOnce(),
+        F: FnOnce(u64),
     {
         let (path, mut file, expected) = self.open_payload_bounded(rel, label, limit)?;
-        after_metadata();
+        after_metadata(expected);
 
         let capacity = usize::try_from(expected).map_err(|_| {
             crate::ModError::Other(format!(
@@ -1397,7 +1406,7 @@ impl LibraryEntry {
         })?;
         file.file
             .by_ref()
-            .take(limit.saturating_add(1))
+            .take(expected.saturating_add(1))
             .read_to_end(&mut bytes)
             .map_err(crate::io(&format!("reading {label} {}", path.display())))?;
         let observed = u64::try_from(bytes.len()).map_err(|_| {
@@ -2252,7 +2261,7 @@ mod tests {
         let payload = entry_path.join("payload.bin");
         let mut writer_was_denied = None;
         let result =
-            entry.read_payload_bounded_with(Path::new("payload.bin"), "test payload", 16, || {
+            entry.read_payload_bounded_with(Path::new("payload.bin"), "test payload", 16, |_| {
                 match std::fs::OpenOptions::new().append(true).open(&payload) {
                     Ok(mut writer) => {
                         writer.write_all(b"6").unwrap();
@@ -2291,7 +2300,7 @@ mod tests {
             Path::new("payload.bin"),
             "same-size payload",
             16,
-            || match std::fs::OpenOptions::new().write(true).open(&payload) {
+            |_| match std::fs::OpenOptions::new().write(true).open(&payload) {
                 Ok(mut writer) => {
                     writer.write_all(b"abcde").unwrap();
                     writer.sync_all().unwrap();

--- a/crates/gore-mod/src/mgr/model.rs
+++ b/crates/gore-mod/src/mgr/model.rs
@@ -98,6 +98,36 @@ pub(crate) enum SecureNode {
     Directory(SecureDirectory),
 }
 
+#[derive(Debug)]
+pub(crate) enum MetaReadFailure {
+    AggregateBudgetExhausted {
+        required: u64,
+        remaining: u64,
+        path: PathBuf,
+    },
+    Other(crate::ModError),
+}
+
+impl MetaReadFailure {
+    fn into_mod_error(self) -> crate::ModError {
+        match self {
+            Self::AggregateBudgetExhausted {
+                remaining, path, ..
+            } => crate::ModError::Other(format!(
+                "library sidecar exceeds the {remaining} byte limit: {}",
+                path.display()
+            )),
+            Self::Other(error) => error,
+        }
+    }
+}
+
+impl From<crate::ModError> for MetaReadFailure {
+    fn from(error: crate::ModError) -> Self {
+        Self::Other(error)
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct TreeSnapshotLimits {
     pub(crate) max_entries: usize,
@@ -1347,12 +1377,39 @@ impl LibraryEntry {
     /// Read metadata within a caller's remaining aggregate budget, charging the authoritative
     /// opened-handle length before any allocation, read, or parsing work begins.
     pub(crate) fn read_meta_bounded(&self, remaining: &mut u64) -> crate::Result<ModEntryMeta> {
-        let limit = (*remaining).min(LIBRARY_META_MAX_BYTES);
-        let bytes = self.read_payload_bounded_with(
-            Path::new(META_FILE),
+        self.read_meta_bounded_classified(remaining)
+            .map_err(MetaReadFailure::into_mod_error)
+    }
+
+    /// The preflight needs to distinguish its aggregate inspection ceiling from an individually
+    /// unsupported sidecar. Both decisions use the authoritative opened handle length.
+    pub(crate) fn read_meta_bounded_classified(
+        &self,
+        remaining: &mut u64,
+    ) -> Result<ModEntryMeta, MetaReadFailure> {
+        let mut file = self.open_payload_file(Path::new(META_FILE), "library sidecar")?;
+        let path = file.path().to_path_buf();
+        let expected = file.len();
+        if expected > LIBRARY_META_MAX_BYTES {
+            return Err(MetaReadFailure::Other(crate::ModError::Other(format!(
+                "library sidecar exceeds the {LIBRARY_META_MAX_BYTES} byte limit: {}",
+                path.display()
+            ))));
+        }
+        if expected > *remaining {
+            return Err(MetaReadFailure::AggregateBudgetExhausted {
+                required: expected,
+                remaining: *remaining,
+                path,
+            });
+        }
+        *remaining -= expected;
+        let bytes = self.read_open_payload_bounded(
+            path,
+            &mut file,
+            expected,
             "library sidecar",
-            limit,
-            |expected| *remaining -= expected,
+            LIBRARY_META_MAX_BYTES,
         )?;
         let meta: ModEntryMeta = serde_json::from_slice(&bytes).map_err(|error| {
             crate::ModError::Other(format!(
@@ -1391,6 +1448,17 @@ impl LibraryEntry {
         let (path, mut file, expected) = self.open_payload_bounded(rel, label, limit)?;
         after_metadata(expected);
 
+        self.read_open_payload_bounded(path, &mut file, expected, label, limit)
+    }
+
+    fn read_open_payload_bounded(
+        &self,
+        path: PathBuf,
+        file: &mut SecureFile,
+        expected: u64,
+        label: &str,
+        limit: u64,
+    ) -> crate::Result<Vec<u8>> {
         let capacity = usize::try_from(expected).map_err(|_| {
             crate::ModError::Other(format!(
                 "{label} is too large for this process address space: {}",
@@ -1418,7 +1486,7 @@ impl LibraryEntry {
                 path.display()
             )));
         }
-        self.verify_open_payload_unchanged(&file, label, expected, observed)?;
+        self.verify_open_payload_unchanged(file, label, expected, observed)?;
         Ok(bytes)
     }
 

--- a/crates/gore-mod/src/mgr/model.rs
+++ b/crates/gore-mod/src/mgr/model.rs
@@ -1543,6 +1543,69 @@ impl LibraryEntry {
         unreachable!("non-empty optional component list returns its final file")
     }
 
+    pub(crate) fn validate_required_payload_file(
+        &self,
+        rel: &Path,
+        label: &str,
+    ) -> crate::Result<()> {
+        match self.open_required_payload_node(rel, label)? {
+            SecureNode::File(_) => Ok(()),
+            SecureNode::Directory(directory) => Err(crate::ModError::Other(format!(
+                "{label} must be a regular file: {}",
+                directory.path().display()
+            ))),
+        }
+    }
+
+    pub(crate) fn validate_optional_payload_file(
+        &self,
+        rel: &Path,
+        label: &str,
+    ) -> crate::Result<()> {
+        self.open_optional_payload_file(rel, label).map(|_| ())
+    }
+
+    pub(crate) fn validate_required_payload_directory(
+        &self,
+        rel: &Path,
+        label: &str,
+    ) -> crate::Result<()> {
+        match self.open_required_payload_node(rel, label)? {
+            SecureNode::Directory(_) => Ok(()),
+            SecureNode::File(file) => Err(crate::ModError::Other(format!(
+                "{label} must be a directory: {}",
+                file.path().display()
+            ))),
+        }
+    }
+
+    fn open_required_payload_node(&self, rel: &Path, label: &str) -> crate::Result<SecureNode> {
+        let rel_text = rel.to_string_lossy();
+        if !crate::is_safe_rel_path(&rel_text) {
+            return Err(crate::ModError::Other(format!(
+                "unsafe {label} path in library entry {:?}: {rel_text:?}",
+                self.id
+            )));
+        }
+        let path = self.path().join(rel);
+        match std::fs::symlink_metadata(&path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(crate::ModError::Other(format!(
+                    "required {label} is missing from library entry {:?}: {rel:?}",
+                    self.id
+                )))
+            }
+            Err(error) => {
+                return Err(crate::io(&format!(
+                    "inspecting required {label} in library entry {:?}",
+                    self.id
+                ))(error))
+            }
+            Ok(_) => {}
+        }
+        self.open_payload_node(rel, label)
+    }
+
     fn open_payload_directory(&self, rel: &Path, label: &str) -> crate::Result<SecureDirectory> {
         match self.open_payload_node(rel, label)? {
             SecureNode::Directory(directory) => Ok(directory),

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -266,7 +266,7 @@ fn defer_deployment_action(
     install_mutation_blocks_recovery: bool,
     ue4ss: &PreflightCheckV1,
 ) {
-    let applies_loadout = matches!(deployment.action, "apply_loadout" | "reapply_after_update");
+    let applies_loadout = matches!(deployment.action, "review_apply" | "review_reapply");
     let mutates_install = applies_loadout
         || matches!(
             deployment.action,
@@ -643,7 +643,7 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
                 PreflightStateV1::Unknown,
                 "enabled_mod_inspection_failed",
                 "inspect_permissions",
-                "one or more enabled metadata entries could not be safely inspected",
+                "one or more enabled mods have metadata or required top-level entry points that could not be safely inspected",
             )
             .with_items(unknowns),
             loadout: Some(loadout),
@@ -661,7 +661,7 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
                 PreflightStateV1::Problem,
                 "enabled_mods_unreadable",
                 "repair_library",
-                "one or more enabled mods do not have readable validated metadata",
+                "one or more enabled mods have invalid metadata or missing or obstructed required top-level entry points",
             )
             .with_items(problems),
             loadout: Some(loadout),
@@ -676,13 +676,16 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
         check: PreflightCheckV1::new(
             PreflightCheckIdV1::Loadout,
             PreflightStateV1::Ok,
-            "loadout_valid",
+            "loadout_metadata_ready",
             "none",
             format!(
-                "the loadout and {} enabled mod metadata entries are valid",
+                "the loadout and {} enabled mod metadata entries passed bounded metadata and top-level entry-point inspection",
                 enabled.len()
             ),
-        ),
+        )
+        .with_items([String::from(
+            "unverified until Apply: nested manifests, referenced payloads, decoding, cross-mod composition, and current install state",
+        )]),
         loadout: Some(loadout),
         ue4ss: if requires_ue4ss {
             Ue4ssRequirement::Required
@@ -1052,16 +1055,16 @@ where
                 PreflightCheckIdV1::Deployment,
                 PreflightStateV1::Problem,
                 "deployment_changes_pending",
-                "apply_loadout",
-                "the selected loadout differs from the active Manager deployment",
+                "review_apply",
+                "the selected loadout differs from the active Manager deployment; Apply performs authoritative validation before mutation",
             )
             .with_items(items)
         }
         Ok(ManagerStatus::GameUpdated { drifted }) => {
             let (action, detail) = if loadout_healthy {
                 (
-                    "reapply_after_update",
-                    "files owned by the active Manager deployment changed outside GORE",
+                    "review_reapply",
+                    "files owned by the active Manager deployment changed outside GORE; Reapply performs authoritative validation before mutation",
                 )
             } else {
                 (
@@ -1640,13 +1643,59 @@ mod tests {
 
         assert_eq!(
             inspect_loadout(&library, &loadout).check.code,
-            "loadout_valid"
+            "loadout_metadata_ready"
         );
         fs::remove_file(entry.join("io/mod.ucas")).unwrap();
         assert_eq!(
             inspect_loadout(&library, &loadout).check.code,
             "enabled_mods_unreadable"
         );
+    }
+
+    #[test]
+    fn nested_payload_validation_is_explicitly_deferred_to_apply() {
+        let root = tempfile::tempdir().unwrap();
+        let library = root.path().join("library");
+        fs::create_dir(&library).unwrap();
+        write_library_meta(
+            &library,
+            "deferred",
+            vec![
+                ComponentInfo::AudioPatch {
+                    rel: "audio".to_owned(),
+                    targets: Vec::new(),
+                },
+                ComponentInfo::AngelScriptPatch {
+                    rel: "scripts".to_owned(),
+                    targets: Vec::new(),
+                },
+                ComponentInfo::FilePatch {
+                    rel: "files".to_owned(),
+                    targets: Vec::new(),
+                },
+            ],
+        );
+        let entry = library.join("deferred");
+        for (directory, manifest) in [
+            ("audio", br#"{"source":"missing.wav"}"#.as_slice()),
+            ("scripts", b"not-json".as_slice()),
+            ("files", br#"{"source":"missing.bin"}"#.as_slice()),
+        ] {
+            fs::create_dir(entry.join(directory)).unwrap();
+            fs::write(entry.join(directory).join("manifest.json"), manifest).unwrap();
+        }
+        let loadout = root.path().join("loadout.json");
+        write_enabled_loadout(&loadout, &["deferred"]);
+
+        let check = inspect_loadout(&library, &loadout).check;
+        assert_eq!(check.state, PreflightStateV1::Ok);
+        assert_eq!(check.code, "loadout_metadata_ready");
+        assert_eq!(check.action, "none");
+        assert_ne!(check.code, "loadout_valid");
+        assert!(check
+            .items
+            .iter()
+            .any(|item| item.contains("unverified until Apply")));
     }
 
     #[test]
@@ -1891,9 +1940,12 @@ mod tests {
         );
         assert_eq!(report.checks[2].code, "enabled_mods_unreadable");
         assert!(report.checks[2]
+            .detail
+            .contains("required top-level entry points"));
+        assert!(report.checks[2]
             .items
             .iter()
-            .any(|item| item.contains("required loose pak is missing")));
+            .any(|item| item.contains("required loose pak child is missing")));
         assert_eq!(report.checks[3].action, "resolve_loadout_check");
     }
 
@@ -1943,7 +1995,7 @@ mod tests {
                 },
                 PreflightStateV1::Problem,
                 "deployment_changes_pending",
-                "apply_loadout",
+                "review_apply",
             ),
             (
                 ManagerStatus::GameUpdated {
@@ -1951,7 +2003,7 @@ mod tests {
                 },
                 PreflightStateV1::Problem,
                 "deployment_game_updated",
-                "reapply_after_update",
+                "review_reapply",
             ),
         ];
         for (status, state, code, action) in cases {
@@ -2027,7 +2079,7 @@ mod tests {
                 PreflightCheckIdV1::Deployment,
                 PreflightStateV1::Problem,
                 "deployment_changes_pending",
-                "apply_loadout",
+                "review_apply",
                 "pending",
             )
         };
@@ -2080,7 +2132,7 @@ mod tests {
 
         let mut healthy = deployment();
         defer_deployment_action(&mut healthy, &ok_install, &clear_mutation, false, &no_ue4ss);
-        assert_eq!(healthy.action, "apply_loadout");
+        assert_eq!(healthy.action, "review_apply");
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -16,7 +16,7 @@ use gore_as::compile::{
 use serde::Serialize;
 
 use super::loadout::Loadout;
-use super::model::{ComponentInfo, LibraryRoot, SecureDirectory, SecureNode};
+use super::model::{ComponentInfo, LibraryRoot, MetaReadFailure, SecureDirectory, SecureNode};
 use super::status::ManagerStatus;
 
 const FORMAT: u32 = 1;
@@ -154,12 +154,13 @@ enum DeploymentRecoveryEvidence {
 enum EvidenceFailure {
     Problem(String),
     Unknown(String),
+    Bounded(String),
 }
 
 impl EvidenceFailure {
     fn message(self) -> String {
         match self {
-            Self::Problem(message) | Self::Unknown(message) => message,
+            Self::Problem(message) | Self::Unknown(message) | Self::Bounded(message) => message,
         }
     }
 }
@@ -635,6 +636,12 @@ fn inspect_loadout_with_meta_budget(
                     "inspect_permissions",
                     "enabled mods exist but the Manager library could not be safely inspected",
                 ),
+                EvidenceFailure::Bounded(_) => (
+                    PreflightStateV1::Unknown,
+                    "enabled_library_inspection_bounded",
+                    "verify_during_apply",
+                    "enabled mods exist but the bounded preflight could not finish inspecting the Manager library",
+                ),
             };
             return LoadoutInspection {
                 check: PreflightCheckV1::new(
@@ -653,6 +660,7 @@ fn inspect_loadout_with_meta_budget(
     };
     let mut problems = Vec::new();
     let mut unknowns = Vec::new();
+    let mut bounded = Vec::new();
     let mut requires_ue4ss = false;
     let mut requires_script_cache = false;
     let mut remaining_meta_bytes = meta_budget;
@@ -679,11 +687,15 @@ fn inspect_loadout_with_meta_budget(
                 EvidenceFailure::Unknown(message) => {
                     push_bounded_evidence(&mut unknowns, format!("{}: {message}", entry.id));
                 }
+                EvidenceFailure::Bounded(message) => {
+                    push_bounded_evidence(&mut bounded, format!("{}: {message}", entry.id));
+                }
             },
         }
     }
     if !unknowns.is_empty() {
         unknowns.extend(problems);
+        unknowns.extend(bounded);
         return LoadoutInspection {
             check: PreflightCheckV1::new(
                 PreflightCheckIdV1::Loadout,
@@ -703,6 +715,7 @@ fn inspect_loadout_with_meta_budget(
         };
     }
     if !problems.is_empty() {
+        problems.extend(bounded);
         return LoadoutInspection {
             check: PreflightCheckV1::new(
                 PreflightCheckIdV1::Loadout,
@@ -712,6 +725,25 @@ fn inspect_loadout_with_meta_budget(
                 "one or more enabled mods have invalid metadata or missing or obstructed required top-level entry points",
             )
             .with_items(problems),
+            loadout: Some(loadout),
+            ue4ss: if requires_ue4ss {
+                Ue4ssRequirement::Required
+            } else {
+                Ue4ssRequirement::Unknown
+            },
+            requires_script_cache,
+        };
+    }
+    if !bounded.is_empty() {
+        return LoadoutInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::Loadout,
+                PreflightStateV1::Unknown,
+                "enabled_mod_metadata_budget_exhausted",
+                "verify_during_apply",
+                "enabled mod metadata exceeded the bounded read-only inspection budget; Apply performs authoritative per-mod validation",
+            )
+            .with_items(bounded),
             loadout: Some(loadout),
             ue4ss: if requires_ue4ss {
                 Ue4ssRequirement::Required
@@ -795,16 +827,28 @@ fn inspect_enabled_meta(
         }
         Ok(_) => {}
     }
-    let result = (|| {
-        let library_entry = library.entry(id)?;
-        let meta = library_entry.read_meta_bounded(remaining_meta_bytes)?;
-        for component in &meta.components {
-            super::apply::validate_component_descriptor_for_default_apply(component)?;
-            validate_component_payload_presence(&library_entry, component)?;
+    let library_entry = library.entry(id).map_err(classify_mod_error)?;
+    let meta = match library_entry.read_meta_bounded_classified(remaining_meta_bytes) {
+        Ok(meta) => meta,
+        Err(MetaReadFailure::AggregateBudgetExhausted {
+            required,
+            remaining,
+            path,
+        }) => {
+            return Err(EvidenceFailure::Bounded(format!(
+                "aggregate metadata inspection budget exhausted: {required} bytes required with {remaining} remaining at {}",
+                display_path(&path)
+            )))
         }
-        Ok(meta)
-    })();
-    result.map_err(classify_mod_error)
+        Err(MetaReadFailure::Other(error)) => return Err(classify_mod_error(error)),
+    };
+    for component in &meta.components {
+        super::apply::validate_component_descriptor_for_default_apply(component)
+            .map_err(classify_mod_error)?;
+        validate_component_payload_presence(&library_entry, component)
+            .map_err(classify_mod_error)?;
+    }
+    Ok(meta)
 }
 
 fn validate_component_payload_presence(
@@ -856,6 +900,12 @@ fn loadout_failure(failure: EvidenceFailure) -> LoadoutInspection {
             "loadout_inspection_failed",
             "inspect_permissions",
             "the Manager loadout could not be safely inspected",
+        ),
+        EvidenceFailure::Bounded(_) => (
+            PreflightStateV1::Unknown,
+            "loadout_inspection_bounded",
+            "verify_during_apply",
+            "the bounded read-only preflight could not finish inspecting the Manager loadout",
         ),
     };
     LoadoutInspection {
@@ -1692,13 +1742,17 @@ mod tests {
         write_enabled_loadout(&loadout, &["alpha", "beta"]);
         let over_budget =
             inspect_loadout_with_meta_budget(&library, &loadout, alpha_len + beta_len - 1);
-        assert_eq!(over_budget.check.state, PreflightStateV1::Problem);
-        assert_eq!(over_budget.check.code, "enabled_mods_unreadable");
+        assert_eq!(over_budget.check.state, PreflightStateV1::Unknown);
+        assert_eq!(
+            over_budget.check.code,
+            "enabled_mod_metadata_budget_exhausted"
+        );
+        assert_eq!(over_budget.check.action, "verify_during_apply");
         assert!(over_budget
             .check
             .items
             .iter()
-            .any(|item| item.contains("byte limit")));
+            .any(|item| item.contains("aggregate metadata inspection budget exhausted")));
 
         assert_eq!(
             inspect_loadout_with_meta_budget(&library, &loadout, alpha_len + beta_len)
@@ -1707,6 +1761,18 @@ mod tests {
             "loadout_metadata_ready"
         );
 
+        let oversized_dir = library.join("oversized");
+        fs::create_dir(&oversized_dir).unwrap();
+        let oversized =
+            fs::File::create(oversized_dir.join(super::super::model::META_FILE)).unwrap();
+        oversized.set_len(MAX_LOADOUT_META_BYTES + 1).unwrap();
+        drop(oversized);
+        write_enabled_loadout(&loadout, &["alpha", "oversized"]);
+        let unsupported = inspect_loadout_with_meta_budget(&library, &loadout, alpha_len);
+        assert_eq!(unsupported.check.state, PreflightStateV1::Problem);
+        assert_eq!(unsupported.check.code, "enabled_mods_unreadable");
+        assert_eq!(unsupported.check.action, "repair_library");
+
         fs::write(
             library
                 .join("alpha")
@@ -1714,12 +1780,15 @@ mod tests {
             b"{",
         )
         .unwrap();
+        write_enabled_loadout(&loadout, &["alpha", "beta"]);
         let corrupt = inspect_loadout_with_meta_budget(&library, &loadout, 1);
+        assert_eq!(corrupt.check.state, PreflightStateV1::Problem);
+        assert_eq!(corrupt.check.code, "enabled_mods_unreadable");
         assert!(corrupt
             .check
             .items
             .iter()
-            .any(|item| item.starts_with("beta:") && item.contains("0 byte limit")));
+            .any(|item| item.starts_with("alpha:") && item.contains("corrupt library sidecar")));
     }
 
     fn write_library_meta(library: &Path, id: &str, components: Vec<ComponentInfo>) {

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -22,6 +22,8 @@ use super::status::ManagerStatus;
 const FORMAT: u32 = 1;
 const MAX_LOADOUT_BYTES: u64 = 1024 * 1024;
 const MAX_LOADOUT_META_BYTES: u64 = 16 * 1024 * 1024;
+// One unit covers either one component descriptor or one no-follow payload path component.
+const MAX_LOADOUT_COMPONENT_PROBES: u64 = 100_000;
 const MAX_CHECK_ITEMS: usize = 16;
 const MAX_DETAIL_BYTES: usize = 2 * 1024;
 const MAX_ITEM_BYTES: usize = 1024;
@@ -130,11 +132,20 @@ enum Ue4ssRequirement {
     Required,
     NotRequired,
     Unknown,
+    VerifyDuringApply,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoadoutReadiness {
+    Verified,
+    ApplyAuthoritative,
+    Blocked,
 }
 
 struct LoadoutInspection {
     check: PreflightCheckV1,
     loadout: Option<Loadout>,
+    readiness: LoadoutReadiness,
     ue4ss: Ue4ssRequirement,
     requires_script_cache: bool,
 }
@@ -226,12 +237,11 @@ where
     let root = inspect_game_root(game_root);
     let loadout = inspect_loadout(library_dir, loadout_path);
     let install = inspect_install(root.directory.as_ref(), loadout.requires_script_cache);
-    let loadout_healthy = loadout.check.state == PreflightStateV1::Ok;
     let (mut deployment, deployment_recovery) = inspect_deployment(
         root.root.as_deref(),
         library_dir,
         loadout.loadout.as_ref(),
-        loadout_healthy,
+        loadout.readiness,
         status,
     );
     let install_mutation = inspect_install_mutation(
@@ -298,6 +308,7 @@ fn defer_deployment_action(
             ue4ss.state,
             PreflightStateV1::Problem | PreflightStateV1::Unknown
         )
+        && ue4ss.action != "verify_during_apply"
     {
         Some((ue4ss, "UE4SS"))
     } else {
@@ -596,6 +607,20 @@ fn inspect_loadout_with_meta_budget(
     loadout_path: &Path,
     meta_budget: u64,
 ) -> LoadoutInspection {
+    inspect_loadout_with_budgets(
+        library_dir,
+        loadout_path,
+        meta_budget,
+        MAX_LOADOUT_COMPONENT_PROBES,
+    )
+}
+
+fn inspect_loadout_with_budgets(
+    library_dir: &Path,
+    loadout_path: &Path,
+    meta_budget: u64,
+    component_probe_budget: u64,
+) -> LoadoutInspection {
     let loadout = match read_loadout_bounded(loadout_path) {
         Ok(loadout) => loadout,
         Err(failure) => return loadout_failure(failure),
@@ -615,6 +640,7 @@ fn inspect_loadout_with_meta_budget(
                 "the loadout is valid and has no enabled mods",
             ),
             loadout: Some(loadout),
+            readiness: LoadoutReadiness::Verified,
             ue4ss: Ue4ssRequirement::NotRequired,
             requires_script_cache: false,
         };
@@ -623,6 +649,7 @@ fn inspect_loadout_with_meta_budget(
     let library = match inspect_library_root(library_dir) {
         Ok(library) => library,
         Err(failure) => {
+            let bounded = matches!(&failure, EvidenceFailure::Bounded(_));
             let (state, code, action, detail) = match &failure {
                 EvidenceFailure::Problem(_) => (
                     PreflightStateV1::Problem,
@@ -653,7 +680,16 @@ fn inspect_loadout_with_meta_budget(
                 )
                 .with_items([failure.message()]),
                 loadout: Some(loadout),
-                ue4ss: Ue4ssRequirement::Unknown,
+                readiness: if bounded {
+                    LoadoutReadiness::ApplyAuthoritative
+                } else {
+                    LoadoutReadiness::Blocked
+                },
+                ue4ss: if bounded {
+                    Ue4ssRequirement::VerifyDuringApply
+                } else {
+                    Ue4ssRequirement::Unknown
+                },
                 requires_script_cache: false,
             };
         }
@@ -664,12 +700,19 @@ fn inspect_loadout_with_meta_budget(
     let mut requires_ue4ss = false;
     let mut requires_script_cache = false;
     let mut remaining_meta_bytes = meta_budget;
+    let mut remaining_component_probes = component_probe_budget;
     let mut inspected_ids = HashSet::new();
     for entry in &enabled {
         if !inspected_ids.insert(entry.id.as_str()) {
             continue;
         }
-        match inspect_enabled_meta(&library, library_dir, &entry.id, &mut remaining_meta_bytes) {
+        match inspect_enabled_meta(
+            &library,
+            library_dir,
+            &entry.id,
+            &mut remaining_meta_bytes,
+            &mut remaining_component_probes,
+        ) {
             Ok(meta) => {
                 requires_ue4ss |= meta
                     .components
@@ -706,6 +749,7 @@ fn inspect_loadout_with_meta_budget(
             )
             .with_items(unknowns),
             loadout: Some(loadout),
+            readiness: LoadoutReadiness::Blocked,
             ue4ss: if requires_ue4ss {
                 Ue4ssRequirement::Required
             } else {
@@ -726,6 +770,7 @@ fn inspect_loadout_with_meta_budget(
             )
             .with_items(problems),
             loadout: Some(loadout),
+            readiness: LoadoutReadiness::Blocked,
             ue4ss: if requires_ue4ss {
                 Ue4ssRequirement::Required
             } else {
@@ -739,16 +784,17 @@ fn inspect_loadout_with_meta_budget(
             check: PreflightCheckV1::new(
                 PreflightCheckIdV1::Loadout,
                 PreflightStateV1::Unknown,
-                "enabled_mod_metadata_budget_exhausted",
+                "enabled_mod_inspection_limit",
                 "verify_during_apply",
-                "enabled mod metadata exceeded the bounded read-only inspection budget; Apply performs authoritative per-mod validation",
+                "enabled mod metadata or top-level entry-point probes exceeded the bounded read-only inspection budget; Apply performs authoritative per-mod validation",
             )
             .with_items(bounded),
             loadout: Some(loadout),
+            readiness: LoadoutReadiness::ApplyAuthoritative,
             ue4ss: if requires_ue4ss {
                 Ue4ssRequirement::Required
             } else {
-                Ue4ssRequirement::Unknown
+                Ue4ssRequirement::VerifyDuringApply
             },
             requires_script_cache,
         };
@@ -768,6 +814,7 @@ fn inspect_loadout_with_meta_budget(
             "unverified until Apply: nested manifests, referenced payloads, decoding, cross-mod composition, and current install state",
         )]),
         loadout: Some(loadout),
+        readiness: LoadoutReadiness::Verified,
         ue4ss: if requires_ue4ss {
             Ue4ssRequirement::Required
         } else {
@@ -782,6 +829,7 @@ fn inspect_enabled_meta(
     library_dir: &Path,
     id: &str,
     remaining_meta_bytes: &mut u64,
+    remaining_component_probes: &mut u64,
 ) -> Result<super::model::ModEntryMeta, EvidenceFailure> {
     let entry_path = library_dir.join(id);
     match std::fs::symlink_metadata(&entry_path) {
@@ -843,12 +891,55 @@ fn inspect_enabled_meta(
         Err(MetaReadFailure::Other(error)) => return Err(classify_mod_error(error)),
     };
     for component in &meta.components {
+        charge_component_probes(remaining_component_probes, 1, "component descriptor")?;
         super::apply::validate_component_descriptor_for_default_apply(component)
             .map_err(classify_mod_error)?;
+        // Charge every path component up front so a partial budget never starts an unbounded
+        // secure traversal. The descriptor check above already bounds each path to Apply's limit.
+        charge_component_probes(
+            remaining_component_probes,
+            component_payload_probe_cost(component),
+            "component payload path",
+        )?;
         validate_component_payload_presence(&library_entry, component)
             .map_err(classify_mod_error)?;
     }
     Ok(meta)
+}
+
+fn charge_component_probes(
+    remaining: &mut u64,
+    required: u64,
+    label: &str,
+) -> Result<(), EvidenceFailure> {
+    if required > *remaining {
+        return Err(EvidenceFailure::Bounded(format!(
+            "aggregate component/probe inspection budget exhausted: {required} units required with {} remaining before {label}",
+            *remaining
+        )));
+    }
+    *remaining -= required;
+    Ok(())
+}
+
+fn component_payload_probe_cost(component: &ComponentInfo) -> u64 {
+    let path_cost = |rel: &str| Path::new(rel).components().count() as u64;
+    match component {
+        ComponentInfo::Ue4ssLua { rel, .. }
+        | ComponentInfo::LocPatch { rel, .. }
+        | ComponentInfo::TexturePatch { rel, .. }
+        | ComponentInfo::PakFilePatch { rel, .. }
+        | ComponentInfo::VoiceArchivePatch { rel, .. }
+        | ComponentInfo::LoosePak { rel, .. }
+        | ComponentInfo::RawFile { rel, .. } => path_cost(rel),
+        ComponentInfo::AudioPatch { rel, .. }
+        | ComponentInfo::AngelScriptPatch { rel, .. }
+        | ComponentInfo::FilePatch { rel, .. } => path_cost(&format!("{rel}/manifest.json")),
+        ComponentInfo::Triplet { rel_base, .. } => ["utoc", "ucas", "pak"]
+            .into_iter()
+            .map(|ext| path_cost(&format!("{rel_base}.{ext}")))
+            .sum(),
+    }
 }
 
 fn validate_component_payload_presence(
@@ -912,6 +1003,7 @@ fn loadout_failure(failure: EvidenceFailure) -> LoadoutInspection {
         check: PreflightCheckV1::new(PreflightCheckIdV1::Loadout, state, code, action, detail)
             .with_items([failure.message()]),
         loadout: None,
+        readiness: LoadoutReadiness::Blocked,
         ue4ss: Ue4ssRequirement::Unknown,
         requires_script_cache: false,
     }
@@ -1061,7 +1153,7 @@ fn inspect_deployment<S>(
     game_root: Option<&Path>,
     library_dir: &Path,
     loadout: Option<&Loadout>,
-    loadout_healthy: bool,
+    loadout_readiness: LoadoutReadiness,
     status: S,
 ) -> (PreflightCheckV1, DeploymentRecoveryEvidence)
 where
@@ -1116,7 +1208,7 @@ where
         )
         .with_items([format!("active mod: {mod_name}")]),
         Ok(ManagerStatus::InSync { .. } | ManagerStatus::ChangesPending { .. })
-            if !loadout_healthy =>
+            if loadout_readiness == LoadoutReadiness::Blocked =>
         {
             PreflightCheckV1::new(
                 PreflightCheckIdV1::Deployment,
@@ -1124,6 +1216,17 @@ where
                 "deployment_not_inspected",
                 "resolve_loadout_check",
                 "resolve the preceding Loadout finding before comparing deployment state",
+            )
+        }
+        Ok(ManagerStatus::InSync { .. })
+            if loadout_readiness == LoadoutReadiness::ApplyAuthoritative =>
+        {
+            PreflightCheckV1::new(
+                PreflightCheckIdV1::Deployment,
+                PreflightStateV1::Unknown,
+                "deployment_loadout_inspection_limit",
+                "review_apply",
+                "deployment fingerprints match, but bounded loadout inspection did not validate every enabled mod; Apply performs authoritative validation before mutation",
             )
         }
         Ok(ManagerStatus::InSync { loadout }) => PreflightCheckV1::new(
@@ -1171,7 +1274,7 @@ where
             .with_items(items)
         }
         Ok(ManagerStatus::GameUpdated { drifted }) => {
-            let (action, detail) = if loadout_healthy {
+            let (action, detail) = if loadout_readiness != LoadoutReadiness::Blocked {
                 (
                     "review_reapply",
                     "files owned by the active Manager deployment changed outside GORE; Reapply performs authoritative validation before mutation",
@@ -1414,6 +1517,15 @@ fn inspect_ue4ss(
                 "ue4ss_requirement_unknown",
                 "resolve_loadout_check",
                 "resolve the preceding Loadout finding before deciding whether UE4SS is required",
+            )
+        }
+        Ue4ssRequirement::VerifyDuringApply => {
+            return PreflightCheckV1::new(
+                PreflightCheckIdV1::Ue4ss,
+                PreflightStateV1::Unknown,
+                "ue4ss_requirement_inspection_limit",
+                "verify_during_apply",
+                "bounded loadout inspection could not establish whether UE4SS is required; Apply re-reads the complete enabled metadata before planning the deployment",
             )
         }
         Ue4ssRequirement::Required => {}
@@ -1755,16 +1867,29 @@ mod tests {
         let over_budget =
             inspect_loadout_with_meta_budget(&library, &loadout, alpha_len + beta_len - 1);
         assert_eq!(over_budget.check.state, PreflightStateV1::Unknown);
-        assert_eq!(
-            over_budget.check.code,
-            "enabled_mod_metadata_budget_exhausted"
-        );
+        assert_eq!(over_budget.check.code, "enabled_mod_inspection_limit");
         assert_eq!(over_budget.check.action, "verify_during_apply");
+        assert_eq!(over_budget.readiness, LoadoutReadiness::ApplyAuthoritative);
         assert!(over_budget
             .check
             .items
             .iter()
             .any(|item| item.contains("aggregate metadata inspection budget exhausted")));
+        let target = over_budget.loadout.as_ref().unwrap();
+        let (deployment, _) = inspect_deployment(
+            Some(Path::new("C:/display-only-game")),
+            &library,
+            Some(target),
+            over_budget.readiness,
+            |_, _, _| {
+                Ok(ManagerStatus::ChangesPending {
+                    deployed: Vec::new(),
+                    target: target.entries.clone(),
+                })
+            },
+        );
+        assert_eq!(deployment.code, "deployment_changes_pending");
+        assert_eq!(deployment.action, "review_apply");
 
         assert_eq!(
             inspect_loadout_with_meta_budget(&library, &loadout, alpha_len + beta_len)
@@ -1801,6 +1926,129 @@ mod tests {
             .items
             .iter()
             .any(|item| item.starts_with("alpha:") && item.contains("corrupt library sidecar")));
+    }
+
+    #[test]
+    fn component_probe_budget_stops_before_traversal_and_keeps_apply_reachable() {
+        let root = tempfile::tempdir().unwrap();
+        let library = root.path().join("library");
+        fs::create_dir(&library).unwrap();
+        for id in ["alpha", "beta"] {
+            write_library_meta(
+                &library,
+                id,
+                vec![ComponentInfo::LoosePak {
+                    rel: "payload.pak".to_owned(),
+                    targets: Vec::new(),
+                }],
+            );
+        }
+        fs::write(library.join("alpha/payload.pak"), b"pak").unwrap();
+        let loadout_path = root.path().join("loadout.json");
+
+        write_enabled_loadout(&loadout_path, &["alpha", "alpha"]);
+        let duplicate =
+            inspect_loadout_with_budgets(&library, &loadout_path, MAX_LOADOUT_META_BYTES, 2);
+        assert_eq!(duplicate.check.code, "loadout_metadata_ready");
+
+        write_enabled_loadout(&loadout_path, &["alpha", "beta"]);
+        let bounded =
+            inspect_loadout_with_budgets(&library, &loadout_path, MAX_LOADOUT_META_BYTES, 3);
+        assert_eq!(bounded.check.state, PreflightStateV1::Unknown);
+        assert_eq!(bounded.check.code, "enabled_mod_inspection_limit");
+        assert_eq!(bounded.check.action, "verify_during_apply");
+        assert_eq!(bounded.readiness, LoadoutReadiness::ApplyAuthoritative);
+        assert!(matches!(bounded.ue4ss, Ue4ssRequirement::VerifyDuringApply));
+        assert!(bounded
+            .check
+            .items
+            .iter()
+            .any(|item| item.contains("component/probe inspection budget exhausted")));
+
+        // The fourth unit permits beta's payload traversal, so the deliberately missing payload
+        // is then an actual library problem rather than an inspection-limit result.
+        let missing =
+            inspect_loadout_with_budgets(&library, &loadout_path, MAX_LOADOUT_META_BYTES, 4);
+        assert_eq!(missing.check.state, PreflightStateV1::Problem);
+        assert_eq!(missing.readiness, LoadoutReadiness::Blocked);
+        assert!(missing
+            .check
+            .items
+            .iter()
+            .any(|item| item.contains("required loose pak child is missing")));
+
+        let target = bounded.loadout.as_ref().unwrap();
+        let cases = [
+            (
+                ManagerStatus::InSync {
+                    loadout: target.entries.clone(),
+                },
+                PreflightStateV1::Unknown,
+                "deployment_loadout_inspection_limit",
+                "review_apply",
+            ),
+            (
+                ManagerStatus::ChangesPending {
+                    deployed: Vec::new(),
+                    target: target.entries.clone(),
+                },
+                PreflightStateV1::Problem,
+                "deployment_changes_pending",
+                "review_apply",
+            ),
+            (
+                ManagerStatus::GameUpdated {
+                    drifted: vec!["changed.bin".to_owned()],
+                },
+                PreflightStateV1::Problem,
+                "deployment_game_updated",
+                "review_reapply",
+            ),
+        ];
+        for (status, state, code, action) in cases {
+            let (deployment, _) = inspect_deployment(
+                Some(Path::new("C:/display-only-game")),
+                &library,
+                Some(target),
+                bounded.readiness,
+                move |_, _, _| Ok(status),
+            );
+            assert_eq!(deployment.state, state, "code: {code}");
+            assert_eq!(deployment.code, code);
+            assert_eq!(deployment.action, action);
+        }
+
+        let ue4ss = inspect_ue4ss(None, bounded.ue4ss);
+        assert_eq!(ue4ss.code, "ue4ss_requirement_inspection_limit");
+        assert_eq!(ue4ss.action, "verify_during_apply");
+        let ok_install = PreflightCheckV1::new(
+            PreflightCheckIdV1::Install,
+            PreflightStateV1::Ok,
+            "install_recognized",
+            "none",
+            "ok",
+        );
+        let clear_mutation = PreflightCheckV1::new(
+            PreflightCheckIdV1::InstallMutation,
+            PreflightStateV1::Ok,
+            "install_mutation_clear",
+            "none",
+            "clear",
+        );
+        let (mut deployment, _) = inspect_deployment(
+            Some(Path::new("C:/display-only-game")),
+            &library,
+            Some(target),
+            bounded.readiness,
+            |_, _, _| {
+                Ok(ManagerStatus::ChangesPending {
+                    deployed: Vec::new(),
+                    target: target.entries.clone(),
+                })
+            },
+        );
+        defer_deployment_action(&mut deployment, &ok_install, &clear_mutation, false, &ue4ss);
+        assert_eq!(deployment.action, "review_apply");
     }
 
     fn write_library_meta(library: &Path, id: &str, components: Vec<ComponentInfo>) {
@@ -2414,7 +2662,7 @@ mod tests {
                 Some(Path::new("C:/display-only-game")),
                 Path::new("C:/display-only-library"),
                 Some(&Loadout::default()),
-                true,
+                LoadoutReadiness::Verified,
                 move |_, _, _| Ok(status),
             );
             assert_eq!(check.state, state, "code: {code}");

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -165,7 +165,7 @@ pub fn preflight_v1(
         game_root,
         library_dir,
         loadout_path,
-        super::status::status,
+        super::status::status_for_preflight,
         gore_as::compile::probe_install_compile_state,
         crate::deploy_recovery_required,
     )

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -858,7 +858,7 @@ fn inspect_deployment<S>(
 where
     S: FnOnce(&Path, &Path, &Loadout) -> crate::Result<ManagerStatus>,
 {
-    let (Some(game_root), Some(loadout)) = (game_root, loadout) else {
+    let Some(game_root) = game_root else {
         return (
             PreflightCheckV1::new(
                 PreflightCheckIdV1::Deployment,
@@ -870,7 +870,12 @@ where
             false,
         );
     };
-    let status = status(game_root, library_dir, loadout);
+    // Status resolves the deploy-record states that do not depend on the target loadout before it
+    // compares loadouts. Preserve those recovery/studio/drift findings even when the loadout is
+    // unreadable, but never project an InSync/ChangesPending conclusion from the fallback target.
+    let fallback_loadout = Loadout::default();
+    let loadout_readable = loadout.is_some();
+    let status = status(game_root, library_dir, loadout.unwrap_or(&fallback_loadout));
     let deployment_recovery_seen = matches!(&status, Ok(ManagerStatus::RecoveryRequired));
     let check = match status {
         Ok(ManagerStatus::NothingDeployed) => PreflightCheckV1::new(
@@ -895,6 +900,17 @@ where
             "a Mod Studio deployment is active and Manager must not replace it",
         )
         .with_items([format!("active mod: {mod_name}")]),
+        Ok(ManagerStatus::InSync { .. } | ManagerStatus::ChangesPending { .. })
+            if !loadout_readable =>
+        {
+            PreflightCheckV1::new(
+                PreflightCheckIdV1::Deployment,
+                PreflightStateV1::Unknown,
+                "deployment_not_inspected",
+                "repair_preflight_inputs",
+                "deployment loadout comparison needs a valid loadout",
+            )
+        }
         Ok(ManagerStatus::InSync { loadout }) => PreflightCheckV1::new(
             PreflightCheckIdV1::Deployment,
             PreflightStateV1::Ok,
@@ -1535,6 +1551,84 @@ mod tests {
         );
         assert_eq!(state.checks[3].state, PreflightStateV1::Unknown);
         assert_eq!(state.checks[3].code, "deployment_inspection_failed");
+    }
+
+    #[test]
+    fn unreadable_loadout_preserves_loadout_independent_deployment_findings() {
+        let install = install_fixture();
+        let library = install.path().join("library");
+        let loadout = install.path().join("loadout.json");
+        fs::write(&loadout, b"{").unwrap();
+
+        let recovery = run_with(
+            install.path(),
+            &library,
+            &loadout,
+            |_, _, target| {
+                assert!(target.entries.is_empty());
+                Ok(ManagerStatus::RecoveryRequired)
+            },
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+        assert_eq!(recovery.checks[2].code, "loadout_unreadable");
+        assert_eq!(recovery.checks[3].code, "deployment_recovery_required");
+        assert_eq!(recovery.checks[4].code, "install_recovery_required");
+
+        let independent = [
+            (
+                ManagerStatus::NothingDeployed,
+                "deployment_none",
+                PreflightStateV1::Ok,
+            ),
+            (
+                ManagerStatus::StudioDeployActive {
+                    mod_name: "studio".to_owned(),
+                },
+                "studio_deployment_active",
+                PreflightStateV1::Problem,
+            ),
+            (
+                ManagerStatus::GameUpdated {
+                    drifted: vec!["changed.bin".to_owned()],
+                },
+                "deployment_game_updated",
+                PreflightStateV1::Problem,
+            ),
+        ];
+        for (status, code, state) in independent {
+            let report = run_with(
+                install.path(),
+                &library,
+                &loadout,
+                move |_, _, _| Ok(status),
+                |_| safe_probe(),
+                |_| Ok(false),
+            );
+            assert_eq!(report.checks[3].code, code);
+            assert_eq!(report.checks[3].state, state);
+        }
+
+        for status in [
+            ManagerStatus::InSync {
+                loadout: Vec::new(),
+            },
+            ManagerStatus::ChangesPending {
+                deployed: Vec::new(),
+                target: Vec::new(),
+            },
+        ] {
+            let report = run_with(
+                install.path(),
+                &library,
+                &loadout,
+                move |_, _, _| Ok(status),
+                |_| safe_probe(),
+                |_| Ok(false),
+            );
+            assert_eq!(report.checks[3].state, PreflightStateV1::Unknown);
+            assert_eq!(report.checks[3].code, "deployment_not_inspected");
+        }
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -5,6 +5,7 @@
 //! Paths in the result are bounded display strings only; callers must send the selected game root
 //! back to the mutating command, which performs its own authoritative preflight.
 
+use std::collections::HashSet;
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
 
@@ -20,6 +21,7 @@ use super::status::ManagerStatus;
 
 const FORMAT: u32 = 1;
 const MAX_LOADOUT_BYTES: u64 = 1024 * 1024;
+const MAX_LOADOUT_META_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_CHECK_ITEMS: usize = 16;
 const MAX_DETAIL_BYTES: usize = 2 * 1024;
 const MAX_ITEM_BYTES: usize = 1024;
@@ -585,6 +587,14 @@ fn inspect_relative(
 }
 
 fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection {
+    inspect_loadout_with_meta_budget(library_dir, loadout_path, MAX_LOADOUT_META_BYTES)
+}
+
+fn inspect_loadout_with_meta_budget(
+    library_dir: &Path,
+    loadout_path: &Path,
+    meta_budget: u64,
+) -> LoadoutInspection {
     let loadout = match read_loadout_bounded(loadout_path) {
         Ok(loadout) => loadout,
         Err(failure) => return loadout_failure(failure),
@@ -645,8 +655,13 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
     let mut unknowns = Vec::new();
     let mut requires_ue4ss = false;
     let mut requires_script_cache = false;
+    let mut remaining_meta_bytes = meta_budget;
+    let mut inspected_ids = HashSet::new();
     for entry in &enabled {
-        match inspect_enabled_meta(&library, library_dir, &entry.id) {
+        if !inspected_ids.insert(entry.id.as_str()) {
+            continue;
+        }
+        match inspect_enabled_meta(&library, library_dir, &entry.id, &mut remaining_meta_bytes) {
             Ok(meta) => {
                 requires_ue4ss |= meta
                     .components
@@ -713,8 +728,8 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
             "loadout_metadata_ready",
             "none",
             format!(
-                "the loadout and {} enabled mod metadata entries passed bounded metadata and top-level entry-point inspection",
-                enabled.len()
+                "the loadout and {} unique enabled mod metadata entries passed bounded metadata and top-level entry-point inspection",
+                inspected_ids.len()
             ),
         )
         .with_items([String::from(
@@ -734,6 +749,7 @@ fn inspect_enabled_meta(
     library: &LibraryRoot,
     library_dir: &Path,
     id: &str,
+    remaining_meta_bytes: &mut u64,
 ) -> Result<super::model::ModEntryMeta, EvidenceFailure> {
     let entry_path = library_dir.join(id);
     match std::fs::symlink_metadata(&entry_path) {
@@ -781,7 +797,7 @@ fn inspect_enabled_meta(
     }
     let result = (|| {
         let library_entry = library.entry(id)?;
-        let meta = library_entry.read_meta()?;
+        let meta = library_entry.read_meta_bounded(remaining_meta_bytes)?;
         for component in &meta.components {
             super::apply::validate_component_descriptor_for_default_apply(component)?;
             validate_component_payload_presence(&library_entry, component)?;
@@ -1650,6 +1666,60 @@ mod tests {
         let empty = inspect_loadout(&root.path().join("missing-library"), &loadout);
         assert_eq!(empty.check.code, "loadout_empty");
         assert!(matches!(empty.ue4ss, Ue4ssRequirement::NotRequired));
+    }
+
+    #[test]
+    fn loadout_metadata_has_an_aggregate_budget_and_deduplicates_ids() {
+        let root = tempfile::tempdir().unwrap();
+        let library = root.path().join("library");
+        fs::create_dir(&library).unwrap();
+        write_library_meta(&library, "alpha", Vec::new());
+        write_library_meta(&library, "beta", Vec::new());
+        let sidecar_len = |id: &str| {
+            fs::metadata(library.join(id).join(super::super::model::META_FILE))
+                .unwrap()
+                .len()
+        };
+        let alpha_len = sidecar_len("alpha");
+        let beta_len = sidecar_len("beta");
+        let loadout = root.path().join("loadout.json");
+
+        write_enabled_loadout(&loadout, &["alpha", "alpha"]);
+        let duplicate = inspect_loadout_with_meta_budget(&library, &loadout, alpha_len);
+        assert_eq!(duplicate.check.code, "loadout_metadata_ready");
+        assert!(duplicate.check.detail.contains("1 unique"));
+
+        write_enabled_loadout(&loadout, &["alpha", "beta"]);
+        let over_budget =
+            inspect_loadout_with_meta_budget(&library, &loadout, alpha_len + beta_len - 1);
+        assert_eq!(over_budget.check.state, PreflightStateV1::Problem);
+        assert_eq!(over_budget.check.code, "enabled_mods_unreadable");
+        assert!(over_budget
+            .check
+            .items
+            .iter()
+            .any(|item| item.contains("byte limit")));
+
+        assert_eq!(
+            inspect_loadout_with_meta_budget(&library, &loadout, alpha_len + beta_len)
+                .check
+                .code,
+            "loadout_metadata_ready"
+        );
+
+        fs::write(
+            library
+                .join("alpha")
+                .join(super::super::model::META_FILE),
+            b"{",
+        )
+        .unwrap();
+        let corrupt = inspect_loadout_with_meta_budget(&library, &loadout, 1);
+        assert!(corrupt
+            .check
+            .items
+            .iter()
+            .any(|item| item.starts_with("beta:") && item.contains("0 byte limit")));
     }
 
     fn write_library_meta(library: &Path, id: &str, components: Vec<ComponentInfo>) {

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -744,6 +744,12 @@ fn inspect_enabled_meta(
     library
         .entry(id)
         .and_then(|library_entry| library_entry.read_meta())
+        .and_then(|meta| {
+            for component in &meta.components {
+                super::apply::validate_component_descriptor_for_default_apply(component)?;
+            }
+            Ok(meta)
+        })
         .map_err(classify_mod_error)
 }
 
@@ -1752,6 +1758,37 @@ mod tests {
         );
         assert_eq!(report.checks[2].code, "enabled_mods_unreadable");
         assert_eq!(report.checks[3].state, PreflightStateV1::Unknown);
+        assert_eq!(report.checks[3].code, "deployment_not_inspected");
+        assert_eq!(report.checks[3].action, "resolve_loadout_check");
+
+        write_library_meta(
+            &library,
+            "unsafe",
+            vec![ComponentInfo::LoosePak {
+                rel: "../outside.pak".to_owned(),
+                targets: Vec::new(),
+            }],
+        );
+        write_enabled_loadout(&loadout, &["unsafe"]);
+        let report = run_with(
+            install.path(),
+            &library,
+            &loadout,
+            |_, _, target| {
+                Ok(ManagerStatus::ChangesPending {
+                    deployed: Vec::new(),
+                    target: target.entries.clone(),
+                })
+            },
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+        assert_eq!(report.checks[2].code, "enabled_mods_unreadable");
+        assert_eq!(report.checks[2].action, "repair_library");
+        assert!(report.checks[2]
+            .items
+            .iter()
+            .any(|item| item.contains("unsafe loose pak path")));
         assert_eq!(report.checks[3].code, "deployment_not_inspected");
         assert_eq!(report.checks[3].action, "resolve_loadout_check");
     }

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -210,10 +210,12 @@ where
     let root = inspect_game_root(game_root);
     let install = inspect_install(root.directory.as_ref());
     let loadout = inspect_loadout(library_dir, loadout_path);
+    let loadout_healthy = loadout.check.state == PreflightStateV1::Ok;
     let (deployment, deployment_recovery_seen) = inspect_deployment(
         root.root.as_deref(),
         library_dir,
         loadout.loadout.as_ref(),
+        loadout_healthy,
         status,
     );
     let install_mutation = inspect_install_mutation(
@@ -853,6 +855,7 @@ fn inspect_deployment<S>(
     game_root: Option<&Path>,
     library_dir: &Path,
     loadout: Option<&Loadout>,
+    loadout_healthy: bool,
     status: S,
 ) -> (PreflightCheckV1, bool)
 where
@@ -874,7 +877,6 @@ where
     // compares loadouts. Preserve those recovery/studio/drift findings even when the loadout is
     // unreadable, but never project an InSync/ChangesPending conclusion from the fallback target.
     let fallback_loadout = Loadout::default();
-    let loadout_readable = loadout.is_some();
     let status = status(game_root, library_dir, loadout.unwrap_or(&fallback_loadout));
     let deployment_recovery_seen = matches!(&status, Ok(ManagerStatus::RecoveryRequired));
     let check = match status {
@@ -901,14 +903,14 @@ where
         )
         .with_items([format!("active mod: {mod_name}")]),
         Ok(ManagerStatus::InSync { .. } | ManagerStatus::ChangesPending { .. })
-            if !loadout_readable =>
+            if !loadout_healthy =>
         {
             PreflightCheckV1::new(
                 PreflightCheckIdV1::Deployment,
                 PreflightStateV1::Unknown,
                 "deployment_not_inspected",
-                "repair_preflight_inputs",
-                "deployment loadout comparison needs a valid loadout",
+                "resolve_loadout_check",
+                "resolve the preceding Loadout finding before comparing deployment state",
             )
         }
         Ok(ManagerStatus::InSync { loadout }) => PreflightCheckV1::new(
@@ -1632,6 +1634,33 @@ mod tests {
     }
 
     #[test]
+    fn unhealthy_enabled_metadata_never_recommends_apply() {
+        let install = install_fixture();
+        let library = install.path().join("library");
+        fs::create_dir(&library).unwrap();
+        let loadout = install.path().join("loadout.json");
+        write_enabled_loadout(&loadout, &["missing"]);
+
+        let report = run_with(
+            install.path(),
+            &library,
+            &loadout,
+            |_, _, target| {
+                Ok(ManagerStatus::ChangesPending {
+                    deployed: Vec::new(),
+                    target: target.entries.clone(),
+                })
+            },
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+        assert_eq!(report.checks[2].code, "enabled_mods_unreadable");
+        assert_eq!(report.checks[3].state, PreflightStateV1::Unknown);
+        assert_eq!(report.checks[3].code, "deployment_not_inspected");
+        assert_eq!(report.checks[3].action, "resolve_loadout_check");
+    }
+
+    #[test]
     fn every_manager_status_maps_to_stable_bounded_deployment_vocabulary() {
         let entry = |id: &str| LoadoutEntry {
             id: id.to_owned(),
@@ -1693,6 +1722,7 @@ mod tests {
                 Some(Path::new("C:/display-only-game")),
                 Path::new("C:/display-only-library"),
                 Some(&Loadout::default()),
+                true,
                 move |_, _, _| Ok(status),
             );
             assert_eq!(check.state, state, "code: {code}");

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -1198,6 +1198,26 @@ where
             blocks_deployment_recovery: true,
         };
     }
+    let active_lock = probe.artifacts.iter().any(|artifact| {
+        matches!(
+            artifact.kind,
+            InstallCompileArtifactKind::InstallMutationLock
+                | InstallCompileArtifactKind::CompileLock
+        )
+    });
+    if active_lock {
+        return InstallMutationInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::InstallMutation,
+                PreflightStateV1::Problem,
+                "install_mutation_lock_present",
+                "wait_for_install_mutation",
+                "an install-mutation or compile lock may belong to an active operation; wait for it to finish, then retry, and inspect a persistent lock before recovery",
+            )
+            .with_items(items),
+            blocks_deployment_recovery: true,
+        };
+    }
     let probe_recovery = probe.disposition
         == InstallCompileStateDisposition::RecoveryArtifactsPresent
         || !probe.artifacts.is_empty();
@@ -2227,7 +2247,7 @@ mod tests {
             .iter()
             .any(|item| item == "deployment status: recovery required"));
 
-        let independent_recovery = InstallCompileStateProbe {
+        let active_lock = InstallCompileStateProbe {
             disposition: InstallCompileStateDisposition::RecoveryArtifactsPresent,
             safe_to_compile: false,
             game_process: InstallCompileGameProcessDisposition::NotRunning,
@@ -2243,10 +2263,34 @@ mod tests {
             &install.path().join("library"),
             &install.path().join("loadout.json"),
             |_, _, _| Ok(ManagerStatus::RecoveryRequired),
-            |_| independent_recovery.clone(),
+            |_| active_lock.clone(),
+            |_| Ok(false),
+        );
+        assert_eq!(state.checks[3].action, "wait_for_install_mutation");
+        assert_eq!(state.checks[4].code, "install_mutation_lock_present");
+        assert_eq!(state.checks[4].action, "wait_for_install_mutation");
+
+        let recovery_artifact = InstallCompileStateProbe {
+            disposition: InstallCompileStateDisposition::RecoveryArtifactsPresent,
+            safe_to_compile: false,
+            game_process: InstallCompileGameProcessDisposition::NotRunning,
+            artifacts: vec![InstallCompileArtifact {
+                kind: InstallCompileArtifactKind::RecoveryJournal,
+                path: "C:/game/.gore-as-recovery.json".to_owned(),
+                path_truncated: false,
+            }],
+            issues: Vec::new(),
+        };
+        let state = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| Ok(ManagerStatus::RecoveryRequired),
+            |_| recovery_artifact.clone(),
             |_| Ok(false),
         );
         assert_eq!(state.checks[3].action, "recover_install");
+        assert_eq!(state.checks[4].code, "install_recovery_required");
         assert_eq!(state.checks[4].action, "recover_install");
 
         let failed = InstallCompileStateProbe {

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -188,7 +188,7 @@ where
         game_root,
         library_dir,
         loadout_path,
-        super::status::status,
+        super::status::status_for_preflight,
         |root| {
             gore_as::compile::probe_install_compile_state_with_stated_game_process(
                 root,
@@ -1793,6 +1793,35 @@ mod tests {
             |_| safe_probe(),
             |_| Ok(false),
         );
+        assert_eq!(state.checks[3].state, PreflightStateV1::Unknown);
+        assert_eq!(state.checks[3].code, "deployment_inspection_failed");
+    }
+
+    #[test]
+    fn stated_process_adapter_preserves_deployment_inspection_failures() {
+        let install = install_fixture();
+        let library = install.path().join("library");
+        let loadout = install.path().join("loadout.json");
+        fs::write(&loadout, serde_json::to_vec(&Loadout::default()).unwrap()).unwrap();
+        let live = install.path().join("G1R/Story/VoiceOver/owned.zip");
+        fs::create_dir_all(&live).unwrap();
+        let record = crate::DeployRecord {
+            mod_name: "manager".into(),
+            owner: "manager".into(),
+            deployed_hashes: std::collections::BTreeMap::from([(
+                live.display().to_string(),
+                crate::content_hash(b"deployed"),
+            )]),
+            ..Default::default()
+        };
+        fs::write(
+            crate::record_path(install.path()),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+
+        let state =
+            preflight_v1_with_stated_game_process(install.path(), &library, &loadout, || Ok(false));
         assert_eq!(state.checks[3].state, PreflightStateV1::Unknown);
         assert_eq!(state.checks[3].code, "deployment_inspection_failed");
     }

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -1,0 +1,1742 @@
+//! Read-only first-run facts for Mod Manager V1.
+//!
+//! This module deliberately reports evidence, not write authority. It never creates a probe file,
+//! repairs a deploy record, reconciles import staging, or falls back to a configured/Steam install.
+//! Paths in the result are bounded display strings only; callers must send the selected game root
+//! back to the mutating command, which performs its own authoritative preflight.
+
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+
+use gore_as::compile::{
+    InstallCompileArtifactKind, InstallCompileGameProcessDisposition,
+    InstallCompileInspectionIssueKind, InstallCompileStateDisposition, InstallCompileStateProbe,
+};
+use serde::Serialize;
+
+use super::loadout::Loadout;
+use super::model::{ComponentInfo, LibraryRoot, SecureDirectory, SecureNode};
+use super::status::ManagerStatus;
+
+const FORMAT: u32 = 1;
+const MAX_LOADOUT_BYTES: u64 = 1024 * 1024;
+const MAX_CHECK_ITEMS: usize = 16;
+const MAX_DETAIL_BYTES: usize = 2 * 1024;
+const MAX_ITEM_BYTES: usize = 1024;
+
+/// One of the fixed Mod Manager V1 first-run checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PreflightCheckIdV1 {
+    GameRoot,
+    Install,
+    Loadout,
+    Deployment,
+    InstallMutation,
+    Ue4ss,
+    WriteAccess,
+}
+
+/// A check's evidence state. `Unverified` is intentionally distinct from `Unknown`: no write
+/// probe was attempted, whereas `Unknown` means a requested read could not establish the fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PreflightStateV1 {
+    Ok,
+    Problem,
+    Unknown,
+    NotRequired,
+    Unverified,
+}
+
+/// One bounded first-run finding. `code` and `action` are closed native vocabulary; `detail` and
+/// `items` are human-readable evidence and must never be interpreted as filesystem authority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PreflightCheckV1 {
+    pub id: PreflightCheckIdV1,
+    pub state: PreflightStateV1,
+    pub code: &'static str,
+    pub action: &'static str,
+    pub detail: String,
+    pub items: Vec<String>,
+}
+
+impl PreflightCheckV1 {
+    fn new(
+        id: PreflightCheckIdV1,
+        state: PreflightStateV1,
+        code: &'static str,
+        action: &'static str,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            id,
+            state,
+            code,
+            action,
+            detail: bounded_text(&detail.into(), MAX_DETAIL_BYTES),
+            items: Vec::new(),
+        }
+    }
+
+    fn with_items(mut self, items: impl IntoIterator<Item = String>) -> Self {
+        let mut source = items.into_iter();
+        self.items = source
+            .by_ref()
+            .take(MAX_CHECK_ITEMS)
+            .map(|item| bounded_text(&item, MAX_ITEM_BYTES))
+            .collect();
+        if source.next().is_some() {
+            if self.items.len() == MAX_CHECK_ITEMS {
+                self.items.pop();
+            }
+            self.items
+                .push("additional evidence omitted by the native bound".to_owned());
+        }
+        self
+    }
+}
+
+/// Fixed-order, bounded, read-only first-run evidence for Mod Manager V1.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ManagerPreflightV1 {
+    pub format: u32,
+    pub checks: [PreflightCheckV1; 7],
+}
+
+struct RootInspection {
+    check: PreflightCheckV1,
+    root: Option<PathBuf>,
+    directory: Option<SecureDirectory>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Wanted {
+    File,
+    Directory,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Occupant {
+    Wanted,
+    Missing,
+    Obstructed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ue4ssRequirement {
+    Required,
+    NotRequired,
+    Unknown,
+}
+
+struct LoadoutInspection {
+    check: PreflightCheckV1,
+    loadout: Option<Loadout>,
+    ue4ss: Ue4ssRequirement,
+}
+
+enum EvidenceFailure {
+    Problem(String),
+    Unknown(String),
+}
+
+impl EvidenceFailure {
+    fn message(self) -> String {
+        match self {
+            Self::Problem(message) | Self::Unknown(message) => message,
+        }
+    }
+}
+
+/// Build the production snapshot. The selected `game_root` is always explicit; optional Manager
+/// paths are resolved by the caller (the FFI uses the shared native defaults when omitted).
+pub fn preflight_v1(
+    game_root: &Path,
+    library_dir: &Path,
+    loadout_path: &Path,
+) -> ManagerPreflightV1 {
+    preflight_v1_with(
+        game_root,
+        library_dir,
+        loadout_path,
+        super::status::status,
+        gore_as::compile::probe_install_compile_state,
+        crate::deploy_recovery_required,
+    )
+}
+
+/// The same read-only snapshot with the machine-global process answer supplied by a native
+/// adapter test. Production callers must use [`preflight_v1`]; this mirrors gore-as's cross-crate
+/// seam so an FFI test never depends on whether the developer happens to have the game open.
+#[doc(hidden)]
+pub fn preflight_v1_with_stated_game_process<C>(
+    game_root: &Path,
+    library_dir: &Path,
+    loadout_path: &Path,
+    check_game_process: C,
+) -> ManagerPreflightV1
+where
+    C: FnOnce() -> Result<bool, String>,
+{
+    preflight_v1_with(
+        game_root,
+        library_dir,
+        loadout_path,
+        super::status::status,
+        |root| {
+            gore_as::compile::probe_install_compile_state_with_stated_game_process(
+                root,
+                check_game_process,
+            )
+        },
+        crate::deploy_recovery_required,
+    )
+}
+
+fn preflight_v1_with<S, P, R>(
+    game_root: &Path,
+    library_dir: &Path,
+    loadout_path: &Path,
+    status: S,
+    install_state: P,
+    deploy_recovery: R,
+) -> ManagerPreflightV1
+where
+    S: FnOnce(&Path, &Path, &Loadout) -> crate::Result<ManagerStatus>,
+    P: FnOnce(&Path) -> InstallCompileStateProbe,
+    R: FnOnce(&Path) -> crate::Result<bool>,
+{
+    let root = inspect_game_root(game_root);
+    let install = inspect_install(root.directory.as_ref());
+    let loadout = inspect_loadout(library_dir, loadout_path);
+    let (deployment, deployment_recovery_seen) = inspect_deployment(
+        root.root.as_deref(),
+        library_dir,
+        loadout.loadout.as_ref(),
+        status,
+    );
+    let install_mutation = inspect_install_mutation(
+        root.root.as_deref(),
+        deployment_recovery_seen,
+        install_state,
+        deploy_recovery,
+    );
+    let ue4ss = inspect_ue4ss(root.directory.as_ref(), loadout.ue4ss);
+    let write_access = PreflightCheckV1::new(
+        PreflightCheckIdV1::WriteAccess,
+        PreflightStateV1::Unverified,
+        "unverified_read_only",
+        "verify_during_apply",
+        "write access was not tested because this preflight is strictly read-only",
+    );
+
+    ManagerPreflightV1 {
+        format: FORMAT,
+        checks: [
+            root.check,
+            install,
+            loadout.check,
+            deployment,
+            install_mutation,
+            ue4ss,
+            write_access,
+        ],
+    }
+}
+
+fn inspect_game_root(selected: &Path) -> RootInspection {
+    if selected.as_os_str().is_empty() {
+        return RootInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::GameRoot,
+                PreflightStateV1::Problem,
+                "game_root_missing",
+                "select_game_root",
+                "no game root was selected",
+            ),
+            root: None,
+            directory: None,
+        };
+    }
+    let selected_display = display_path(selected);
+    let canonical = match std::fs::canonicalize(selected) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return RootInspection {
+                check: PreflightCheckV1::new(
+                    PreflightCheckIdV1::GameRoot,
+                    PreflightStateV1::Problem,
+                    "game_root_not_found",
+                    "select_game_root",
+                    "the selected game root does not exist",
+                )
+                .with_items([format!("selected: {selected_display}")]),
+                root: None,
+                directory: None,
+            }
+        }
+        Err(error) => {
+            return RootInspection {
+                check: PreflightCheckV1::new(
+                    PreflightCheckIdV1::GameRoot,
+                    PreflightStateV1::Unknown,
+                    "game_root_inspection_failed",
+                    "inspect_permissions",
+                    "the selected game root could not be resolved",
+                )
+                .with_items([
+                    format!("selected: {selected_display}"),
+                    format!("inspection: {error}"),
+                ]),
+                root: None,
+                directory: None,
+            }
+        }
+    };
+    match std::fs::symlink_metadata(&canonical) {
+        Ok(metadata) if !metadata.is_dir() => {
+            return RootInspection {
+                check: PreflightCheckV1::new(
+                    PreflightCheckIdV1::GameRoot,
+                    PreflightStateV1::Problem,
+                    "game_root_not_directory",
+                    "select_game_root",
+                    "the selected game root resolves to a non-directory node",
+                )
+                .with_items([format!("selected: {selected_display}")]),
+                root: None,
+                directory: None,
+            }
+        }
+        Err(error) => {
+            return RootInspection {
+                check: PreflightCheckV1::new(
+                    PreflightCheckIdV1::GameRoot,
+                    PreflightStateV1::Unknown,
+                    "game_root_inspection_failed",
+                    "inspect_permissions",
+                    "the selected game root target could not be inspected",
+                )
+                .with_items([
+                    format!("selected: {selected_display}"),
+                    format!("inspection: {error}"),
+                ]),
+                root: None,
+                directory: None,
+            }
+        }
+        Ok(_) => {}
+    }
+    let semantic = crate::semantic_install_root(&canonical);
+    match super::model::open_directory_chain_nofollow(&semantic, "selected game root") {
+        Ok(directory) => RootInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::GameRoot,
+                PreflightStateV1::Ok,
+                "game_root_selected",
+                "none",
+                "the explicit game root resolves to a readable real directory",
+            )
+            .with_items([
+                format!("selected: {selected_display}"),
+                format!("resolved: {}", display_path(&semantic)),
+            ]),
+            root: Some(semantic),
+            directory: Some(directory),
+        },
+        Err(error) => RootInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::GameRoot,
+                PreflightStateV1::Unknown,
+                "game_root_inspection_failed",
+                "inspect_permissions",
+                "the resolved game root could not be safely opened",
+            )
+            .with_items([
+                format!("selected: {selected_display}"),
+                format!("inspection: {error}"),
+            ]),
+            root: None,
+            directory: None,
+        },
+    }
+}
+
+fn inspect_install(root: Option<&SecureDirectory>) -> PreflightCheckV1 {
+    let Some(root) = root else {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Install,
+            PreflightStateV1::Unknown,
+            "install_not_inspected",
+            "select_game_root",
+            "the install cannot be inspected until the game root is readable",
+        );
+    };
+    let required: [(&str, &[&str], Wanted); 4] = [
+        (
+            r"G1R\Binaries\Win64\G1R-Win64-Shipping.exe",
+            &["G1R", "Binaries", "Win64", "G1R-Win64-Shipping.exe"],
+            Wanted::File,
+        ),
+        (
+            r"G1R\Content\Paks",
+            &["G1R", "Content", "Paks"],
+            Wanted::Directory,
+        ),
+        (
+            r"G1R\Story\Cache",
+            &["G1R", "Story", "Cache"],
+            Wanted::Directory,
+        ),
+        (r"G1R\Script", &["G1R", "Script"], Wanted::Directory),
+    ];
+    let mut missing = Vec::new();
+    let mut obstructed = Vec::new();
+    let mut failures = Vec::new();
+    for (label, components, wanted) in required {
+        match inspect_relative(root, components, wanted) {
+            Ok(Occupant::Wanted) => {}
+            Ok(Occupant::Missing) => missing.push(label.to_owned()),
+            Ok(Occupant::Obstructed) => obstructed.push(label.to_owned()),
+            Err(error) => failures.push(format!("{label}: {error}")),
+        }
+    }
+    if !failures.is_empty() {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Install,
+            PreflightStateV1::Unknown,
+            "install_inspection_failed",
+            "inspect_permissions",
+            "one or more identifying install paths could not be safely inspected",
+        )
+        .with_items(failures);
+    }
+    if !obstructed.is_empty() {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Install,
+            PreflightStateV1::Problem,
+            "install_paths_obstructed",
+            "remove_obstruction",
+            "one or more install paths are occupied by the wrong kind of node",
+        )
+        .with_items(obstructed);
+    }
+    if missing.is_empty() {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Install,
+            PreflightStateV1::Ok,
+            "install_recognized",
+            "none",
+            "the executable, Paks, Story\\Cache, and Script paths are present",
+        );
+    }
+    let executable_missing = missing.iter().any(|item| item.ends_with(".exe"));
+    PreflightCheckV1::new(
+        PreflightCheckIdV1::Install,
+        PreflightStateV1::Problem,
+        if executable_missing {
+            "install_not_recognized"
+        } else {
+            "install_incomplete"
+        },
+        if executable_missing {
+            "select_game_root"
+        } else {
+            "verify_game_files"
+        },
+        if executable_missing {
+            "the selected root does not identify a Gothic 1 Remake installation"
+        } else {
+            "the installation is missing paths required by current GORE operations"
+        },
+    )
+    .with_items(missing)
+}
+
+fn inspect_relative(
+    root: &SecureDirectory,
+    components: &[&str],
+    wanted: Wanted,
+) -> Result<Occupant, String> {
+    let mut directory = root.clone();
+    for (index, component) in components.iter().enumerate() {
+        let name = std::ffi::OsStr::new(component);
+        let child_path = directory.path().join(name);
+        match std::fs::symlink_metadata(&child_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Occupant::Missing)
+            }
+            Err(error) => {
+                return Err(format!(
+                    "inspecting preflight path {}: {error}",
+                    display_path(&child_path)
+                ))
+            }
+            Ok(metadata) if super::model::metadata_is_link(&metadata) => {
+                return Err(format!(
+                    "preflight path is a symbolic link or reparse point: {}",
+                    display_path(&child_path)
+                ))
+            }
+            Ok(_) => {}
+        }
+        let final_component = index + 1 == components.len();
+        match directory
+            .open_child(name, "preflight path")
+            .map_err(|error| error.to_string())?
+        {
+            SecureNode::File(_) if final_component && wanted == Wanted::File => {
+                return Ok(Occupant::Wanted)
+            }
+            SecureNode::Directory(_) if final_component && wanted == Wanted::Directory => {
+                return Ok(Occupant::Wanted)
+            }
+            SecureNode::Directory(child) if !final_component => directory = child,
+            SecureNode::File(_) | SecureNode::Directory(_) => return Ok(Occupant::Obstructed),
+        }
+    }
+    Ok(Occupant::Missing)
+}
+
+fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection {
+    let loadout = match read_loadout_bounded(loadout_path) {
+        Ok(loadout) => loadout,
+        Err(failure) => return loadout_failure(failure),
+    };
+    let enabled = loadout
+        .entries
+        .iter()
+        .filter(|entry| entry.enabled)
+        .collect::<Vec<_>>();
+    if enabled.is_empty() {
+        return LoadoutInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::Loadout,
+                PreflightStateV1::Ok,
+                "loadout_empty",
+                "none",
+                "the loadout is valid and has no enabled mods",
+            ),
+            loadout: Some(loadout),
+            ue4ss: Ue4ssRequirement::NotRequired,
+        };
+    }
+
+    let library = match inspect_library_root(library_dir) {
+        Ok(library) => library,
+        Err(failure) => {
+            let (state, code, action, detail) = match &failure {
+                EvidenceFailure::Problem(_) => (
+                    PreflightStateV1::Problem,
+                    "enabled_library_unavailable",
+                    "repair_library",
+                    "enabled mods exist but the Manager library is missing or obstructed",
+                ),
+                EvidenceFailure::Unknown(_) => (
+                    PreflightStateV1::Unknown,
+                    "enabled_library_inspection_failed",
+                    "inspect_permissions",
+                    "enabled mods exist but the Manager library could not be safely inspected",
+                ),
+            };
+            return LoadoutInspection {
+                check: PreflightCheckV1::new(
+                    PreflightCheckIdV1::Loadout,
+                    state,
+                    code,
+                    action,
+                    detail,
+                )
+                .with_items([failure.message()]),
+                loadout: Some(loadout),
+                ue4ss: Ue4ssRequirement::Unknown,
+            };
+        }
+    };
+    let mut problems = Vec::new();
+    let mut unknowns = Vec::new();
+    let mut requires_ue4ss = false;
+    for entry in &enabled {
+        match inspect_enabled_meta(&library, library_dir, &entry.id) {
+            Ok(meta) => {
+                requires_ue4ss |= meta
+                    .components
+                    .iter()
+                    .any(|component| matches!(component, ComponentInfo::Ue4ssLua { .. }));
+            }
+            Err(error) => match error {
+                EvidenceFailure::Problem(message) => {
+                    push_bounded_evidence(&mut problems, format!("{}: {message}", entry.id));
+                }
+                EvidenceFailure::Unknown(message) => {
+                    push_bounded_evidence(&mut unknowns, format!("{}: {message}", entry.id));
+                }
+            },
+        }
+    }
+    if !unknowns.is_empty() {
+        unknowns.extend(problems);
+        return LoadoutInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::Loadout,
+                PreflightStateV1::Unknown,
+                "enabled_mod_inspection_failed",
+                "inspect_permissions",
+                "one or more enabled metadata entries could not be safely inspected",
+            )
+            .with_items(unknowns),
+            loadout: Some(loadout),
+            ue4ss: if requires_ue4ss {
+                Ue4ssRequirement::Required
+            } else {
+                Ue4ssRequirement::Unknown
+            },
+        };
+    }
+    if !problems.is_empty() {
+        return LoadoutInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::Loadout,
+                PreflightStateV1::Problem,
+                "enabled_mods_unreadable",
+                "repair_library",
+                "one or more enabled mods do not have readable validated metadata",
+            )
+            .with_items(problems),
+            loadout: Some(loadout),
+            ue4ss: if requires_ue4ss {
+                Ue4ssRequirement::Required
+            } else {
+                Ue4ssRequirement::Unknown
+            },
+        };
+    }
+    LoadoutInspection {
+        check: PreflightCheckV1::new(
+            PreflightCheckIdV1::Loadout,
+            PreflightStateV1::Ok,
+            "loadout_valid",
+            "none",
+            format!(
+                "the loadout and {} enabled mod metadata entries are valid",
+                enabled.len()
+            ),
+        ),
+        loadout: Some(loadout),
+        ue4ss: if requires_ue4ss {
+            Ue4ssRequirement::Required
+        } else {
+            Ue4ssRequirement::NotRequired
+        },
+    }
+}
+
+fn inspect_enabled_meta(
+    library: &LibraryRoot,
+    library_dir: &Path,
+    id: &str,
+) -> Result<super::model::ModEntryMeta, EvidenceFailure> {
+    let entry_path = library_dir.join(id);
+    match std::fs::symlink_metadata(&entry_path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(EvidenceFailure::Problem(format!(
+                "enabled library entry is missing: {}",
+                display_path(&entry_path)
+            )))
+        }
+        Err(error) => {
+            return Err(EvidenceFailure::Unknown(format!(
+                "inspecting enabled library entry {}: {error}",
+                display_path(&entry_path)
+            )))
+        }
+        Ok(metadata) if super::model::metadata_is_link(&metadata) || !metadata.is_dir() => {
+            return Err(EvidenceFailure::Problem(format!(
+                "enabled library entry is not a real directory: {}",
+                display_path(&entry_path)
+            )))
+        }
+        Ok(_) => {}
+    }
+    let sidecar = entry_path.join(super::model::META_FILE);
+    match std::fs::symlink_metadata(&sidecar) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(EvidenceFailure::Problem(format!(
+                "enabled library sidecar is missing: {}",
+                display_path(&sidecar)
+            )))
+        }
+        Err(error) => {
+            return Err(EvidenceFailure::Unknown(format!(
+                "inspecting enabled library sidecar {}: {error}",
+                display_path(&sidecar)
+            )))
+        }
+        Ok(metadata) if super::model::metadata_is_link(&metadata) || !metadata.is_file() => {
+            return Err(EvidenceFailure::Problem(format!(
+                "enabled library sidecar is not a real file: {}",
+                display_path(&sidecar)
+            )))
+        }
+        Ok(_) => {}
+    }
+    library
+        .entry(id)
+        .and_then(|library_entry| library_entry.read_meta())
+        .map_err(classify_mod_error)
+}
+
+fn loadout_failure(failure: EvidenceFailure) -> LoadoutInspection {
+    let (state, code, action, detail) = match &failure {
+        EvidenceFailure::Problem(_) => (
+            PreflightStateV1::Problem,
+            "loadout_unreadable",
+            "repair_loadout",
+            "the Manager loadout is invalid, obstructed, or exceeds its bound",
+        ),
+        EvidenceFailure::Unknown(_) => (
+            PreflightStateV1::Unknown,
+            "loadout_inspection_failed",
+            "inspect_permissions",
+            "the Manager loadout could not be safely inspected",
+        ),
+    };
+    LoadoutInspection {
+        check: PreflightCheckV1::new(PreflightCheckIdV1::Loadout, state, code, action, detail)
+            .with_items([failure.message()]),
+        loadout: None,
+        ue4ss: Ue4ssRequirement::Unknown,
+    }
+}
+
+fn inspect_library_root(path: &Path) -> Result<LibraryRoot, EvidenceFailure> {
+    match std::fs::symlink_metadata(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(EvidenceFailure::Problem(format!(
+                "manager library does not exist: {}",
+                display_path(path)
+            )))
+        }
+        Err(error) => {
+            return Err(EvidenceFailure::Unknown(format!(
+                "inspecting manager library {}: {error}",
+                display_path(path)
+            )))
+        }
+        Ok(metadata) if !metadata.is_dir() && !super::model::metadata_is_link(&metadata) => {
+            return Err(EvidenceFailure::Problem(format!(
+                "manager library is not a directory: {}",
+                display_path(path)
+            )))
+        }
+        Ok(_) => {}
+    }
+    let canonical = std::fs::canonicalize(path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            EvidenceFailure::Problem(format!(
+                "manager library target does not exist: {}",
+                display_path(path)
+            ))
+        } else {
+            EvidenceFailure::Unknown(format!(
+                "resolving manager library {}: {error}",
+                display_path(path)
+            ))
+        }
+    })?;
+    match std::fs::symlink_metadata(&canonical) {
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(EvidenceFailure::Problem(format!(
+                "manager library resolves to a non-directory node: {}",
+                display_path(&canonical)
+            )))
+        }
+        Err(error) => {
+            return Err(EvidenceFailure::Unknown(format!(
+                "inspecting manager library target {}: {error}",
+                display_path(&canonical)
+            )))
+        }
+        Ok(_) => {}
+    }
+    LibraryRoot::open(path).map_err(|error| {
+        EvidenceFailure::Unknown(format!(
+            "opening manager library {}: {error}",
+            display_path(path)
+        ))
+    })
+}
+
+fn classify_mod_error(error: crate::ModError) -> EvidenceFailure {
+    match error {
+        crate::ModError::Io(message) => EvidenceFailure::Unknown(format!("io: {message}")),
+        other => EvidenceFailure::Problem(other.to_string()),
+    }
+}
+
+fn push_bounded_evidence(items: &mut Vec<String>, item: String) {
+    if items.len() <= MAX_CHECK_ITEMS {
+        items.push(item);
+    }
+}
+
+fn read_loadout_bounded(path: &Path) -> Result<Loadout, EvidenceFailure> {
+    match std::fs::symlink_metadata(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Loadout::default()),
+        Err(error) => {
+            return Err(EvidenceFailure::Unknown(format!(
+                "inspecting loadout {}: {error}",
+                display_path(path)
+            )))
+        }
+        Ok(metadata) if super::model::metadata_is_link(&metadata) => {
+            return Err(EvidenceFailure::Problem(format!(
+                "loadout is a symbolic link or reparse point: {}",
+                display_path(path)
+            )))
+        }
+        Ok(metadata) if !metadata.is_file() => {
+            return Err(EvidenceFailure::Problem(format!(
+                "loadout is not a regular file: {}",
+                display_path(path)
+            )))
+        }
+        Ok(_) => {}
+    }
+    let mut file = super::model::open_file_nofollow(path, "manager loadout")
+        .map_err(|error| EvidenceFailure::Unknown(error.to_string()))?;
+    if file.len() > MAX_LOADOUT_BYTES {
+        return Err(EvidenceFailure::Problem(format!(
+            "loadout exceeds the {MAX_LOADOUT_BYTES}-byte limit: {}",
+            display_path(path)
+        )));
+    }
+    let expected = file.len();
+    let capacity = usize::try_from(expected)
+        .map_err(|_| EvidenceFailure::Problem("loadout is too large".to_owned()))?;
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(capacity).map_err(|_| {
+        EvidenceFailure::Unknown("could not reserve bounded loadout bytes".to_owned())
+    })?;
+    file.file
+        .by_ref()
+        .take(MAX_LOADOUT_BYTES.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            EvidenceFailure::Unknown(format!("reading loadout {}: {error}", display_path(path)))
+        })?;
+    if bytes.len() as u64 > MAX_LOADOUT_BYTES {
+        return Err(EvidenceFailure::Problem(format!(
+            "loadout exceeds the {MAX_LOADOUT_BYTES}-byte limit: {}",
+            display_path(path)
+        )));
+    }
+    file.verify_len(expected, "manager loadout")
+        .map_err(|error| EvidenceFailure::Unknown(error.to_string()))?;
+    let parsed: Loadout = serde_json::from_slice(&bytes).map_err(|error| {
+        EvidenceFailure::Problem(format!("parsing loadout {}: {error}", display_path(path)))
+    })?;
+    if parsed.format > FORMAT {
+        return Err(EvidenceFailure::Problem(format!(
+            "loadout format {} is newer than this tool supports",
+            parsed.format
+        )));
+    }
+    parsed
+        .validate()
+        .map_err(|error| EvidenceFailure::Problem(error.to_string()))?;
+    Ok(parsed)
+}
+
+fn inspect_deployment<S>(
+    game_root: Option<&Path>,
+    library_dir: &Path,
+    loadout: Option<&Loadout>,
+    status: S,
+) -> (PreflightCheckV1, bool)
+where
+    S: FnOnce(&Path, &Path, &Loadout) -> crate::Result<ManagerStatus>,
+{
+    let (Some(game_root), Some(loadout)) = (game_root, loadout) else {
+        return (
+            PreflightCheckV1::new(
+                PreflightCheckIdV1::Deployment,
+                PreflightStateV1::Unknown,
+                "deployment_not_inspected",
+                "repair_preflight_inputs",
+                "deployment state needs a readable game root and valid loadout",
+            ),
+            false,
+        );
+    };
+    let status = status(game_root, library_dir, loadout);
+    let deployment_recovery_seen = matches!(&status, Ok(ManagerStatus::RecoveryRequired));
+    let check = match status {
+        Ok(ManagerStatus::NothingDeployed) => PreflightCheckV1::new(
+            PreflightCheckIdV1::Deployment,
+            PreflightStateV1::Ok,
+            "deployment_none",
+            "none",
+            "no GORE deployment record is active",
+        ),
+        Ok(ManagerStatus::RecoveryRequired) => PreflightCheckV1::new(
+            PreflightCheckIdV1::Deployment,
+            PreflightStateV1::Problem,
+            "deployment_recovery_required",
+            "recover_deployment",
+            "the active deployment record requires recovery before another apply",
+        ),
+        Ok(ManagerStatus::StudioDeployActive { mod_name }) => PreflightCheckV1::new(
+            PreflightCheckIdV1::Deployment,
+            PreflightStateV1::Problem,
+            "studio_deployment_active",
+            "remove_studio_deployment",
+            "a Mod Studio deployment is active and Manager must not replace it",
+        )
+        .with_items([format!("active mod: {mod_name}")]),
+        Ok(ManagerStatus::InSync { loadout }) => PreflightCheckV1::new(
+            PreflightCheckIdV1::Deployment,
+            PreflightStateV1::Ok,
+            "deployment_in_sync",
+            "none",
+            "the active Manager deployment matches the selected loadout",
+        )
+        .with_items(
+            loadout
+                .into_iter()
+                .map(|entry| format!("enabled: {}", entry.id)),
+        ),
+        Ok(ManagerStatus::ChangesPending { deployed, target }) => {
+            const SAMPLE_PER_SIDE: usize = 6;
+            let deployed_count = deployed.len();
+            let target_count = target.len();
+            let mut items = vec![
+                format!("deployed count: {deployed_count}"),
+                format!("target count: {target_count}"),
+            ];
+            items.extend(
+                deployed
+                    .into_iter()
+                    .take(SAMPLE_PER_SIDE)
+                    .map(|entry| format!("deployed: {}", entry.id)),
+            );
+            items.extend(
+                target
+                    .into_iter()
+                    .take(SAMPLE_PER_SIDE)
+                    .map(|entry| format!("target: {}", entry.id)),
+            );
+            if deployed_count > SAMPLE_PER_SIDE || target_count > SAMPLE_PER_SIDE {
+                items.push("additional deployed/target entries omitted by the native bound".into());
+            }
+            PreflightCheckV1::new(
+                PreflightCheckIdV1::Deployment,
+                PreflightStateV1::Problem,
+                "deployment_changes_pending",
+                "apply_loadout",
+                "the selected loadout differs from the active Manager deployment",
+            )
+            .with_items(items)
+        }
+        Ok(ManagerStatus::GameUpdated { drifted }) => PreflightCheckV1::new(
+            PreflightCheckIdV1::Deployment,
+            PreflightStateV1::Problem,
+            "deployment_game_updated",
+            "reapply_after_update",
+            "files owned by the active Manager deployment changed outside GORE",
+        )
+        .with_items(drifted.into_iter().map(|path| format!("drifted: {path}"))),
+        Err(error) => PreflightCheckV1::new(
+            PreflightCheckIdV1::Deployment,
+            PreflightStateV1::Unknown,
+            "deployment_inspection_failed",
+            "inspect_deployment",
+            "the bounded deployment record/status inspection failed",
+        )
+        .with_items([error.to_string()]),
+    };
+    (check, deployment_recovery_seen)
+}
+
+fn inspect_install_mutation<P, R>(
+    game_root: Option<&Path>,
+    deployment_recovery_seen: bool,
+    install_state: P,
+    deploy_recovery: R,
+) -> PreflightCheckV1
+where
+    P: FnOnce(&Path) -> InstallCompileStateProbe,
+    R: FnOnce(&Path) -> crate::Result<bool>,
+{
+    let Some(game_root) = game_root else {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::InstallMutation,
+            PreflightStateV1::Unknown,
+            "install_mutation_not_inspected",
+            "select_game_root",
+            "process, lock, and recovery state need a readable game root",
+        );
+    };
+    let probe = install_state(game_root);
+    let recovery = deploy_recovery(game_root);
+    let mut items = Vec::new();
+    items.extend(probe.artifacts.iter().map(|artifact| {
+        format!(
+            "{}: {}{}",
+            artifact_kind_label(artifact.kind),
+            artifact.path,
+            if artifact.path_truncated {
+                " [truncated]"
+            } else {
+                ""
+            }
+        )
+    }));
+    items.extend(probe.issues.iter().map(|issue| {
+        let path = issue
+            .path
+            .as_deref()
+            .map(|path| {
+                format!(
+                    " at {path}{}",
+                    if issue.path_truncated {
+                        " [truncated]"
+                    } else {
+                        ""
+                    }
+                )
+            })
+            .unwrap_or_default();
+        format!(
+            "{}{path}: {}{}",
+            issue_kind_label(issue.kind),
+            issue.message,
+            if issue.message_truncated {
+                " [truncated]"
+            } else {
+                ""
+            }
+        )
+    }));
+    if deployment_recovery_seen {
+        items.push("deployment status: recovery required".to_owned());
+    }
+    if recovery.as_ref().is_ok_and(|required| *required) {
+        items.push("deploy record: recovery required".to_owned());
+    }
+    if let Err(error) = &recovery {
+        items.push(format!("deploy recovery inspection: {error}"));
+    }
+
+    if probe.disposition == InstallCompileStateDisposition::InspectionFailed
+        || probe.game_process == InstallCompileGameProcessDisposition::InspectionFailed
+        || !probe.issues.is_empty()
+        || recovery.is_err()
+    {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::InstallMutation,
+            PreflightStateV1::Unknown,
+            "install_mutation_inspection_failed",
+            "inspect_permissions",
+            "process or recovery state could not be established safely",
+        )
+        .with_items(items);
+    }
+    if probe.game_process == InstallCompileGameProcessDisposition::Running
+        || probe.disposition == InstallCompileStateDisposition::GameProcessRunning
+    {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::InstallMutation,
+            PreflightStateV1::Problem,
+            "game_process_running",
+            "close_game",
+            "the shipping game process is running",
+        )
+        .with_items(items);
+    }
+    if deployment_recovery_seen
+        || recovery.is_ok_and(|required| required)
+        || probe.disposition == InstallCompileStateDisposition::RecoveryArtifactsPresent
+        || !probe.artifacts.is_empty()
+    {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::InstallMutation,
+            PreflightStateV1::Problem,
+            "install_recovery_required",
+            "recover_install",
+            "a lock, journal, backup, or deploy recovery record blocks a new install mutation",
+        )
+        .with_items(items);
+    }
+    PreflightCheckV1::new(
+        PreflightCheckIdV1::InstallMutation,
+        PreflightStateV1::Ok,
+        "install_mutation_clear",
+        "none",
+        "the game is closed and no known GORE recovery artifact is present",
+    )
+}
+
+fn inspect_ue4ss(
+    root: Option<&SecureDirectory>,
+    requirement: Ue4ssRequirement,
+) -> PreflightCheckV1 {
+    match requirement {
+        Ue4ssRequirement::NotRequired => {
+            return PreflightCheckV1::new(
+                PreflightCheckIdV1::Ue4ss,
+                PreflightStateV1::NotRequired,
+                "ue4ss_not_required",
+                "none",
+                "no readable enabled component requires UE4SS Lua",
+            )
+        }
+        Ue4ssRequirement::Unknown => {
+            return PreflightCheckV1::new(
+                PreflightCheckIdV1::Ue4ss,
+                PreflightStateV1::Unknown,
+                "ue4ss_requirement_unknown",
+                "resolve_loadout_check",
+                "resolve the preceding Loadout finding before deciding whether UE4SS is required",
+            )
+        }
+        Ue4ssRequirement::Required => {}
+    }
+    let Some(root) = root else {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Ue4ss,
+            PreflightStateV1::Unknown,
+            "ue4ss_not_inspected",
+            "select_game_root",
+            "UE4SS is required but the game root is not readable",
+        );
+    };
+    let ue4ss = &["G1R", "Binaries", "Win64", "ue4ss"];
+    let dll = &["G1R", "Binaries", "Win64", "ue4ss", "UE4SS.dll"];
+    let mods = &["G1R", "Binaries", "Win64", "ue4ss", "Mods"];
+    let proxy = &["G1R", "Binaries", "Win64", "dwmapi.dll"];
+    let inspect = |components, wanted| inspect_relative(root, components, wanted);
+    let ue4ss_state = inspect(ue4ss, Wanted::Directory);
+    let dll_state = inspect(dll, Wanted::File);
+    let mods_state = inspect(mods, Wanted::Directory);
+    let proxy_state = inspect(proxy, Wanted::File);
+    let mut failures = Vec::new();
+    for (label, state) in [
+        ("ue4ss", &ue4ss_state),
+        ("UE4SS.dll", &dll_state),
+        ("Mods", &mods_state),
+        ("dwmapi.dll", &proxy_state),
+    ] {
+        if let Err(error) = state {
+            failures.push(format!("{label}: {error}"));
+        }
+    }
+    if !failures.is_empty() {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Ue4ss,
+            PreflightStateV1::Unknown,
+            "ue4ss_inspection_failed",
+            "inspect_permissions",
+            "required UE4SS paths could not be safely inspected",
+        )
+        .with_items(failures);
+    }
+    if matches!(ue4ss_state, Ok(Occupant::Obstructed))
+        || matches!(dll_state, Ok(Occupant::Obstructed))
+    {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Ue4ss,
+            PreflightStateV1::Problem,
+            "ue4ss_paths_obstructed",
+            "remove_obstruction",
+            "a required UE4SS directory or DLL path is occupied by the wrong kind of node",
+        );
+    }
+    if !matches!(ue4ss_state, Ok(Occupant::Wanted)) || !matches!(dll_state, Ok(Occupant::Wanted)) {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Ue4ss,
+            PreflightStateV1::Problem,
+            "ue4ss_dll_missing",
+            "install_ue4ss",
+            "an enabled Lua component requires UE4SS, but UE4SS.dll is not ready",
+        );
+    }
+    if matches!(mods_state, Ok(Occupant::Obstructed)) {
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Ue4ss,
+            PreflightStateV1::Problem,
+            "ue4ss_mods_obstructed",
+            "remove_obstruction",
+            "UE4SS Mods is occupied by a non-directory node",
+        );
+    }
+    let mut items = Vec::new();
+    if matches!(mods_state, Ok(Occupant::Missing)) {
+        items.push("Mods: missing; a later apply may create it".to_owned());
+    }
+    if !matches!(proxy_state, Ok(Occupant::Wanted)) {
+        items.push(
+            "dwmapi.dll: not proven; UE4SS may use a supported alternate proxy name".to_owned(),
+        );
+        return PreflightCheckV1::new(
+            PreflightCheckIdV1::Ue4ss,
+            PreflightStateV1::Ok,
+            "ue4ss_proxy_unverified",
+            "verify_ue4ss_proxy",
+            "UE4SS.dll is present; the known loader proxy is absent or obstructed",
+        )
+        .with_items(items);
+    }
+    PreflightCheckV1::new(
+        PreflightCheckIdV1::Ue4ss,
+        PreflightStateV1::Ok,
+        "ue4ss_ready",
+        "none",
+        "UE4SS.dll and the known loader proxy are present",
+    )
+    .with_items(items)
+}
+
+fn artifact_kind_label(kind: InstallCompileArtifactKind) -> &'static str {
+    match kind {
+        InstallCompileArtifactKind::InstallMutationLock => "install_mutation_lock",
+        InstallCompileArtifactKind::CompileLock => "compile_lock",
+        InstallCompileArtifactKind::RecoveryJournal => "recovery_journal",
+        InstallCompileArtifactKind::ShippingCacheBackup => "shipping_cache_backup",
+        InstallCompileArtifactKind::JittedCodeBackup => "jitted_code_backup",
+        InstallCompileArtifactKind::Ue4ssProxyBackup => "ue4ss_proxy_backup",
+    }
+}
+
+fn issue_kind_label(kind: InstallCompileInspectionIssueKind) -> &'static str {
+    match kind {
+        InstallCompileInspectionIssueKind::GameProcessEnumeration => "game_process_enumeration",
+        InstallCompileInspectionIssueKind::ArtifactMetadata => "artifact_metadata",
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    bounded_text(&path.as_os_str().to_string_lossy(), MAX_ITEM_BYTES / 2)
+}
+
+fn bounded_text(value: &str, limit: usize) -> String {
+    if value.len() <= limit {
+        return value.to_owned();
+    }
+    let mut end = limit;
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    let suffix = " [truncated]";
+    let keep = end.saturating_sub(suffix.len());
+    let mut keep = keep;
+    while keep > 0 && !value.is_char_boundary(keep) {
+        keep -= 1;
+    }
+    format!("{}{}", &value[..keep], suffix)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use gore_as::compile::{InstallCompileArtifact, InstallCompileInspectionIssue};
+
+    use super::*;
+    use crate::mgr::{LoadoutEntry, ModEntryMeta, ModKind};
+
+    fn install_fixture() -> tempfile::TempDir {
+        let root = tempfile::tempdir().unwrap();
+        for directory in [
+            "G1R/Binaries/Win64",
+            "G1R/Content/Paks",
+            "G1R/Story/Cache",
+            "G1R/Script",
+        ] {
+            fs::create_dir_all(root.path().join(directory)).unwrap();
+        }
+        fs::write(
+            root.path()
+                .join("G1R/Binaries/Win64/G1R-Win64-Shipping.exe"),
+            b"exe",
+        )
+        .unwrap();
+        root
+    }
+
+    fn safe_probe() -> InstallCompileStateProbe {
+        InstallCompileStateProbe {
+            disposition: InstallCompileStateDisposition::SafeToCompile,
+            safe_to_compile: true,
+            game_process: InstallCompileGameProcessDisposition::NotRunning,
+            artifacts: Vec::new(),
+            issues: Vec::new(),
+        }
+    }
+
+    fn run_with<S, P, R>(
+        root: &Path,
+        library: &Path,
+        loadout: &Path,
+        status: S,
+        probe: P,
+        recovery: R,
+    ) -> ManagerPreflightV1
+    where
+        S: FnOnce(&Path, &Path, &Loadout) -> crate::Result<ManagerStatus>,
+        P: FnOnce(&Path) -> InstallCompileStateProbe,
+        R: FnOnce(&Path) -> crate::Result<bool>,
+    {
+        preflight_v1_with(root, library, loadout, status, probe, recovery)
+    }
+
+    #[test]
+    fn fixed_order_and_read_only_write_access_are_stable() {
+        let install = install_fixture();
+        let state = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| Ok(ManagerStatus::NothingDeployed),
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+        assert_eq!(state.format, 1);
+        assert_eq!(
+            state.checks.each_ref().map(|check| check.id),
+            [
+                PreflightCheckIdV1::GameRoot,
+                PreflightCheckIdV1::Install,
+                PreflightCheckIdV1::Loadout,
+                PreflightCheckIdV1::Deployment,
+                PreflightCheckIdV1::InstallMutation,
+                PreflightCheckIdV1::Ue4ss,
+                PreflightCheckIdV1::WriteAccess,
+            ]
+        );
+        let write = &state.checks[6];
+        assert_eq!(write.state, PreflightStateV1::Unverified);
+        assert_eq!(write.code, "unverified_read_only");
+    }
+
+    #[test]
+    fn install_distinguishes_missing_executable_and_incomplete_tree() {
+        let install = install_fixture();
+        fs::remove_file(
+            install
+                .path()
+                .join("G1R/Binaries/Win64/G1R-Win64-Shipping.exe"),
+        )
+        .unwrap();
+        let root = inspect_game_root(install.path());
+        assert_eq!(
+            inspect_install(root.directory.as_ref()).code,
+            "install_not_recognized"
+        );
+
+        fs::write(
+            install
+                .path()
+                .join("G1R/Binaries/Win64/G1R-Win64-Shipping.exe"),
+            b"exe",
+        )
+        .unwrap();
+        fs::remove_dir(install.path().join("G1R/Script")).unwrap();
+        let root = inspect_game_root(install.path());
+        assert_eq!(
+            inspect_install(root.directory.as_ref()).code,
+            "install_incomplete"
+        );
+    }
+
+    #[test]
+    fn a_selected_file_named_g1r_is_not_folded_into_a_valid_parent() {
+        let root = tempfile::tempdir().unwrap();
+        let selected = root.path().join("G1R");
+        fs::write(&selected, b"not a directory").unwrap();
+
+        let inspected = inspect_game_root(&selected);
+        assert_eq!(inspected.check.state, PreflightStateV1::Problem);
+        assert_eq!(inspected.check.code, "game_root_not_directory");
+        assert!(inspected.root.is_none());
+    }
+
+    #[test]
+    fn loadout_is_bounded_and_never_opens_library_when_empty() {
+        let root = tempfile::tempdir().unwrap();
+        let loadout = root.path().join("loadout.json");
+        let oversized = fs::File::create(&loadout).unwrap();
+        oversized.set_len(MAX_LOADOUT_BYTES + 1).unwrap();
+        drop(oversized);
+        assert_eq!(
+            inspect_loadout(&root.path().join("missing-library"), &loadout)
+                .check
+                .code,
+            "loadout_unreadable"
+        );
+        fs::remove_file(&loadout).unwrap();
+        let empty = inspect_loadout(&root.path().join("missing-library"), &loadout);
+        assert_eq!(empty.check.code, "loadout_empty");
+        assert!(matches!(empty.ue4ss, Ue4ssRequirement::NotRequired));
+    }
+
+    fn write_library_meta(library: &Path, id: &str, components: Vec<ComponentInfo>) {
+        let entry = library.join(id);
+        fs::create_dir_all(&entry).unwrap();
+        let meta = ModEntryMeta {
+            id: id.to_owned(),
+            kind: ModKind::Goremod,
+            name: id.to_owned(),
+            version: String::new(),
+            author: String::new(),
+            imported_at: "2026-08-10T00:00:00Z".to_owned(),
+            source: String::new(),
+            components,
+        };
+        fs::write(
+            entry.join(super::super::model::META_FILE),
+            serde_json::to_vec(&meta).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn write_enabled_loadout(path: &Path, ids: &[&str]) {
+        fs::write(
+            path,
+            serde_json::to_vec(&Loadout {
+                format: 1,
+                entries: ids
+                    .iter()
+                    .map(|id| LoadoutEntry {
+                        id: (*id).to_owned(),
+                        enabled: true,
+                    })
+                    .collect(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn only_enabled_readable_lua_metadata_requires_ue4ss() {
+        let root = tempfile::tempdir().unwrap();
+        let library = root.path().join("library");
+        fs::create_dir(&library).unwrap();
+        write_library_meta(
+            &library,
+            "lua",
+            vec![ComponentInfo::Ue4ssLua {
+                name: "lua".to_owned(),
+                rel: "main.lua".to_owned(),
+                targets: Vec::new(),
+                opaque: false,
+            }],
+        );
+        write_library_meta(&library, "plain", Vec::new());
+        let loadout = root.path().join("loadout.json");
+        write_enabled_loadout(&loadout, &["plain"]);
+        assert!(matches!(
+            inspect_loadout(&library, &loadout).ue4ss,
+            Ue4ssRequirement::NotRequired
+        ));
+        write_enabled_loadout(&loadout, &["lua"]);
+        assert!(matches!(
+            inspect_loadout(&library, &loadout).ue4ss,
+            Ue4ssRequirement::Required
+        ));
+        write_enabled_loadout(&loadout, &["missing"]);
+        let missing = inspect_loadout(&library, &loadout);
+        assert_eq!(missing.check.state, PreflightStateV1::Problem);
+        assert_eq!(missing.check.code, "enabled_mods_unreadable");
+        assert!(matches!(missing.ue4ss, Ue4ssRequirement::Unknown));
+
+        write_enabled_loadout(&loadout, &["lua", "missing"]);
+        let partial = inspect_loadout(&library, &loadout);
+        assert_eq!(partial.check.state, PreflightStateV1::Problem);
+        assert!(matches!(partial.ue4ss, Ue4ssRequirement::Required));
+    }
+
+    #[test]
+    fn evidence_failures_distinguish_repairs_from_uninspectable_io() {
+        let problem = loadout_failure(EvidenceFailure::Problem("corrupt".to_owned()));
+        assert_eq!(problem.check.state, PreflightStateV1::Problem);
+        assert_eq!(problem.check.code, "loadout_unreadable");
+        assert_eq!(problem.check.action, "repair_loadout");
+
+        let unknown = loadout_failure(EvidenceFailure::Unknown("denied".to_owned()));
+        assert_eq!(unknown.check.state, PreflightStateV1::Unknown);
+        assert_eq!(unknown.check.code, "loadout_inspection_failed");
+        assert_eq!(unknown.check.action, "inspect_permissions");
+        assert_eq!(
+            inspect_ue4ss(None, Ue4ssRequirement::Unknown).action,
+            "resolve_loadout_check"
+        );
+
+        assert!(matches!(
+            classify_mod_error(crate::ModError::Io("sharing violation".to_owned())),
+            EvidenceFailure::Unknown(_)
+        ));
+        assert!(matches!(
+            classify_mod_error(crate::ModError::Other("corrupt sidecar".to_owned())),
+            EvidenceFailure::Problem(_)
+        ));
+    }
+
+    #[test]
+    fn ue4ss_requires_dll_but_not_mods_and_proxy_is_advisory() {
+        let install = install_fixture();
+        let root = inspect_game_root(install.path());
+        assert_eq!(
+            inspect_ue4ss(root.directory.as_ref(), Ue4ssRequirement::Required).code,
+            "ue4ss_dll_missing"
+        );
+        let ue4ss = install.path().join("G1R/Binaries/Win64/ue4ss");
+        fs::create_dir(&ue4ss).unwrap();
+        fs::write(ue4ss.join("UE4SS.dll"), b"dll").unwrap();
+        let root = inspect_game_root(install.path());
+        let advisory = inspect_ue4ss(root.directory.as_ref(), Ue4ssRequirement::Required);
+        assert_eq!(advisory.state, PreflightStateV1::Ok);
+        assert_eq!(advisory.code, "ue4ss_proxy_unverified");
+        assert!(advisory
+            .items
+            .iter()
+            .any(|item| item.contains("Mods: missing")));
+        fs::write(
+            install.path().join("G1R/Binaries/Win64/dwmapi.dll"),
+            b"proxy",
+        )
+        .unwrap();
+        let root = inspect_game_root(install.path());
+        assert_eq!(
+            inspect_ue4ss(root.directory.as_ref(), Ue4ssRequirement::Required).code,
+            "ue4ss_ready"
+        );
+
+        fs::remove_file(ue4ss.join("UE4SS.dll")).unwrap();
+        fs::create_dir(ue4ss.join("UE4SS.dll")).unwrap();
+        let root = inspect_game_root(install.path());
+        let obstructed = inspect_ue4ss(root.directory.as_ref(), Ue4ssRequirement::Required);
+        assert_eq!(obstructed.code, "ue4ss_paths_obstructed");
+        assert_eq!(obstructed.action, "remove_obstruction");
+    }
+
+    #[test]
+    fn status_failure_is_an_unknown_environmental_finding() {
+        let install = install_fixture();
+        let state = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| Err(crate::ModError::Other("status denied".to_owned())),
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+        assert_eq!(state.checks[3].state, PreflightStateV1::Unknown);
+        assert_eq!(state.checks[3].code, "deployment_inspection_failed");
+    }
+
+    #[test]
+    fn every_manager_status_maps_to_stable_bounded_deployment_vocabulary() {
+        let entry = |id: &str| LoadoutEntry {
+            id: id.to_owned(),
+            enabled: true,
+        };
+        let cases = [
+            (
+                ManagerStatus::NothingDeployed,
+                PreflightStateV1::Ok,
+                "deployment_none",
+                "none",
+            ),
+            (
+                ManagerStatus::RecoveryRequired,
+                PreflightStateV1::Problem,
+                "deployment_recovery_required",
+                "recover_deployment",
+            ),
+            (
+                ManagerStatus::StudioDeployActive {
+                    mod_name: "studio".to_owned(),
+                },
+                PreflightStateV1::Problem,
+                "studio_deployment_active",
+                "remove_studio_deployment",
+            ),
+            (
+                ManagerStatus::InSync {
+                    loadout: vec![entry("one")],
+                },
+                PreflightStateV1::Ok,
+                "deployment_in_sync",
+                "none",
+            ),
+            (
+                ManagerStatus::ChangesPending {
+                    deployed: (0..40)
+                        .map(|index| entry(&format!("old-{index}")))
+                        .collect(),
+                    target: (0..40)
+                        .map(|index| entry(&format!("new-{index}")))
+                        .collect(),
+                },
+                PreflightStateV1::Problem,
+                "deployment_changes_pending",
+                "apply_loadout",
+            ),
+            (
+                ManagerStatus::GameUpdated {
+                    drifted: vec!["changed.bin".to_owned()],
+                },
+                PreflightStateV1::Problem,
+                "deployment_game_updated",
+                "reapply_after_update",
+            ),
+        ];
+        for (status, state, code, action) in cases {
+            let (check, recovery_seen) = inspect_deployment(
+                Some(Path::new("C:/display-only-game")),
+                Path::new("C:/display-only-library"),
+                Some(&Loadout::default()),
+                move |_, _, _| Ok(status),
+            );
+            assert_eq!(check.state, state, "code: {code}");
+            assert_eq!(check.code, code);
+            assert_eq!(check.action, action);
+            assert!(check.items.len() <= MAX_CHECK_ITEMS);
+            assert!(check.items.iter().all(|item| item.len() <= MAX_ITEM_BYTES));
+            if code == "deployment_changes_pending" {
+                assert!(check
+                    .items
+                    .iter()
+                    .any(|item| item.starts_with("deployed: ")));
+                assert!(check.items.iter().any(|item| item.starts_with("target: ")));
+            }
+            assert_eq!(recovery_seen, code == "deployment_recovery_required");
+        }
+    }
+
+    #[test]
+    fn process_recovery_and_inspection_failures_fail_closed() {
+        let install = install_fixture();
+        let running = InstallCompileStateProbe {
+            disposition: InstallCompileStateDisposition::GameProcessRunning,
+            safe_to_compile: false,
+            game_process: InstallCompileGameProcessDisposition::Running,
+            artifacts: Vec::new(),
+            issues: Vec::new(),
+        };
+        let state = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| Ok(ManagerStatus::NothingDeployed),
+            |_| running.clone(),
+            |_| Ok(false),
+        );
+        assert_eq!(state.checks[4].code, "game_process_running");
+
+        let state = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| Ok(ManagerStatus::NothingDeployed),
+            |_| safe_probe(),
+            |_| Ok(true),
+        );
+        assert_eq!(state.checks[4].code, "install_recovery_required");
+
+        let state = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| Ok(ManagerStatus::RecoveryRequired),
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+        assert_eq!(state.checks[3].code, "deployment_recovery_required");
+        assert_eq!(state.checks[4].code, "install_recovery_required");
+        assert!(state.checks[4]
+            .items
+            .iter()
+            .any(|item| item == "deployment status: recovery required"));
+
+        let failed = InstallCompileStateProbe {
+            disposition: InstallCompileStateDisposition::InspectionFailed,
+            safe_to_compile: false,
+            game_process: InstallCompileGameProcessDisposition::InspectionFailed,
+            artifacts: vec![InstallCompileArtifact {
+                kind: InstallCompileArtifactKind::CompileLock,
+                path: "x".repeat(MAX_ITEM_BYTES * 2),
+                path_truncated: false,
+            }],
+            issues: vec![InstallCompileInspectionIssue {
+                kind: InstallCompileInspectionIssueKind::ArtifactMetadata,
+                path: Some("C:/game/.gore-install-mutation.lock".to_owned()),
+                path_truncated: true,
+                message: "denied".repeat(MAX_ITEM_BYTES),
+                message_truncated: false,
+            }],
+        };
+        let state = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| Ok(ManagerStatus::NothingDeployed),
+            |_| failed.clone(),
+            |_| Err(crate::ModError::Other("recovery denied".repeat(1000))),
+        );
+        assert_eq!(state.checks[4].state, PreflightStateV1::Unknown);
+        assert!(state.checks[4]
+            .items
+            .iter()
+            .any(|item| item.contains("C:/game/.gore-install-mutation.lock [truncated]")));
+        assert!(state.checks[4]
+            .items
+            .iter()
+            .all(|item| item.len() <= MAX_ITEM_BYTES));
+    }
+
+    #[test]
+    fn evidence_vectors_are_capped() {
+        let check = PreflightCheckV1::new(
+            PreflightCheckIdV1::Deployment,
+            PreflightStateV1::Problem,
+            "test",
+            "none",
+            "d".repeat(MAX_DETAIL_BYTES * 2),
+        )
+        .with_items((0..100).map(|_| "i".repeat(MAX_ITEM_BYTES * 2)));
+        assert!(check.detail.len() <= MAX_DETAIL_BYTES);
+        assert_eq!(check.items.len(), MAX_CHECK_ITEMS);
+        assert!(check.items.iter().all(|item| item.len() <= MAX_ITEM_BYTES));
+        assert_eq!(
+            check.items.last().unwrap(),
+            "additional evidence omitted by the native bound"
+        );
+    }
+
+    #[test]
+    fn preflight_never_reconciles_replacing_artifacts() {
+        let install = install_fixture();
+        let library = install.path().join("library");
+        let replacing = library.join(".replacing-preserve-me");
+        fs::create_dir_all(&replacing).unwrap();
+        let evidence = replacing.join("bytes.bin");
+        fs::write(&evidence, b"byte-identical-after-preflight").unwrap();
+        let before = fs::read(&evidence).unwrap();
+
+        let _ = run_with(
+            install.path(),
+            &library,
+            &install.path().join("loadout.json"),
+            |_, _, _| Ok(ManagerStatus::NothingDeployed),
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+
+        assert!(replacing.is_dir());
+        assert_eq!(fs::read(&evidence).unwrap(), before);
+    }
+}

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -741,16 +741,52 @@ fn inspect_enabled_meta(
         }
         Ok(_) => {}
     }
-    library
-        .entry(id)
-        .and_then(|library_entry| library_entry.read_meta())
-        .and_then(|meta| {
-            for component in &meta.components {
-                super::apply::validate_component_descriptor_for_default_apply(component)?;
+    let result = (|| {
+        let library_entry = library.entry(id)?;
+        let meta = library_entry.read_meta()?;
+        for component in &meta.components {
+            super::apply::validate_component_descriptor_for_default_apply(component)?;
+            validate_component_payload_presence(&library_entry, component)?;
+        }
+        Ok(meta)
+    })();
+    result.map_err(classify_mod_error)
+}
+
+fn validate_component_payload_presence(
+    entry: &super::model::LibraryEntry,
+    component: &ComponentInfo,
+) -> crate::Result<()> {
+    let file = |rel: &str, label: &str| entry.validate_required_payload_file(Path::new(rel), label);
+    let directory =
+        |rel: &str, label: &str| entry.validate_required_payload_directory(Path::new(rel), label);
+    match component {
+        ComponentInfo::Ue4ssLua { rel, .. } => directory(rel, "ue4ss component"),
+        ComponentInfo::LocPatch { rel, .. } => file(rel, "localization manifest"),
+        ComponentInfo::AudioPatch { rel, .. } => {
+            file(&format!("{rel}/manifest.json"), "audio manifest")
+        }
+        ComponentInfo::TexturePatch { rel, .. } => directory(rel, "texture component"),
+        ComponentInfo::AngelScriptPatch { rel, .. } => {
+            file(&format!("{rel}/manifest.json"), "script manifest")
+        }
+        ComponentInfo::FilePatch { rel, .. } => {
+            file(&format!("{rel}/manifest.json"), "loose file manifest")
+        }
+        ComponentInfo::PakFilePatch { rel, .. } => directory(rel, "pak file component"),
+        ComponentInfo::VoiceArchivePatch { rel, .. } => directory(rel, "voice component"),
+        ComponentInfo::Triplet { rel_base, .. } => {
+            for ext in ["utoc", "ucas"] {
+                file(&format!("{rel_base}.{ext}"), "triplet component")?;
             }
-            Ok(meta)
-        })
-        .map_err(classify_mod_error)
+            entry.validate_optional_payload_file(
+                Path::new(&format!("{rel_base}.pak")),
+                "optional triplet pak",
+            )
+        }
+        ComponentInfo::LoosePak { rel, .. } => file(rel, "loose pak"),
+        ComponentInfo::RawFile { rel, .. } => file(rel, "raw file"),
+    }
 }
 
 fn loadout_failure(failure: EvidenceFailure) -> LoadoutInspection {
@@ -1545,11 +1581,12 @@ mod tests {
             "lua",
             vec![ComponentInfo::Ue4ssLua {
                 name: "lua".to_owned(),
-                rel: "main.lua".to_owned(),
+                rel: "ue4ss".to_owned(),
                 targets: Vec::new(),
                 opaque: false,
             }],
         );
+        fs::create_dir(library.join("lua/ue4ss")).unwrap();
         write_library_meta(&library, "plain", Vec::new());
         let loadout = root.path().join("loadout.json");
         write_enabled_loadout(&loadout, &["plain"]);
@@ -1572,6 +1609,44 @@ mod tests {
         let partial = inspect_loadout(&library, &loadout);
         assert_eq!(partial.check.state, PreflightStateV1::Problem);
         assert!(matches!(partial.ue4ss, Ue4ssRequirement::Required));
+    }
+
+    #[test]
+    fn required_payloads_are_opened_without_making_the_triplet_pak_mandatory() {
+        let root = tempfile::tempdir().unwrap();
+        let library = root.path().join("library");
+        fs::create_dir(&library).unwrap();
+        write_library_meta(
+            &library,
+            "payloads",
+            vec![
+                ComponentInfo::LoosePak {
+                    rel: "payload.pak".to_owned(),
+                    targets: Vec::new(),
+                },
+                ComponentInfo::Triplet {
+                    rel_base: "io/mod".to_owned(),
+                    targets: Vec::new(),
+                },
+            ],
+        );
+        let entry = library.join("payloads");
+        fs::write(entry.join("payload.pak"), b"pak").unwrap();
+        fs::create_dir(entry.join("io")).unwrap();
+        fs::write(entry.join("io/mod.utoc"), b"utoc").unwrap();
+        fs::write(entry.join("io/mod.ucas"), b"ucas").unwrap();
+        let loadout = root.path().join("loadout.json");
+        write_enabled_loadout(&loadout, &["payloads"]);
+
+        assert_eq!(
+            inspect_loadout(&library, &loadout).check.code,
+            "loadout_valid"
+        );
+        fs::remove_file(entry.join("io/mod.ucas")).unwrap();
+        assert_eq!(
+            inspect_loadout(&library, &loadout).check.code,
+            "enabled_mods_unreadable"
+        );
     }
 
     #[test]
@@ -1790,6 +1865,35 @@ mod tests {
             .iter()
             .any(|item| item.contains("unsafe loose pak path")));
         assert_eq!(report.checks[3].code, "deployment_not_inspected");
+        assert_eq!(report.checks[3].action, "resolve_loadout_check");
+
+        write_library_meta(
+            &library,
+            "missing-payload",
+            vec![ComponentInfo::LoosePak {
+                rel: "payload.pak".to_owned(),
+                targets: Vec::new(),
+            }],
+        );
+        write_enabled_loadout(&loadout, &["missing-payload"]);
+        let report = run_with(
+            install.path(),
+            &library,
+            &loadout,
+            |_, _, target| {
+                Ok(ManagerStatus::ChangesPending {
+                    deployed: Vec::new(),
+                    target: target.entries.clone(),
+                })
+            },
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+        assert_eq!(report.checks[2].code, "enabled_mods_unreadable");
+        assert!(report.checks[2]
+            .items
+            .iter()
+            .any(|item| item.contains("required loose pak is missing")));
         assert_eq!(report.checks[3].action, "resolve_loadout_check");
     }
 

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -1923,13 +1923,14 @@ mod tests {
         let loadout = install.path().join("loadout.json");
         fs::write(&loadout, serde_json::to_vec(&Loadout::default()).unwrap()).unwrap();
         let live = install.path().join("G1R/Story/VoiceOver/owned.zip");
-        fs::create_dir_all(&live).unwrap();
+        fs::create_dir_all(live.parent().unwrap()).unwrap();
+        fs::write(&live, b"deployed").unwrap();
         let record = crate::DeployRecord {
             mod_name: "manager".into(),
             owner: "manager".into(),
             deployed_hashes: std::collections::BTreeMap::from([(
                 live.display().to_string(),
-                crate::content_hash(b"deployed"),
+                "malformed".to_owned(),
             )]),
             ..Default::default()
         };

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -142,6 +142,13 @@ struct InstallMutationInspection {
     blocks_deployment_recovery: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeploymentRecoveryEvidence {
+    NotSeen,
+    Seen,
+    InspectionFailed,
+}
+
 enum EvidenceFailure {
     Problem(String),
     Unknown(String),
@@ -217,7 +224,7 @@ where
     let loadout = inspect_loadout(library_dir, loadout_path);
     let install = inspect_install(root.directory.as_ref(), loadout.requires_script_cache);
     let loadout_healthy = loadout.check.state == PreflightStateV1::Ok;
-    let (mut deployment, deployment_recovery_seen) = inspect_deployment(
+    let (mut deployment, deployment_recovery) = inspect_deployment(
         root.root.as_deref(),
         library_dir,
         loadout.loadout.as_ref(),
@@ -226,7 +233,7 @@ where
     );
     let install_mutation = inspect_install_mutation(
         root.root.as_deref(),
-        deployment_recovery_seen,
+        deployment_recovery,
         install_state,
         deploy_recovery,
     );
@@ -989,7 +996,7 @@ fn inspect_deployment<S>(
     loadout: Option<&Loadout>,
     loadout_healthy: bool,
     status: S,
-) -> (PreflightCheckV1, bool)
+) -> (PreflightCheckV1, DeploymentRecoveryEvidence)
 where
     S: FnOnce(&Path, &Path, &Loadout) -> crate::Result<ManagerStatus>,
 {
@@ -1002,7 +1009,7 @@ where
                 "repair_preflight_inputs",
                 "deployment state needs a readable game root and valid loadout",
             ),
-            false,
+            DeploymentRecoveryEvidence::NotSeen,
         );
     };
     // Status resolves the deploy-record states that do not depend on the target loadout before it
@@ -1010,7 +1017,11 @@ where
     // unreadable, but never project an InSync/ChangesPending conclusion from the fallback target.
     let fallback_loadout = Loadout::default();
     let status = status(game_root, library_dir, loadout.unwrap_or(&fallback_loadout));
-    let deployment_recovery_seen = matches!(&status, Ok(ManagerStatus::RecoveryRequired));
+    let deployment_recovery = match &status {
+        Ok(ManagerStatus::RecoveryRequired) => DeploymentRecoveryEvidence::Seen,
+        Err(_) => DeploymentRecoveryEvidence::InspectionFailed,
+        _ => DeploymentRecoveryEvidence::NotSeen,
+    };
     let check = match status {
         Ok(ManagerStatus::NothingDeployed) => PreflightCheckV1::new(
             PreflightCheckIdV1::Deployment,
@@ -1119,12 +1130,12 @@ where
         )
         .with_items([error.to_string()]),
     };
-    (check, deployment_recovery_seen)
+    (check, deployment_recovery)
 }
 
 fn inspect_install_mutation<P, R>(
     game_root: Option<&Path>,
-    deployment_recovery_seen: bool,
+    deployment_recovery: DeploymentRecoveryEvidence,
     install_state: P,
     deploy_recovery: R,
 ) -> InstallMutationInspection
@@ -1185,8 +1196,14 @@ where
             }
         )
     }));
-    if deployment_recovery_seen {
-        items.push("deployment status: recovery required".to_owned());
+    match deployment_recovery {
+        DeploymentRecoveryEvidence::Seen => {
+            items.push("deployment status: recovery required".to_owned())
+        }
+        DeploymentRecoveryEvidence::InspectionFailed => {
+            items.push("deployment status: inspection failed".to_owned())
+        }
+        DeploymentRecoveryEvidence::NotSeen => {}
     }
     if recovery.as_ref().is_ok_and(|required| *required) {
         items.push("deploy record: recovery required".to_owned());
@@ -1210,6 +1227,9 @@ where
             blocks_deployment_recovery: true,
         };
     }
+    let unauthenticated_deploy_recovery = deployment_recovery
+        == DeploymentRecoveryEvidence::InspectionFailed
+        && recovery.as_ref().is_ok_and(|required| *required);
     if probe.disposition == InstallCompileStateDisposition::InspectionFailed
         || probe.game_process == InstallCompileGameProcessDisposition::InspectionFailed
         || !probe.issues.is_empty()
@@ -1247,13 +1267,26 @@ where
             blocks_deployment_recovery: true,
         };
     }
+    if unauthenticated_deploy_recovery {
+        return InstallMutationInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::InstallMutation,
+                PreflightStateV1::Unknown,
+                "install_mutation_inspection_failed",
+                "inspect_deployment",
+                "the deploy record requires recovery but its ownership evidence could not be authenticated",
+            )
+            .with_items(items),
+            blocks_deployment_recovery: true,
+        };
+    }
     let probe_recovery = probe.disposition
         == InstallCompileStateDisposition::RecoveryArtifactsPresent
         || !probe.artifacts.is_empty();
-    let independent_deploy_recovery =
-        recovery.is_ok_and(|required| required) && !deployment_recovery_seen;
+    let independent_deploy_recovery = recovery.is_ok_and(|required| required)
+        && deployment_recovery == DeploymentRecoveryEvidence::NotSeen;
     let independent_recovery = probe_recovery || independent_deploy_recovery;
-    if deployment_recovery_seen || independent_recovery {
+    if deployment_recovery == DeploymentRecoveryEvidence::Seen || independent_recovery {
         return InstallMutationInspection {
             check: PreflightCheckV1::new(
                 PreflightCheckIdV1::InstallMutation,
@@ -1914,6 +1947,26 @@ mod tests {
         );
         assert_eq!(state.checks[3].state, PreflightStateV1::Unknown);
         assert_eq!(state.checks[3].code, "deployment_inspection_failed");
+
+        let recovery = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| {
+                Err(crate::ModError::Other(
+                    "invalid recovery identity".to_owned(),
+                ))
+            },
+            |_| safe_probe(),
+            |_| Ok(true),
+        );
+        assert_eq!(recovery.checks[3].action, "inspect_deployment");
+        assert_eq!(recovery.checks[4].state, PreflightStateV1::Unknown);
+        assert_eq!(
+            recovery.checks[4].code,
+            "install_mutation_inspection_failed"
+        );
+        assert_eq!(recovery.checks[4].action, "inspect_deployment");
     }
 
     #[test]
@@ -2195,7 +2248,14 @@ mod tests {
                     .any(|item| item.starts_with("deployed: ")));
                 assert!(check.items.iter().any(|item| item.starts_with("target: ")));
             }
-            assert_eq!(recovery_seen, code == "deployment_recovery_required");
+            assert_eq!(
+                recovery_seen,
+                if code == "deployment_recovery_required" {
+                    DeploymentRecoveryEvidence::Seen
+                } else {
+                    DeploymentRecoveryEvidence::NotSeen
+                }
+            );
         }
     }
 

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -136,6 +136,11 @@ struct LoadoutInspection {
     ue4ss: Ue4ssRequirement,
 }
 
+struct InstallMutationInspection {
+    check: PreflightCheckV1,
+    blocks_deployment_recovery: bool,
+}
+
 enum EvidenceFailure {
     Problem(String),
     Unknown(String),
@@ -211,7 +216,7 @@ where
     let install = inspect_install(root.directory.as_ref());
     let loadout = inspect_loadout(library_dir, loadout_path);
     let loadout_healthy = loadout.check.state == PreflightStateV1::Ok;
-    let (deployment, deployment_recovery_seen) = inspect_deployment(
+    let (mut deployment, deployment_recovery_seen) = inspect_deployment(
         root.root.as_deref(),
         library_dir,
         loadout.loadout.as_ref(),
@@ -225,6 +230,13 @@ where
         deploy_recovery,
     );
     let ue4ss = inspect_ue4ss(root.directory.as_ref(), loadout.ue4ss);
+    defer_deployment_action(
+        &mut deployment,
+        &install,
+        &install_mutation.check,
+        install_mutation.blocks_deployment_recovery,
+        &ue4ss,
+    );
     let write_access = PreflightCheckV1::new(
         PreflightCheckIdV1::WriteAccess,
         PreflightStateV1::Unverified,
@@ -240,11 +252,57 @@ where
             install,
             loadout.check,
             deployment,
-            install_mutation,
+            install_mutation.check,
             ue4ss,
             write_access,
         ],
     }
+}
+
+fn defer_deployment_action(
+    deployment: &mut PreflightCheckV1,
+    install: &PreflightCheckV1,
+    install_mutation: &PreflightCheckV1,
+    install_mutation_blocks_recovery: bool,
+    ue4ss: &PreflightCheckV1,
+) {
+    let applies_loadout = matches!(deployment.action, "apply_loadout" | "reapply_after_update");
+    let mutates_install = applies_loadout
+        || matches!(
+            deployment.action,
+            "recover_deployment" | "remove_studio_deployment"
+        );
+    if !mutates_install {
+        return;
+    }
+
+    let blocker = if install_mutation.state != PreflightStateV1::Ok
+        && (applies_loadout || install_mutation_blocks_recovery)
+    {
+        Some((install_mutation, "InstallMutation"))
+    } else if applies_loadout && install.state != PreflightStateV1::Ok {
+        Some((install, "Install"))
+    } else if applies_loadout
+        && matches!(
+            ue4ss.state,
+            PreflightStateV1::Problem | PreflightStateV1::Unknown
+        )
+    {
+        Some((ue4ss, "UE4SS"))
+    } else {
+        None
+    };
+    let Some((blocker, label)) = blocker else {
+        return;
+    };
+    deployment.action = blocker.action;
+    deployment.detail = bounded_text(
+        &format!(
+            "{}; resolve the {label} finding before this deployment action",
+            deployment.detail,
+        ),
+        MAX_DETAIL_BYTES,
+    );
 }
 
 fn inspect_game_root(selected: &Path) -> RootInspection {
@@ -995,19 +1053,22 @@ fn inspect_install_mutation<P, R>(
     deployment_recovery_seen: bool,
     install_state: P,
     deploy_recovery: R,
-) -> PreflightCheckV1
+) -> InstallMutationInspection
 where
     P: FnOnce(&Path) -> InstallCompileStateProbe,
     R: FnOnce(&Path) -> crate::Result<bool>,
 {
     let Some(game_root) = game_root else {
-        return PreflightCheckV1::new(
-            PreflightCheckIdV1::InstallMutation,
-            PreflightStateV1::Unknown,
-            "install_mutation_not_inspected",
-            "select_game_root",
-            "process, lock, and recovery state need a readable game root",
-        );
+        return InstallMutationInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::InstallMutation,
+                PreflightStateV1::Unknown,
+                "install_mutation_not_inspected",
+                "select_game_root",
+                "process, lock, and recovery state need a readable game root",
+            ),
+            blocks_deployment_recovery: true,
+        };
     };
     let probe = install_state(game_root);
     let recovery = deploy_recovery(game_root);
@@ -1060,53 +1121,71 @@ where
         items.push(format!("deploy recovery inspection: {error}"));
     }
 
+    if probe.game_process == InstallCompileGameProcessDisposition::Running
+        || probe.disposition == InstallCompileStateDisposition::GameProcessRunning
+    {
+        return InstallMutationInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::InstallMutation,
+                PreflightStateV1::Problem,
+                "game_process_running",
+                "close_game",
+                "the shipping game process is running",
+            )
+            .with_items(items),
+            blocks_deployment_recovery: true,
+        };
+    }
     if probe.disposition == InstallCompileStateDisposition::InspectionFailed
         || probe.game_process == InstallCompileGameProcessDisposition::InspectionFailed
         || !probe.issues.is_empty()
         || recovery.is_err()
     {
-        return PreflightCheckV1::new(
-            PreflightCheckIdV1::InstallMutation,
-            PreflightStateV1::Unknown,
-            "install_mutation_inspection_failed",
-            "inspect_permissions",
-            "process or recovery state could not be established safely",
-        )
-        .with_items(items);
+        return InstallMutationInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::InstallMutation,
+                PreflightStateV1::Unknown,
+                "install_mutation_inspection_failed",
+                "inspect_permissions",
+                "process or recovery state could not be established safely",
+            )
+            .with_items(items),
+            blocks_deployment_recovery: true,
+        };
     }
-    if probe.game_process == InstallCompileGameProcessDisposition::Running
-        || probe.disposition == InstallCompileStateDisposition::GameProcessRunning
-    {
-        return PreflightCheckV1::new(
-            PreflightCheckIdV1::InstallMutation,
-            PreflightStateV1::Problem,
-            "game_process_running",
-            "close_game",
-            "the shipping game process is running",
-        )
-        .with_items(items);
+    let probe_recovery = probe.disposition
+        == InstallCompileStateDisposition::RecoveryArtifactsPresent
+        || !probe.artifacts.is_empty();
+    let independent_deploy_recovery =
+        recovery.is_ok_and(|required| required) && !deployment_recovery_seen;
+    let independent_recovery = probe_recovery || independent_deploy_recovery;
+    if deployment_recovery_seen || independent_recovery {
+        return InstallMutationInspection {
+            check: PreflightCheckV1::new(
+                PreflightCheckIdV1::InstallMutation,
+                PreflightStateV1::Problem,
+                "install_recovery_required",
+                if independent_recovery {
+                    "recover_install"
+                } else {
+                    "recover_deployment"
+                },
+                "a lock, journal, backup, or deploy recovery record blocks a new install mutation",
+            )
+            .with_items(items),
+            blocks_deployment_recovery: independent_recovery,
+        };
     }
-    if deployment_recovery_seen
-        || recovery.is_ok_and(|required| required)
-        || probe.disposition == InstallCompileStateDisposition::RecoveryArtifactsPresent
-        || !probe.artifacts.is_empty()
-    {
-        return PreflightCheckV1::new(
+    InstallMutationInspection {
+        check: PreflightCheckV1::new(
             PreflightCheckIdV1::InstallMutation,
-            PreflightStateV1::Problem,
-            "install_recovery_required",
-            "recover_install",
-            "a lock, journal, backup, or deploy recovery record blocks a new install mutation",
-        )
-        .with_items(items);
+            PreflightStateV1::Ok,
+            "install_mutation_clear",
+            "none",
+            "the game is closed and no known GORE recovery artifact is present",
+        ),
+        blocks_deployment_recovery: false,
     }
-    PreflightCheckV1::new(
-        PreflightCheckIdV1::InstallMutation,
-        PreflightStateV1::Ok,
-        "install_mutation_clear",
-        "none",
-        "the game is closed and no known GORE recovery artifact is present",
-    )
 }
 
 fn inspect_ue4ss(
@@ -1759,6 +1838,111 @@ mod tests {
     }
 
     #[test]
+    fn deployment_actions_defer_to_relevant_preflight_blockers() {
+        let ok_install = PreflightCheckV1::new(
+            PreflightCheckIdV1::Install,
+            PreflightStateV1::Ok,
+            "install_recognized",
+            "none",
+            "ok",
+        );
+        let bad_install = PreflightCheckV1::new(
+            PreflightCheckIdV1::Install,
+            PreflightStateV1::Problem,
+            "install_incomplete",
+            "verify_game_files",
+            "bad",
+        );
+        let clear_mutation = PreflightCheckV1::new(
+            PreflightCheckIdV1::InstallMutation,
+            PreflightStateV1::Ok,
+            "install_mutation_clear",
+            "none",
+            "clear",
+        );
+        let running = PreflightCheckV1::new(
+            PreflightCheckIdV1::InstallMutation,
+            PreflightStateV1::Problem,
+            "game_process_running",
+            "close_game",
+            "running",
+        );
+        let no_ue4ss = PreflightCheckV1::new(
+            PreflightCheckIdV1::Ue4ss,
+            PreflightStateV1::NotRequired,
+            "ue4ss_not_required",
+            "none",
+            "not required",
+        );
+        let missing_ue4ss = PreflightCheckV1::new(
+            PreflightCheckIdV1::Ue4ss,
+            PreflightStateV1::Problem,
+            "ue4ss_dll_missing",
+            "install_ue4ss",
+            "missing",
+        );
+        let deployment = || {
+            PreflightCheckV1::new(
+                PreflightCheckIdV1::Deployment,
+                PreflightStateV1::Problem,
+                "deployment_changes_pending",
+                "apply_loadout",
+                "pending",
+            )
+        };
+
+        let mut blocked_by_process = deployment();
+        defer_deployment_action(
+            &mut blocked_by_process,
+            &bad_install,
+            &running,
+            true,
+            &missing_ue4ss,
+        );
+        assert_eq!(blocked_by_process.action, "close_game");
+
+        let mut blocked_by_install = deployment();
+        defer_deployment_action(
+            &mut blocked_by_install,
+            &bad_install,
+            &clear_mutation,
+            false,
+            &missing_ue4ss,
+        );
+        assert_eq!(blocked_by_install.action, "verify_game_files");
+
+        let mut blocked_by_ue4ss = deployment();
+        defer_deployment_action(
+            &mut blocked_by_ue4ss,
+            &ok_install,
+            &clear_mutation,
+            false,
+            &missing_ue4ss,
+        );
+        assert_eq!(blocked_by_ue4ss.action, "install_ue4ss");
+
+        let mut recovery = PreflightCheckV1::new(
+            PreflightCheckIdV1::Deployment,
+            PreflightStateV1::Problem,
+            "deployment_recovery_required",
+            "recover_deployment",
+            "recover",
+        );
+        defer_deployment_action(
+            &mut recovery,
+            &bad_install,
+            &clear_mutation,
+            false,
+            &missing_ue4ss,
+        );
+        assert_eq!(recovery.action, "recover_deployment");
+
+        let mut healthy = deployment();
+        defer_deployment_action(&mut healthy, &ok_install, &clear_mutation, false, &no_ue4ss);
+        assert_eq!(healthy.action, "apply_loadout");
+    }
+
+    #[test]
     fn process_recovery_and_inspection_failures_fail_closed() {
         let install = install_fixture();
         let running = InstallCompileStateProbe {
@@ -1777,6 +1961,51 @@ mod tests {
             |_| Ok(false),
         );
         assert_eq!(state.checks[4].code, "game_process_running");
+
+        let deferred = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| {
+                Ok(ManagerStatus::ChangesPending {
+                    deployed: Vec::new(),
+                    target: Vec::new(),
+                })
+            },
+            |_| running.clone(),
+            |_| Ok(false),
+        );
+        assert_eq!(deferred.checks[3].code, "deployment_changes_pending");
+        assert_eq!(deferred.checks[3].action, "close_game");
+        assert_eq!(deferred.checks[4].action, "close_game");
+
+        let running_with_errors = InstallCompileStateProbe {
+            disposition: InstallCompileStateDisposition::GameProcessRunning,
+            safe_to_compile: false,
+            game_process: InstallCompileGameProcessDisposition::Running,
+            artifacts: Vec::new(),
+            issues: vec![InstallCompileInspectionIssue {
+                kind: InstallCompileInspectionIssueKind::ArtifactMetadata,
+                path: None,
+                path_truncated: false,
+                message: "metadata denied".to_owned(),
+                message_truncated: false,
+            }],
+        };
+        let known_running = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| Ok(ManagerStatus::NothingDeployed),
+            |_| running_with_errors.clone(),
+            |_| Err(crate::ModError::Other("recovery denied".to_owned())),
+        );
+        assert_eq!(known_running.checks[4].code, "game_process_running");
+        assert_eq!(known_running.checks[4].action, "close_game");
+        assert!(known_running.checks[4]
+            .items
+            .iter()
+            .any(|item| item.contains("recovery denied")));
 
         let state = run_with(
             install.path(),
@@ -1797,11 +2026,35 @@ mod tests {
             |_| Ok(false),
         );
         assert_eq!(state.checks[3].code, "deployment_recovery_required");
+        assert_eq!(state.checks[3].action, "recover_deployment");
         assert_eq!(state.checks[4].code, "install_recovery_required");
+        assert_eq!(state.checks[4].action, "recover_deployment");
         assert!(state.checks[4]
             .items
             .iter()
             .any(|item| item == "deployment status: recovery required"));
+
+        let independent_recovery = InstallCompileStateProbe {
+            disposition: InstallCompileStateDisposition::RecoveryArtifactsPresent,
+            safe_to_compile: false,
+            game_process: InstallCompileGameProcessDisposition::NotRunning,
+            artifacts: vec![InstallCompileArtifact {
+                kind: InstallCompileArtifactKind::CompileLock,
+                path: "C:/game/.gore-as-compile.lock".to_owned(),
+                path_truncated: false,
+            }],
+            issues: Vec::new(),
+        };
+        let state = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| Ok(ManagerStatus::RecoveryRequired),
+            |_| independent_recovery.clone(),
+            |_| Ok(false),
+        );
+        assert_eq!(state.checks[3].action, "recover_install");
+        assert_eq!(state.checks[4].action, "recover_install");
 
         let failed = InstallCompileStateProbe {
             disposition: InstallCompileStateDisposition::InspectionFailed,

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -721,7 +721,13 @@ fn inspect_loadout_with_budgets(
                 requires_script_cache |= meta
                     .components
                     .iter()
-                    .any(|component| matches!(component, ComponentInfo::AngelScriptPatch { .. }));
+                    .any(|component| {
+                        matches!(
+                            component,
+                            ComponentInfo::AngelScriptPatch { targets, .. }
+                                if !targets.is_empty()
+                        )
+                    });
             }
             Err(error) => match error {
                 EvidenceFailure::Problem(message) => {
@@ -2227,7 +2233,7 @@ mod tests {
         write_enabled_loadout(&loadout, &["deferred"]);
 
         let inspected = inspect_loadout(&library, &loadout);
-        assert!(inspected.requires_script_cache);
+        assert!(!inspected.requires_script_cache);
         let check = inspected.check;
         assert_eq!(check.state, PreflightStateV1::Ok);
         assert_eq!(check.code, "loadout_metadata_ready");
@@ -2240,7 +2246,7 @@ mod tests {
     }
 
     #[test]
-    fn script_patch_defers_apply_until_the_install_cache_exists() {
+    fn script_cache_is_required_only_for_declared_script_edits() {
         let install = install_fixture();
         let library = install.path().join("library");
         fs::create_dir(&library).unwrap();
@@ -2272,6 +2278,24 @@ mod tests {
                 |_| Ok(false),
             )
         };
+        let empty = inspect();
+        assert_eq!(empty.checks[1].code, "install_recognized");
+        assert_eq!(empty.checks[3].action, "review_apply");
+
+        write_library_meta(
+            &library,
+            "script",
+            vec![ComponentInfo::AngelScriptPatch {
+                rel: "scripts".to_owned(),
+                targets: vec!["TestModule".to_owned()],
+            }],
+        );
+        fs::write(
+            library.join("script/scripts/manifest.json"),
+            br#"[{"op":"add","module":"TestModule","mini":"TestModule.mini"}]"#,
+        )
+        .unwrap();
+
         let missing = inspect();
         assert_eq!(missing.checks[1].code, "install_incomplete");
         assert_eq!(missing.checks[1].action, "verify_game_files");

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -957,14 +957,27 @@ where
             )
             .with_items(items)
         }
-        Ok(ManagerStatus::GameUpdated { drifted }) => PreflightCheckV1::new(
-            PreflightCheckIdV1::Deployment,
-            PreflightStateV1::Problem,
-            "deployment_game_updated",
-            "reapply_after_update",
-            "files owned by the active Manager deployment changed outside GORE",
-        )
-        .with_items(drifted.into_iter().map(|path| format!("drifted: {path}"))),
+        Ok(ManagerStatus::GameUpdated { drifted }) => {
+            let (action, detail) = if loadout_healthy {
+                (
+                    "reapply_after_update",
+                    "files owned by the active Manager deployment changed outside GORE",
+                )
+            } else {
+                (
+                    "resolve_loadout_check",
+                    "owned deployment files changed; resolve the Loadout finding before reapplying",
+                )
+            };
+            PreflightCheckV1::new(
+                PreflightCheckIdV1::Deployment,
+                PreflightStateV1::Problem,
+                "deployment_game_updated",
+                action,
+                detail,
+            )
+            .with_items(drifted.into_iter().map(|path| format!("drifted: {path}")))
+        }
         Err(error) => PreflightCheckV1::new(
             PreflightCheckIdV1::Deployment,
             PreflightStateV1::Unknown,
@@ -1582,6 +1595,7 @@ mod tests {
                 ManagerStatus::NothingDeployed,
                 "deployment_none",
                 PreflightStateV1::Ok,
+                "none",
             ),
             (
                 ManagerStatus::StudioDeployActive {
@@ -1589,6 +1603,7 @@ mod tests {
                 },
                 "studio_deployment_active",
                 PreflightStateV1::Problem,
+                "remove_studio_deployment",
             ),
             (
                 ManagerStatus::GameUpdated {
@@ -1596,9 +1611,10 @@ mod tests {
                 },
                 "deployment_game_updated",
                 PreflightStateV1::Problem,
+                "resolve_loadout_check",
             ),
         ];
-        for (status, code, state) in independent {
+        for (status, code, state, action) in independent {
             let report = run_with(
                 install.path(),
                 &library,
@@ -1609,6 +1625,7 @@ mod tests {
             );
             assert_eq!(report.checks[3].code, code);
             assert_eq!(report.checks[3].state, state);
+            assert_eq!(report.checks[3].action, action);
         }
 
         for status in [

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -555,10 +555,7 @@ fn inspect_relative(
                 ))
             }
             Ok(metadata) if super::model::metadata_is_link(&metadata) => {
-                return Err(format!(
-                    "preflight path is a symbolic link or reparse point: {}",
-                    display_path(&child_path)
-                ))
+                return Ok(Occupant::Obstructed)
             }
             Ok(_) => {}
         }
@@ -1453,6 +1450,21 @@ mod tests {
     use super::*;
     use crate::mgr::{LoadoutEntry, ModEntryMeta, ModKind};
 
+    #[cfg(unix)]
+    fn make_dir_link(target: &Path, link: &Path) -> bool {
+        std::os::unix::fs::symlink(target, link).unwrap();
+        true
+    }
+
+    #[cfg(windows)]
+    fn make_dir_link(target: &Path, link: &Path) -> bool {
+        match std::os::windows::fs::symlink_dir(target, link) {
+            Ok(()) => true,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => false,
+            Err(error) => panic!("creating test directory symlink failed: {error}"),
+        }
+    }
+
     fn install_fixture() -> tempfile::TempDir {
         let root = tempfile::tempdir().unwrap();
         for directory in [
@@ -1555,6 +1567,25 @@ mod tests {
             inspect_install(root.directory.as_ref(), false).code,
             "install_incomplete"
         );
+    }
+
+    #[test]
+    fn install_link_occupants_are_removable_obstructions() {
+        let install = install_fixture();
+        let script = install.path().join("G1R/Script");
+        let target = install.path().join("linked-script-target");
+        fs::remove_dir(&script).unwrap();
+        fs::create_dir(&target).unwrap();
+        if !make_dir_link(&target, &script) {
+            return;
+        }
+
+        let root = inspect_game_root(install.path());
+        let check = inspect_install(root.directory.as_ref(), false);
+        assert_eq!(check.state, PreflightStateV1::Problem);
+        assert_eq!(check.code, "install_paths_obstructed");
+        assert_eq!(check.action, "remove_obstruction");
+        assert_eq!(check.items, vec![r"G1R\Script"]);
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -134,6 +134,7 @@ struct LoadoutInspection {
     check: PreflightCheckV1,
     loadout: Option<Loadout>,
     ue4ss: Ue4ssRequirement,
+    requires_script_cache: bool,
 }
 
 struct InstallMutationInspection {
@@ -213,8 +214,8 @@ where
     R: FnOnce(&Path) -> crate::Result<bool>,
 {
     let root = inspect_game_root(game_root);
-    let install = inspect_install(root.directory.as_ref());
     let loadout = inspect_loadout(library_dir, loadout_path);
+    let install = inspect_install(root.directory.as_ref(), loadout.requires_script_cache);
     let loadout_healthy = loadout.check.state == PreflightStateV1::Ok;
     let (mut deployment, deployment_recovery_seen) = inspect_deployment(
         root.root.as_deref(),
@@ -423,7 +424,10 @@ fn inspect_game_root(selected: &Path) -> RootInspection {
     }
 }
 
-fn inspect_install(root: Option<&SecureDirectory>) -> PreflightCheckV1 {
+fn inspect_install(
+    root: Option<&SecureDirectory>,
+    requires_script_cache: bool,
+) -> PreflightCheckV1 {
     let Some(root) = root else {
         return PreflightCheckV1::new(
             PreflightCheckIdV1::Install,
@@ -462,6 +466,19 @@ fn inspect_install(root: Option<&SecureDirectory>) -> PreflightCheckV1 {
             Err(error) => failures.push(format!("{label}: {error}")),
         }
     }
+    if requires_script_cache {
+        let label = r"G1R\Script\PrecompiledScript_Shipping.Cache";
+        match inspect_relative(
+            root,
+            &["G1R", "Script", "PrecompiledScript_Shipping.Cache"],
+            Wanted::File,
+        ) {
+            Ok(Occupant::Wanted) => {}
+            Ok(Occupant::Missing) => missing.push(label.to_owned()),
+            Ok(Occupant::Obstructed) => obstructed.push(label.to_owned()),
+            Err(error) => failures.push(format!("{label}: {error}")),
+        }
+    }
     if !failures.is_empty() {
         return PreflightCheckV1::new(
             PreflightCheckIdV1::Install,
@@ -488,7 +505,11 @@ fn inspect_install(root: Option<&SecureDirectory>) -> PreflightCheckV1 {
             PreflightStateV1::Ok,
             "install_recognized",
             "none",
-            "the executable, Paks, Story\\Cache, and Script paths are present",
+            if requires_script_cache {
+                "the executable, Paks, Story\\Cache, Script, and required AngelScript cache paths are present"
+            } else {
+                "the executable, Paks, Story\\Cache, and Script paths are present"
+            },
         );
     }
     let executable_missing = missing.iter().any(|item| item.ends_with(".exe"));
@@ -580,6 +601,7 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
             ),
             loadout: Some(loadout),
             ue4ss: Ue4ssRequirement::NotRequired,
+            requires_script_cache: false,
         };
     }
 
@@ -611,12 +633,14 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
                 .with_items([failure.message()]),
                 loadout: Some(loadout),
                 ue4ss: Ue4ssRequirement::Unknown,
+                requires_script_cache: false,
             };
         }
     };
     let mut problems = Vec::new();
     let mut unknowns = Vec::new();
     let mut requires_ue4ss = false;
+    let mut requires_script_cache = false;
     for entry in &enabled {
         match inspect_enabled_meta(&library, library_dir, &entry.id) {
             Ok(meta) => {
@@ -624,6 +648,10 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
                     .components
                     .iter()
                     .any(|component| matches!(component, ComponentInfo::Ue4ssLua { .. }));
+                requires_script_cache |= meta
+                    .components
+                    .iter()
+                    .any(|component| matches!(component, ComponentInfo::AngelScriptPatch { .. }));
             }
             Err(error) => match error {
                 EvidenceFailure::Problem(message) => {
@@ -652,6 +680,7 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
             } else {
                 Ue4ssRequirement::Unknown
             },
+            requires_script_cache,
         };
     }
     if !problems.is_empty() {
@@ -670,6 +699,7 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
             } else {
                 Ue4ssRequirement::Unknown
             },
+            requires_script_cache,
         };
     }
     LoadoutInspection {
@@ -692,6 +722,7 @@ fn inspect_loadout(library_dir: &Path, loadout_path: &Path) -> LoadoutInspection
         } else {
             Ue4ssRequirement::NotRequired
         },
+        requires_script_cache,
     }
 }
 
@@ -812,6 +843,7 @@ fn loadout_failure(failure: EvidenceFailure) -> LoadoutInspection {
             .with_items([failure.message()]),
         loadout: None,
         ue4ss: Ue4ssRequirement::Unknown,
+        requires_script_cache: false,
     }
 }
 
@@ -1506,7 +1538,7 @@ mod tests {
         .unwrap();
         let root = inspect_game_root(install.path());
         assert_eq!(
-            inspect_install(root.directory.as_ref()).code,
+            inspect_install(root.directory.as_ref(), false).code,
             "install_not_recognized"
         );
 
@@ -1520,7 +1552,7 @@ mod tests {
         fs::remove_dir(install.path().join("G1R/Script")).unwrap();
         let root = inspect_game_root(install.path());
         assert_eq!(
-            inspect_install(root.directory.as_ref()).code,
+            inspect_install(root.directory.as_ref(), false).code,
             "install_incomplete"
         );
     }
@@ -1707,7 +1739,9 @@ mod tests {
         let loadout = root.path().join("loadout.json");
         write_enabled_loadout(&loadout, &["deferred"]);
 
-        let check = inspect_loadout(&library, &loadout).check;
+        let inspected = inspect_loadout(&library, &loadout);
+        assert!(inspected.requires_script_cache);
+        let check = inspected.check;
         assert_eq!(check.state, PreflightStateV1::Ok);
         assert_eq!(check.code, "loadout_metadata_ready");
         assert_eq!(check.action, "none");
@@ -1716,6 +1750,60 @@ mod tests {
             .items
             .iter()
             .any(|item| item.contains("unverified until Apply")));
+    }
+
+    #[test]
+    fn script_patch_defers_apply_until_the_install_cache_exists() {
+        let install = install_fixture();
+        let library = install.path().join("library");
+        fs::create_dir(&library).unwrap();
+        write_library_meta(
+            &library,
+            "script",
+            vec![ComponentInfo::AngelScriptPatch {
+                rel: "scripts".to_owned(),
+                targets: Vec::new(),
+            }],
+        );
+        fs::create_dir(library.join("script/scripts")).unwrap();
+        fs::write(library.join("script/scripts/manifest.json"), b"[]").unwrap();
+        let loadout = install.path().join("loadout.json");
+        write_enabled_loadout(&loadout, &["script"]);
+
+        let inspect = || {
+            run_with(
+                install.path(),
+                &library,
+                &loadout,
+                |_, _, _| {
+                    Ok(ManagerStatus::ChangesPending {
+                        deployed: Vec::new(),
+                        target: Vec::new(),
+                    })
+                },
+                |_| safe_probe(),
+                |_| Ok(false),
+            )
+        };
+        let missing = inspect();
+        assert_eq!(missing.checks[1].code, "install_incomplete");
+        assert_eq!(missing.checks[1].action, "verify_game_files");
+        assert!(missing.checks[1]
+            .items
+            .iter()
+            .any(|item| item.ends_with("PrecompiledScript_Shipping.Cache")));
+        assert_eq!(missing.checks[3].action, "verify_game_files");
+
+        fs::write(
+            install
+                .path()
+                .join("G1R/Script/PrecompiledScript_Shipping.Cache"),
+            b"cache",
+        )
+        .unwrap();
+        let ready = inspect();
+        assert_eq!(ready.checks[1].code, "install_recognized");
+        assert_eq!(ready.checks[3].action, "review_apply");
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -786,7 +786,7 @@ fn inspect_loadout_with_budgets(
                 PreflightStateV1::Unknown,
                 "enabled_mod_inspection_limit",
                 "verify_during_apply",
-                "enabled mod metadata or top-level entry-point probes exceeded the bounded read-only inspection budget; Apply performs authoritative per-mod validation",
+                "enabled mod metadata or top-level entry-point probes exceeded the bounded read-only inspection budget; the next Apply operation performs authoritative per-mod validation",
             )
             .with_items(bounded),
             loadout: Some(loadout),
@@ -1218,17 +1218,6 @@ where
                 "resolve the preceding Loadout finding before comparing deployment state",
             )
         }
-        Ok(ManagerStatus::InSync { .. })
-            if loadout_readiness == LoadoutReadiness::ApplyAuthoritative =>
-        {
-            PreflightCheckV1::new(
-                PreflightCheckIdV1::Deployment,
-                PreflightStateV1::Unknown,
-                "deployment_loadout_inspection_limit",
-                "review_apply",
-                "deployment fingerprints match, but bounded loadout inspection did not validate every enabled mod; Apply performs authoritative validation before mutation",
-            )
-        }
         Ok(ManagerStatus::InSync { loadout }) => PreflightCheckV1::new(
             PreflightCheckIdV1::Deployment,
             PreflightStateV1::Ok,
@@ -1525,7 +1514,7 @@ fn inspect_ue4ss(
                 PreflightStateV1::Unknown,
                 "ue4ss_requirement_inspection_limit",
                 "verify_during_apply",
-                "bounded loadout inspection could not establish whether UE4SS is required; Apply re-reads the complete enabled metadata before planning the deployment",
+                "bounded loadout inspection could not establish whether UE4SS is required; the next Apply operation re-reads the complete enabled metadata before planning the deployment",
             )
         }
         Ue4ssRequirement::Required => {}
@@ -1983,9 +1972,9 @@ mod tests {
                 ManagerStatus::InSync {
                     loadout: target.entries.clone(),
                 },
-                PreflightStateV1::Unknown,
-                "deployment_loadout_inspection_limit",
-                "review_apply",
+                PreflightStateV1::Ok,
+                "deployment_in_sync",
+                "none",
             ),
             (
                 ManagerStatus::ChangesPending {

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -1185,6 +1185,41 @@ where
         _ => DeploymentRecoveryEvidence::NotSeen,
     };
     let check = match status {
+        Ok(ManagerStatus::NothingDeployed)
+            if loadout_readiness != LoadoutReadiness::Blocked
+                && loadout.is_some_and(|loadout| {
+                    loadout.entries.iter().any(|entry| entry.enabled)
+                }) =>
+        {
+            const SAMPLE_TARGETS: usize = 6;
+            let enabled = loadout
+                .expect("the match guard established a loadout")
+                .entries
+                .iter()
+                .filter(|entry| entry.enabled)
+                .collect::<Vec<_>>();
+            let target_count = enabled.len();
+            let mut items = vec!["deployed count: 0".to_owned(), format!(
+                "target count: {target_count}"
+            )];
+            items.extend(
+                enabled
+                    .into_iter()
+                    .take(SAMPLE_TARGETS)
+                    .map(|entry| format!("target: {}", entry.id)),
+            );
+            if target_count > SAMPLE_TARGETS {
+                items.push("additional target entries omitted by the native bound".into());
+            }
+            PreflightCheckV1::new(
+                PreflightCheckIdV1::Deployment,
+                PreflightStateV1::Problem,
+                "deployment_changes_pending",
+                "review_apply",
+                "no Manager deployment is active; Apply performs authoritative validation before deploying the selected loadout",
+            )
+            .with_items(items)
+        }
         Ok(ManagerStatus::NothingDeployed) => PreflightCheckV1::new(
             PreflightCheckIdV1::Deployment,
             PreflightStateV1::Ok,
@@ -2525,6 +2560,18 @@ mod tests {
         assert_eq!(report.checks[3].code, "deployment_not_inspected");
         assert_eq!(report.checks[3].action, "resolve_loadout_check");
 
+        let undeployed = run_with(
+            install.path(),
+            &library,
+            &loadout,
+            |_, _, _| Ok(ManagerStatus::NothingDeployed),
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+        assert_eq!(undeployed.checks[2].code, "enabled_mods_unreadable");
+        assert_eq!(undeployed.checks[3].code, "deployment_none");
+        assert_eq!(undeployed.checks[3].action, "none");
+
         write_library_meta(
             &library,
             "unsafe",
@@ -2587,6 +2634,50 @@ mod tests {
             .iter()
             .any(|item| item.contains("required loose pak child is missing")));
         assert_eq!(report.checks[3].action, "resolve_loadout_check");
+    }
+
+    #[test]
+    fn first_apply_is_actionable_for_a_ready_nonempty_loadout() {
+        let install = install_fixture();
+        let library = install.path().join("library");
+        fs::create_dir(&library).unwrap();
+        write_library_meta(&library, "alpha", Vec::new());
+        let loadout = install.path().join("loadout.json");
+        write_enabled_loadout(&loadout, &["alpha"]);
+
+        let inspect = |probe: InstallCompileStateProbe| {
+            run_with(
+                install.path(),
+                &library,
+                &loadout,
+                |_, _, _| Ok(ManagerStatus::NothingDeployed),
+                |_| probe,
+                |_| Ok(false),
+            )
+        };
+        let ready = inspect(safe_probe());
+        assert_eq!(ready.checks[2].code, "loadout_metadata_ready");
+        assert_eq!(ready.checks[3].state, PreflightStateV1::Problem);
+        assert_eq!(ready.checks[3].code, "deployment_changes_pending");
+        assert_eq!(ready.checks[3].action, "review_apply");
+        assert!(ready.checks[3]
+            .items
+            .iter()
+            .any(|item| item == "target: alpha"));
+
+        let running = InstallCompileStateProbe {
+            disposition: InstallCompileStateDisposition::GameProcessRunning,
+            safe_to_compile: false,
+            game_process: InstallCompileGameProcessDisposition::Running,
+            artifacts: Vec::new(),
+            issues: Vec::new(),
+        };
+        assert_eq!(inspect(running).checks[3].action, "close_game");
+
+        fs::write(&loadout, serde_json::to_vec(&Loadout::default()).unwrap()).unwrap();
+        let empty = inspect(safe_probe());
+        assert_eq!(empty.checks[3].code, "deployment_none");
+        assert_eq!(empty.checks[3].action, "none");
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -978,6 +978,7 @@ fn inspect_library_root(path: &Path) -> Result<LibraryRoot, EvidenceFailure> {
 fn classify_mod_error(error: crate::ModError) -> EvidenceFailure {
     match error {
         crate::ModError::Io(message) => EvidenceFailure::Unknown(format!("io: {message}")),
+        crate::ModError::InspectionBound(message) => EvidenceFailure::Bounded(message),
         other => EvidenceFailure::Problem(other.to_string()),
     }
 }
@@ -1085,6 +1086,9 @@ where
     let status = status(game_root, library_dir, loadout.unwrap_or(&fallback_loadout));
     let deployment_recovery = match &status {
         Ok(ManagerStatus::RecoveryRequired) => DeploymentRecoveryEvidence::Seen,
+        // Status reaches aggregate content ceilings only after parsing the record and returning
+        // early for recovery. This is an unknown sync/drift answer, not failed recovery evidence.
+        Err(crate::ModError::InspectionBound(_)) => DeploymentRecoveryEvidence::NotSeen,
         Err(_) => DeploymentRecoveryEvidence::InspectionFailed,
         _ => DeploymentRecoveryEvidence::NotSeen,
     };
@@ -1187,6 +1191,14 @@ where
             )
             .with_items(drifted.into_iter().map(|path| format!("drifted: {path}")))
         }
+        Err(crate::ModError::InspectionBound(message)) => PreflightCheckV1::new(
+            PreflightCheckIdV1::Deployment,
+            PreflightStateV1::Unknown,
+            "deployment_inspection_limit",
+            "run_full_status",
+            "deployment content exceeded the bounded read-only snapshot; full status can establish the exact state, while Reset remains separately gated by its own root, process, lock, and recovery checks",
+        )
+        .with_items([message]),
         Err(error) => PreflightCheckV1::new(
             PreflightCheckIdV1::Deployment,
             PreflightStateV1::Unknown,
@@ -2033,6 +2045,12 @@ mod tests {
             classify_mod_error(crate::ModError::Other("corrupt sidecar".to_owned())),
             EvidenceFailure::Problem(_)
         ));
+        assert!(matches!(
+            classify_mod_error(crate::ModError::InspectionBound(
+                "aggregate ceiling".to_owned()
+            )),
+            EvidenceFailure::Bounded(_)
+        ));
     }
 
     #[test]
@@ -2086,6 +2104,30 @@ mod tests {
         );
         assert_eq!(state.checks[3].state, PreflightStateV1::Unknown);
         assert_eq!(state.checks[3].code, "deployment_inspection_failed");
+
+        let bounded = run_with(
+            install.path(),
+            &install.path().join("library"),
+            &install.path().join("loadout.json"),
+            |_, _, _| {
+                Err(crate::ModError::InspectionBound(
+                    "aggregate hash ceiling".to_owned(),
+                ))
+            },
+            |_| safe_probe(),
+            |_| Ok(false),
+        );
+        assert_eq!(bounded.checks[3].state, PreflightStateV1::Unknown);
+        assert_eq!(bounded.checks[3].code, "deployment_inspection_limit");
+        assert_eq!(bounded.checks[3].action, "run_full_status");
+        assert!(bounded.checks[3]
+            .detail
+            .contains("Reset remains separately gated"));
+        assert_eq!(bounded.checks[4].state, PreflightStateV1::Ok);
+        assert!(!bounded.checks[4]
+            .items
+            .iter()
+            .any(|item| item.contains("deployment status: inspection failed")));
 
         let recovery = run_with(
             install.path(),

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -37,6 +37,7 @@ const MAX_PREFLIGHT_STATUS_META_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_PREFLIGHT_STATUS_HASH_BYTES: u64 = 64 * 1024 * 1024 * 1024;
 const MAX_PREFLIGHT_STATUS_HASH_ENTRIES: u64 = 250_000;
 const MAX_PREFLIGHT_STATUS_TREE_ENTRIES: u64 = 250_000;
+const MAX_PREFLIGHT_STATUS_PATH_ENTRIES: u64 = 250_000;
 
 /// The manager's deployment state relative to a target loadout. `#[serde(tag = "state")]` so the
 /// UI can switch on a single discriminant field.
@@ -79,6 +80,7 @@ struct DeploymentInspection {
     remaining_hash_bytes: u64,
     remaining_hash_entries: u64,
     remaining_tree_entries: u64,
+    remaining_path_entries: u64,
     file_matches: HashMap<(String, String), bool>,
     legacy_hashes: HashMap<String, String>,
     tree_fingerprints: HashMap<String, String>,
@@ -90,11 +92,13 @@ impl DeploymentInspection {
         remaining_hash_bytes: u64,
         remaining_hash_entries: u64,
         remaining_tree_entries: u64,
+        remaining_path_entries: u64,
     ) -> Self {
         Self {
             remaining_hash_bytes,
             remaining_hash_entries,
             remaining_tree_entries,
+            remaining_path_entries,
             file_matches: HashMap::new(),
             legacy_hashes: HashMap::new(),
             tree_fingerprints: HashMap::new(),
@@ -111,6 +115,75 @@ impl DeploymentInspection {
         self.remaining_hash_entries -= 1;
         Ok(())
     }
+
+    fn deployment_path_key(&mut self, path: &Path) -> crate::Result<String> {
+        if self.remaining_path_entries == 0 {
+            return Err(crate::ModError::InspectionBound(
+                "deployment inspection exhausted its path-entry budget".into(),
+            ));
+        }
+        self.remaining_path_entries -= 1;
+
+        // Preserve the old `same_path` semantics by resolving existing aliases, but do so only
+        // once per budgeted record entry instead of once per active/stale pair. Missing or
+        // inaccessible paths still get a component-normalized lexical key.
+        let canonical = std::fs::canonicalize(path).ok();
+        let normalized: std::path::PathBuf = canonical
+            .as_deref()
+            .unwrap_or(path)
+            .components()
+            .collect();
+        Ok(crate::record_path_key(&normalized))
+    }
+}
+
+#[derive(Debug)]
+struct Ue4ssPathIndex<'a> {
+    active_keys: HashSet<String>,
+    active: Vec<(&'a str, String)>,
+    stale: Vec<(&'a str, String)>,
+    fingerprints: HashMap<String, &'a str>,
+}
+
+fn ue4ss_path_index<'a>(
+    record: &'a crate::DeployRecord,
+    inspection: &mut DeploymentInspection,
+) -> crate::Result<Ue4ssPathIndex<'a>> {
+    let mut active_keys = HashSet::new();
+    let mut active = Vec::new();
+    for path in record
+        .ue4ss_mod_dir
+        .iter()
+        .chain(record.ue4ss_mod_dirs.iter())
+    {
+        let key = inspection.deployment_path_key(Path::new(path))?;
+        if active_keys.insert(key.clone()) {
+            active.push((path.as_str(), key));
+        }
+    }
+
+    let mut fingerprints = HashMap::new();
+    for (path, fingerprint) in &record.ue4ss_tree_fingerprints {
+        let key = inspection.deployment_path_key(Path::new(path))?;
+        // BTreeMap iteration is stable; retaining the first alias preserves the old
+        // `tree_fingerprint_for_path` lookup order while making subsequent reads constant-time.
+        fingerprints.entry(key).or_insert(fingerprint.as_str());
+    }
+
+    let mut seen_stale = HashSet::new();
+    let mut stale = Vec::new();
+    for path in &record.stale_ue4ss_dirs {
+        let key = inspection.deployment_path_key(Path::new(path))?;
+        if seen_stale.insert(key.clone()) {
+            stale.push((path.as_str(), key));
+        }
+    }
+    Ok(Ue4ssPathIndex {
+        active_keys,
+        active,
+        stale,
+        fingerprints,
+    })
 }
 
 fn metadata_for_status(path: &Path) -> crate::Result<Option<std::fs::Metadata>> {
@@ -367,12 +440,13 @@ fn status_with_failure_policy(
     // modded file and is now gone/replaced).
     let mut inspection = match failure_policy {
         InspectionFailurePolicy::TreatAsDrift => {
-            DeploymentInspection::new(u64::MAX, u64::MAX, u64::MAX)
+            DeploymentInspection::new(u64::MAX, u64::MAX, u64::MAX, u64::MAX)
         }
         InspectionFailurePolicy::Preserve => DeploymentInspection::new(
             MAX_PREFLIGHT_STATUS_HASH_BYTES,
             MAX_PREFLIGHT_STATUS_HASH_ENTRIES,
             MAX_PREFLIGHT_STATUS_TREE_ENTRIES,
+            MAX_PREFLIGHT_STATUS_PATH_ENTRIES,
         ),
     };
     let mut drifted = Vec::new();
@@ -479,19 +553,18 @@ fn status_with_failure_policy(
             drifted.push(path.clone());
         }
     }
-    for path in record
-        .ue4ss_mod_dir
-        .iter()
-        .chain(record.ue4ss_mod_dirs.iter())
-    {
-        let expected = crate::tree_fingerprint_for_path(
-            Path::new(path.as_str()),
-            &record.ue4ss_tree_fingerprints,
-        );
+    let Ue4ssPathIndex {
+        active_keys: active_ue4ss_paths,
+        active: active_ue4ss_entries,
+        stale: stale_ue4ss_paths,
+        fingerprints: ue4ss_fingerprints,
+    } = ue4ss_path_index(&record, &mut inspection)?;
+    for (path, key) in active_ue4ss_entries {
+        let expected = ue4ss_fingerprints.get(&key).copied();
         let matches = match expected {
             Some(fingerprint) => {
                 tree_matches_for_status(
-                    Path::new(path.as_str()),
+                    Path::new(path),
                     fingerprint,
                     failure_policy,
                     &mut inspection,
@@ -500,17 +573,14 @@ fn status_with_failure_policy(
             None => false,
         };
         if !matches {
-            drifted.push(path.clone());
+            drifted.push(path.to_owned());
         }
     }
-    for path in &record.stale_ue4ss_dirs {
-        let mirrors_active = record
-            .ue4ss_mod_dir
-            .iter()
-            .chain(record.ue4ss_mod_dirs.iter())
-            .any(|active| crate::same_path(Path::new(path), active));
-        if !mirrors_active && path_exists_for_status(Path::new(path), failure_policy)? {
-            drifted.push(path.clone());
+    for (path, key) in stale_ue4ss_paths {
+        if !active_ue4ss_paths.contains(&key)
+            && path_exists_for_status(Path::new(path), failure_policy)?
+        {
+            drifted.push(path.to_owned());
         }
     }
 
@@ -1689,6 +1759,117 @@ mod tests {
     }
 
     #[test]
+    fn ue4ss_path_index_deduplicates_aliases_and_bounds_linear_work() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active = tmp.path().join("game/G1R/Binaries/Win64/ue4ss/Mods/Active");
+        let stale = tmp.path().join("game/G1R/Binaries/Win64/ue4ss/Mods/Stale");
+        let active_alias = format!("{}{}", active.display(), std::path::MAIN_SEPARATOR);
+        let stale_alias = format!("{}{}", stale.display(), std::path::MAIN_SEPARATOR);
+        let record = DeployRecord {
+            ue4ss_mod_dir: Some(active.display().to_string()),
+            ue4ss_mod_dirs: vec![active_alias.clone()],
+            stale_ue4ss_dirs: vec![active_alias, stale.display().to_string(), stale_alias],
+            ue4ss_tree_fingerprints: BTreeMap::from([
+                (active.display().to_string(), "same".into()),
+                (
+                    format!("{}{}", active.display(), std::path::MAIN_SEPARATOR),
+                    "same".into(),
+                ),
+            ]),
+            ..Default::default()
+        };
+
+        // Two active, two fingerprints, and three stale entries consume seven units, regardless
+        // of the number of possible pairs. Normalized aliases retain only one key apiece.
+        let mut exact = DeploymentInspection::new(0, 0, 0, 7);
+        let Ue4ssPathIndex {
+            active_keys,
+            active: active_paths,
+            stale: stale_paths,
+            fingerprints,
+        } = ue4ss_path_index(&record, &mut exact).unwrap();
+        assert_eq!(exact.remaining_path_entries, 0);
+        assert_eq!(active_keys.len(), 1);
+        assert_eq!(active_paths.len(), 1);
+        assert_eq!(stale_paths.len(), 2);
+        assert_eq!(fingerprints.len(), 1);
+        assert!(active_keys.contains(&stale_paths[0].1));
+        assert!(!active_keys.contains(&stale_paths[1].1));
+
+        let mut short = DeploymentInspection::new(0, 0, 0, 6);
+        let error = ue4ss_path_index(&record, &mut short).unwrap_err();
+        assert!(matches!(&error, crate::ModError::InspectionBound(_)));
+        assert!(error.to_string().contains("path-entry budget"), "{error}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ue4ss_path_index_preserves_existing_short_name_aliases() {
+        use std::os::windows::ffi::{OsStrExt as _, OsStringExt as _};
+        use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
+
+        fn short_path(path: &Path) -> Option<std::path::PathBuf> {
+            let input: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+            let required = unsafe { GetShortPathNameW(input.as_ptr(), std::ptr::null_mut(), 0) };
+            if required == 0 {
+                return None;
+            }
+            let mut output = vec![0u16; required as usize];
+            let written = unsafe {
+                GetShortPathNameW(input.as_ptr(), output.as_mut_ptr(), output.len() as u32)
+            };
+            if written == 0 || written as usize >= output.len() {
+                return None;
+            }
+            output.truncate(written as usize);
+            Some(std::ffi::OsString::from_wide(&output).into())
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("game");
+        let library = tmp.path().join("library");
+        let active = game.join(
+            "G1R/Binaries/Win64/ue4ss/Mods/A deliberately long UE4SS directory name",
+        );
+        std::fs::create_dir_all(&active).unwrap();
+        std::fs::create_dir_all(&library).unwrap();
+        let Some(short_name) =
+            short_path(&active).and_then(|path| path.file_name().map(|name| name.to_os_string()))
+        else {
+            return;
+        };
+        let short_alias = active.parent().unwrap().join(short_name);
+        if crate::record_path_key(&active) == crate::record_path_key(&short_alias) {
+            return;
+        }
+        assert!(short_alias.is_dir());
+
+        write_record(
+            &game,
+            &DeployRecord {
+                mod_name: "manager".into(),
+                owner: "manager".into(),
+                ue4ss_mod_dirs: vec![active.display().to_string()],
+                stale_ue4ss_dirs: vec![short_alias.display().to_string()],
+                ue4ss_tree_fingerprints: BTreeMap::from([(
+                    short_alias.display().to_string(),
+                    crate::tree_fingerprint(&active).unwrap(),
+                )]),
+                ..Default::default()
+            },
+        );
+
+        let expected = ManagerStatus::InSync {
+            loadout: Vec::new(),
+        };
+        assert_eq!(status(&game, &library, &Loadout::default()).unwrap(), expected);
+        assert_eq!(
+            status_for_preflight(&game, &library, &Loadout::default()).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
     fn deployment_hashing_is_cached_and_aggregate_bounded() {
         assert!(
             MAX_PREFLIGHT_STATUS_HASH_BYTES
@@ -1701,7 +1882,7 @@ mod tests {
         std::fs::write(&beta, b"beta").unwrap();
         let alpha_hash = crate::sha256_file(&alpha).unwrap();
         let beta_hash = crate::sha256_file(&beta).unwrap();
-        let mut files = DeploymentInspection::new(5, 2, 0);
+        let mut files = DeploymentInspection::new(5, 2, 0, u64::MAX);
 
         for _ in 0..2 {
             assert!(file_matches_for_status(
@@ -1724,7 +1905,7 @@ mod tests {
         assert!(error.to_string().contains("hashing budget"), "{error}");
 
         let alpha_legacy_hash = crate::content_hash(b"alpha");
-        let mut legacy = DeploymentInspection::new(4, 1, 0);
+        let mut legacy = DeploymentInspection::new(4, 1, 0, u64::MAX);
         let error = file_matches_for_status(
             &alpha,
             &alpha_legacy_hash,
@@ -1735,7 +1916,7 @@ mod tests {
         assert!(matches!(&error, crate::ModError::InspectionBound(_)));
         assert!(error.to_string().contains("hashing budget"), "{error}");
 
-        let mut file_entries = DeploymentInspection::new(100, 1, 0);
+        let mut file_entries = DeploymentInspection::new(100, 1, 0, u64::MAX);
         assert!(file_matches_for_status(
             &alpha,
             &alpha_hash,
@@ -1760,7 +1941,7 @@ mod tests {
         std::fs::write(tree.join("payload"), b"tree").unwrap();
         std::fs::write(other_tree.join("payload"), b"tree").unwrap();
         let tree_hash = crate::tree_fingerprint(&tree).unwrap();
-        let mut trees = DeploymentInspection::new(4, 0, 1);
+        let mut trees = DeploymentInspection::new(4, 0, 1, u64::MAX);
         for _ in 0..2 {
             assert!(tree_matches_for_status(
                 &tree,
@@ -1808,7 +1989,7 @@ mod tests {
 
         let legacy_hash = crate::content_hash(b"alpha");
         let wrong_legacy_hash = crate::content_hash(b"other");
-        let mut legacy = DeploymentInspection::new(5, 1, 0);
+        let mut legacy = DeploymentInspection::new(5, 1, 0, u64::MAX);
         assert!(file_matches_for_status(
             &file,
             &legacy_hash,
@@ -1835,7 +2016,7 @@ mod tests {
         assert_eq!(legacy.file_matches.len(), 2);
         assert_eq!(legacy.legacy_hashes.len(), 1);
 
-        let mut sha256 = DeploymentInspection::new(5, 1, 0);
+        let mut sha256 = DeploymentInspection::new(5, 1, 0, u64::MAX);
         assert_eq!(
             sha256_for_status(&file, InspectionFailurePolicy::Preserve, &mut sha256).unwrap(),
             sha256_for_status(
@@ -1855,7 +2036,7 @@ mod tests {
         let tree_alias = toggle_verbatim(&tree.with_file_name("TREE"));
         assert!(tree_alias.is_dir());
         let tree_hash = crate::tree_fingerprint(&tree).unwrap();
-        let mut trees = DeploymentInspection::new(4, 0, 1);
+        let mut trees = DeploymentInspection::new(4, 0, 1, u64::MAX);
         assert!(tree_matches_for_status(
             &tree,
             &tree_hash,

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -50,6 +50,57 @@ pub enum ManagerStatus {
     GameUpdated { drifted: Vec<String> },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InspectionFailurePolicy {
+    TreatAsDrift,
+    Preserve,
+}
+
+fn path_exists_for_status(
+    path: &Path,
+    failure_policy: InspectionFailurePolicy,
+) -> crate::Result<bool> {
+    if failure_policy == InspectionFailurePolicy::TreatAsDrift {
+        return Ok(crate::path_exists_no_follow(path));
+    }
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(crate::ModError::Io(format!(
+            "reading deployment path metadata {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+fn file_matches_for_status(
+    path: &Path,
+    expected: &str,
+    failure_policy: InspectionFailurePolicy,
+) -> crate::Result<bool> {
+    if failure_policy == InspectionFailurePolicy::TreatAsDrift {
+        return Ok(crate::file_matches_recorded_hash(path, expected));
+    }
+    if !path_exists_for_status(path, failure_policy)? {
+        return Ok(false);
+    }
+    crate::file_matches_recorded_hash_result(path, expected)
+}
+
+fn tree_matches_for_status(
+    path: &Path,
+    expected: &str,
+    failure_policy: InspectionFailurePolicy,
+) -> crate::Result<bool> {
+    if failure_policy == InspectionFailurePolicy::TreatAsDrift {
+        return Ok(crate::tree_matches_recorded_fingerprint(path, expected));
+    }
+    if !path_exists_for_status(path, failure_policy)? {
+        return Ok(false);
+    }
+    crate::tree_fingerprint(path).map(|current| current == expected)
+}
+
 /// Report the manager's state at `game_root` relative to `target` (see [`ManagerStatus`]).
 /// `library_dir` is the mod library root, needed to fingerprint each enabled mod's current
 /// on-disk content and compare it to what the deploy record snapshotted — so a same-id UPDATE
@@ -59,6 +110,35 @@ pub fn status(
     game_root: &Path,
     library_dir: &Path,
     target: &Loadout,
+) -> crate::Result<ManagerStatus> {
+    status_with_failure_policy(
+        game_root,
+        library_dir,
+        target,
+        InspectionFailurePolicy::TreatAsDrift,
+    )
+}
+
+/// Preflight must distinguish confirmed drift (including a missing owned path) from evidence it
+/// could not inspect. The public status command retains its conservative drift contract.
+pub(super) fn status_for_preflight(
+    game_root: &Path,
+    library_dir: &Path,
+    target: &Loadout,
+) -> crate::Result<ManagerStatus> {
+    status_with_failure_policy(
+        game_root,
+        library_dir,
+        target,
+        InspectionFailurePolicy::Preserve,
+    )
+}
+
+fn status_with_failure_policy(
+    game_root: &Path,
+    library_dir: &Path,
+    target: &Loadout,
+    failure_policy: InspectionFailurePolicy,
 ) -> crate::Result<ManagerStatus> {
     // Match deploy/undeploy's record location logic so status reads the SAME record they wrote,
     // regardless of whether the caller passed the install dir or its `G1R` child, or a relative
@@ -87,19 +167,19 @@ pub fn status(
     // Drift beats loadout comparison: if the game changed a file we wrote, the deployment is stale
     // no matter what the loadout says. A missing recorded file counts as drifted (it was our
     // modded file and is now gone/replaced).
-    let mut drifted: Vec<String> = record
-        .deployed_hashes
-        .iter()
-        .filter(|(live, expected)| {
-            !crate::file_matches_recorded_hash(Path::new(live.as_str()), expected)
-        })
-        .map(|(live, _)| live.clone())
-        .collect();
+    let mut drifted = Vec::new();
+    for (live, expected) in &record.deployed_hashes {
+        if !file_matches_for_status(Path::new(live.as_str()), expected, failure_policy)? {
+            drifted.push(live.clone());
+        }
+    }
     for (live, backup, _) in &record.backups {
         let expected = crate::deployed_hash_for_path(live, &record.deployed_hashes);
-        if expected
-            .is_none_or(|hash| !crate::file_matches_recorded_hash(Path::new(live.as_str()), hash))
-        {
+        let live_matches = match expected {
+            Some(hash) => file_matches_for_status(Path::new(live.as_str()), hash, failure_policy)?,
+            None => false,
+        };
+        if !live_matches {
             drifted.push(live.clone());
         }
 
@@ -113,7 +193,18 @@ pub fn status(
         let backup_path = Path::new(backup.as_str());
         let backup_matches = match crate::backup_hash_for_path(backup_path, &record.backup_hashes) {
             Some(hash) => {
-                hash.starts_with("sha256:") && crate::file_matches_recorded_hash(backup_path, hash)
+                hash.starts_with("sha256:")
+                    && file_matches_for_status(backup_path, hash, failure_policy)?
+            }
+            None if failure_policy == InspectionFailurePolicy::Preserve => {
+                let live_path = Path::new(live.as_str());
+                if !path_exists_for_status(live_path, failure_policy)?
+                    || !path_exists_for_status(backup_path, failure_policy)?
+                {
+                    false
+                } else {
+                    crate::sha256_file(live_path)? == crate::sha256_file(backup_path)?
+                }
             }
             None => match (
                 crate::sha256_file(Path::new(live.as_str())),
@@ -137,10 +228,13 @@ pub fn status(
         .chain(record.texture_triplets.iter())
     {
         let expected = crate::deployed_hash_for_path(path, &record.deployed_hashes);
-        if expected.is_none_or(|hash| {
-            !hash.starts_with("sha256:")
-                || !crate::file_matches_recorded_hash(Path::new(path.as_str()), hash)
-        }) {
+        let matches = match expected {
+            Some(hash) if hash.starts_with("sha256:") => {
+                file_matches_for_status(Path::new(path.as_str()), hash, failure_policy)?
+            }
+            _ => false,
+        };
+        if !matches {
             drifted.push(path.clone());
         }
     }
@@ -153,9 +247,13 @@ pub fn status(
             Path::new(path.as_str()),
             &record.ue4ss_tree_fingerprints,
         );
-        if expected.is_none_or(|fingerprint| {
-            !crate::tree_matches_recorded_fingerprint(Path::new(path.as_str()), fingerprint)
-        }) {
+        let matches = match expected {
+            Some(fingerprint) => {
+                tree_matches_for_status(Path::new(path.as_str()), fingerprint, failure_policy)?
+            }
+            None => false,
+        };
+        if !matches {
             drifted.push(path.clone());
         }
     }
@@ -165,7 +263,7 @@ pub fn status(
             .iter()
             .chain(record.ue4ss_mod_dirs.iter())
             .any(|active| crate::same_path(Path::new(path), active));
-        if !mirrors_active && crate::path_exists_no_follow(Path::new(path)) {
+        if !mirrors_active && path_exists_for_status(Path::new(path), failure_policy)? {
             drifted.push(path.clone());
         }
     }
@@ -507,6 +605,41 @@ mod tests {
         assert_eq!(
             status(&game, &lib, &target).unwrap(),
             ManagerStatus::GameUpdated { drifted: expected }
+        );
+    }
+
+    #[test]
+    fn preflight_status_preserves_ownership_inspection_failures() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("game");
+        let lib = tmp.path().join("lib");
+        let live = game.join("G1R/Story/VoiceOver/owned.zip");
+        std::fs::create_dir_all(&live).unwrap();
+        let record = DeployRecord {
+            mod_name: "manager".into(),
+            owner: "manager".into(),
+            deployed_hashes: BTreeMap::from([(
+                live.display().to_string(),
+                crate::content_hash(b"deployed"),
+            )]),
+            ..Default::default()
+        };
+        write_record(&game, &record);
+
+        assert_eq!(
+            status(&game, &lib, &Loadout::default()).unwrap(),
+            ManagerStatus::GameUpdated {
+                drifted: vec![live.display().to_string()]
+            }
+        );
+        assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
+
+        std::fs::remove_dir(&live).unwrap();
+        assert_eq!(
+            status_for_preflight(&game, &lib, &Loadout::default()).unwrap(),
+            ManagerStatus::GameUpdated {
+                drifted: vec![live.display().to_string()]
+            }
         );
     }
 

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -56,6 +56,17 @@ enum InspectionFailurePolicy {
     Preserve,
 }
 
+fn metadata_for_status(path: &Path) -> crate::Result<Option<std::fs::Metadata>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(crate::ModError::Io(format!(
+            "reading deployment path metadata {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
 fn path_exists_for_status(
     path: &Path,
     failure_policy: InspectionFailurePolicy,
@@ -63,14 +74,7 @@ fn path_exists_for_status(
     if failure_policy == InspectionFailurePolicy::TreatAsDrift {
         return Ok(crate::path_exists_no_follow(path));
     }
-    match std::fs::symlink_metadata(path) {
-        Ok(_) => Ok(true),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(crate::ModError::Io(format!(
-            "reading deployment path metadata {}: {error}",
-            path.display()
-        ))),
-    }
+    Ok(metadata_for_status(path)?.is_some())
 }
 
 fn file_matches_for_status(
@@ -81,7 +85,10 @@ fn file_matches_for_status(
     if failure_policy == InspectionFailurePolicy::TreatAsDrift {
         return Ok(crate::file_matches_recorded_hash(path, expected));
     }
-    if !path_exists_for_status(path, failure_policy)? {
+    let Some(metadata) = metadata_for_status(path)? else {
+        return Ok(false);
+    };
+    if crate::metadata_is_link(&metadata) || !metadata.is_file() {
         return Ok(false);
     }
     crate::file_matches_recorded_hash_result(path, expected)
@@ -95,7 +102,10 @@ fn tree_matches_for_status(
     if failure_policy == InspectionFailurePolicy::TreatAsDrift {
         return Ok(crate::tree_matches_recorded_fingerprint(path, expected));
     }
-    if !path_exists_for_status(path, failure_policy)? {
+    let Some(metadata) = metadata_for_status(path)? else {
+        return Ok(false);
+    };
+    if crate::metadata_is_link(&metadata) || !metadata.is_dir() {
         return Ok(false);
     }
     crate::tree_fingerprint(path).map(|current| current == expected)
@@ -198,9 +208,15 @@ fn status_with_failure_policy(
             }
             None if failure_policy == InspectionFailurePolicy::Preserve => {
                 let live_path = Path::new(live.as_str());
-                if !path_exists_for_status(live_path, failure_policy)?
-                    || !path_exists_for_status(backup_path, failure_policy)?
-                {
+                let live_metadata = metadata_for_status(live_path)?;
+                let backup_metadata = metadata_for_status(backup_path)?;
+                let live_is_file = live_metadata.as_ref().is_some_and(|metadata| {
+                    !crate::metadata_is_link(metadata) && metadata.is_file()
+                });
+                let backup_is_file = backup_metadata.as_ref().is_some_and(|metadata| {
+                    !crate::metadata_is_link(metadata) && metadata.is_file()
+                });
+                if !live_is_file || !backup_is_file {
                     false
                 } else {
                     crate::sha256_file(live_path)? == crate::sha256_file(backup_path)?
@@ -614,14 +630,12 @@ mod tests {
         let game = tmp.path().join("game");
         let lib = tmp.path().join("lib");
         let live = game.join("G1R/Story/VoiceOver/owned.zip");
-        std::fs::create_dir_all(&live).unwrap();
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"deployed").unwrap();
         let record = DeployRecord {
             mod_name: "manager".into(),
             owner: "manager".into(),
-            deployed_hashes: BTreeMap::from([(
-                live.display().to_string(),
-                crate::content_hash(b"deployed"),
-            )]),
+            deployed_hashes: BTreeMap::from([(live.display().to_string(), "malformed".into())]),
             ..Default::default()
         };
         write_record(&game, &record);
@@ -634,7 +648,15 @@ mod tests {
         );
         assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
 
-        std::fs::remove_dir(&live).unwrap();
+        std::fs::remove_file(&live).unwrap();
+        assert_eq!(
+            status_for_preflight(&game, &lib, &Loadout::default()).unwrap(),
+            ManagerStatus::GameUpdated {
+                drifted: vec![live.display().to_string()]
+            }
+        );
+
+        std::fs::create_dir(&live).unwrap();
         assert_eq!(
             status_for_preflight(&game, &lib, &Loadout::default()).unwrap(),
             ManagerStatus::GameUpdated {

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -113,63 +113,6 @@ impl DeploymentInspection {
     }
 }
 
-fn valid_sha256_identity(identity: &str) -> bool {
-    identity.strip_prefix("sha256:").is_some_and(|hex| {
-        hex.len() == 64
-            && hex
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-    })
-}
-
-fn valid_file_identity(identity: &str) -> bool {
-    valid_sha256_identity(identity)
-        || (identity.len() == 16
-            && identity
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)))
-}
-
-fn validate_record_identities(record: &crate::DeployRecord) -> crate::Result<()> {
-    for (path, identity) in &record.deployed_hashes {
-        if !valid_file_identity(identity) {
-            return Err(crate::ModError::Other(format!(
-                "deploy record contains an invalid deployed file identity for {path}"
-            )));
-        }
-    }
-    for (path, identities) in &record.recovery_file_hashes {
-        if identities.is_empty()
-            || identities
-                .iter()
-                .any(|identity| !valid_file_identity(identity))
-        {
-            return Err(crate::ModError::Other(format!(
-                "deploy record contains an invalid alternate file identity for {path}"
-            )));
-        }
-    }
-    for (path, identity) in &record.ue4ss_tree_fingerprints {
-        if !valid_sha256_identity(identity) {
-            return Err(crate::ModError::Other(format!(
-                "deploy record contains an invalid UE4SS tree identity for {path}"
-            )));
-        }
-    }
-    for (path, identities) in &record.recovery_tree_fingerprints {
-        if identities.is_empty()
-            || identities
-                .iter()
-                .any(|identity| !valid_sha256_identity(identity))
-        {
-            return Err(crate::ModError::Other(format!(
-                "deploy record contains an invalid alternate UE4SS tree identity for {path}"
-            )));
-        }
-    }
-    Ok(())
-}
-
 fn metadata_for_status(path: &Path) -> crate::Result<Option<std::fs::Metadata>> {
     match std::fs::symlink_metadata(path) {
         Ok(metadata) => Ok(Some(metadata)),
@@ -261,7 +204,7 @@ fn tree_matches_for_status(
         if crate::metadata_is_link(&metadata) || !metadata.is_dir() {
             return Ok(false);
         }
-        if !valid_sha256_identity(expected) {
+        if !crate::valid_sha256_identity(expected) {
             return Err(crate::ModError::Other(format!(
                 "invalid recorded UE4SS tree SHA-256 identity for {}",
                 path.display()
@@ -407,7 +350,7 @@ fn status_with_failure_policy(
     if failure_policy == InspectionFailurePolicy::Preserve
         && (recovery_required || record.owner != "manager")
     {
-        validate_record_identities(&record)?;
+        crate::validate_record_identities(&record)?;
     }
     if recovery_required {
         return Ok(ManagerStatus::RecoveryRequired);
@@ -904,6 +847,58 @@ mod tests {
         let error = status_for_preflight(&game, &lib, &Loadout::default()).unwrap_err();
         assert!(
             error.to_string().contains("invalid deployed file identity"),
+            "{error}"
+        );
+        assert_eq!(std::fs::read(record_path(&game)).unwrap(), before);
+    }
+
+    #[test]
+    fn preflight_rejects_noncanonical_studio_backup_before_removal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("game");
+        let lib = tmp.path().join("lib");
+        let live = game.join("G1R/Story/VoiceOver/owned.zip");
+        let backup = crate::bak_path(&live);
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"deployed").unwrap();
+        std::fs::write(&backup, b"pristine").unwrap();
+        let canonical = crate::sha256_file(&backup).unwrap();
+        let noncanonical = format!(
+            "sha256:{}",
+            canonical
+                .strip_prefix("sha256:")
+                .unwrap()
+                .to_ascii_uppercase()
+        );
+        assert_ne!(noncanonical, canonical);
+        let record = DeployRecord {
+            mod_name: "SoloMod".into(),
+            backups: vec![(
+                live.display().to_string(),
+                backup.display().to_string(),
+                true,
+            )],
+            deployed_hashes: BTreeMap::from([(
+                live.display().to_string(),
+                crate::content_hash(b"deployed"),
+            )]),
+            backup_hashes: BTreeMap::from([(backup.display().to_string(), noncanonical)]),
+            ..Default::default()
+        };
+        write_record(&game, &record);
+        let before = std::fs::read(record_path(&game)).unwrap();
+
+        assert_eq!(
+            status(&game, &lib, &Loadout::default()).unwrap(),
+            ManagerStatus::StudioDeployActive {
+                mod_name: "SoloMod".into()
+            }
+        );
+        let error = status_for_preflight(&game, &lib, &Loadout::default()).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("invalid backup SHA-256 identity"),
             "{error}"
         );
         assert_eq!(std::fs::read(record_path(&game)).unwrap(), before);

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -108,6 +108,15 @@ fn tree_matches_for_status(
     if crate::metadata_is_link(&metadata) || !metadata.is_dir() {
         return Ok(false);
     }
+    let valid_identity = expected
+        .strip_prefix("sha256:")
+        .is_some_and(|hex| hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    if !valid_identity {
+        return Err(crate::ModError::Other(format!(
+            "invalid recorded UE4SS tree SHA-256 identity for {}",
+            path.display()
+        )));
+    }
     crate::tree_fingerprint(path).map(|current| current == expected)
 }
 
@@ -1023,6 +1032,43 @@ mod tests {
 
         assert_eq!(
             status(&game, &lib, &loadout(&[("mod-a", true)])).unwrap(),
+            ManagerStatus::GameUpdated {
+                drifted: vec![tree.display().to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn preflight_status_preserves_invalid_ue4ss_tree_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("game");
+        let lib = tmp.path().join("lib");
+        let tree = game.join("G1R/Binaries/Win64/ue4ss/Mods/Owned");
+        std::fs::create_dir_all(&tree).unwrap();
+        std::fs::write(tree.join("deployed.txt"), b"deployed").unwrap();
+        let record = DeployRecord {
+            mod_name: "manager".into(),
+            owner: "manager".into(),
+            ue4ss_mod_dirs: vec![tree.display().to_string()],
+            ue4ss_tree_fingerprints: BTreeMap::from([(
+                tree.display().to_string(),
+                "malformed".into(),
+            )]),
+            ..Default::default()
+        };
+        write_record(&game, &record);
+
+        assert_eq!(
+            status(&game, &lib, &Loadout::default()).unwrap(),
+            ManagerStatus::GameUpdated {
+                drifted: vec![tree.display().to_string()]
+            }
+        );
+        assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
+
+        std::fs::remove_dir_all(&tree).unwrap();
+        assert_eq!(
+            status_for_preflight(&game, &lib, &Loadout::default()).unwrap(),
             ManagerStatus::GameUpdated {
                 drifted: vec![tree.display().to_string()]
             }

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -130,11 +130,11 @@ fn valid_file_identity(identity: &str) -> bool {
                 .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)))
 }
 
-fn validate_recovery_identities(record: &crate::DeployRecord) -> crate::Result<()> {
+fn validate_record_identities(record: &crate::DeployRecord) -> crate::Result<()> {
     for (path, identity) in &record.deployed_hashes {
         if !valid_file_identity(identity) {
             return Err(crate::ModError::Other(format!(
-                "recovery record contains an invalid deployed file identity for {path}"
+                "deploy record contains an invalid deployed file identity for {path}"
             )));
         }
     }
@@ -145,14 +145,14 @@ fn validate_recovery_identities(record: &crate::DeployRecord) -> crate::Result<(
                 .any(|identity| !valid_file_identity(identity))
         {
             return Err(crate::ModError::Other(format!(
-                "recovery record contains an invalid alternate file identity for {path}"
+                "deploy record contains an invalid alternate file identity for {path}"
             )));
         }
     }
     for (path, identity) in &record.ue4ss_tree_fingerprints {
         if !valid_sha256_identity(identity) {
             return Err(crate::ModError::Other(format!(
-                "recovery record contains an invalid UE4SS tree identity for {path}"
+                "deploy record contains an invalid UE4SS tree identity for {path}"
             )));
         }
     }
@@ -163,7 +163,7 @@ fn validate_recovery_identities(record: &crate::DeployRecord) -> crate::Result<(
                 .any(|identity| !valid_sha256_identity(identity))
         {
             return Err(crate::ModError::Other(format!(
-                "recovery record contains an invalid alternate UE4SS tree identity for {path}"
+                "deploy record contains an invalid alternate UE4SS tree identity for {path}"
             )));
         }
     }
@@ -404,8 +404,10 @@ fn status_with_failure_policy(
     let recovery_required = record.phase == crate::DeployPhase::RecoveryRequired
         || !record.file_cleanup_claims.is_empty()
         || !record.ue4ss_cleanup_claims.is_empty();
-    if recovery_required && failure_policy == InspectionFailurePolicy::Preserve {
-        validate_recovery_identities(&record)?;
+    if failure_policy == InspectionFailurePolicy::Preserve
+        && (recovery_required || record.owner != "manager")
+    {
+        validate_record_identities(&record)?;
     }
     if recovery_required {
         return Ok(ManagerStatus::RecoveryRequired);
@@ -877,6 +879,34 @@ mod tests {
                 mod_name: "SoloMod".into()
             }
         );
+    }
+
+    #[test]
+    fn preflight_rejects_malformed_studio_ownership_before_removal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("game");
+        let lib = tmp.path().join("lib");
+        let live = game.join("G1R/Story/VoiceOver/owned.zip");
+        let record = DeployRecord {
+            mod_name: "SoloMod".into(),
+            deployed_hashes: BTreeMap::from([(live.display().to_string(), "malformed".into())]),
+            ..Default::default()
+        };
+        write_record(&game, &record);
+        let before = std::fs::read(record_path(&game)).unwrap();
+
+        assert_eq!(
+            status(&game, &lib, &Loadout::default()).unwrap(),
+            ManagerStatus::StudioDeployActive {
+                mod_name: "SoloMod".into()
+            }
+        );
+        let error = status_for_preflight(&game, &lib, &Loadout::default()).unwrap_err();
+        assert!(
+            error.to_string().contains("invalid deployed file identity"),
+            "{error}"
+        );
+        assert_eq!(std::fs::read(record_path(&game)).unwrap(), before);
     }
 
     /// A manager record whose loadout equals the target's enabled entries AND whose recorded

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -19,12 +19,15 @@
 //! Pure read-only: it reads the record, verifies the recorded live files and pristine backups, and
 //! reads each enabled mod's library sidecar to fingerprint it; it never writes.
 
+use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
 use serde::Serialize;
 
 use super::loadout::{Loadout, LoadoutEntry};
 use super::model::LibraryRoot;
+
+const MAX_STATUS_META_BYTES: u64 = 16 * 1024 * 1024;
 
 /// The manager's deployment state relative to a target loadout. `#[serde(tag = "state")]` so the
 /// UI can switch on a single discriminant field.
@@ -388,23 +391,17 @@ fn status_with_failure_policy(
             });
         }
     };
-    for e in &target_enabled {
-        let current = match read_library_fingerprint(&library, &e.id) {
-            Some(fp) => fp,
-            // Can't read/parse the library entry → treat as changed (re-apply rebuilds from it).
-            None => {
-                return Ok(ManagerStatus::ChangesPending {
-                    deployed: record.loadout,
-                    target: target_enabled,
-                });
-            }
-        };
-        if record.deployed_fingerprints.get(&e.id) != Some(&current) {
-            return Ok(ManagerStatus::ChangesPending {
-                deployed: record.loadout,
-                target: target_enabled,
-            });
-        }
+    let mut remaining_meta_bytes = MAX_STATUS_META_BYTES;
+    if !library_fingerprints_match(
+        &library,
+        &target_enabled,
+        &record.deployed_fingerprints,
+        &mut remaining_meta_bytes,
+    ) {
+        return Ok(ManagerStatus::ChangesPending {
+            deployed: record.loadout,
+            target: target_enabled,
+        });
     }
 
     Ok(ManagerStatus::InSync {
@@ -415,8 +412,42 @@ fn status_with_failure_policy(
 /// Read `<library_dir>/<id>/gore-manager-meta.json` and compute its content [`ModEntryMeta::fingerprint`].
 /// `None` if the sidecar is missing or unparseable — the caller treats that as "changed" so a
 /// removed/corrupt library entry can never leave status reporting InSync over stale deployed bytes.
-fn read_library_fingerprint(library: &LibraryRoot, id: &str) -> Option<String> {
-    Some(library.entry(id).ok()?.read_meta().ok()?.fingerprint())
+fn library_fingerprints_match(
+    library: &LibraryRoot,
+    target: &[LoadoutEntry],
+    deployed: &BTreeMap<String, String>,
+    remaining_meta_bytes: &mut u64,
+) -> bool {
+    let mut inspected_ids = HashSet::new();
+    for entry in target {
+        if !inspected_ids.insert(entry.id.as_str()) {
+            continue;
+        }
+        let Some(current) =
+            read_library_fingerprint(library, &entry.id, remaining_meta_bytes)
+        else {
+            return false;
+        };
+        if deployed.get(&entry.id) != Some(&current) {
+            return false;
+        }
+    }
+    true
+}
+
+fn read_library_fingerprint(
+    library: &LibraryRoot,
+    id: &str,
+    remaining_meta_bytes: &mut u64,
+) -> Option<String> {
+    Some(
+        library
+            .entry(id)
+            .ok()?
+            .read_meta_bounded(remaining_meta_bytes)
+            .ok()?
+            .fingerprint(),
+    )
 }
 
 #[cfg(test)]
@@ -1317,6 +1348,55 @@ mod tests {
             status(&game, &lib, &loadout(&[("mod-a", true)])).unwrap(),
             ManagerStatus::InSync { loadout: deployed }
         );
+    }
+
+    #[test]
+    fn fingerprint_pass_has_an_aggregate_budget_and_deduplicates_ids() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("lib");
+        let alpha = lib_meta_with("alpha", "same");
+        let beta = lib_meta_with("beta", "same");
+        let alpha_fp = write_lib_meta(&lib, &alpha);
+        let beta_fp = write_lib_meta(&lib, &beta);
+        let sidecar_len = |id: &str| {
+            std::fs::metadata(lib.join(id).join(META_FILE))
+                .unwrap()
+                .len()
+        };
+        let alpha_len = sidecar_len("alpha");
+        let beta_len = sidecar_len("beta");
+        let library = LibraryRoot::open(&lib).unwrap();
+        let deployed = BTreeMap::from([
+            ("alpha".to_string(), alpha_fp),
+            ("beta".to_string(), beta_fp),
+        ]);
+
+        let mut duplicate_budget = alpha_len;
+        assert!(library_fingerprints_match(
+            &library,
+            &[le("alpha", true), le("alpha", true)],
+            &deployed,
+            &mut duplicate_budget,
+        ));
+        assert_eq!(duplicate_budget, 0);
+
+        let distinct = [le("alpha", true), le("beta", true)];
+        let mut short_budget = alpha_len + beta_len - 1;
+        assert!(!library_fingerprints_match(
+            &library,
+            &distinct,
+            &deployed,
+            &mut short_budget,
+        ));
+
+        let mut exact_budget = alpha_len + beta_len;
+        assert!(library_fingerprints_match(
+            &library,
+            &distinct,
+            &deployed,
+            &mut exact_budget,
+        ));
+        assert_eq!(exact_budget, 0);
     }
 
     #[cfg(any(unix, windows))]

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -102,7 +102,7 @@ impl DeploymentInspection {
 
     fn charge_file_hash(&mut self) -> crate::Result<()> {
         if self.remaining_hash_entries == 0 {
-            return Err(crate::ModError::Other(
+            return Err(crate::ModError::InspectionBound(
                 "deployment inspection exhausted its file-hash budget".into(),
             ));
         }
@@ -1619,6 +1619,19 @@ mod tests {
             &mut files,
         )
         .unwrap_err();
+        assert!(matches!(&error, crate::ModError::InspectionBound(_)));
+        assert!(error.to_string().contains("hashing budget"), "{error}");
+
+        let alpha_legacy_hash = crate::content_hash(b"alpha");
+        let mut legacy = DeploymentInspection::new(4, 1, 0);
+        let error = file_matches_for_status(
+            &alpha,
+            &alpha_legacy_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut legacy,
+        )
+        .unwrap_err();
+        assert!(matches!(&error, crate::ModError::InspectionBound(_)));
         assert!(error.to_string().contains("hashing budget"), "{error}");
 
         let mut file_entries = DeploymentInspection::new(100, 1, 0);
@@ -1636,6 +1649,7 @@ mod tests {
             &mut file_entries,
         )
         .unwrap_err();
+        assert!(matches!(&error, crate::ModError::InspectionBound(_)));
         assert!(error.to_string().contains("file-hash budget"), "{error}");
 
         let tree = tmp.path().join("tree");
@@ -1664,6 +1678,7 @@ mod tests {
             &mut trees,
         )
         .unwrap_err();
+        assert!(matches!(&error, crate::ModError::InspectionBound(_)));
         assert!(error.to_string().contains("tree-entry budget"), "{error}");
     }
 

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -56,6 +56,61 @@ enum InspectionFailurePolicy {
     Preserve,
 }
 
+fn valid_sha256_identity(identity: &str) -> bool {
+    identity.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+fn valid_file_identity(identity: &str) -> bool {
+    valid_sha256_identity(identity)
+        || (identity.len() == 16
+            && identity
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)))
+}
+
+fn validate_recovery_identities(record: &crate::DeployRecord) -> crate::Result<()> {
+    for (path, identity) in &record.deployed_hashes {
+        if !valid_file_identity(identity) {
+            return Err(crate::ModError::Other(format!(
+                "recovery record contains an invalid deployed file identity for {path}"
+            )));
+        }
+    }
+    for (path, identities) in &record.recovery_file_hashes {
+        if identities
+            .iter()
+            .any(|identity| !valid_file_identity(identity))
+        {
+            return Err(crate::ModError::Other(format!(
+                "recovery record contains an invalid alternate file identity for {path}"
+            )));
+        }
+    }
+    for (path, identity) in &record.ue4ss_tree_fingerprints {
+        if !valid_sha256_identity(identity) {
+            return Err(crate::ModError::Other(format!(
+                "recovery record contains an invalid UE4SS tree identity for {path}"
+            )));
+        }
+    }
+    for (path, identities) in &record.recovery_tree_fingerprints {
+        if identities
+            .iter()
+            .any(|identity| !valid_sha256_identity(identity))
+        {
+            return Err(crate::ModError::Other(format!(
+                "recovery record contains an invalid alternate UE4SS tree identity for {path}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn metadata_for_status(path: &Path) -> crate::Result<Option<std::fs::Metadata>> {
     match std::fs::symlink_metadata(path) {
         Ok(metadata) => Ok(Some(metadata)),
@@ -108,10 +163,7 @@ fn tree_matches_for_status(
     if crate::metadata_is_link(&metadata) || !metadata.is_dir() {
         return Ok(false);
     }
-    let valid_identity = expected
-        .strip_prefix("sha256:")
-        .is_some_and(|hex| hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit()));
-    if !valid_identity {
+    if !valid_sha256_identity(expected) {
         return Err(crate::ModError::Other(format!(
             "invalid recorded UE4SS tree SHA-256 identity for {}",
             path.display()
@@ -168,10 +220,13 @@ fn status_with_failure_policy(
     };
     let record = stored.record;
 
-    if record.phase == crate::DeployPhase::RecoveryRequired
+    let recovery_required = record.phase == crate::DeployPhase::RecoveryRequired
         || !record.file_cleanup_claims.is_empty()
-        || !record.ue4ss_cleanup_claims.is_empty()
-    {
+        || !record.ue4ss_cleanup_claims.is_empty();
+    if recovery_required && failure_policy == InspectionFailurePolicy::Preserve {
+        validate_recovery_identities(&record)?;
+    }
+    if recovery_required {
         return Ok(ManagerStatus::RecoveryRequired);
     }
 
@@ -490,6 +545,56 @@ mod tests {
             status(&game, &lib, &Loadout::default()).unwrap(),
             ManagerStatus::RecoveryRequired
         );
+    }
+
+    #[test]
+    fn preflight_rejects_malformed_recovery_identities() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("game");
+        let lib = tmp.path().join("lib");
+        let live = game.join("G1R/Story/VoiceOver/owned.zip");
+        let tree = game.join("G1R/Binaries/Win64/ue4ss/Mods/Owned");
+        let cases = [
+            DeployRecord {
+                deployed_hashes: BTreeMap::from([(live.display().to_string(), "malformed".into())]),
+                ..Default::default()
+            },
+            DeployRecord {
+                recovery_file_hashes: BTreeMap::from([(
+                    live.display().to_string(),
+                    vec!["malformed".into()],
+                )]),
+                ..Default::default()
+            },
+            DeployRecord {
+                ue4ss_mod_dirs: vec![tree.display().to_string()],
+                ue4ss_tree_fingerprints: BTreeMap::from([(
+                    tree.display().to_string(),
+                    "malformed".into(),
+                )]),
+                ..Default::default()
+            },
+            DeployRecord {
+                ue4ss_mod_dirs: vec![tree.display().to_string()],
+                recovery_tree_fingerprints: BTreeMap::from([(
+                    tree.display().to_string(),
+                    vec!["malformed".into()],
+                )]),
+                ..Default::default()
+            },
+        ];
+
+        for mut record in cases {
+            record.mod_name = "manager".into();
+            record.owner = "manager".into();
+            record.phase = DeployPhase::RecoveryRequired;
+            write_record(&game, &record);
+            assert_eq!(
+                status(&game, &lib, &Loadout::default()).unwrap(),
+                ManagerStatus::RecoveryRequired
+            );
+            assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
+        }
     }
 
     /// A studio (owner == "") record → StudioDeployActive, carrying the mod name.

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -19,7 +19,7 @@
 //! Pure read-only: it reads the record, verifies the recorded live files and pristine backups, and
 //! reads each enabled mod's library sidecar to fingerprint it; it never writes.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
 use serde::Serialize;
@@ -28,6 +28,12 @@ use super::loadout::{Loadout, LoadoutEntry};
 use super::model::LibraryRoot;
 
 const MAX_STATUS_META_BYTES: u64 = 16 * 1024 * 1024;
+// One synchronous status snapshot shares these ceilings across every recorded live file, backup,
+// and UE4SS tree. Successful exact-path reads are cached below, so duplicate record entries are
+// evidence aliases rather than repeated I/O.
+const MAX_STATUS_HASH_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+const MAX_STATUS_HASH_ENTRIES: u64 = 65_536;
+const MAX_STATUS_TREE_ENTRIES: u64 = 250_000;
 
 /// The manager's deployment state relative to a target loadout. `#[serde(tag = "state")]` so the
 /// UI can switch on a single discriminant field.
@@ -57,6 +63,42 @@ pub enum ManagerStatus {
 enum InspectionFailurePolicy {
     TreatAsDrift,
     Preserve,
+}
+
+struct DeploymentInspection {
+    remaining_hash_bytes: u64,
+    remaining_hash_entries: u64,
+    remaining_tree_entries: u64,
+    file_matches: HashMap<(String, String), bool>,
+    tree_fingerprints: HashMap<String, String>,
+    sha256: HashMap<String, String>,
+}
+
+impl DeploymentInspection {
+    fn new(
+        remaining_hash_bytes: u64,
+        remaining_hash_entries: u64,
+        remaining_tree_entries: u64,
+    ) -> Self {
+        Self {
+            remaining_hash_bytes,
+            remaining_hash_entries,
+            remaining_tree_entries,
+            file_matches: HashMap::new(),
+            tree_fingerprints: HashMap::new(),
+            sha256: HashMap::new(),
+        }
+    }
+
+    fn charge_file_hash(&mut self) -> crate::Result<()> {
+        if self.remaining_hash_entries == 0 {
+            return Err(crate::ModError::Other(
+                "deployment inspection exhausted its file-hash budget".into(),
+            ));
+        }
+        self.remaining_hash_entries -= 1;
+        Ok(())
+    }
 }
 
 fn valid_sha256_identity(identity: &str) -> bool {
@@ -141,40 +183,122 @@ fn file_matches_for_status(
     path: &Path,
     expected: &str,
     failure_policy: InspectionFailurePolicy,
+    inspection: &mut DeploymentInspection,
 ) -> crate::Result<bool> {
-    if failure_policy == InspectionFailurePolicy::TreatAsDrift {
-        return Ok(crate::file_matches_recorded_hash(path, expected));
+    let cache_key = (path.display().to_string(), expected.to_owned());
+    if let Some(cached) = inspection.file_matches.get(&cache_key) {
+        return Ok(*cached);
     }
-    let Some(metadata) = metadata_for_status(path)? else {
-        return Ok(false);
+    let sha256_expected = expected.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+    });
+    let matches = if failure_policy == InspectionFailurePolicy::TreatAsDrift {
+        if sha256_expected {
+            sha256_for_status(path, failure_policy, inspection)?
+                .as_deref()
+                == Some(expected)
+        } else if inspection.charge_file_hash().is_err() {
+            false
+        } else {
+            crate::file_matches_recorded_hash_bounded(
+                path,
+                expected,
+                &mut inspection.remaining_hash_bytes,
+            )
+            .unwrap_or(false)
+        }
+    } else {
+        let Some(metadata) = metadata_for_status(path)? else {
+            inspection.file_matches.insert(cache_key, false);
+            return Ok(false);
+        };
+        if crate::metadata_is_link(&metadata) || !metadata.is_file() {
+            false
+        } else if sha256_expected {
+            sha256_for_status(path, failure_policy, inspection)?
+                .as_deref()
+                == Some(expected)
+        } else {
+            inspection.charge_file_hash()?;
+            crate::file_matches_recorded_hash_bounded(
+                path,
+                expected,
+                &mut inspection.remaining_hash_bytes,
+            )?
+        }
     };
-    if crate::metadata_is_link(&metadata) || !metadata.is_file() {
-        return Ok(false);
-    }
-    crate::file_matches_recorded_hash_result(path, expected)
+    inspection.file_matches.insert(cache_key, matches);
+    Ok(matches)
 }
 
 fn tree_matches_for_status(
     path: &Path,
     expected: &str,
     failure_policy: InspectionFailurePolicy,
+    inspection: &mut DeploymentInspection,
 ) -> crate::Result<bool> {
-    if failure_policy == InspectionFailurePolicy::TreatAsDrift {
-        return Ok(crate::tree_matches_recorded_fingerprint(path, expected));
+    if failure_policy == InspectionFailurePolicy::Preserve {
+        let Some(metadata) = metadata_for_status(path)? else {
+            return Ok(false);
+        };
+        if crate::metadata_is_link(&metadata) || !metadata.is_dir() {
+            return Ok(false);
+        }
+        if !valid_sha256_identity(expected) {
+            return Err(crate::ModError::Other(format!(
+                "invalid recorded UE4SS tree SHA-256 identity for {}",
+                path.display()
+            )));
+        }
     }
-    let Some(metadata) = metadata_for_status(path)? else {
-        return Ok(false);
+    let cache_key = path.display().to_string();
+    if let Some(cached) = inspection.tree_fingerprints.get(&cache_key) {
+        return Ok(cached == expected);
+    }
+    let current = if failure_policy == InspectionFailurePolicy::TreatAsDrift {
+        let Ok(current) = crate::tree_fingerprint_bounded(
+            path,
+            &mut inspection.remaining_hash_bytes,
+            &mut inspection.remaining_tree_entries,
+        ) else {
+            return Ok(false);
+        };
+        current
+    } else {
+        crate::tree_fingerprint_bounded(
+            path,
+            &mut inspection.remaining_hash_bytes,
+            &mut inspection.remaining_tree_entries,
+        )?
     };
-    if crate::metadata_is_link(&metadata) || !metadata.is_dir() {
-        return Ok(false);
+    let matches = current == expected;
+    inspection.tree_fingerprints.insert(cache_key, current);
+    Ok(matches)
+}
+
+fn sha256_for_status(
+    path: &Path,
+    failure_policy: InspectionFailurePolicy,
+    inspection: &mut DeploymentInspection,
+) -> crate::Result<Option<String>> {
+    let cache_key = path.display().to_string();
+    if let Some(cached) = inspection.sha256.get(&cache_key) {
+        return Ok(Some(cached.clone()));
     }
-    if !valid_sha256_identity(expected) {
-        return Err(crate::ModError::Other(format!(
-            "invalid recorded UE4SS tree SHA-256 identity for {}",
-            path.display()
-        )));
+    if let Err(error) = inspection.charge_file_hash() {
+        return match failure_policy {
+            InspectionFailurePolicy::TreatAsDrift => Ok(None),
+            InspectionFailurePolicy::Preserve => Err(error),
+        };
     }
-    crate::tree_fingerprint(path).map(|current| current == expected)
+    let hashed = crate::sha256_file_bounded(path, &mut inspection.remaining_hash_bytes);
+    let hashed = match (failure_policy, hashed) {
+        (_, Ok(hashed)) => hashed,
+        (InspectionFailurePolicy::TreatAsDrift, Err(_)) => return Ok(None),
+        (InspectionFailurePolicy::Preserve, Err(error)) => return Err(error),
+    };
+    inspection.sha256.insert(cache_key, hashed.clone());
+    Ok(Some(hashed))
 }
 
 /// Report the manager's state at `game_root` relative to `target` (see [`ManagerStatus`]).
@@ -246,16 +370,31 @@ fn status_with_failure_policy(
     // Drift beats loadout comparison: if the game changed a file we wrote, the deployment is stale
     // no matter what the loadout says. A missing recorded file counts as drifted (it was our
     // modded file and is now gone/replaced).
+    let mut inspection = DeploymentInspection::new(
+        MAX_STATUS_HASH_BYTES,
+        MAX_STATUS_HASH_ENTRIES,
+        MAX_STATUS_TREE_ENTRIES,
+    );
     let mut drifted = Vec::new();
     for (live, expected) in &record.deployed_hashes {
-        if !file_matches_for_status(Path::new(live.as_str()), expected, failure_policy)? {
+        if !file_matches_for_status(
+            Path::new(live.as_str()),
+            expected,
+            failure_policy,
+            &mut inspection,
+        )? {
             drifted.push(live.clone());
         }
     }
     for (live, backup, _) in &record.backups {
         let expected = crate::deployed_hash_for_path(live, &record.deployed_hashes);
         let live_matches = match expected {
-            Some(hash) => file_matches_for_status(Path::new(live.as_str()), hash, failure_policy)?,
+            Some(hash) => file_matches_for_status(
+                Path::new(live.as_str()),
+                hash,
+                failure_policy,
+                &mut inspection,
+            )?,
             None => false,
         };
         if !live_matches {
@@ -273,7 +412,12 @@ fn status_with_failure_policy(
         let backup_matches = match crate::backup_hash_for_path(backup_path, &record.backup_hashes) {
             Some(hash) => {
                 hash.starts_with("sha256:")
-                    && file_matches_for_status(backup_path, hash, failure_policy)?
+                    && file_matches_for_status(
+                        backup_path,
+                        hash,
+                        failure_policy,
+                        &mut inspection,
+                    )?
             }
             None if failure_policy == InspectionFailurePolicy::Preserve => {
                 let live_path = Path::new(live.as_str());
@@ -288,16 +432,23 @@ fn status_with_failure_policy(
                 if !live_is_file || !backup_is_file {
                     false
                 } else {
-                    crate::sha256_file(live_path)? == crate::sha256_file(backup_path)?
+                    let live_hash =
+                        sha256_for_status(live_path, failure_policy, &mut inspection)?;
+                    let backup_hash =
+                        sha256_for_status(backup_path, failure_policy, &mut inspection)?;
+                    live_hash.is_some() && live_hash == backup_hash
                 }
             }
-            None => match (
-                crate::sha256_file(Path::new(live.as_str())),
-                crate::sha256_file(backup_path),
-            ) {
-                (Ok(live_hash), Ok(backup_hash)) => live_hash == backup_hash,
-                _ => false,
-            },
+            None => {
+                let live_hash = sha256_for_status(
+                    Path::new(live.as_str()),
+                    failure_policy,
+                    &mut inspection,
+                )?;
+                let backup_hash =
+                    sha256_for_status(backup_path, failure_policy, &mut inspection)?;
+                live_hash.is_some() && live_hash == backup_hash
+            }
         };
         if !backup_matches {
             drifted.push(backup.clone());
@@ -315,7 +466,12 @@ fn status_with_failure_policy(
         let expected = crate::deployed_hash_for_path(path, &record.deployed_hashes);
         let matches = match expected {
             Some(hash) if hash.starts_with("sha256:") => {
-                file_matches_for_status(Path::new(path.as_str()), hash, failure_policy)?
+                file_matches_for_status(
+                    Path::new(path.as_str()),
+                    hash,
+                    failure_policy,
+                    &mut inspection,
+                )?
             }
             _ => false,
         };
@@ -334,7 +490,12 @@ fn status_with_failure_policy(
         );
         let matches = match expected {
             Some(fingerprint) => {
-                tree_matches_for_status(Path::new(path.as_str()), fingerprint, failure_policy)?
+                tree_matches_for_status(
+                    Path::new(path.as_str()),
+                    fingerprint,
+                    failure_policy,
+                    &mut inspection,
+                )?
             }
             None => false,
         };
@@ -1397,6 +1558,82 @@ mod tests {
             &mut exact_budget,
         ));
         assert_eq!(exact_budget, 0);
+    }
+
+    #[test]
+    fn deployment_hashing_is_cached_and_aggregate_bounded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let alpha = tmp.path().join("alpha.bin");
+        let beta = tmp.path().join("beta.bin");
+        std::fs::write(&alpha, b"alpha").unwrap();
+        std::fs::write(&beta, b"beta").unwrap();
+        let alpha_hash = crate::sha256_file(&alpha).unwrap();
+        let beta_hash = crate::sha256_file(&beta).unwrap();
+        let mut files = DeploymentInspection::new(5, 2, 0);
+
+        for _ in 0..2 {
+            assert!(file_matches_for_status(
+                &alpha,
+                &alpha_hash,
+                InspectionFailurePolicy::Preserve,
+                &mut files,
+            )
+            .unwrap());
+        }
+        assert_eq!(files.remaining_hash_bytes, 0);
+        let error = file_matches_for_status(
+            &beta,
+            &beta_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut files,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("hashing budget"), "{error}");
+
+        let mut file_entries = DeploymentInspection::new(100, 1, 0);
+        assert!(file_matches_for_status(
+            &alpha,
+            &alpha_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut file_entries,
+        )
+        .unwrap());
+        let error = file_matches_for_status(
+            &beta,
+            &beta_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut file_entries,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("file-hash budget"), "{error}");
+
+        let tree = tmp.path().join("tree");
+        let other_tree = tmp.path().join("other-tree");
+        std::fs::create_dir(&tree).unwrap();
+        std::fs::create_dir(&other_tree).unwrap();
+        std::fs::write(tree.join("payload"), b"tree").unwrap();
+        std::fs::write(other_tree.join("payload"), b"tree").unwrap();
+        let tree_hash = crate::tree_fingerprint(&tree).unwrap();
+        let mut trees = DeploymentInspection::new(4, 0, 1);
+        for _ in 0..2 {
+            assert!(tree_matches_for_status(
+                &tree,
+                &tree_hash,
+                InspectionFailurePolicy::Preserve,
+                &mut trees,
+            )
+            .unwrap());
+        }
+        assert_eq!(trees.remaining_hash_bytes, 0);
+        assert_eq!(trees.remaining_tree_entries, 0);
+        let error = tree_matches_for_status(
+            &other_tree,
+            &tree_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut trees,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("tree-entry budget"), "{error}");
     }
 
     #[cfg(any(unix, windows))]

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -31,9 +31,12 @@ const MAX_STATUS_META_BYTES: u64 = 16 * 1024 * 1024;
 // One synchronous status snapshot shares these ceilings across every recorded live file, backup,
 // and UE4SS tree. Successful exact-path reads are cached below, so duplicate record entries are
 // evidence aliases rather than repeated I/O.
-const MAX_STATUS_HASH_BYTES: u64 = 4 * 1024 * 1024 * 1024;
-const MAX_STATUS_HASH_ENTRIES: u64 = 65_536;
-const MAX_STATUS_TREE_ENTRIES: u64 = 250_000;
+// Preflight admits a supported 16-GiB voice archive plus its equally-sized pristine backup with
+// room for the rest of the deployment. Public `status` retains its pre-existing no-total-ceiling
+// semantics while still benefiting from duplicate-read caching and growth-bounded individual I/O.
+const MAX_PREFLIGHT_STATUS_HASH_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+const MAX_PREFLIGHT_STATUS_HASH_ENTRIES: u64 = 250_000;
+const MAX_PREFLIGHT_STATUS_TREE_ENTRIES: u64 = 250_000;
 
 /// The manager's deployment state relative to a target loadout. `#[serde(tag = "state")]` so the
 /// UI can switch on a single discriminant field.
@@ -370,11 +373,16 @@ fn status_with_failure_policy(
     // Drift beats loadout comparison: if the game changed a file we wrote, the deployment is stale
     // no matter what the loadout says. A missing recorded file counts as drifted (it was our
     // modded file and is now gone/replaced).
-    let mut inspection = DeploymentInspection::new(
-        MAX_STATUS_HASH_BYTES,
-        MAX_STATUS_HASH_ENTRIES,
-        MAX_STATUS_TREE_ENTRIES,
-    );
+    let mut inspection = match failure_policy {
+        InspectionFailurePolicy::TreatAsDrift => {
+            DeploymentInspection::new(u64::MAX, u64::MAX, u64::MAX)
+        }
+        InspectionFailurePolicy::Preserve => DeploymentInspection::new(
+            MAX_PREFLIGHT_STATUS_HASH_BYTES,
+            MAX_PREFLIGHT_STATUS_HASH_ENTRIES,
+            MAX_PREFLIGHT_STATUS_TREE_ENTRIES,
+        ),
+    };
     let mut drifted = Vec::new();
     for (live, expected) in &record.deployed_hashes {
         if !file_matches_for_status(
@@ -1562,6 +1570,10 @@ mod tests {
 
     #[test]
     fn deployment_hashing_is_cached_and_aggregate_bounded() {
+        assert!(
+            MAX_PREFLIGHT_STATUS_HASH_BYTES
+                >= gore_vo::Limits::default().max_archive_bytes * 2
+        );
         let tmp = tempfile::tempdir().unwrap();
         let alpha = tmp.path().join("alpha.bin");
         let beta = tmp.path().join("beta.bin");

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -82,9 +82,10 @@ fn validate_recovery_identities(record: &crate::DeployRecord) -> crate::Result<(
         }
     }
     for (path, identities) in &record.recovery_file_hashes {
-        if identities
-            .iter()
-            .any(|identity| !valid_file_identity(identity))
+        if identities.is_empty()
+            || identities
+                .iter()
+                .any(|identity| !valid_file_identity(identity))
         {
             return Err(crate::ModError::Other(format!(
                 "recovery record contains an invalid alternate file identity for {path}"
@@ -99,9 +100,10 @@ fn validate_recovery_identities(record: &crate::DeployRecord) -> crate::Result<(
         }
     }
     for (path, identities) in &record.recovery_tree_fingerprints {
-        if identities
-            .iter()
-            .any(|identity| !valid_sha256_identity(identity))
+        if identities.is_empty()
+            || identities
+                .iter()
+                .any(|identity| !valid_sha256_identity(identity))
         {
             return Err(crate::ModError::Other(format!(
                 "recovery record contains an invalid alternate UE4SS tree identity for {path}"
@@ -567,6 +569,10 @@ mod tests {
                 ..Default::default()
             },
             DeployRecord {
+                recovery_file_hashes: BTreeMap::from([(live.display().to_string(), Vec::new())]),
+                ..Default::default()
+            },
+            DeployRecord {
                 ue4ss_mod_dirs: vec![tree.display().to_string()],
                 ue4ss_tree_fingerprints: BTreeMap::from([(
                     tree.display().to_string(),
@@ -579,6 +585,14 @@ mod tests {
                 recovery_tree_fingerprints: BTreeMap::from([(
                     tree.display().to_string(),
                     vec!["malformed".into()],
+                )]),
+                ..Default::default()
+            },
+            DeployRecord {
+                ue4ss_mod_dirs: vec![tree.display().to_string()],
+                recovery_tree_fingerprints: BTreeMap::from([(
+                    tree.display().to_string(),
+                    Vec::new(),
                 )]),
                 ..Default::default()
             },

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -80,6 +80,7 @@ struct DeploymentInspection {
     remaining_hash_entries: u64,
     remaining_tree_entries: u64,
     file_matches: HashMap<(String, String), bool>,
+    legacy_hashes: HashMap<String, String>,
     tree_fingerprints: HashMap<String, String>,
     sha256: HashMap<String, String>,
 }
@@ -95,6 +96,7 @@ impl DeploymentInspection {
             remaining_hash_entries,
             remaining_tree_entries,
             file_matches: HashMap::new(),
+            legacy_hashes: HashMap::new(),
             tree_fingerprints: HashMap::new(),
             sha256: HashMap::new(),
         }
@@ -195,27 +197,27 @@ fn file_matches_for_status(
     failure_policy: InspectionFailurePolicy,
     inspection: &mut DeploymentInspection,
 ) -> crate::Result<bool> {
-    let cache_key = (path.display().to_string(), expected.to_owned());
+    let cache_key = (crate::record_path_key(path), expected.to_owned());
     if let Some(cached) = inspection.file_matches.get(&cache_key) {
         return Ok(*cached);
     }
+    let sha256_prefixed = expected.starts_with("sha256:");
     let sha256_expected = expected.strip_prefix("sha256:").is_some_and(|hex| {
         hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
     });
+    let legacy_expected = expected.len() == 16
+        && expected
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit());
     let matches = if failure_policy == InspectionFailurePolicy::TreatAsDrift {
         if sha256_expected {
             sha256_for_status(path, failure_policy, inspection)?
                 .as_deref()
                 == Some(expected)
-        } else if inspection.charge_file_hash().is_err() {
+        } else if sha256_prefixed || !legacy_expected {
             false
         } else {
-            crate::file_matches_recorded_hash_bounded(
-                path,
-                expected,
-                &mut inspection.remaining_hash_bytes,
-            )
-            .unwrap_or(false)
+            legacy_hash_for_status(path, failure_policy, inspection)?.as_deref() == Some(expected)
         }
     } else {
         let Some(metadata) = metadata_for_status(path)? else {
@@ -228,13 +230,18 @@ fn file_matches_for_status(
             sha256_for_status(path, failure_policy, inspection)?
                 .as_deref()
                 == Some(expected)
+        } else if sha256_prefixed {
+            return Err(crate::ModError::Other(format!(
+                "invalid recorded SHA-256 identity for {}",
+                path.display()
+            )));
+        } else if !legacy_expected {
+            return Err(crate::ModError::Other(format!(
+                "invalid recorded legacy content hash for {}",
+                path.display()
+            )));
         } else {
-            inspection.charge_file_hash()?;
-            crate::file_matches_recorded_hash_bounded(
-                path,
-                expected,
-                &mut inspection.remaining_hash_bytes,
-            )?
+            legacy_hash_for_status(path, failure_policy, inspection)?.as_deref() == Some(expected)
         }
     };
     inspection.file_matches.insert(cache_key, matches);
@@ -261,7 +268,7 @@ fn tree_matches_for_status(
             )));
         }
     }
-    let cache_key = path.display().to_string();
+    let cache_key = crate::record_path_key(path);
     if let Some(cached) = inspection.tree_fingerprints.get(&cache_key) {
         return Ok(cached == expected);
     }
@@ -291,7 +298,7 @@ fn sha256_for_status(
     failure_policy: InspectionFailurePolicy,
     inspection: &mut DeploymentInspection,
 ) -> crate::Result<Option<String>> {
-    let cache_key = path.display().to_string();
+    let cache_key = crate::record_path_key(path);
     if let Some(cached) = inspection.sha256.get(&cache_key) {
         return Ok(Some(cached.clone()));
     }
@@ -308,6 +315,41 @@ fn sha256_for_status(
         (InspectionFailurePolicy::Preserve, Err(error)) => return Err(error),
     };
     inspection.sha256.insert(cache_key, hashed.clone());
+    Ok(Some(hashed))
+}
+
+fn legacy_hash_for_status(
+    path: &Path,
+    failure_policy: InspectionFailurePolicy,
+    inspection: &mut DeploymentInspection,
+) -> crate::Result<Option<String>> {
+    let cache_key = crate::record_path_key(path);
+    if let Some(cached) = inspection.legacy_hashes.get(&cache_key) {
+        return Ok(Some(cached.clone()));
+    }
+    if let Err(error) = inspection.charge_file_hash() {
+        return match failure_policy {
+            InspectionFailurePolicy::TreatAsDrift => Ok(None),
+            InspectionFailurePolicy::Preserve => Err(error),
+        };
+    }
+    let hashed = crate::content_hash_file_bounded(path, &mut inspection.remaining_hash_bytes);
+    let hashed = match (failure_policy, hashed) {
+        (_, Ok(hashed)) => hashed,
+        (InspectionFailurePolicy::TreatAsDrift, Err(_)) => return Ok(None),
+        (InspectionFailurePolicy::Preserve, Err(error)) => {
+            return match crate::inspection_bound_from_io(&error) {
+                Some(message) => Err(crate::ModError::InspectionBound(message)),
+                None => Err(crate::io(&format!(
+                    "hashing deployed file {}",
+                    path.display()
+                ))(error)),
+            }
+        }
+    };
+    inspection
+        .legacy_hashes
+        .insert(cache_key, hashed.clone());
     Ok(Some(hashed))
 }
 
@@ -1680,6 +1722,98 @@ mod tests {
         .unwrap_err();
         assert!(matches!(&error, crate::ModError::InspectionBound(_)));
         assert!(error.to_string().contains("tree-entry budget"), "{error}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn deployment_hash_caches_fold_windows_record_path_aliases() {
+        fn toggle_verbatim(path: &Path) -> std::path::PathBuf {
+            let text = path.to_string_lossy();
+            if let Some(plain) = text.strip_prefix(r"\\?\") {
+                plain.into()
+            } else {
+                format!(r"\\?\{text}").into()
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("alpha.bin");
+        std::fs::write(&file, b"alpha").unwrap();
+        let case_alias = file.with_file_name("ALPHA.BIN");
+        let verbatim_alias = toggle_verbatim(&case_alias);
+        assert!(verbatim_alias.is_file());
+        assert_eq!(
+            crate::record_path_key(&file),
+            crate::record_path_key(&verbatim_alias)
+        );
+
+        let legacy_hash = crate::content_hash(b"alpha");
+        let wrong_legacy_hash = crate::content_hash(b"other");
+        let mut legacy = DeploymentInspection::new(5, 1, 0);
+        assert!(file_matches_for_status(
+            &file,
+            &legacy_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut legacy,
+        )
+        .unwrap());
+        assert!(file_matches_for_status(
+            &verbatim_alias,
+            &legacy_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut legacy,
+        )
+        .unwrap());
+        assert!(!file_matches_for_status(
+            &case_alias,
+            &wrong_legacy_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut legacy,
+        )
+        .unwrap());
+        assert_eq!(legacy.remaining_hash_bytes, 0);
+        assert_eq!(legacy.remaining_hash_entries, 0);
+        assert_eq!(legacy.file_matches.len(), 2);
+        assert_eq!(legacy.legacy_hashes.len(), 1);
+
+        let mut sha256 = DeploymentInspection::new(5, 1, 0);
+        assert_eq!(
+            sha256_for_status(&file, InspectionFailurePolicy::Preserve, &mut sha256).unwrap(),
+            sha256_for_status(
+                &verbatim_alias,
+                InspectionFailurePolicy::Preserve,
+                &mut sha256,
+            )
+            .unwrap()
+        );
+        assert_eq!(sha256.remaining_hash_bytes, 0);
+        assert_eq!(sha256.remaining_hash_entries, 0);
+        assert_eq!(sha256.sha256.len(), 1);
+
+        let tree = tmp.path().join("tree");
+        std::fs::create_dir(&tree).unwrap();
+        std::fs::write(tree.join("payload"), b"tree").unwrap();
+        let tree_alias = toggle_verbatim(&tree.with_file_name("TREE"));
+        assert!(tree_alias.is_dir());
+        let tree_hash = crate::tree_fingerprint(&tree).unwrap();
+        let mut trees = DeploymentInspection::new(4, 0, 1);
+        assert!(tree_matches_for_status(
+            &tree,
+            &tree_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut trees,
+        )
+        .unwrap());
+        assert!(tree_matches_for_status(
+            &tree_alias,
+            &tree_hash,
+            InspectionFailurePolicy::Preserve,
+            &mut trees,
+        )
+        .unwrap());
+        assert_eq!(trees.remaining_hash_bytes, 0);
+        assert_eq!(trees.remaining_tree_entries, 0);
+        assert_eq!(trees.tree_fingerprints.len(), 1);
     }
 
     #[cfg(any(unix, windows))]

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -27,7 +27,7 @@ use serde::Serialize;
 use super::loadout::{Loadout, LoadoutEntry};
 use super::model::LibraryRoot;
 
-const MAX_STATUS_META_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_PREFLIGHT_STATUS_META_BYTES: u64 = 16 * 1024 * 1024;
 // One synchronous status snapshot shares these ceilings across every recorded live file, backup,
 // and UE4SS tree. Successful exact-path reads are cached below, so duplicate record entries are
 // evidence aliases rather than repeated I/O.
@@ -66,6 +66,13 @@ pub enum ManagerStatus {
 enum InspectionFailurePolicy {
     TreatAsDrift,
     Preserve,
+}
+
+fn metadata_budget_for_status(failure_policy: InspectionFailurePolicy) -> u64 {
+    match failure_policy {
+        InspectionFailurePolicy::TreatAsDrift => u64::MAX,
+        InspectionFailurePolicy::Preserve => MAX_PREFLIGHT_STATUS_META_BYTES,
+    }
 }
 
 struct DeploymentInspection {
@@ -560,7 +567,7 @@ fn status_with_failure_policy(
             });
         }
     };
-    let mut remaining_meta_bytes = MAX_STATUS_META_BYTES;
+    let mut remaining_meta_bytes = metadata_budget_for_status(failure_policy);
     if !library_fingerprints_match(
         &library,
         &target_enabled,
@@ -1566,6 +1573,18 @@ mod tests {
             &mut exact_budget,
         ));
         assert_eq!(exact_budget, 0);
+    }
+
+    #[test]
+    fn metadata_budget_preserves_public_status_and_bounds_preflight() {
+        assert_eq!(
+            metadata_budget_for_status(InspectionFailurePolicy::TreatAsDrift),
+            u64::MAX
+        );
+        assert_eq!(
+            metadata_budget_for_status(InspectionFailurePolicy::Preserve),
+            MAX_PREFLIGHT_STATUS_META_BYTES
+        );
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/status.rs
+++ b/crates/gore-mod/src/mgr/status.rs
@@ -347,9 +347,7 @@ fn status_with_failure_policy(
     let recovery_required = record.phase == crate::DeployPhase::RecoveryRequired
         || !record.file_cleanup_claims.is_empty()
         || !record.ue4ss_cleanup_claims.is_empty();
-    if failure_policy == InspectionFailurePolicy::Preserve
-        && (recovery_required || record.owner != "manager")
-    {
+    if failure_policy == InspectionFailurePolicy::Preserve {
         crate::validate_record_identities(&record)?;
     }
     if recovery_required {
@@ -904,6 +902,57 @@ mod tests {
         assert_eq!(std::fs::read(record_path(&game)).unwrap(), before);
     }
 
+    #[test]
+    fn preflight_rejects_noncanonical_manager_ownership_before_reapply() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("game");
+        let lib = tmp.path().join("lib");
+        let live = game.join("G1R/Story/VoiceOver/owned.zip");
+        let backup = crate::bak_path(&live);
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"deployed").unwrap();
+        std::fs::write(&backup, b"pristine").unwrap();
+        let live_identity = crate::content_hash(b"deployed");
+        let noncanonical_live = live_identity.to_ascii_uppercase();
+        assert_ne!(noncanonical_live, live_identity);
+        let backup_identity = crate::sha256_file(&backup).unwrap();
+        let noncanonical_backup = format!(
+            "sha256:{}",
+            backup_identity
+                .strip_prefix("sha256:")
+                .unwrap()
+                .to_ascii_uppercase()
+        );
+        assert_ne!(noncanonical_backup, backup_identity);
+        let record = |deployed, backup_hash| DeployRecord {
+            mod_name: "manager".into(),
+            owner: "manager".into(),
+            backups: vec![(
+                live.display().to_string(),
+                backup.display().to_string(),
+                true,
+            )],
+            deployed_hashes: BTreeMap::from([(live.display().to_string(), deployed)]),
+            backup_hashes: BTreeMap::from([(backup.display().to_string(), backup_hash)]),
+            ..Default::default()
+        };
+        let cases = [
+            record(noncanonical_live, backup_identity),
+            record(live_identity, noncanonical_backup),
+        ];
+
+        for record in cases {
+            write_record(&game, &record);
+            let before = std::fs::read(record_path(&game)).unwrap();
+            assert!(matches!(
+                status(&game, &lib, &Loadout::default()).unwrap(),
+                ManagerStatus::GameUpdated { .. }
+            ));
+            assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
+            assert_eq!(std::fs::read(record_path(&game)).unwrap(), before);
+        }
+    }
+
     /// A manager record whose loadout equals the target's enabled entries AND whose recorded
     /// fingerprints still match the library → InSync; a disabled target entry is excluded from the
     /// comparison.
@@ -1051,20 +1100,10 @@ mod tests {
         assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
 
         std::fs::remove_file(&live).unwrap();
-        assert_eq!(
-            status_for_preflight(&game, &lib, &Loadout::default()).unwrap(),
-            ManagerStatus::GameUpdated {
-                drifted: vec![live.display().to_string()]
-            }
-        );
+        assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
 
         std::fs::create_dir(&live).unwrap();
-        assert_eq!(
-            status_for_preflight(&game, &lib, &Loadout::default()).unwrap(),
-            ManagerStatus::GameUpdated {
-                drifted: vec![live.display().to_string()]
-            }
-        );
+        assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
     }
 
     #[test]
@@ -1460,12 +1499,7 @@ mod tests {
         assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
 
         std::fs::remove_dir_all(&tree).unwrap();
-        assert_eq!(
-            status_for_preflight(&game, &lib, &Loadout::default()).unwrap(),
-            ManagerStatus::GameUpdated {
-                drifted: vec![tree.display().to_string()]
-            }
-        );
+        assert!(status_for_preflight(&game, &lib, &Loadout::default()).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a bounded, strictly read-only `mgr_preflight_v1` diagnostic snapshot
- report install, loadout, deployment/recovery, conditional UE4SS, and mutation-state findings with stable codes/actions
- keep write access explicitly unverified and expose no Apply/readiness authorization
- add strict raw FFI schema, bounds, no-write, and semantic regressions

## Safety boundary
- no config or Steam fallback
- no write probe, recovery, import/list, Apply, reset, launch, or repair
- returned paths are display evidence only

## Validation
- `cargo test -p gore-mod -p gore-ffi`
- focused preflight tests: gore-mod 12/12, gore-ffi 8/8
- `cargo fmt --check`
- focused Clippy with warnings denied
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New FFI surface and large preflight logic are read-only, but changes also tighten deploy-record identity validation and bounded inspection on commit/undeploy paths that gate recovery and deployment.
> 
> **Overview**
> **Adds a strictly read-only Mod Manager first-run diagnostic** exposed as `mgr_preflight_v1` through a new strict raw FFI route (wire/response caps, schema validation, no `ready`/`can_apply`). Callers pass an explicit `game_root` and optional library/loadout paths; the snapshot returns seven fixed checks (game root, install, loadout, deployment, install mutation, UE4SS when needed, write access always unverified) with stable codes and display-only paths—no Steam/config discovery, write probes, or repairs.
> 
> **Core logic lives in** `gore-mod` `preflight` module: bounded loadout/library metadata and top-level payload probes (aligned with default Apply descriptor rules), deployment status via `status_for_preflight`, install/process/lock/recovery evidence from compile-state and deploy-record probes, and deferred deployment actions when Install, InstallMutation, or UE4SS block Apply.
> 
> **Supporting hardening** includes `ModError::InspectionBound` and byte/entry budgets on deployment hashing and UE4SS tree walks; **canonical deploy-record file identities** validated on commit, record write, and undeploy; safer library traversal (optional children, aggregate meta budget, `O_NONBLOCK` on Unix opens); and shared `validate_component_descriptor_for_default_apply` used during Apply planning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f771cee32860135eea5f6de9e1b4ba7f92039d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->