### PR TITLE
feat(manager): expose component footprint coverage

### DIFF
--- a/apps/mod-manager/lib/library/domain/conflicts_provider.dart
+++ b/apps/mod-manager/lib/library/domain/conflicts_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/providers.dart';
@@ -12,7 +14,7 @@ import 'models.dart';
 final conflictsProvider = FutureProvider<List<ConflictView>>((ref) {
   // Key on a stable String derived from BOTH:
   //  * the loadout entries (id + enabled) — toggling/reordering changes this;
-  //  * each mod's content signature (id + its components' kind|opaque|targets) —
+  //  * each mod's content signature (id + every analyzer-relevant component fact) —
   //    re-importing a mod under the SAME id changes LibraryState.mods (its
   //    components/targets) but NOT the loadout entries, so without this a
   //    same-id update would keep the stale conflicts.
@@ -30,20 +32,56 @@ final conflictsProvider = FutureProvider<List<ConflictView>>((ref) {
 });
 
 /// A stable, value-comparable key that changes when the loadout entries change
-/// OR when any mod's deployable content (its components' kinds + opacity +
-/// targets) changes — including a same-id re-import that swaps a mod's targets.
+/// OR when any mod's deployable content (kind, coverage, opacity, targets, or
+/// raw-file destination) changes — including a same-id re-import.
 String _conflictsKey(LibraryState s) {
-  final loadout = [
-    for (final e in s.loadout.entries) '${e.id}:${e.enabled}',
-  ].join(',');
-  // Per mod: id plus each component's kind, opacity and target list, so either
-  // a changed known footprint or newly-incomplete UE4SS metadata alters the key.
-  final mods = [
-    for (final m in s.mods)
-      '${m.id}='
-          '${[for (final c in m.components) '${c.kind}:${c.opaque}[${c.targets.join('+')}]'].join(';')}',
-  ].join(',');
-  return '$loadout|$mods';
+  // JSON gives every list and string an unambiguous boundary. Hand-built
+  // delimiters alias valid values (`['a+b']` versus `['a', 'b']`) and can keep
+  // a stale analysis cached after a same-id re-import.
+  return jsonEncode({
+    'loadout': [
+      for (final entry in s.loadout.entries)
+        {'id': entry.id, 'enabled': entry.enabled},
+    ],
+    'mods': [
+      for (final mod in s.mods)
+        {
+          'id': mod.id,
+          'components': [
+            for (final component in mod.components)
+              {
+                // `raw` preserves fields this app version does not model. They
+                // can still affect a newer native analyzer, so reconstructing
+                // only today's view would leave stale conflicts cached.
+                'raw': _canonicalJson(component.raw),
+                // Missing/unknown wire values are interpreted conservatively
+                // by ComponentView; cache that effective grade as well.
+                'coverage': component.coverage.name,
+              },
+          ],
+        },
+    ],
+  });
+}
+
+/// Recursively sort JSON object keys while preserving array order and scalar
+/// types. FFI-decoded component [raw] values are JSON by contract, so this is
+/// a stable semantic encoding rather than one that depends on map insertion
+/// order.
+Object? _canonicalJson(Object? value) {
+  if (value is List) {
+    return [for (final item in value) _canonicalJson(item)];
+  }
+  if (value is Map) {
+    final entries = [
+      for (final entry in value.entries)
+        MapEntry(entry.key as String, _canonicalJson(entry.value)),
+    ]..sort((a, b) => a.key.compareTo(b.key));
+    return <String, Object?>{
+      for (final entry in entries) entry.key: entry.value,
+    };
+  }
+  return value;
 }
 
 /// Every conflict that involves [modId].

--- a/apps/mod-manager/lib/library/domain/models.dart
+++ b/apps/mod-manager/lib/library/domain/models.dart
@@ -76,6 +76,53 @@ class ModEntryMetaView {
   final List<ComponentView> components;
 }
 
+/// How completely a component's metadata describes its conflict footprint.
+enum FootprintCoverage { exact, partial, advisory, opaque }
+
+FootprintCoverage _footprintCoverage(
+  Map<String, Object?> json,
+  String kind,
+  List<String> targets,
+  bool opaque,
+) {
+  // A present but future/invalid value is not safe to infer through. Missing is
+  // different: it means an older DLL, for which the current native derivation
+  // can be reproduced conservatively from the unchanged component contract.
+  if (json.containsKey('coverage')) {
+    return switch (json['coverage']) {
+      'exact' => FootprintCoverage.exact,
+      'partial' => FootprintCoverage.partial,
+      'advisory' => FootprintCoverage.advisory,
+      'opaque' => FootprintCoverage.opaque,
+      _ => FootprintCoverage.opaque,
+    };
+  }
+
+  return switch (kind) {
+    'ue4ss_lua' =>
+      !opaque
+          ? FootprintCoverage.exact
+          : targets.isNotEmpty
+          ? FootprintCoverage.partial
+          : FootprintCoverage.opaque,
+    'triplet' =>
+      targets.isNotEmpty
+          ? FootprintCoverage.advisory
+          : FootprintCoverage.opaque,
+    'loose_pak' =>
+      targets.isNotEmpty ? FootprintCoverage.exact : FootprintCoverage.opaque,
+    'loc_patch' ||
+    'audio_patch' ||
+    'texture_patch' ||
+    'angel_script_patch' ||
+    'file_patch' ||
+    'pak_file_patch' ||
+    'voice_archive_patch' ||
+    'raw_file' => FootprintCoverage.exact,
+    _ => FootprintCoverage.opaque,
+  };
+}
+
 /// One deployable component of a mod. [kind] is the raw serde `type` tag:
 /// `ue4ss_lua` (name, rel, targets, opaque), `loc_patch` / `audio_patch` /
 /// `texture_patch` / `angel_script_patch` (rel, targets), `triplet`
@@ -85,6 +132,7 @@ class ModEntryMetaView {
 class ComponentView {
   const ComponentView({
     required this.kind,
+    required this.coverage,
     this.name,
     this.rel,
     this.targets = const [],
@@ -95,12 +143,15 @@ class ComponentView {
 
   factory ComponentView.fromJson(Map<String, Object?> json) {
     final kind = _stringOr(json['type'], 'unknown');
+    final targets = _stringList(json['targets']);
+    final opaque = json['opaque'] == true;
     return ComponentView(
       kind: kind,
+      coverage: _footprintCoverage(json, kind, targets, opaque),
       name: _optString(json['name']),
       rel: _optString(json['rel']) ?? _optString(json['rel_base']),
-      targets: _stringList(json['targets']),
-      opaque: json['opaque'] == true,
+      targets: targets,
+      opaque: opaque,
       rawFileTarget: kind == 'raw_file'
           ? RawFileTargetView.fromJson(json['target_file'])
           : null,
@@ -111,6 +162,10 @@ class ComponentView {
   /// Raw component type tag (see class doc); never null, `unknown` when the
   /// tag is missing.
   final String kind;
+
+  /// How completely [targets] (or [rawFileTarget]) describe this component's
+  /// footprint. This does not claim anything about runtime precedence.
+  final FootprintCoverage coverage;
 
   /// Script name (`ue4ss_lua` only).
   final String? name;
@@ -212,9 +267,9 @@ class LoadoutView {
   final List<LoadoutEntryView> entries;
 
   Map<String, Object?> toJson() => {
-        'format': format,
-        'entries': [for (final entry in entries) entry.toJson()],
-      };
+    'format': format,
+    'entries': [for (final entry in entries) entry.toJson()],
+  };
 }
 
 /// One conflict between mods of the current loadout (`mgr_analyze`).
@@ -305,7 +360,7 @@ class ManagerStatusRecoveryRequired extends ManagerStatusView {
 /// touch the install until that deploy is undone on the studio side.
 class ManagerStatusStudioDeployActive extends ManagerStatusView {
   ManagerStatusStudioDeployActive(super.raw)
-      : modName = _optString(raw['mod_name']) ?? '';
+    : modName = _optString(raw['mod_name']) ?? '';
 
   /// Name of the studio-deployed mod ('' when the DLL omitted it).
   final String modName;
@@ -328,8 +383,8 @@ class ManagerStatusInSync extends ManagerStatusView {
 /// The loadout was edited since the last apply: deployed != target.
 class ManagerStatusChangesPending extends ManagerStatusView {
   ManagerStatusChangesPending(super.raw)
-      : deployed = _loadoutOrNull(raw['deployed']),
-        target = _loadoutOrNull(raw['target']);
+    : deployed = _loadoutOrNull(raw['deployed']),
+      target = _loadoutOrNull(raw['target']);
 
   final LoadoutView? deployed;
   final LoadoutView? target;

--- a/apps/mod-manager/test/conflicts_provider_recompute_test.dart
+++ b/apps/mod-manager/test/conflicts_provider_recompute_test.dart
@@ -71,8 +71,8 @@ class _StatefulFake implements GoreCoreFfiService {
 
 /// A single loc_patch component whose target set we can vary.
 List<Map<String, Object?>> _loc(List<String> targets) => [
-      {'type': 'loc_patch', 'rel': 'loc/edits.json', 'targets': targets},
-    ];
+  {'type': 'loc_patch', 'rel': 'loc/edits.json', 'targets': targets},
+];
 
 List<Map<String, Object?>> _lua({required bool opaque}) => [
   {
@@ -84,53 +84,99 @@ List<Map<String, Object?>> _lua({required bool opaque}) => [
   },
 ];
 
+List<Map<String, Object?>> _covered(String coverage) => [
+  {
+    'type': 'triplet',
+    'rel_base': 'containers/Pack',
+    'targets': const ['/Game/Observed'],
+    'coverage': coverage,
+  },
+];
+
+List<Map<String, Object?>> _raw(Object target) => [
+  {
+    'type': 'raw_file',
+    'rel': 'raw/payload.bin',
+    'target_file': target,
+    'coverage': 'exact',
+  },
+];
+
+List<Map<String, Object?>> _unknownTarget(String target) => [
+  {
+    'type': 'future_component',
+    'rel': 'future/payload',
+    'future_target': target,
+    'coverage': 'future_precision',
+  },
+];
+
+List<Map<String, Object?>> _futureRawTarget(String slot) => [
+  {
+    'type': 'raw_file',
+    'rel': 'raw/future.bin',
+    'target_file': {
+      'future_destination': {'slot': slot},
+    },
+    'coverage': 'opaque',
+  },
+];
+
 /// Drive the container until every pending microtask/future settles.
 Future<void> _settle() => Future<void>.delayed(Duration.zero);
 
 void main() {
-  test('conflictsProvider re-analyzes when a mod content changes (same loadout)',
-      () async {
-    final fake = _StatefulFake(_loc(const ['itfo_cheese|german']));
-    final container = ProviderContainer(overrides: [
-      coreServiceProvider.overrideWithValue(fake),
-    ]);
-    addTearDown(container.dispose);
+  test(
+    'conflictsProvider re-analyzes when a mod content changes (same loadout)',
+    () async {
+      final fake = _StatefulFake(_loc(const ['itfo_cheese|german']));
+      final container = ProviderContainer(
+        overrides: [coreServiceProvider.overrideWithValue(fake)],
+      );
+      addTearDown(container.dispose);
 
-    // Hold live subscriptions so neither provider is auto-disposed between
-    // reads — otherwise a bare `read` would recompute from scratch each time
-    // (re-running analyze regardless of the key) and the test would prove
-    // nothing about the key. With a listener, analyze only re-runs when the
-    // watched key actually changes.
-    container.listen(libraryProvider, (_, _) {});
-    container.listen(conflictsProvider, (_, _) {});
+      // Hold live subscriptions so neither provider is auto-disposed between
+      // reads — otherwise a bare `read` would recompute from scratch each time
+      // (re-running analyze regardless of the key) and the test would prove
+      // nothing about the key. With a listener, analyze only re-runs when the
+      // watched key actually changes.
+      container.listen(libraryProvider, (_, _) {});
+      container.listen(conflictsProvider, (_, _) {});
 
-    // Let the initial library refresh + first analyze settle.
-    await container.read(conflictsProvider.future);
-    await container.read(libraryProvider.notifier).refresh();
-    await _settle();
-    await container.read(conflictsProvider.future);
-    final baseline = fake.analyzeCount;
-    expect(baseline, greaterThanOrEqualTo(1), reason: 'analyze ran at least once');
+      // Let the initial library refresh + first analyze settle.
+      await container.read(conflictsProvider.future);
+      await container.read(libraryProvider.notifier).refresh();
+      await _settle();
+      await container.read(conflictsProvider.future);
+      final baseline = fake.analyzeCount;
+      expect(
+        baseline,
+        greaterThanOrEqualTo(1),
+        reason: 'analyze ran at least once',
+      );
 
-    // Same-id UPDATE: change m1's component targets, keep the loadout identical.
-    fake.setComponents(_loc(const ['itfo_apple|german', 'itfo_bread|german']));
-    await container.read(libraryProvider.notifier).refresh();
-    await _settle();
-    // The conflicts key now folds in the changed targets → analyze re-runs.
-    await container.read(conflictsProvider.future);
+      // Same-id UPDATE: change m1's component targets, keep the loadout identical.
+      fake.setComponents(
+        _loc(const ['itfo_apple|german', 'itfo_bread|german']),
+      );
+      await container.read(libraryProvider.notifier).refresh();
+      await _settle();
+      // The conflicts key now folds in the changed targets → analyze re-runs.
+      await container.read(conflictsProvider.future);
 
-    expect(
-      fake.analyzeCount,
-      greaterThan(baseline),
-      reason: 'a same-id content change must trigger a re-analyze',
-    );
-  });
+      expect(
+        fake.analyzeCount,
+        greaterThan(baseline),
+        reason: 'a same-id content change must trigger a re-analyze',
+      );
+    },
+  );
 
   test('conflictsProvider does NOT re-analyze when nothing changed', () async {
     final fake = _StatefulFake(_loc(const ['itfo_cheese|german']));
-    final container = ProviderContainer(overrides: [
-      coreServiceProvider.overrideWithValue(fake),
-    ]);
+    final container = ProviderContainer(
+      overrides: [coreServiceProvider.overrideWithValue(fake)],
+    );
     addTearDown(container.dispose);
 
     container.listen(libraryProvider, (_, _) {});
@@ -180,6 +226,138 @@ void main() {
       expect(fake.analyzeCount, greaterThan(baseline));
     },
   );
+
+  test('conflictsProvider re-analyzes when only coverage changes', () async {
+    final fake = _StatefulFake(_covered('advisory'));
+    final container = ProviderContainer(
+      overrides: [coreServiceProvider.overrideWithValue(fake)],
+    );
+    addTearDown(container.dispose);
+    container.listen(libraryProvider, (_, _) {});
+    container.listen(conflictsProvider, (_, _) {});
+
+    await container.read(conflictsProvider.future);
+    await container.read(libraryProvider.notifier).refresh();
+    await _settle();
+    await container.read(conflictsProvider.future);
+    final baseline = fake.analyzeCount;
+
+    fake.setComponents(_covered('opaque'));
+    await container.read(libraryProvider.notifier).refresh();
+    await _settle();
+    await container.read(conflictsProvider.future);
+
+    expect(fake.analyzeCount, greaterThan(baseline));
+  });
+
+  test(
+    'raw target variant and bank name changes invalidate conflicts',
+    () async {
+      final fake = _StatefulFake(_raw('lcache'));
+      final container = ProviderContainer(
+        overrides: [coreServiceProvider.overrideWithValue(fake)],
+      );
+      addTearDown(container.dispose);
+      container.listen(libraryProvider, (_, _) {});
+      container.listen(conflictsProvider, (_, _) {});
+
+      await container.read(conflictsProvider.future);
+      await container.read(libraryProvider.notifier).refresh();
+      await _settle();
+      await container.read(conflictsProvider.future);
+      var baseline = fake.analyzeCount;
+
+      fake.setComponents(
+        _raw({
+          'bank': {'name': 'SFX.bank'},
+        }),
+      );
+      await container.read(libraryProvider.notifier).refresh();
+      await _settle();
+      await container.read(conflictsProvider.future);
+      expect(fake.analyzeCount, greaterThan(baseline));
+      baseline = fake.analyzeCount;
+
+      fake.setComponents(
+        _raw({
+          'bank': {'name': 'Music.bank'},
+        }),
+      );
+      await container.read(libraryProvider.notifier).refresh();
+      await _settle();
+      await container.read(conflictsProvider.future);
+      expect(fake.analyzeCount, greaterThan(baseline));
+    },
+  );
+
+  test('structured key distinguishes delimiter-bearing target sets', () async {
+    final fake = _StatefulFake(_loc(const ['a+b']));
+    final container = ProviderContainer(
+      overrides: [coreServiceProvider.overrideWithValue(fake)],
+    );
+    addTearDown(container.dispose);
+    container.listen(libraryProvider, (_, _) {});
+    container.listen(conflictsProvider, (_, _) {});
+
+    await container.read(conflictsProvider.future);
+    await container.read(libraryProvider.notifier).refresh();
+    await _settle();
+    await container.read(conflictsProvider.future);
+    final baseline = fake.analyzeCount;
+
+    fake.setComponents(_loc(const ['a', 'b']));
+    await container.read(libraryProvider.notifier).refresh();
+    await _settle();
+    await container.read(conflictsProvider.future);
+
+    expect(fake.analyzeCount, greaterThan(baseline));
+  });
+
+  test('unknown component payload changes invalidate conflicts', () async {
+    final fake = _StatefulFake(_unknownTarget('A'));
+    final container = ProviderContainer(
+      overrides: [coreServiceProvider.overrideWithValue(fake)],
+    );
+    addTearDown(container.dispose);
+    container.listen(libraryProvider, (_, _) {});
+    container.listen(conflictsProvider, (_, _) {});
+
+    await container.read(conflictsProvider.future);
+    await container.read(libraryProvider.notifier).refresh();
+    await _settle();
+    await container.read(conflictsProvider.future);
+    final baseline = fake.analyzeCount;
+
+    fake.setComponents(_unknownTarget('B'));
+    await container.read(libraryProvider.notifier).refresh();
+    await _settle();
+    await container.read(conflictsProvider.future);
+
+    expect(fake.analyzeCount, greaterThan(baseline));
+  });
+
+  test('future raw-target payload changes invalidate conflicts', () async {
+    final fake = _StatefulFake(_futureRawTarget('A'));
+    final container = ProviderContainer(
+      overrides: [coreServiceProvider.overrideWithValue(fake)],
+    );
+    addTearDown(container.dispose);
+    container.listen(libraryProvider, (_, _) {});
+    container.listen(conflictsProvider, (_, _) {});
+
+    await container.read(conflictsProvider.future);
+    await container.read(libraryProvider.notifier).refresh();
+    await _settle();
+    await container.read(conflictsProvider.future);
+    final baseline = fake.analyzeCount;
+
+    fake.setComponents(_futureRawTarget('B'));
+    await container.read(libraryProvider.notifier).refresh();
+    await _settle();
+    await container.read(conflictsProvider.future);
+
+    expect(fake.analyzeCount, greaterThan(baseline));
+  });
 
   test('unknown info advisory is ordered but has no winner', () {
     const conflict = ConflictView(

--- a/apps/mod-manager/test/core/mgr_ffi_test.dart
+++ b/apps/mod-manager/test/core/mgr_ffi_test.dart
@@ -7,101 +7,112 @@ import 'package:gore_manager/library/domain/models.dart';
 /// type of the contract (plus one unknown type), the raw_file target_file
 /// externally-tagged variants, and a loadout with mixed enabled flags.
 Map<String, Object?> _libraryListResponse() => {
-      'ok': true,
-      'mods': [
+  'ok': true,
+  'mods': [
+    {
+      'id': 'mod-a',
+      'kind': 'goremod',
+      'name': 'Better Torches',
+      'version': '1.2.0',
+      'author': 'dh',
+      'imported_at': '2026-07-01T12:00:00Z',
+      'source': 'BetterTorches.goremod',
+      // `targets` are conflict-analysis footprint keys, not file paths:
+      // ue4ss dir name, loc "id|set", audio "bank|sample", asset paths,
+      // AngelScript module names.
+      'components': [
         {
-          'id': 'mod-a',
-          'kind': 'goremod',
-          'name': 'Better Torches',
-          'version': '1.2.0',
-          'author': 'dh',
-          'imported_at': '2026-07-01T12:00:00Z',
-          'source': 'BetterTorches.goremod',
-          // `targets` are conflict-analysis footprint keys, not file paths:
-          // ue4ss dir name, loc "id|set", audio "bank|sample", asset paths,
-          // AngelScript module names.
-          'components': [
-            {
-              'type': 'ue4ss_lua',
-              'name': 'torches',
-              'rel': 'scripts/torches',
-              'targets': ['torches'],
-              'opaque': true,
-            },
-            {
-              'type': 'loc_patch',
-              'rel': 'loc/patch.json',
-              'targets': ['itlstorch|german'],
-            },
-            {
-              'type': 'audio_patch',
-              'rel': 'audio/sfx_patch.json',
-              'targets': ['SFX|vob_fire_torch'],
-            },
-            {
-              'type': 'texture_patch',
-              'rel': 'textures/torches',
-              'targets': ['/Game/Gothic/Textures/T_Torch_D'],
-            },
-            {
-              'type': 'angel_script_patch',
-              'rel': 'scripts/patch.as',
-              'targets': ['Game/Items/ItLsTorch'],
-            },
-          ],
+          'type': 'ue4ss_lua',
+          'name': 'torches',
+          'rel': 'scripts/torches',
+          'targets': ['torches'],
+          'opaque': true,
+          'coverage': 'partial',
         },
         {
-          'id': 'mod-b',
-          'kind': 'foreign_mixed',
-          'name': 'Foreign Pack',
-          'components': [
-            {
-              'type': 'triplet',
-              'rel_base': 'triplet/pack',
-              'targets': [
-                '/Game/Gothic/Textures/T_Pack_A',
-                '/Game/Gothic/Textures/T_Pack_B',
-                '/Game/Gothic/Meshes/SM_Pack',
-              ],
-            },
-            {
-              'type': 'loose_pak',
-              'rel': 'paks/loose_P.pak',
-              'targets': ['/Game/Gothic/Textures/T_Loose'],
-            },
-            {
-              'type': 'raw_file',
-              'rel': 'raw/SFX.bank',
-              'target_file': {
-                'bank': {'name': 'SFX'},
-              },
-            },
-            {
-              'type': 'raw_file',
-              'rel': 'raw/Game.lcache',
-              'target_file': 'lcache',
-            },
-            {
-              'type': 'raw_file',
-              'rel': 'raw/cache.bin',
-              'target_file': 'script_cache',
-            },
-            {
-              // Unknown/future component type: must parse as a generic view.
-              'type': 'hologram',
-              'rel': 'future/thing',
-            },
-          ],
+          'type': 'loc_patch',
+          'rel': 'loc/patch.json',
+          'targets': ['itlstorch|german'],
+          'coverage': 'exact',
+        },
+        {
+          'type': 'audio_patch',
+          'rel': 'audio/sfx_patch.json',
+          'targets': ['SFX|vob_fire_torch'],
+          'coverage': 'exact',
+        },
+        {
+          'type': 'texture_patch',
+          'rel': 'textures/torches',
+          'targets': ['/Game/Gothic/Textures/T_Torch_D'],
+          'coverage': 'exact',
+        },
+        {
+          'type': 'angel_script_patch',
+          'rel': 'scripts/patch.as',
+          'targets': ['Game/Items/ItLsTorch'],
+          'coverage': 'exact',
         },
       ],
-      'loadout': {
-        'format': 1,
-        'entries': [
-          {'id': 'mod-a', 'enabled': true},
-          {'id': 'mod-b', 'enabled': false},
-        ],
-      },
-    };
+    },
+    {
+      'id': 'mod-b',
+      'kind': 'foreign_mixed',
+      'name': 'Foreign Pack',
+      'components': [
+        {
+          'type': 'triplet',
+          'rel_base': 'triplet/pack',
+          'targets': [
+            '/Game/Gothic/Textures/T_Pack_A',
+            '/Game/Gothic/Textures/T_Pack_B',
+            '/Game/Gothic/Meshes/SM_Pack',
+          ],
+          'coverage': 'advisory',
+        },
+        {
+          'type': 'loose_pak',
+          'rel': 'paks/loose_P.pak',
+          'targets': ['/Game/Gothic/Textures/T_Loose'],
+          'coverage': 'exact',
+        },
+        {
+          'type': 'raw_file',
+          'rel': 'raw/SFX.bank',
+          'target_file': {
+            'bank': {'name': 'SFX'},
+          },
+          'coverage': 'exact',
+        },
+        {
+          'type': 'raw_file',
+          'rel': 'raw/Game.lcache',
+          'target_file': 'lcache',
+          'coverage': 'exact',
+        },
+        {
+          'type': 'raw_file',
+          'rel': 'raw/cache.bin',
+          'target_file': 'script_cache',
+          'coverage': 'exact',
+        },
+        {
+          // Unknown/future component type: must parse as a generic view.
+          'type': 'hologram',
+          'rel': 'future/thing',
+          'coverage': 'future_precision',
+        },
+      ],
+    },
+  ],
+  'loadout': {
+    'format': 1,
+    'entries': [
+      {'id': 'mod-a', 'enabled': true},
+      {'id': 'mod-b', 'enabled': false},
+    ],
+  },
+};
 
 void main() {
   group('canonical native response decoding', () {
@@ -146,26 +157,25 @@ void main() {
       expect(a.author, 'dh');
       expect(a.importedAt, '2026-07-01T12:00:00Z');
       expect(a.source, 'BetterTorches.goremod');
-      expect(
-        a.components.map((c) => c.kind),
-        [
-          'ue4ss_lua',
-          'loc_patch',
-          'audio_patch',
-          'texture_patch',
-          'angel_script_patch',
-        ],
-      );
+      expect(a.components.map((c) => c.kind), [
+        'ue4ss_lua',
+        'loc_patch',
+        'audio_patch',
+        'texture_patch',
+        'angel_script_patch',
+      ]);
       final lua = a.components[0];
       expect(lua.name, 'torches');
       expect(lua.rel, 'scripts/torches');
       expect(lua.targets, ['torches']);
       expect(lua.opaque, isTrue);
+      expect(lua.coverage, FootprintCoverage.partial);
       expect(lua.displayLabel, 'torches');
       final loc = a.components[1];
       expect(loc.rel, 'loc/patch.json');
       expect(loc.targets, ['itlstorch|german']);
       expect(loc.opaque, isFalse);
+      expect(loc.coverage, FootprintCoverage.exact);
       expect(loc.displayLabel, 'loc/patch.json');
 
       final b = mods[1];
@@ -177,13 +187,16 @@ void main() {
       expect(triplet.kind, 'triplet');
       expect(triplet.rel, 'triplet/pack'); // rel_base surfaces as rel
       expect(triplet.targets, hasLength(3));
+      expect(triplet.coverage, FootprintCoverage.advisory);
       final loosePak = b.components[1];
       expect(loosePak.kind, 'loose_pak');
       expect(loosePak.rel, 'paks/loose_P.pak');
+      expect(loosePak.coverage, FootprintCoverage.exact);
       final rawBank = b.components[2];
       expect(rawBank.kind, 'raw_file');
       expect(rawBank.rawFileTarget?.kind, 'bank');
       expect(rawBank.rawFileTarget?.bankName, 'SFX');
+      expect(rawBank.coverage, FootprintCoverage.exact);
       final rawLcache = b.components[3];
       expect(rawLcache.rawFileTarget?.kind, 'lcache');
       expect(rawLcache.rawFileTarget?.bankName, isNull);
@@ -195,6 +208,7 @@ void main() {
       expect(unknown.rel, 'future/thing');
       expect(unknown.rawFileTarget, isNull);
       expect(unknown.raw['type'], 'hologram');
+      expect(unknown.coverage, FootprintCoverage.opaque);
 
       expect(loadout.format, 1);
       expect(loadout.entries, hasLength(2));
@@ -203,6 +217,61 @@ void main() {
       expect(loadout.entries[1].id, 'mod-b');
       expect(loadout.entries[1].enabled, isFalse);
     });
+
+    test(
+      'older DLL coverage is inferred conservatively from component facts',
+      () {
+        FootprintCoverage coverage(Map<String, Object?> json) =>
+            ComponentView.fromJson(json).coverage;
+
+        expect(
+          coverage({'type': 'loc_patch', 'targets': <String>[]}),
+          FootprintCoverage.exact,
+        );
+        expect(
+          coverage({'type': 'raw_file', 'target_file': 'lcache'}),
+          FootprintCoverage.exact,
+        );
+        expect(
+          coverage({
+            'type': 'ue4ss_lua',
+            'targets': ['Class.Field'],
+            'opaque': true,
+          }),
+          FootprintCoverage.partial,
+        );
+        expect(
+          coverage({'type': 'ue4ss_lua', 'opaque': true}),
+          FootprintCoverage.opaque,
+        );
+        expect(
+          coverage({
+            'type': 'triplet',
+            'targets': ['/Game/Observed'],
+          }),
+          FootprintCoverage.advisory,
+        );
+        expect(coverage({'type': 'triplet'}), FootprintCoverage.opaque);
+        expect(
+          coverage({
+            'type': 'loose_pak',
+            'targets': ['/Game/Indexed'],
+          }),
+          FootprintCoverage.exact,
+        );
+        expect(coverage({'type': 'loose_pak'}), FootprintCoverage.opaque);
+        expect(
+          coverage({'type': 'future_component'}),
+          FootprintCoverage.opaque,
+        );
+        expect(
+          coverage({'type': 'loc_patch', 'coverage': 'future_precision'}),
+          FootprintCoverage.opaque,
+          reason:
+              'a present unknown grade must fail closed instead of inferring',
+        );
+      },
+    );
   });
 
   group('MgrFfi.status', () {
@@ -286,18 +355,20 @@ void main() {
         'drifted': ['G1R/Content/FMOD/Desktop/SFX.bank'],
       });
       expect(s, isA<ManagerStatusGameUpdated>());
-      expect(
-        (s as ManagerStatusGameUpdated).drifted,
-        ['G1R/Content/FMOD/Desktop/SFX.bank'],
-      );
+      expect((s as ManagerStatusGameUpdated).drifted, [
+        'G1R/Content/FMOD/Desktop/SFX.bank',
+      ]);
     });
 
-    test('parses a future state as ManagerStatusUnknown, keeping raw', () async {
-      final s = await parse({'state': 'reticulating_splines', 'foo': 1});
-      expect(s, isA<ManagerStatusUnknown>());
-      expect(s.state, 'reticulating_splines');
-      expect(s.raw['foo'], 1);
-    });
+    test(
+      'parses a future state as ManagerStatusUnknown, keeping raw',
+      () async {
+        final s = await parse({'state': 'reticulating_splines', 'foo': 1});
+        expect(s, isA<ManagerStatusUnknown>());
+        expect(s.state, 'reticulating_splines');
+        expect(s.raw['foo'], 1);
+      },
+    );
   });
 
   group('MgrFfi errors', () {
@@ -409,6 +480,7 @@ void main() {
                   'type': 'loose_pak',
                   'rel': 'paks/loose_P.pak',
                   'targets': ['G1R/Content/Paks/~mods/loose_P.pak'],
+                  'coverage': 'exact',
                 },
               ],
             },
@@ -418,6 +490,7 @@ void main() {
       final entry = await MgrFfi(fake).import('D:/downloads/loose_P.pak');
       expect(entry.id, 'mod-c');
       expect(entry.kind, 'foreign_pak');
+      expect(entry.components.single.coverage, FootprintCoverage.exact);
       expect(fake.calls.single.payload, {'path': 'D:/downloads/loose_P.pak'});
     });
 

--- a/crates/gore-ffi/src/lib.rs
+++ b/crates/gore-ffi/src/lib.rs
@@ -1523,6 +1523,41 @@ fn mgr_loadout_path(payload: &Value) -> PathBuf {
     }
 }
 
+/// Project one stored manager component onto the GUI wire contract.
+///
+/// `coverage` is deliberately injected here instead of added to `ComponentInfo`: library sidecars
+/// and their fingerprints remain byte/shape compatible while every Manager response receives the
+/// current derived truth.
+fn mgr_component_wire_value(component: &gore_mod::mgr::ComponentInfo) -> Value {
+    let mut value = serde_json::to_value(component).unwrap_or(Value::Null);
+    if let Value::Object(object) = &mut value {
+        object.insert(
+            "coverage".to_string(),
+            serde_json::to_value(component.footprint_coverage())
+                .unwrap_or_else(|_| Value::String("opaque".to_string())),
+        );
+    }
+    value
+}
+
+/// The single shared Manager entry projection for both library listing and import responses.
+fn mgr_entry_wire_value(entry: &gore_mod::mgr::ModEntryMeta) -> Value {
+    let mut value = serde_json::to_value(entry).unwrap_or(Value::Null);
+    if let Value::Object(object) = &mut value {
+        object.insert(
+            "components".to_string(),
+            Value::Array(
+                entry
+                    .components
+                    .iter()
+                    .map(mgr_component_wire_value)
+                    .collect(),
+            ),
+        );
+    }
+    value
+}
+
 /// `{library_dir?, loadout_path?}` → `{ok, mods:[ModEntryMeta], loadout:Loadout}`. Raw library +
 /// loadout, unreconciled (the UI reconciles ids against the library itself).
 fn mgr_library_list(payload: Value) -> Value {
@@ -1538,7 +1573,7 @@ fn mgr_library_list(payload: Value) -> Value {
     };
     json!({
         "ok": true,
-        "mods": serde_json::to_value(&mods).unwrap_or(Value::Null),
+        "mods": Value::Array(mods.iter().map(mgr_entry_wire_value).collect()),
         "loadout": serde_json::to_value(&loadout).unwrap_or(Value::Null),
     })
 }
@@ -1588,7 +1623,7 @@ fn mgr_import(payload: Value) -> Value {
             )
         }
     }
-    json!({"ok": true, "entry": serde_json::to_value(&entry).unwrap_or(Value::Null)})
+    json!({"ok": true, "entry": mgr_entry_wire_value(&entry)})
 }
 
 /// `{id, library_dir?}` → `{ok, removed:bool}` — delete a library entry (absent id → removed:false).
@@ -2397,6 +2432,28 @@ mod tests {
         assert_eq!(imp["entry"]["name"], "Probe");
         assert_eq!(imp["entry"]["kind"], "goremod");
         let id = imp["entry"]["id"].as_str().unwrap().to_string();
+        let imported_components = imp["entry"]["components"].as_array().unwrap();
+        assert!(!imported_components.is_empty(), "fixture component: {imp}");
+        assert!(
+            imported_components
+                .iter()
+                .all(|component| component.get("coverage").is_some()),
+            "mgr_import must project mandatory coverage: {imp}"
+        );
+        assert_eq!(imported_components[0]["coverage"], "exact");
+
+        let sidecar: Value = serde_json::from_slice(
+            &std::fs::read(lib.join(&id).join(gore_mod::mgr::META_FILE)).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            sidecar["components"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|component| component.get("coverage").is_none()),
+            "coverage is a derived wire field, not persisted metadata: {sidecar}"
+        );
 
         let list = mgr_call(
             "mgr_library_list",
@@ -2407,6 +2464,18 @@ mod tests {
         assert_eq!(mods.len(), 1, "one imported mod: {list}");
         assert_eq!(mods[0]["id"], id);
         assert_eq!(mods[0]["name"], "Probe");
+        assert_eq!(
+            mods[0]["components"], imp["entry"]["components"],
+            "list and import must share one entry projection"
+        );
+        assert!(
+            mods[0]["components"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|component| component.get("coverage").is_some()),
+            "mgr_library_list must project mandatory coverage: {list}"
+        );
 
         // BUG 3: the import must ALSO register a disabled loadout slot (mirror `gore mgr import`),
         // so a GUI-imported mod is visible to apply/status/analyze (which read the on-disk loadout)

--- a/crates/gore-mod/src/mgr/import.rs
+++ b/crates/gore-mod/src/mgr/import.rs
@@ -2820,6 +2820,7 @@ impl Drop for StagingGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mgr::FootprintCoverage;
     use crate::{
         build_bundle, write_bundle, BuildSpec, LooseFileReplacement, ModMeta, ScriptModule,
         VoiceArchiveEdit, VoicePatchOp,
@@ -3812,6 +3813,12 @@ mod tests {
                 ..
             }) if targets == &["ItFo_Apple.m_Value"]
         ));
+        let lua = meta
+            .components
+            .iter()
+            .find(|component| matches!(component, ComponentInfo::Ue4ssLua { .. }))
+            .unwrap();
+        assert_eq!(lua.footprint_coverage(), FootprintCoverage::Partial);
         let persisted: ModEntryMeta =
             serde_json::from_slice(&fs::read(lib.join(&meta.id).join(META_FILE)).unwrap()).unwrap();
         assert_eq!(persisted, meta);
@@ -3851,6 +3858,12 @@ mod tests {
                 ..
             }) if targets.is_empty()
         ));
+        let lua = meta
+            .components
+            .iter()
+            .find(|component| matches!(component, ComponentInfo::Ue4ssLua { .. }))
+            .unwrap();
+        assert_eq!(lua.footprint_coverage(), FootprintCoverage::Exact);
     }
 
     #[test]
@@ -3888,6 +3901,12 @@ mod tests {
                 ..
             }) if targets.is_empty()
         ));
+        let lua = meta
+            .components
+            .iter()
+            .find(|component| matches!(component, ComponentInfo::Ue4ssLua { .. }))
+            .unwrap();
+        assert_eq!(lua.footprint_coverage(), FootprintCoverage::Opaque);
     }
 
     #[test]
@@ -4280,6 +4299,11 @@ mod tests {
                 targets: vec![]
             }]
         );
+        assert_eq!(
+            meta.components[0].footprint_coverage(),
+            FootprintCoverage::Opaque,
+            "an unreadable Pak keeps importing with an explicitly unknown footprint"
+        );
         assert!(lib.join(&meta.id).join("foo_P.pak").is_file());
     }
 
@@ -4310,6 +4334,11 @@ mod tests {
                 rel_base: "zzz_foo_P".into(),
                 targets: vec![]
             }]
+        );
+        assert_eq!(
+            meta.components[0].footprint_coverage(),
+            FootprintCoverage::Opaque,
+            "an unreadable IoStore container keeps importing with an explicitly unknown footprint"
         );
         // All three members were staged into the entry.
         let entry = lib.join(&meta.id);
@@ -4409,6 +4438,10 @@ mod tests {
                 rel_base: "bar".into(),
                 targets: vec![]
             }]
+        );
+        assert_eq!(
+            meta.components[0].footprint_coverage(),
+            FootprintCoverage::Opaque
         );
         let entry = lib.join(&meta.id);
         assert!(entry.join("bar.ucas").is_file());
@@ -4832,6 +4865,11 @@ mod tests {
                 targets: vec![],
                 opaque: true,
             }]
+        );
+        assert_eq!(
+            meta.components[0].footprint_coverage(),
+            FootprintCoverage::Opaque,
+            "a foreign UE4SS tree has no complete declared script footprint"
         );
         let entry = lib.join(&meta.id);
         assert!(entry

--- a/crates/gore-mod/src/mgr/model.rs
+++ b/crates/gore-mod/src/mgr/model.rs
@@ -1813,6 +1813,20 @@ pub enum ModKind {
     ForeignMixed,
 }
 
+/// How completely a component's metadata describes its conflict-analysis footprint.
+///
+/// This is derived from [`ComponentInfo`] rather than stored in the library sidecar. It says
+/// nothing about runtime precedence: even an exact footprint can still have unproven ordering
+/// semantics in the game.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FootprintCoverage {
+    Exact,
+    Partial,
+    Advisory,
+    Opaque,
+}
+
 /// One deployable component of a library mod. `rel`/`rel_base` are paths inside the mod's
 /// library dir; `targets` are the game-side footprint keys used for conflict analysis.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1877,6 +1891,48 @@ pub enum ComponentInfo {
     },
 }
 
+impl ComponentInfo {
+    /// Derive how completely this component's metadata describes its footprint.
+    ///
+    /// Container scans remain compatible with corrupt or unreadable inputs: an empty scan is
+    /// opaque rather than an import failure. IoStore package discovery is advisory even when it
+    /// finds packages, while a successfully indexed plain Pak is exhaustive.
+    #[must_use]
+    pub fn footprint_coverage(&self) -> FootprintCoverage {
+        match self {
+            Self::Ue4ssLua {
+                targets, opaque, ..
+            } => match (*opaque, targets.is_empty()) {
+                (false, _) => FootprintCoverage::Exact,
+                (true, false) => FootprintCoverage::Partial,
+                (true, true) => FootprintCoverage::Opaque,
+            },
+            Self::Triplet { targets, .. } => {
+                if targets.is_empty() {
+                    FootprintCoverage::Opaque
+                } else {
+                    FootprintCoverage::Advisory
+                }
+            }
+            Self::LoosePak { targets, .. } => {
+                if targets.is_empty() {
+                    FootprintCoverage::Opaque
+                } else {
+                    FootprintCoverage::Exact
+                }
+            }
+            Self::LocPatch { .. }
+            | Self::AudioPatch { .. }
+            | Self::TexturePatch { .. }
+            | Self::AngelScriptPatch { .. }
+            | Self::FilePatch { .. }
+            | Self::PakFilePatch { .. }
+            | Self::VoiceArchivePatch { .. }
+            | Self::RawFile { .. } => FootprintCoverage::Exact,
+        }
+    }
+}
+
 /// The single live game file a [`ComponentInfo::RawFile`] replaces wholesale.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1890,6 +1946,135 @@ pub enum RawTarget {
 mod tests {
     use super::*;
     use std::io::Write as _;
+
+    #[test]
+    fn footprint_coverage_matrix_is_conservative_and_derived() {
+        let exact = vec![
+            ComponentInfo::Ue4ssLua {
+                name: "Precise".into(),
+                rel: "ue4ss/Precise".into(),
+                targets: vec![],
+                opaque: false,
+            },
+            ComponentInfo::LocPatch {
+                rel: "loc".into(),
+                targets: vec![],
+            },
+            ComponentInfo::AudioPatch {
+                rel: "audio".into(),
+                targets: vec![],
+            },
+            ComponentInfo::TexturePatch {
+                rel: "texture".into(),
+                targets: vec![],
+            },
+            ComponentInfo::AngelScriptPatch {
+                rel: "scripts".into(),
+                targets: vec![],
+            },
+            ComponentInfo::FilePatch {
+                rel: "files".into(),
+                targets: vec![],
+            },
+            ComponentInfo::PakFilePatch {
+                rel: "pak_files".into(),
+                targets: vec![],
+            },
+            ComponentInfo::VoiceArchivePatch {
+                rel: "voice".into(),
+                targets: vec![],
+            },
+            ComponentInfo::LoosePak {
+                rel: "indexed.pak".into(),
+                targets: vec!["/Game/Indexed".into()],
+            },
+            ComponentInfo::RawFile {
+                rel: "raw/Game.lcache".into(),
+                target_file: RawTarget::Lcache,
+            },
+        ];
+        for component in exact {
+            assert_eq!(
+                component.footprint_coverage(),
+                FootprintCoverage::Exact,
+                "component: {component:?}"
+            );
+        }
+
+        let cases = [
+            (
+                ComponentInfo::Ue4ssLua {
+                    name: "Partial".into(),
+                    rel: "ue4ss/Partial".into(),
+                    targets: vec!["Class.Field".into()],
+                    opaque: true,
+                },
+                FootprintCoverage::Partial,
+            ),
+            (
+                ComponentInfo::Ue4ssLua {
+                    name: "Opaque".into(),
+                    rel: "ue4ss/Opaque".into(),
+                    targets: vec![],
+                    opaque: true,
+                },
+                FootprintCoverage::Opaque,
+            ),
+            (
+                ComponentInfo::Triplet {
+                    rel_base: "container".into(),
+                    targets: vec!["/Game/Observed".into()],
+                },
+                FootprintCoverage::Advisory,
+            ),
+            (
+                ComponentInfo::Triplet {
+                    rel_base: "unreadable".into(),
+                    targets: vec![],
+                },
+                FootprintCoverage::Opaque,
+            ),
+            (
+                ComponentInfo::LoosePak {
+                    rel: "unreadable.pak".into(),
+                    targets: vec![],
+                },
+                FootprintCoverage::Opaque,
+            ),
+        ];
+        for (component, expected) in cases {
+            assert_eq!(
+                component.footprint_coverage(),
+                expected,
+                "component: {component:?}"
+            );
+        }
+
+        let serialized = serde_json::to_value(ComponentInfo::LoosePak {
+            rel: "indexed.pak".into(),
+            targets: vec!["/Game/Indexed".into()],
+        })
+        .unwrap();
+        assert!(
+            serialized.get("coverage").is_none(),
+            "derived coverage must not enter library metadata: {serialized}"
+        );
+        assert_eq!(
+            [
+                FootprintCoverage::Exact,
+                FootprintCoverage::Partial,
+                FootprintCoverage::Advisory,
+                FootprintCoverage::Opaque,
+            ]
+            .map(|coverage| serde_json::to_value(coverage).unwrap()),
+            [
+                serde_json::json!("exact"),
+                serde_json::json!("partial"),
+                serde_json::json!("advisory"),
+                serde_json::json!("opaque"),
+            ]
+        );
+    }
 
     #[cfg(unix)]
     fn make_file_link(target: &Path, link: &Path) -> bool {


### PR DESCRIPTION
## Summary

- derive `exact`, `partial`, `advisory`, or `opaque` coverage from each manager component
- expose the same derived field from `mgr_import` and `mgr_library_list` without changing sidecars or fingerprints
- decode older/newer DLL responses conservatively in Flutter
- invalidate cached conflict analysis when full component evidence changes, including future component and raw-target payloads

Coverage describes how complete the available conflict footprint metadata is. It does **not** prove runtime precedence or identify a runtime winner.

## Validation

- Rust coverage model test: 1 passed
- `gore-mod` import tests: 65 passed, 4 privilege-gated ignored
- `gore-ffi` import/list roundtrip: 1 passed
- Flutter focused tests: 30 passed
- Flutter focused analyze: clean
- Dart format and `git diff --check`: clean
- scoped Clippy: clean apart from explicitly excluded pre-existing `main` lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches conflict-analysis caching and FFI contract for library/import responses; incorrect keys could show stale conflicts, but changes are well-tested and sidecar persistence is unchanged.
> 
> **Overview**
> Adds **footprint coverage** (`exact`, `partial`, `advisory`, `opaque`) so the UI and conflict cache know how complete each component’s conflict metadata is. Coverage is **derived in Rust** from component facts, **injected on FFI wire responses** for `mgr_library_list` and `mgr_import` only (sidecars and fingerprints stay unchanged), and **decoded in Flutter** with conservative fallbacks when an older DLL omits the field or sends an unknown grade.
> 
> The mod manager **conflicts cache key** is rebuilt as canonical JSON over loadout entries plus each component’s full `raw` payload and effective `coverage`, fixing delimiter aliasing in target lists and ensuring same-id re-imports, opacity/coverage/raw-target changes, and future component fields invalidate stale `mgr_analyze` results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ea4b5d9dbc4e363446af957d46cdec192016641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->