### PR TITLE
Save faster: one write per Save, and one payload parse per edit

### DIFF
--- a/apps/save-editor/CHANGELOG.md
+++ b/apps/save-editor/CHANGELOG.md
@@ -15,10 +15,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   instead of walking back within seconds. It can be switched back on again, as
   long as the savegame still holds what the move wrote.
 
+### Changed
+
+- Saving is much faster. A save with eight changed values took eleven seconds
+  and now takes one. Changes that used to be written one after another are
+  written together, so a mixed save runs in a single pass instead of one per
+  change.
+
 ### Fixed
 
 - Version 1.2.1 said an NPC's position cannot be changed because the game
   restores it from the level. That was wrong.
+- Removing an item from a list and then editing another item in the same list
+  could change the wrong one.
 
 ## [1.2.1] - 2026-08-03
 

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -3707,8 +3707,21 @@ String? _structuredEditTarget(Map<String, Object?> edit) {
 /// One part of a target key, folded the way the core folds it — and the way the
 /// pending registry has to key these operations so two entries cannot collapse
 /// into one target only once the core sees them.
-String foldEditTargetPart(Object? part) =>
-    part is String ? part.trim().toLowerCase() : '';
+///
+/// The core folds ASCII case only (`to_ascii_lowercase`), so this does too:
+/// Dart's own `toLowerCase` also folds Ä to ä, which would put two targets the
+/// core keeps apart under one key and let the second edit quietly replace the
+/// first.
+String foldEditTargetPart(Object? part) {
+  if (part is! String) return '';
+  final trimmed = part.trim();
+  final folded = StringBuffer();
+  for (final unit in trimmed.codeUnits) {
+    const a = 0x41, z = 0x5a, toLower = 0x20;
+    folded.writeCharCode(unit >= a && unit <= z ? unit + toLower : unit);
+  }
+  return folded.toString();
+}
 
 /// The asset name of a `/Package.Asset` class reference, folded. The core keys a
 /// glossary segment by the asset names and refuses a pair whose packages differ.

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -1425,6 +1425,18 @@ class EditorNotifier extends StateNotifier<EditorState> {
               k.edit['path'] != repairSlotsPath,
         )
         .toList();
+    // Only one edit in this batch can move anything: a raw write to a slot's
+    // m_Id, which renumbers the ids and positions that a count or an indexed
+    // edit is addressed BY. Splitting the two would not make them safe — the
+    // second write would still resolve an id the first had already moved — but
+    // their order among the fixed edits is free, so let everything that moves
+    // nothing go first, where it still resolves against the layout the user was
+    // looking at. That is also the order the core accepts, so the pair keeps
+    // sharing one write.
+    final fixedMoversLast = [
+      ...fixedBatch.where((k) => !_mayInvalidateOrdinals(k.edit)),
+      ...fixedBatch.where((k) => _mayInvalidateOrdinals(k.edit)),
+    ];
 
     // The edits in the exact order they must reach the core, which applies a batch
     // sequentially against one payload and re-resolves every edit's target as it
@@ -1440,7 +1452,7 @@ class EditorNotifier extends StateNotifier<EditorState> {
     //  - story goes last: it always needs its own write, and putting it at the end
     //    keeps it from taking the backup away from the syncPersistentDataList one.
     final ordered = <_KeyedEdit>[
-      ...fixedBatch,
+      ...fixedMoversLast,
       ...orderedSplicing.where((k) => k.edit['path'] != storyStateApplyPath),
       ...skillEdits,
       ...repairEdits,
@@ -1448,13 +1460,19 @@ class EditorNotifier extends StateNotifier<EditorState> {
     ];
 
     // Pack that sequence into as few write_saves as the core will accept. It
-    // refuses two combinations — an edit addressed by an index or slot id placed
-    // after an edit that can change how many elements a container holds, and a
-    // raw typed edit sharing a write with a structured operation that rewrites
-    // what it addresses (order-independent) — so a new sub-write starts exactly
-    // when the next edit would hit either rule, plus one each for the two
-    // operations that must stand alone. In practice a whole editing session
-    // lands in a single write instead of one per splicing edit.
+    // refuses three combinations — an edit addressed by an index or slot id
+    // placed after an edit that can change how many elements a container holds,
+    // a raw typed edit sharing a write with a structured operation that rewrites
+    // what it addresses, and two structured operations that rewrite one target
+    // (the last two order-independent) — so a new sub-write starts exactly when
+    // the next edit would hit any of them, plus one each for the two operations
+    // that must stand alone. In practice a whole editing session lands in a
+    // single write instead of one per splicing edit.
+    //
+    // A split is not a way to make a pair safe, only a way to keep the core from
+    // refusing the whole write: the checks further up refuse the combinations
+    // where running the two in sequence would resolve the second against a
+    // layout the first moved.
     final worklist = <_SubWrite>[];
     var current = <Map<String, Object?>>[];
     var currentMayInvalidateOrdinals = false;
@@ -1483,7 +1501,11 @@ class EditorNotifier extends StateNotifier<EditorState> {
       // the same-target rule (order-independent, so it is checked against every
       // edit already in this batch, both ways round).
       if ((currentMayInvalidateOrdinals && _carriesCallerOrdinal(keyed.edit)) ||
-          current.any((edit) => editsRewriteSameTarget(edit, keyed.edit))) {
+          current.any(
+            (edit) =>
+                editsRewriteSameTarget(edit, keyed.edit) ||
+                structuredEditsShareATarget(edit, keyed.edit),
+          )) {
         flush();
       }
       current.add(keyed.edit);
@@ -2894,10 +2916,9 @@ class EditorNotifier extends StateNotifier<EditorState> {
     return GlossaryPage.fromJson(data);
   }
 
-  static String _glossaryPendingKey(
-    String documentClass,
-    String segmentClass,
-  ) => 'glossary.segment:$documentClass::$segmentClass';
+  static String _glossaryPendingKey(String documentClass, String segmentClass) =>
+      'glossary.segment:${foldEditTargetPart(documentClass)}'
+      '::${foldEditTargetPart(segmentClass)}';
 
   /// Queue one atomic glossary segment toggle. Each segment deliberately owns
   /// its own pending key because the core may splice the Hero memory array;
@@ -3411,7 +3432,10 @@ class EditorNotifier extends StateNotifier<EditorState> {
     );
   }
 
-  static String _npcRelationshipPendingKey(String id) => 'npc.relationship:$id';
+  /// Folded like the core folds the id it keys the operation by, so two entries
+  /// for one NPC cannot sit in the registry side by side and then collide.
+  static String _npcRelationshipPendingKey(String id) =>
+      'npc.relationship:${foldEditTargetPart(id)}';
 
   /// Register an explicit permanent NPC-to-Hero relationship override under
   /// its own structural pending key. The game otherwise derives this value at
@@ -3624,6 +3648,71 @@ bool _sameEditorPath(List<Object?> left, List<Object?> right) {
     if (left[i] != right[i]) return false;
   }
   return true;
+}
+
+/// What a structured edit rewrites as a whole, for the operations that resolve
+/// their target from a key and then replace whatever they find there. Two edits
+/// naming the same one cannot share a write.
+///
+/// Mirrors `structured_edit_target` in crates/gore-save/src/lib.rs, down to how
+/// it folds each part of the key and how it reads an asset name out of a class
+/// reference. The pending registry keys these operations by the same folded
+/// target, so a pair should not get this far; if one does, two writes lose less
+/// than a refusal that takes every unrelated edit in the batch down with it.
+/// Whether [left] and [right] are two structured operations rewriting one
+/// target — the pair the core refuses, so the packer splits it.
+@visibleForTesting
+bool structuredEditsShareATarget(
+  Map<String, Object?> left,
+  Map<String, Object?> right,
+) {
+  final target = _structuredEditTarget(left);
+  return target != null && _structuredEditTarget(right) == target;
+}
+
+String? _structuredEditTarget(Map<String, Object?> edit) {
+  final op = edit['path'];
+  if (op is! String) return null;
+  final value = edit['value'];
+  final fields = value is Map ? value : const <Object?, Object?>{};
+  String key(List<String> parts) => [op, ...parts].join('');
+  switch (op) {
+    case 'private.npc.setRelationship':
+      return key([foldEditTargetPart(fields['id'])]);
+    case 'private.skills.set':
+      // An absent actor is the hero, as the core reads it.
+      final actor = fields['actor'] is String ? fields['actor'] : 'Hero';
+      return key([
+        foldEditTargetPart(actor),
+        foldEditTargetPart(fields['base']),
+      ]);
+    case 'private.knowledge.setEntry':
+      return key([
+        foldEditTargetPart(fields['character']),
+        foldEditTargetPart(fields['entry']),
+      ]);
+    case 'private.glossary.setSegment':
+      return key([
+        _foldAssetName(fields['documentClass']),
+        _foldAssetName(fields['segmentClass']),
+      ]);
+    default:
+      return null;
+  }
+}
+
+/// One part of a target key, folded the way the core folds it — and the way the
+/// pending registry has to key these operations so two entries cannot collapse
+/// into one target only once the core sees them.
+String foldEditTargetPart(Object? part) =>
+    part is String ? part.trim().toLowerCase() : '';
+
+/// The asset name of a `/Package.Asset` class reference, folded. The core keys a
+/// glossary segment by the asset names and refuses a pair whose packages differ.
+String _foldAssetName(Object? part) {
+  final text = part is String ? part : '';
+  final dot = text.lastIndexOf('.');
+  return foldEditTargetPart(dot < 0 ? text : text.substring(dot + 1));
 }
 
 /// Whether [path] addresses the `CurrentState` of a quest entry — the leaf a

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -1098,18 +1098,40 @@ class EditorNotifier extends StateNotifier<EditorState> {
     // A glossary segment operation with a questStatePath updates that
     // CurrentState itself. Refuse a raw typed write to the exact same path;
     // sequencing the two would silently make whichever sub-write runs last win.
-    for (final keyed in allEdits) {
-      final edit = keyed.edit;
-      if (edit['path'] != 'private.glossary.setSegment') continue;
-      final value = edit['value'];
-      if (value is! Map) continue;
-      final rawQuestPath = value['questStatePath'];
-      if (rawQuestPath is! List) continue;
-      final questPath = List<Object?>.from(rawQuestPath);
-      if (!typedPaths.any((path) => _sameEditorPath(path, questPath))) continue;
-      final path = questPath.join(' › ');
-      state = state.copyWith(error: _l10n.editorGlossaryQuestConflict(path));
-      return false;
+    //
+    // This has to catch every pair the core's own rule claims, or the packer
+    // splits the pair into two writes and lets the later one win in silence.
+    // So: any raw typed operation, not only a value write; the quest path under
+    // either of the two names the core reads it from; and the paths compared the
+    // way the core compares them, where an index segment is a number and [04]
+    // and [4] are one and the same.
+    if (hasGlossarySegmentEdit) {
+      final rawTypedPaths = <List<Object?>>[];
+      for (final keyed in allEdits) {
+        final editPath = keyed.edit['path'];
+        if (editPath is! String || !editPath.startsWith('private.typed.')) {
+          continue;
+        }
+        final value = keyed.edit['value'];
+        if (value is! Map) continue;
+        final rawPath = value['path'];
+        if (rawPath is List) rawTypedPaths.add(List<Object?>.from(rawPath));
+      }
+      for (final keyed in allEdits) {
+        final edit = keyed.edit;
+        if (edit['path'] != 'private.glossary.setSegment') continue;
+        final value = edit['value'];
+        if (value is! Map) continue;
+        final rawQuestPath = value['questStatePath'] ?? value['statePath'];
+        if (rawQuestPath is! List) continue;
+        final questPath = List<Object?>.from(rawQuestPath);
+        if (!rawTypedPaths.any((path) => _sameCorePath(path, questPath))) {
+          continue;
+        }
+        final path = questPath.join(' › ');
+        state = state.copyWith(error: _l10n.editorGlossaryQuestConflict(path));
+        return false;
+      }
     }
 
     // A structured relationship edit patches or appends an object below this

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -3680,8 +3680,11 @@ String? _structuredEditTarget(Map<String, Object?> edit) {
     case 'private.npc.setRelationship':
       return key([foldEditTargetPart(fields['id'])]);
     case 'private.skills.set':
-      // An absent actor is the hero, as the core reads it.
-      final actor = fields['actor'] is String ? fields['actor'] : 'Hero';
+      // The core takes the actor when it is a non-empty string and the hero
+      // otherwise — before any folding, so a blank of spaces is an actor to it
+      // and must stay one here.
+      final rawActor = fields['actor'];
+      final actor = rawActor is String && rawActor.isNotEmpty ? rawActor : 'Hero';
       return key([
         foldEditTargetPart(actor),
         foldEditTargetPart(fields['base']),

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -3626,6 +3626,20 @@ bool _sameEditorPath(List<Object?> left, List<Object?> right) {
   return true;
 }
 
+/// Whether [path] addresses the `CurrentState` of a quest entry — the leaf a
+/// glossary segment operation rewrites beside the hero's memory.
+///
+/// Mirrors `path_is_a_quest_current_state` in crates/gore-save/src/lib.rs,
+/// including why it claims the shape rather than one entry: the operation can be
+/// sent without a quest path at all and the core then derives the leaf from the
+/// save, which nothing here can do.
+bool _pathIsAQuestCurrentState(List<Object?> path) {
+  if (path.length < 2) return false;
+  if (path.last != 'CurrentState') return false;
+  if (_mapKeySegment(path[path.length - 2]) == null) return false;
+  return _pathHasName(path, 'QuestDataByClass');
+}
+
 /// Whether two raw segment lists address the same path in the sense the core
 /// gives them: `parse_path` reads `{k}` as a map key and `[n]` as an index, so
 /// `[03]` and `[3]` are one and the same segment to it even though the two
@@ -3890,15 +3904,12 @@ bool structuredEditRewrites(
       return actor != null &&
           _pathHasName(typedPath, 'ActiveEffects') &&
           _pathHasKey(typedPath, actor);
-    // Adds or removes an unlock event in the hero's memory — and, when the
-    // caller supplied one, rewrites that quest's CurrentState as well.
+    // Adds or removes an unlock event in the hero's memory, and rewrites the
+    // CurrentState of the quest leaf that stands for the same segment.
     case 'private.glossary.setSegment':
-      if (_pathHasName(typedPath, 'MemorizedEvents') &&
-          _pathHasKey(typedPath, 'Hero')) {
-        return true;
-      }
-      final questPath = fields['questStatePath'] ?? fields['statePath'];
-      return questPath is List && _sameCorePath(questPath, typedPath);
+      return (_pathHasName(typedPath, 'MemorizedEvents') &&
+              _pathHasKey(typedPath, 'Hero')) ||
+          _pathIsAQuestCurrentState(typedPath);
     // Strips memory events, death tags and the corpse entry.
     case 'private.npc.revive':
       return _pathHasName(typedPath, 'MemorizedEvents') ||

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -1425,12 +1425,14 @@ class EditorNotifier extends StateNotifier<EditorState> {
       ...orderedSplicing.where((k) => k.edit['path'] == storyStateApplyPath),
     ];
 
-    // Pack that sequence into as few write_saves as the core will accept. It only
-    // refuses one combination — an edit addressed by an index or slot id placed
-    // after an edit that can change how many elements a container holds — so a new
-    // sub-write starts exactly when the next edit would hit that rule, plus one
-    // each for the two operations that must stand alone. In practice a whole
-    // editing session lands in a single write instead of one per splicing edit.
+    // Pack that sequence into as few write_saves as the core will accept. It
+    // refuses two combinations — an edit addressed by an index or slot id placed
+    // after an edit that can change how many elements a container holds, and a
+    // raw typed edit sharing a write with a structured operation that rewrites
+    // what it addresses (order-independent) — so a new sub-write starts exactly
+    // when the next edit would hit either rule, plus one each for the two
+    // operations that must stand alone. In practice a whole editing session
+    // lands in a single write instead of one per splicing edit.
     final worklist = <_SubWrite>[];
     var current = <Map<String, Object?>>[];
     var currentMayInvalidateOrdinals = false;
@@ -1454,7 +1456,12 @@ class EditorNotifier extends StateNotifier<EditorState> {
         worklist.add(_SubWrite(edits: [keyed.edit]));
         continue;
       }
-      if (currentMayInvalidateOrdinals && _carriesCallerOrdinal(keyed.edit)) {
+      // Two reasons to start a new sub-write: the ordinal rule (positional —
+      // only an ordinal-carrying edit AFTER an ordinal-invalidating one), and
+      // the same-target rule (order-independent, so it is checked against every
+      // edit already in this batch, both ways round).
+      if ((currentMayInvalidateOrdinals && _carriesCallerOrdinal(keyed.edit)) ||
+          current.any((edit) => editsRewriteSameTarget(edit, keyed.edit))) {
         flush();
       }
       current.add(keyed.edit);
@@ -3697,6 +3704,193 @@ const _typedEditPaths = {
   'private.typed.arrayDuplicate',
 };
 
+/// The path a raw `private.typed.*` edit addresses, or `null` when [edit] is not
+/// one. Mirrors `raw_typed_path` in crates/gore-save/src/lib.rs.
+List<Object?>? _rawTypedEditPath(Map<String, Object?> edit) {
+  if (!_typedEditPaths.contains(edit['path'])) return null;
+  final value = edit['value'];
+  if (value is! Map) return null;
+  final path = value['path'];
+  return path is List ? path : null;
+}
+
+/// The key of a `{likeThis}` map-key segment, or `null` when [segment] is not
+/// one. The generic All-data browser writes map keys wrapped in braces, and the
+/// core's `parse_path` turns exactly those into `PathSeg::MapKey`.
+String? _mapKeySegment(Object? segment) {
+  if (segment is! String) return null;
+  if (segment.length < 2 ||
+      !segment.startsWith('{') ||
+      !segment.endsWith('}')) {
+    return null;
+  }
+  return segment.substring(1, segment.length - 1);
+}
+
+/// Whether [segment] is an `[i]` element segment.
+bool _isIndexSegment(Object? segment) =>
+    segment is String &&
+    segment.length >= 2 &&
+    segment.startsWith('[') &&
+    segment.endsWith(']');
+
+/// Map keys compare trimmed and case-insensitively, as the core does.
+bool _sameMapKey(String left, String right) =>
+    left.trim().toLowerCase() == right.trim().toLowerCase();
+
+/// Mirrors `path_has_name` in crates/gore-save/src/lib.rs.
+bool _pathHasName(List<Object?> path, String name) =>
+    path.any((segment) => segment == name);
+
+/// Mirrors `path_has_key` in crates/gore-save/src/lib.rs.
+bool _pathHasKey(List<Object?> path, String key) => path.any((segment) {
+  final found = _mapKeySegment(segment);
+  return found != null && _sameMapKey(found, key);
+});
+
+/// Whether [path] descends into [map]'s entry for [key] — or into the map as a
+/// whole, which collides with every entry in it.
+///
+/// Mirrors `path_enters_map_entry` in crates/gore-save/src/lib.rs, including its
+/// last clause: a segment after the map that is not a `{key}` addresses it some
+/// other way, which is too unclear to call safe.
+bool _pathEntersMapEntry(List<Object?> path, String map, String key) {
+  final at = path.indexWhere((segment) => segment == map);
+  if (at < 0) return false;
+  if (at + 1 >= path.length) return true;
+  final found = _mapKeySegment(path[at + 1]);
+  if (found == null) return true;
+  return _sameMapKey(found, key);
+}
+
+/// Whether [path] reaches a slot of an inventory container — the array itself,
+/// or an element of it.
+///
+/// Mirrors `path_reaches_inventory_slot` in crates/gore-save/src/lib.rs.
+bool _pathReachesInventorySlot(List<Object?> path) {
+  final at = path.indexWhere((segment) => segment == 'm_Slots');
+  if (at < 0) return false;
+  if (at + 1 >= path.length) return true;
+  return _isIndexSegment(path[at + 1]);
+}
+
+/// Whether a slot-reaching [path] belongs to the inventory [actorId] names. An
+/// NPC's inventory hangs under that character's own map entry, so its key
+/// settles it; the controlled player's hangs off `m_SavedPlayers`. A path that
+/// fits neither description is treated as a conflict rather than waved through.
+///
+/// Mirrors `slot_edit_targets_actor` in crates/gore-save/src/lib.rs.
+bool _slotEditTargetsActor(List<Object?> path, String? actorId) {
+  if (!_pathReachesInventorySlot(path)) return false;
+  if (actorId != null) return _pathHasKey(path, actorId);
+  return _pathHasName(path, 'm_SavedPlayers') ||
+      !path.any((segment) => _mapKeySegment(segment) != null);
+}
+
+/// The actor a structured inventory edit targets, or `null` for the controlled
+/// player — which is also what a blank `actorId` means to the core.
+String? _inventoryEditActorId(Map<String, Object?> edit) {
+  final value = edit['value'];
+  final actorId = value is Map ? value['actorId'] : null;
+  return actorId is String && actorId.trim().isNotEmpty ? actorId : null;
+}
+
+/// Whether the raw typed edit at [typedPath] addresses something the structured
+/// [structured] edit rewrites AS A WHOLE.
+///
+/// Mirrors `structured_edit_rewrites` in crates/gore-save/src/lib.rs. Ordering
+/// cannot rescue such a pair — a structured operation resolves its own target
+/// and recreates it, so whichever runs second discards the other's work — which
+/// is why the core refuses the two in ONE write whichever way round they come.
+/// The packer therefore has to put them in SEPARATE sub-writes; sequential
+/// writes are safe, because the core re-reads the file and re-resolves every
+/// symbolic target per write.
+@visibleForTesting
+bool structuredEditRewrites(
+  Map<String, Object?> structured,
+  List<Object?> typedPath,
+) {
+  final op = structured['path'];
+  if (op is! String) return false;
+  final value = structured['value'];
+  final fields = value is Map ? value : const <Object?, Object?>{};
+  switch (op) {
+    // Patches or appends a modifier under this NPC's relationship entry.
+    case 'private.npc.setRelationship':
+      final id = fields['id'];
+      return id is String &&
+          id.trim().isNotEmpty &&
+          _pathEntersMapEntry(typedPath, 'RelationshipByGlobalId', id);
+    // Learning or unlearning rewrites this actor's effect elements. Broader
+    // than the same-actor `EffectSpec/Def` refusal above: ANY leaf of that
+    // actor's ActiveEffects is rewritten wholesale.
+    case 'private.skills.set':
+      final actor = _skillEditActor(structured);
+      return actor != null &&
+          _pathHasName(typedPath, 'ActiveEffects') &&
+          _pathHasKey(typedPath, actor);
+    // Adds or removes an unlock event in the hero's memory.
+    case 'private.glossary.setSegment':
+      return _pathHasName(typedPath, 'MemorizedEvents') &&
+          _pathHasKey(typedPath, 'Hero');
+    // Strips memory events, death tags and the corpse entry.
+    case 'private.npc.revive':
+      return _pathHasName(typedPath, 'MemorizedEvents') ||
+          _pathHasName(typedPath, 'LooseTagsByGlobalId') ||
+          _pathHasName(typedPath, 'm_SavedInventories');
+    // Insert or update ONE character's knowledge entry. Another character's
+    // entry is a different map value, and every applier re-resolves its target
+    // by key, so the two do not collide.
+    case 'private.knowledge.addCharacter':
+      final name = fields['value'];
+      return name is String &&
+          _pathEntersMapEntry(
+            typedPath,
+            'CharacterKnowledgeByUniqueName',
+            name,
+          );
+    case 'private.knowledge.setEntry':
+      final character = fields['character'];
+      return character is String &&
+          _pathEntersMapEntry(
+            typedPath,
+            'CharacterKnowledgeByUniqueName',
+            character,
+          );
+    // Claims a whole slot — but only in the inventory it targets; another
+    // actor's slots are a different subtree.
+    case 'private.inventory.addItem':
+    case 'private.inventory.removeItem':
+      return _slotEditTargetsActor(
+        typedPath,
+        _inventoryEditActorId(structured),
+      );
+    // Narrower still: it only rewrites ids, but it does so across every
+    // container in the save, so it is not scoped to one actor.
+    case 'private.inventory.repairSlots':
+      if (typedPath.isEmpty || typedPath.last != 'm_Id') return false;
+      return _pathReachesInventorySlot(
+        typedPath.sublist(0, typedPath.length - 1),
+      );
+    default:
+      return false;
+  }
+}
+
+/// Whether [left] and [right] address the same target in the sense above, in
+/// EITHER direction — the pair test the packer uses. The core's rule is
+/// order-independent, so a batch may hold neither ordering of such a pair.
+@visibleForTesting
+bool editsRewriteSameTarget(
+  Map<String, Object?> left,
+  Map<String, Object?> right,
+) {
+  final leftPath = _rawTypedEditPath(left);
+  if (leftPath != null && structuredEditRewrites(right, leftPath)) return true;
+  final rightPath = _rawTypedEditPath(right);
+  return rightPath != null && structuredEditRewrites(left, rightPath);
+}
+
 /// Edits that must be the only edit in their `write_save`, whatever else is
 /// pending. Both are refused as peers by the core: a story batch takes its
 /// compare-and-set snapshot from the payload as it enters and proves its own
@@ -3782,22 +3976,21 @@ bool _carriesCallerOrdinal(Map<String, Object?> edit) {
 /// `npc::npc_inventory_path`), and both are rewritten alike.
 @visibleForTesting
 bool isInventorySlotTypedEdit(Map<String, Object?> edit) {
-  if (!_typedEditPaths.contains(edit['path'])) return false;
-  final path = (edit['value'] as Map?)?['path'];
-  if (path is! List) return false;
-  final segments = path.whereType<String>().toList();
-  if (segments.isNotEmpty && segments.last == 'm_Slots') return true;
-  for (var index = 0; index + 1 < segments.length; index++) {
-    if (segments[index] != 'm_Slots') continue;
-    final slot = segments[index + 1];
-    if (slot.startsWith('[') && slot.endsWith(']')) return true;
-  }
-  return false;
+  // Exactly the reach the core's `path_reaches_inventory_slot` describes, so
+  // the two cannot drift apart. This predicate is broader than the core's rule
+  // in one respect on purpose: it is not scoped to the add's/removal's actor,
+  // so a queued slot edit for ANY actor is refused rather than merely split.
+  final path = _rawTypedEditPath(edit);
+  return path != null && _pathReachesInventorySlot(path);
 }
 
 /// A raw typed edit that writes a slot's `m_Id` — the one field the whole-save
 /// repair rewrites, and therefore the only one it can collide with. Anything
 /// else inside a slot survives the repair untouched.
+///
+/// Deliberately narrower than [structuredEditRewrites]'s repair arm, which
+/// matches any `m_Id` leaf below a slot: the shapes only that one catches are
+/// SPLIT across sub-writes by the packer, not refused with an error.
 @visibleForTesting
 bool isInventorySlotIdTypedEdit(Map<String, Object?> edit) {
   if (!_typedEditPaths.contains(edit['path'])) return false;

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -3604,6 +3604,36 @@ bool _sameEditorPath(List<Object?> left, List<Object?> right) {
   return true;
 }
 
+/// Whether two raw segment lists address the same path in the sense the core
+/// gives them: `parse_path` reads `{k}` as a map key and `[n]` as an index, so
+/// `[03]` and `[3]` are one and the same segment to it even though the two
+/// strings differ. Used where a mirror has to agree with the core exactly;
+/// [_sameEditorPath] compares the segments as the editor wrote them.
+bool _sameCorePath(List<Object?> left, List<Object?> right) {
+  if (left.length != right.length) return false;
+  for (var i = 0; i < left.length; i++) {
+    if (!_sameCoreSegment(left[i], right[i])) return false;
+  }
+  return true;
+}
+
+bool _sameCoreSegment(Object? left, Object? right) {
+  if (left == right) return true;
+  final index = _indexSegment(left);
+  return index != null && index == _indexSegment(right);
+}
+
+/// The number of an `[n]` index segment, or null when [segment] is not one.
+int? _indexSegment(Object? segment) {
+  if (segment is! String) return null;
+  if (segment.length < 3 ||
+      !segment.startsWith('[') ||
+      !segment.endsWith(']')) {
+    return null;
+  }
+  return int.tryParse(segment.substring(1, segment.length - 1));
+}
+
 bool _editorPathIsPrefix(List<Object?> prefix, List<Object?> path) {
   if (prefix.length > path.length) return false;
   for (var i = 0; i < prefix.length; i++) {
@@ -3838,10 +3868,15 @@ bool structuredEditRewrites(
       return actor != null &&
           _pathHasName(typedPath, 'ActiveEffects') &&
           _pathHasKey(typedPath, actor);
-    // Adds or removes an unlock event in the hero's memory.
+    // Adds or removes an unlock event in the hero's memory — and, when the
+    // caller supplied one, rewrites that quest's CurrentState as well.
     case 'private.glossary.setSegment':
-      return _pathHasName(typedPath, 'MemorizedEvents') &&
-          _pathHasKey(typedPath, 'Hero');
+      if (_pathHasName(typedPath, 'MemorizedEvents') &&
+          _pathHasKey(typedPath, 'Hero')) {
+        return true;
+      }
+      final questPath = fields['questStatePath'] ?? fields['statePath'];
+      return questPath is List && _sameCorePath(questPath, typedPath);
     // Strips memory events, death tags and the corpse entry.
     case 'private.npc.revive':
       return _pathHasName(typedPath, 'MemorizedEvents') ||

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -3680,13 +3680,11 @@ String? _structuredEditTarget(Map<String, Object?> edit) {
     case 'private.npc.setRelationship':
       return key([foldEditTargetPart(fields['id'])]);
     case 'private.skills.set':
-      // The core takes the actor when it is a non-empty string and the hero
-      // otherwise — before any folding, so a blank of spaces is an actor to it
-      // and must stay one here.
-      final rawActor = fields['actor'];
-      final actor = rawActor is String && rawActor.isNotEmpty ? rawActor : 'Hero';
+      // Read through the same helper the other rules use, so an actor left
+      // empty resolves to the hero everywhere or nowhere. It reads the raw
+      // text, before any folding, so a blank of spaces stays an actor.
       return key([
-        foldEditTargetPart(actor),
+        foldEditTargetPart(_skillEditActor(edit)),
         foldEditTargetPart(fields['base']),
       ]);
     case 'private.knowledge.setEntry':
@@ -3831,7 +3829,11 @@ String? _skillEditActor(Map<String, Object?> edit) {
   if (edit['path'] != 'private.skills.set') return null;
   final value = edit['value'];
   if (value is! Map) return null;
-  return (value['actor'] as String?) ?? 'Hero';
+  // The core takes the actor when it is a non-empty string and the hero
+  // otherwise, so an empty one is the hero here too — a rule this shares with
+  // the target key, and the two must not disagree.
+  final actor = value['actor'];
+  return actor is String && actor.isNotEmpty ? actor : 'Hero';
 }
 
 /// The actor whose ActiveEffects a raw `private.typed.setValue` on an

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -1404,38 +1404,64 @@ class EditorNotifier extends StateNotifier<EditorState> {
         )
         .toList();
 
-    // Build the worklist: ONE write for the fixed-size batch (if any) FIRST,
-    // then one write per splicing edit. Backup is taken on the FIRST sub-write
-    // only, so a Save makes exactly one pristine snapshot regardless of
-    // sub-write count.
-    //
-    // The fixed batch leads for two reasons:
-    //  - It carries syncPersistentDataList, so making it the backup-taking write
-    //    means the PersistentDataList.sav companion is updated WITH a restorable
-    //    companion backup (the synced write must be the one that takes backup).
-    //  - A splicing npc.revive writes HP (restore→Max). Running the fixed batch
-    //    first means a conflicting manual Health edit on the SAME NPC is applied
-    //    BEFORE revive, so the Revive action's HP wins (last write).
-    // If there is no fixed batch, the first splice takes backup:true instead.
-    final worklist = <_SubWrite>[
-      if (fixedBatch.isNotEmpty)
-        _SubWrite(
-          edits: [for (final keyed in fixedBatch) keyed.edit],
-          // syncPersistentDataList keys off a public/fixed edit, so it rides the
-          // fixed-size batch.
-          syncPersistentDataList: syncPersistent,
-        ),
-      for (final keyed in orderedSplicing) _SubWrite(edits: [keyed.edit]),
-      // All skill edits together, in their own trailing write: they batch safely
-      // among themselves but must not share a write with an index-addressed peer
-      // (see skillPath above).
-      if (skillEdits.isNotEmpty)
-        _SubWrite(edits: [for (final keyed in skillEdits) keyed.edit]),
-      // Last: the slot repair, so every id-addressed edit above resolved against
-      // the ids the user saw (see repairSlotsPath).
-      if (repairEdits.isNotEmpty)
-        _SubWrite(edits: [for (final keyed in repairEdits) keyed.edit]),
+    // The edits in the exact order they must reach the core, which applies a batch
+    // sequentially against one payload and re-resolves every edit's target as it
+    // goes. All the ordering this method computed above is preserved by simple
+    // concatenation:
+    //  - the fixed batch leads. It carries syncPersistentDataList, so it is the
+    //    backup-taking write; and a manual Health edit lands before a splicing
+    //    npc.revive's HP restore, so the Revive action still wins as last writer.
+    //  - the splices keep glossary adds ahead of removals and array removals
+    //    index-descending.
+    //  - skills follow, then the slot repair, so every id-addressed edit above
+    //    resolved against the ids the user actually saw.
+    //  - story goes last: it always needs its own write, and putting it at the end
+    //    keeps it from taking the backup away from the syncPersistentDataList one.
+    final ordered = <_KeyedEdit>[
+      ...fixedBatch,
+      ...orderedSplicing.where((k) => k.edit['path'] != storyStateApplyPath),
+      ...skillEdits,
+      ...repairEdits,
+      ...orderedSplicing.where((k) => k.edit['path'] == storyStateApplyPath),
     ];
+
+    // Pack that sequence into as few write_saves as the core will accept. It only
+    // refuses one combination — an edit addressed by an index or slot id placed
+    // after an edit that can change how many elements a container holds — so a new
+    // sub-write starts exactly when the next edit would hit that rule, plus one
+    // each for the two operations that must stand alone. In practice a whole
+    // editing session lands in a single write instead of one per splicing edit.
+    final worklist = <_SubWrite>[];
+    var current = <Map<String, Object?>>[];
+    var currentMayInvalidateOrdinals = false;
+    // syncPersistentDataList keys off a public/fixed edit, so it belongs to the
+    // first batch — which is also the one that takes the backup, so the companion
+    // file is updated with a restorable snapshot beside it.
+    var syncPending = syncPersistent;
+    void flush() {
+      if (current.isEmpty) return;
+      worklist.add(
+        _SubWrite(edits: current, syncPersistentDataList: syncPending),
+      );
+      syncPending = false;
+      current = <Map<String, Object?>>[];
+      currentMayInvalidateOrdinals = false;
+    }
+
+    for (final keyed in ordered) {
+      if (_exclusiveEditPaths.contains(keyed.edit['path'])) {
+        flush();
+        worklist.add(_SubWrite(edits: [keyed.edit]));
+        continue;
+      }
+      if (currentMayInvalidateOrdinals && _carriesCallerOrdinal(keyed.edit)) {
+        flush();
+      }
+      current.add(keyed.edit);
+      currentMayInvalidateOrdinals =
+          currentMayInvalidateOrdinals || _mayInvalidateOrdinals(keyed.edit);
+    }
+    flush();
     // Hang the placement notes on whichever sub-write goes first. It is the one
     // that takes the backup, and — for a position edit, which is never a
     // splicing edit — the one that actually carries the move.
@@ -3670,6 +3696,76 @@ const _typedEditPaths = {
   'private.typed.arrayRemove',
   'private.typed.arrayDuplicate',
 };
+
+/// Edits that must be the only edit in their `write_save`, whatever else is
+/// pending. Both are refused as peers by the core: a story batch takes its
+/// compare-and-set snapshot from the payload as it enters and proves its own
+/// postconditions before committing, and a reset replaces the whole inventory.
+const _exclusiveEditPaths = {
+  storyStateApplyPath,
+  'private.inventory.reset',
+};
+
+/// Whether [edit] can change how many elements a container holds, or renumber
+/// inventory slot ids — the only two things that invalidate an index or slot id a
+/// later edit in the same write was addressed with.
+///
+/// Mirrors `may_invalidate_caller_ordinals` in crates/gore-save/src/lib.rs. Keep the
+/// two in step: the core rejects the write outright when they disagree.
+bool _mayInvalidateOrdinals(Map<String, Object?> edit) {
+  final path = edit['path'];
+  if (path is! String) return true;
+  if (_typedEditPaths.contains(path) && path != 'private.typed.setValue') {
+    // setAdd/setRemove change a set's cardinality, arrayRemove/arrayDuplicate an
+    // array's length.
+    return true;
+  }
+  return const {
+    'private.inventory.addItem',
+    'private.inventory.removeItem',
+    'private.inventory.reset',
+    'private.inventory.repairSlots',
+    'private.knowledge.addCharacter',
+    'private.knowledge.setEntry',
+    'private.npc.revive',
+    'private.npc.setRelationship',
+    'private.glossary.setSegment',
+    'private.skills.set',
+    storyStateApplyPath,
+  }.contains(path);
+}
+
+/// Whether [edit] addresses its target with an index or slot id the user's view of
+/// the save supplied — something an earlier length change would silently retarget.
+///
+/// Mirrors `carries_caller_ordinal` in crates/gore-save/src/lib.rs.
+bool _carriesCallerOrdinal(Map<String, Object?> edit) {
+  final path = edit['path'];
+  if (path is! String) return false;
+  final value = edit['value'];
+  if (path == 'private.typed.arrayRemove' ||
+      path == 'private.typed.arrayDuplicate') {
+    return true;
+  }
+  if (_typedEditPaths.contains(path)) {
+    final raw = value is Map ? value['path'] : null;
+    return raw is List &&
+        raw.whereType<String>().any(
+          (segment) => segment.startsWith('[') && segment.endsWith(']'),
+        );
+  }
+  if (path == 'private.inventory.setItemCount') {
+    // A slot id is an index by invariant. The player path carries an ordinal even
+    // without one: it finds the stack through a positional scan of the payload
+    // rather than through the typed tree.
+    return (value is Map ? value['slotId'] : null) != null ||
+        (value is Map ? value['actorId'] : null) == null;
+  }
+  if (path == 'private.inventory.removeItem') {
+    return (value is Map ? value['slotId'] : null) != null;
+  }
+  return false;
+}
 
 /// A raw typed edit that reaches a slot — INTO one (its id, its count, a set or
 /// array inside its payload, anything below `m_Slots/[i]`) or AT the slot array

--- a/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
+++ b/apps/save-editor/lib/features/editor/domain/editor_notifier.dart
@@ -3774,6 +3774,15 @@ bool _pathReachesInventorySlot(List<Object?> path) {
   return _isIndexSegment(path[at + 1]);
 }
 
+/// Whether [path] writes a slot's `m_Id` — the field a slot is selected by, so a
+/// write to it renumbers slots exactly as a repair does.
+///
+/// Mirrors `path_writes_a_slot_id` in crates/gore-save/src/lib.rs.
+bool _pathWritesASlotId(List<Object?> path) {
+  if (path.isEmpty || path.last != 'm_Id') return false;
+  return _pathReachesInventorySlot(path.sublist(0, path.length - 1));
+}
+
 /// Whether a slot-reaching [path] belongs to the inventory [actorId] names. An
 /// NPC's inventory hangs under that character's own map entry, so its key
 /// settles it; the controlled player's hangs off `m_SavedPlayers`. A path that
@@ -3868,10 +3877,7 @@ bool structuredEditRewrites(
     // Narrower still: it only rewrites ids, but it does so across every
     // container in the save, so it is not scoped to one actor.
     case 'private.inventory.repairSlots':
-      if (typedPath.isEmpty || typedPath.last != 'm_Id') return false;
-      return _pathReachesInventorySlot(
-        typedPath.sublist(0, typedPath.length - 1),
-      );
+      return _pathWritesASlotId(typedPath);
     default:
       return false;
   }
@@ -3913,6 +3919,13 @@ bool _mayInvalidateOrdinals(Map<String, Object?> edit) {
     // setAdd/setRemove change a set's cardinality, arrayRemove/arrayDuplicate an
     // array's length.
     return true;
+  }
+  if (path == 'private.typed.setValue') {
+    // It can add or drop no container element — but writing a slot's m_Id
+    // renumbers slots, which is the other half of what invalidates an ordinal a
+    // later edit was addressed with.
+    final typedPath = _rawTypedEditPath(edit);
+    return typedPath != null && _pathWritesASlotId(typedPath);
   }
   return const {
     'private.inventory.addItem',

--- a/apps/save-editor/lib/features/editor/ui/attribute_detail.dart
+++ b/apps/save-editor/lib/features/editor/ui/attribute_detail.dart
@@ -190,7 +190,7 @@ class AttributeDetail extends ConsumerWidget {
               editable: editable,
               reloadKey: (inspection, npcId),
               actor: npcId,
-              pendingKey: 'skills:$npcId',
+              pendingKey: 'skills:${foldEditTargetPart(npcId)}',
               showRoster: false,
             ),
             attributeLabel: attributeLabel,

--- a/apps/save-editor/lib/features/editor/ui/progression_panel.dart
+++ b/apps/save-editor/lib/features/editor/ui/progression_panel.dart
@@ -907,13 +907,13 @@ class _KnowledgeDetailState extends ConsumerState<KnowledgeDetail> {
     }
   }
 
-  /// UE Names compare case-insensitively, so the entry part of the pending
-  /// key is folded to lower case: an add and a remove that differ only in
-  /// casing address the same logical entry and toggle instead of coexisting
-  /// as conflicting setAdd + setRemove ops. The queued edit itself keeps the
-  /// caller's original casing.
+  /// UE Names compare case-insensitively and the core folds surrounding space
+  /// too, so both parts of the pending key are folded the same way: an add and a
+  /// remove that differ only in casing or spacing address the same logical entry
+  /// and toggle instead of coexisting as two entries the core then sees as one
+  /// target and refuses. The queued edit itself keeps the caller's original text.
   String _pendingKey(String character, String entry) =>
-      '$character\t${entry.toLowerCase()}';
+      '${foldEditTargetPart(character)}\t${foldEditTargetPart(entry)}';
 
   void _removeEntry(String entry) {
     final character = _selectedCharacter;
@@ -1043,7 +1043,7 @@ class _KnowledgeDetailState extends ConsumerState<KnowledgeDetail> {
     final removedEntries = <String>{};
     final addedEntries = <String>[];
     if (character != null) {
-      final prefix = '$character\t';
+      final prefix = '${foldEditTargetPart(character)}\t';
       for (final e in _pending.entries) {
         if (!e.key.startsWith(prefix)) continue;
         if (!e.value.isAdd) removedEntries.add(e.value.entry.toLowerCase());

--- a/apps/save-editor/lib/features/editor/ui/progression_panel.dart
+++ b/apps/save-editor/lib/features/editor/ui/progression_panel.dart
@@ -1038,15 +1038,17 @@ class _KnowledgeDetailState extends ConsumerState<KnowledgeDetail> {
     final character = _selectedCharacter;
 
     // Compute sets for rendering — only include edits for the selected NPC.
-    // removedEntries holds lower-cased values to match the case-folded
-    // pending keys: lookups against displayed entries fold too.
+    // removedEntries holds folded values to match the folded pending keys:
+    // lookups against displayed entries fold the same way.
     final removedEntries = <String>{};
     final addedEntries = <String>[];
     if (character != null) {
       final prefix = '${foldEditTargetPart(character)}\t';
       for (final e in _pending.entries) {
         if (!e.key.startsWith(prefix)) continue;
-        if (!e.value.isAdd) removedEntries.add(e.value.entry.toLowerCase());
+        if (!e.value.isAdd) {
+          removedEntries.add(foldEditTargetPart(e.value.entry));
+        }
         if (e.value.isAdd) addedEntries.add(e.value.entry);
       }
     }
@@ -1254,7 +1256,7 @@ class _KnowledgeDetailState extends ConsumerState<KnowledgeDetail> {
                               itemBuilder: (context, index) {
                                 final entry = _entries.entries[index];
                                 final isRemoved = removedEntries.contains(
-                                  entry.toLowerCase(),
+                                  foldEditTargetPart(entry),
                                 );
                                 final meta = _knowledgeCatalog?.entryById(
                                   entry,

--- a/apps/save-editor/test/editor_notifier_test.dart
+++ b/apps/save-editor/test/editor_notifier_test.dart
@@ -2638,64 +2638,67 @@ void main() {
       Map<String, Object?> glossary(List<String>? questStatePath) => {
         'path': 'private.glossary.setSegment',
         'value': {
-          'documentClass': '/Script/Angelscript.Document_Glossary_Creatures',
-          'segmentClass': '/Script/Angelscript.DocumentSegment_Scavenger',
+          'documentClass': '/Script/Angelscript.Document_Glossary_Meatbug',
+          'segmentClass':
+              '/Script/Angelscript.DocumentSegment_Glossary_Meatbug_Entry2',
           'unlocked': true,
           'questStatePath': ?questStatePath,
         },
       };
-      const questPath = [
-        'm_QuestStates',
-        '{Quest_Creatures}',
-        'SubQuests',
-        '[4]',
+      const questState = [
+        'QuestDataByClass',
+        '{/Script/Angelscript.Quest_OldCamp_SLEEPER}',
         'CurrentState',
       ];
 
       // The core rewrites that CurrentState itself, so the two cannot share a
-      // write — the packer has to split them, in either order.
+      // write — in either order.
       expect(
-        editsRewriteSameTarget(glossary(questPath), typedEdit(questPath)),
+        editsRewriteSameTarget(glossary(questState), typedEdit(questState)),
         isTrue,
       );
       expect(
-        editsRewriteSameTarget(typedEdit(questPath), glossary(questPath)),
+        editsRewriteSameTarget(typedEdit(questState), glossary(questState)),
         isTrue,
       );
 
-      // An index the core reads as the same number is the same segment to it,
-      // however the editor spelled it.
+      // Sending no quest path does not make it someone else's business: the core
+      // then derives the same leaf from the document and segment. Which leaf that
+      // is cannot be known here, so any quest's CurrentState is claimed.
+      expect(
+        editsRewriteSameTarget(glossary(null), typedEdit(questState)),
+        isTrue,
+      );
       expect(
         editsRewriteSameTarget(
-          glossary(questPath),
+          glossary(null),
           typedEdit([
-            'm_QuestStates',
-            '{Quest_Creatures}',
-            'SubQuests',
-            '[04]',
+            'QuestDataByClass',
+            '{/Script/Angelscript.Quest_Something_Else}',
             'CurrentState',
           ]),
         ),
         isTrue,
       );
 
-      // Another quest's state, and a segment operation that names no quest at
-      // all, stay packable.
+      // Another field of the same entry, and a CurrentState that is not a
+      // quest's, stay packable.
       expect(
         editsRewriteSameTarget(
-          glossary(questPath),
+          glossary(questState),
           typedEdit([
-            'm_QuestStates',
-            '{Quest_Creatures}',
-            'SubQuests',
-            '[5]',
-            'CurrentState',
+            'QuestDataByClass',
+            '{/Script/Angelscript.Quest_OldCamp_SLEEPER}',
+            'm_Comment',
           ]),
         ),
         isFalse,
       );
       expect(
-        editsRewriteSameTarget(glossary(null), typedEdit(questPath)),
+        editsRewriteSameTarget(
+          glossary(questState),
+          typedEdit(['m_GenericData', '{Dialogue}', 'CurrentState']),
+        ),
         isFalse,
       );
     });

--- a/apps/save-editor/test/editor_notifier_test.dart
+++ b/apps/save-editor/test/editor_notifier_test.dart
@@ -1398,6 +1398,62 @@ void main() {
     },
   );
 
+  test(
+    'saveAllPending refuses a container edit to a glossary quest CurrentState '
+    'path spelled another way',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:	mp\saves');
+      await notifier.inspect(r'C:	mp\saves\G1R-001.sav');
+
+      // The index the editor wrote as [4]; the core reads both spellings as the
+      // same segment, so the pair has to be refused here rather than split into
+      // two writes where the later one silently wins.
+      notifier.setPendingGlossarySegment(
+        const GlossarySegmentEdit(
+          documentClass: '/Script/Angelscript.Document_Glossary_Wolf',
+          segmentClass:
+              '/Script/Angelscript.DocumentSegment_Glossary_Wolf_Unlock',
+          unlocked: true,
+          questStatePath: [
+            'QuestDataByClass',
+            '{/Script/Angelscript.Quest_CreaturesGlossary_Wolf_WolfUnlock}',
+            'SubQuests',
+            '[4]',
+            'CurrentState',
+          ],
+        ),
+      );
+      notifier.setPendingEdit(
+        'typed:wolf-current-state',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.arrayRemove',
+              'value': {
+                'path': [
+                  'QuestDataByClass',
+                  '{/Script/Angelscript.Quest_CreaturesGlossary_Wolf_WolfUnlock}',
+                  'SubQuests',
+                  '[04]',
+                  'CurrentState',
+                ],
+                'index': 0,
+              },
+            },
+          ],
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isFalse);
+      expect(notifier.state.error, contains('same quest CurrentState'));
+      expect(core.requests.where((r) => r.command == 'write_save'), isEmpty);
+      expect(notifier.state.pendingEdits, hasLength(2));
+    },
+  );
+
   test('saveAllPending refuses a typed value edit inside Hero MemorizedEvents '
       'alongside a glossary segment change', () async {
     final core = _RecordingCoreService();

--- a/apps/save-editor/test/editor_notifier_test.dart
+++ b/apps/save-editor/test/editor_notifier_test.dart
@@ -2792,6 +2792,32 @@ void main() {
       );
     });
 
+    test('a skill edit sent with an empty actor is the hero everywhere', () {
+      final emptyActor = {
+        'path': 'private.skills.set',
+        'value': {'actor': '', 'base': 'Ranged_Bow', 'tier': 'Trained'},
+      };
+      final heroDef = typedEdit([
+        'ActiveEffectsByGlobalId',
+        '{Hero}',
+        'ActiveEffects',
+        '[2]',
+        'EffectSpec',
+        'Def',
+      ]);
+
+      // Both rules read the actor the same way, so the packer splits this pair
+      // exactly where the core refuses it.
+      expect(editsRewriteSameTarget(emptyActor, heroDef), isTrue);
+      expect(
+        structuredEditsShareATarget(emptyActor, {
+          'path': 'private.skills.set',
+          'value': {'actor': 'Hero', 'base': 'Ranged_Bow', 'tier': 'Untrained'},
+        }),
+        isTrue,
+      );
+    });
+
     test('two structured edits for one target land in separate writes', () {
       Map<String, Object?> skill(String actor, String base, String tier) => {
         'path': 'private.skills.set',

--- a/apps/save-editor/test/editor_notifier_test.dart
+++ b/apps/save-editor/test/editor_notifier_test.dart
@@ -1403,8 +1403,8 @@ void main() {
     'path spelled another way',
     () async {
       final core = _RecordingCoreService();
-      final notifier = EditorNotifier(core, saveDir: r'C:	mp\saves');
-      await notifier.inspect(r'C:	mp\saves\G1R-001.sav');
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
 
       // The index the editor wrote as [4]; the core reads both spellings as the
       // same segment, so the pair has to be refused here rather than split into
@@ -2698,6 +2698,168 @@ void main() {
         editsRewriteSameTarget(
           glossary(questState),
           typedEdit(['m_GenericData', '{Dialogue}', 'CurrentState']),
+        ),
+        isFalse,
+      );
+    });
+
+    test('the packer really splits such a pair into two writes', () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:	mp\saves');
+      await notifier.inspect(r'C:	mp\saves\G1R-001.sav');
+
+      Map<String, Object?> entry(String character, String name, bool present) => {
+        'path': 'private.knowledge.setEntry',
+        'value': {'character': character, 'entry': name, 'present': present},
+      };
+      // Two registry entries the core folds into one target. It refuses the
+      // pair, so both have to reach it in writes of their own.
+      notifier.setPendingEdit(
+        'knowledge:a',
+        PendingSaveEdit(edits: [entry('Diego', 'Info_Ore ', false)]),
+      );
+      notifier.setPendingEdit(
+        'knowledge:b',
+        PendingSaveEdit(edits: [entry('diego', 'Info_Ore', true)]),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isTrue);
+      final writes = core.requests
+          .where((request) => request.command == 'write_save')
+          .toList();
+      expect(writes, hasLength(2));
+      for (final write in writes) {
+        expect((write.payload['edits'] as List), hasLength(1));
+      }
+    });
+
+    test('an id-addressed edit is written before the write that renumbers ids', () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:	mp\saves');
+      await notifier.inspect(r'C:	mp\saves\G1R-001.sav');
+
+      // A raw write to a slot's m_Id renumbers what the count edit is addressed
+      // by. Two writes would not help — the second would resolve the id this one
+      // moved — so they share one write with the addressed edit first, which is
+      // the order the core accepts.
+      notifier.setPendingEdit(
+        'a-slot-id',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {
+                'path': [
+                  'm_Inventory',
+                  'm_Containers',
+                  '[0]',
+                  'm_Slots',
+                  '[3]',
+                  'm_Id',
+                ],
+                'value': 9,
+              },
+            },
+          ],
+        ),
+      );
+      notifier.setPendingEdit(
+        'z-count',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.inventory.setItemCount',
+              'value': {'path': '/Script/Angelscript.ItMi_Orenugget', 'count': 5},
+            },
+          ],
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isTrue);
+      final writes = core.requests
+          .where((request) => request.command == 'write_save')
+          .toList();
+      expect(writes, hasLength(1));
+      final edits = (writes.single.payload['edits'] as List)
+          .cast<Map<String, Object?>>();
+      expect(
+        edits.map((edit) => edit['path']),
+        ['private.inventory.setItemCount', 'private.typed.setValue'],
+      );
+    });
+
+    test('two structured edits for one target land in separate writes', () {
+      Map<String, Object?> skill(String actor, String base, String tier) => {
+        'path': 'private.skills.set',
+        'value': {'actor': actor, 'base': base, 'tier': tier},
+      };
+
+      // The core refuses this pair outright, so the packer has to split it or
+      // the whole Save fails and takes every unrelated edit with it. The parts
+      // of the target are folded as the core folds them.
+      expect(
+        structuredEditsShareATarget(
+          skill('Hero', 'Ranged_Bow', 'Trained'),
+          skill(' hero ', 'ranged_bow', 'Untrained'),
+        ),
+        isTrue,
+      );
+
+      // Two skills of one character, and one skill of two characters, are two
+      // targets — batching those is the point.
+      expect(
+        structuredEditsShareATarget(
+          skill('Hero', 'Ranged_Bow', 'Trained'),
+          skill('Hero', 'Ranged_Crossbow', 'Trained'),
+        ),
+        isFalse,
+      );
+      expect(
+        structuredEditsShareATarget(
+          skill('Hero', 'Ranged_Bow', 'Trained'),
+          skill('Diego', 'Ranged_Bow', 'Trained'),
+        ),
+        isFalse,
+      );
+
+      // A glossary segment is keyed by the two asset names, as the core keys it.
+      Map<String, Object?> segment(String document, String seg) => {
+        'path': 'private.glossary.setSegment',
+        'value': {
+          'documentClass': document,
+          'segmentClass': seg,
+          'unlocked': true,
+        },
+      };
+      expect(
+        structuredEditsShareATarget(
+          segment(
+            '/Script/Angelscript.Document_Glossary_Meatbug',
+            '/Script/Angelscript.DocumentSegment_Meatbug_Entry2',
+          ),
+          segment(
+            '/Script/Angelscript.Document_Glossary_Meatbug',
+            '/Script/Angelscript.DocumentSegment_Meatbug_Unlock',
+          ),
+        ),
+        isFalse,
+      );
+
+      // An operation that adds to what is there has no such target at all.
+      expect(
+        structuredEditsShareATarget(
+          {
+            'path': 'private.inventory.addItem',
+            'value': {'path': '/Script/Angelscript.ItFo_Cheese', 'count': 1},
+          },
+          {
+            'path': 'private.inventory.addItem',
+            'value': {'path': '/Script/Angelscript.ItFo_Cheese', 'count': 1},
+          },
         ),
         isFalse,
       );

--- a/apps/save-editor/test/editor_notifier_test.dart
+++ b/apps/save-editor/test/editor_notifier_test.dart
@@ -2578,6 +2578,72 @@ void main() {
       expect(editsRewriteSameTarget(typed, revive), isTrue);
     });
 
+    test('a glossary segment claims the quest CurrentState it rewrites', () {
+      Map<String, Object?> glossary(List<String>? questStatePath) => {
+        'path': 'private.glossary.setSegment',
+        'value': {
+          'documentClass': '/Script/Angelscript.Document_Glossary_Creatures',
+          'segmentClass': '/Script/Angelscript.DocumentSegment_Scavenger',
+          'unlocked': true,
+          'questStatePath': ?questStatePath,
+        },
+      };
+      const questPath = [
+        'm_QuestStates',
+        '{Quest_Creatures}',
+        'SubQuests',
+        '[4]',
+        'CurrentState',
+      ];
+
+      // The core rewrites that CurrentState itself, so the two cannot share a
+      // write — the packer has to split them, in either order.
+      expect(
+        editsRewriteSameTarget(glossary(questPath), typedEdit(questPath)),
+        isTrue,
+      );
+      expect(
+        editsRewriteSameTarget(typedEdit(questPath), glossary(questPath)),
+        isTrue,
+      );
+
+      // An index the core reads as the same number is the same segment to it,
+      // however the editor spelled it.
+      expect(
+        editsRewriteSameTarget(
+          glossary(questPath),
+          typedEdit([
+            'm_QuestStates',
+            '{Quest_Creatures}',
+            'SubQuests',
+            '[04]',
+            'CurrentState',
+          ]),
+        ),
+        isTrue,
+      );
+
+      // Another quest's state, and a segment operation that names no quest at
+      // all, stay packable.
+      expect(
+        editsRewriteSameTarget(
+          glossary(questPath),
+          typedEdit([
+            'm_QuestStates',
+            '{Quest_Creatures}',
+            'SubQuests',
+            '[5]',
+            'CurrentState',
+          ]),
+        ),
+        isFalse,
+      );
+      expect(
+        editsRewriteSameTarget(glossary(null), typedEdit(questPath)),
+        isFalse,
+      );
+    });
+
     test('addressing a whole map collides with every entry in it', () {
       final setEntry = {
         'path': 'private.knowledge.setEntry',

--- a/apps/save-editor/test/editor_notifier_test.dart
+++ b/apps/save-editor/test/editor_notifier_test.dart
@@ -2098,6 +2098,563 @@ void main() {
   );
 
   // ---------------------------------------------------------------------------
+  // The core's SAME-TARGET rule is order-independent: a structured operation
+  // rewrites its target wholesale, so a raw typed edit addressing what it
+  // rewrites is refused in the same write whichever way round the two come.
+  // The packer must SPLIT those pairs into sequential sub-writes (which is how
+  // they ran before batching existed) instead of building a write the core
+  // rejects — a rejection fails the whole Save with nothing committed.
+  // ---------------------------------------------------------------------------
+
+  test(
+    'saveAllPending splits an All-Data MemorizedEvents edit from an NPC revive',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      // A plain value edit inside an NPC's MemorizedEvents (not a structural
+      // array op, so the memory-event guard above does not refuse it)...
+      notifier.setPendingEdit(
+        'typed:lizard-memory-time',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {
+                'path': [
+                  'LongTermMemoryByGlobalId',
+                  '{Lizard-1}',
+                  'MemorizedEvents',
+                  '[2]',
+                  'Time',
+                  'TotalSeconds',
+                ],
+                'value': 12.0,
+              },
+            },
+          ],
+        ),
+      );
+      // ...plus the revive, which strips memory events wholesale.
+      notifier.setPendingEdit(
+        'npc.revive:Lizard-1',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.npc.revive',
+              'value': {'id': 'Lizard-1'},
+            },
+          ],
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isTrue);
+      expect(notifier.state.error, isNull);
+      final writes = core.requests
+          .where((r) => r.command == 'write_save')
+          .toList();
+      // TWO writes: sequential, so the typed edit lands and the revive then
+      // re-reads the file and strips events from what is on disk.
+      expect(writes, hasLength(2));
+      expect(
+        (writes[0].payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.typed.setValue'],
+      );
+      expect(
+        (writes[1].payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.npc.revive'],
+      );
+      // Backup-once still holds, on the first write.
+      expect(writes.where((w) => w.payload['backup'] == true), hasLength(1));
+      expect(writes.first.payload['backup'], isTrue);
+      expect(notifier.state.pendingEdits, isEmpty);
+    },
+  );
+
+  test(
+    'saveAllPending splits a knowledge edit from a typed edit in the SAME entry',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      notifier.setPendingEdit(
+        'knowledge',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.knowledge.setEntry',
+              'value': {
+                'character': 'Diego',
+                'entry': 'Info_Whatslife',
+                'present': true,
+              },
+            },
+          ],
+        ),
+      );
+      // An All-data edit inside the very entry that setEntry rewrites.
+      notifier.setPendingEdit(
+        'typed:diego-knowledge',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {
+                'path': [
+                  'CharacterKnowledgeByUniqueName',
+                  '{Diego}',
+                  'Knowledge',
+                  'm_Size',
+                ],
+                'value': 3,
+              },
+            },
+          ],
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isTrue);
+      final writes = core.requests
+          .where((r) => r.command == 'write_save')
+          .toList();
+      expect(writes, hasLength(2));
+      expect(
+        (writes[0].payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.typed.setValue'],
+      );
+      expect(
+        (writes[1].payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.knowledge.setEntry'],
+      );
+    },
+  );
+
+  test(
+    'saveAllPending keeps a knowledge edit and a DIFFERENT entry in one write',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      notifier.setPendingEdit(
+        'knowledge',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.knowledge.setEntry',
+              'value': {
+                'character': 'Diego',
+                'entry': 'Info_Whatslife',
+                'present': true,
+              },
+            },
+          ],
+        ),
+      );
+      // Another character's entry is a different map value; every applier
+      // re-resolves its target by key, so the two do not collide.
+      notifier.setPendingEdit(
+        'typed:xardas-knowledge',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {
+                'path': [
+                  'CharacterKnowledgeByUniqueName',
+                  '{Xardas}',
+                  'Knowledge',
+                  'm_Size',
+                ],
+                'value': 3,
+              },
+            },
+          ],
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isTrue);
+      final writes = core.requests
+          .where((r) => r.command == 'write_save')
+          .toList();
+      expect(writes, hasLength(1));
+      expect(
+        (writes.single.payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.typed.setValue', 'private.knowledge.setEntry'],
+      );
+    },
+  );
+
+  test(
+    'saveAllPending splits a non-Def ActiveEffects edit from a same-actor skill edit',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      // A leaf of the hero's ActiveEffects that is NOT EffectSpec/Def, so the
+      // same-actor Def refusal does not fire — but the core still rejects the
+      // pair in one write, because a skill edit rewrites that actor's effect
+      // elements wholesale.
+      notifier.setPendingEdit(
+        'typed:effect-level',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {
+                'path': [
+                  'ActiveEffectsByGlobalId',
+                  '{Hero}',
+                  'ActiveEffects',
+                  '[0]',
+                  'EffectSpec',
+                  'Level',
+                ],
+                'value': 3.0,
+              },
+            },
+          ],
+        ),
+      );
+      notifier.setPendingEdit(
+        'skills',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.skills.set',
+              'value': {
+                'actor': 'Hero',
+                'base': 'Melee_OneHanded',
+                'tier': 'Master',
+              },
+            },
+          ],
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      // Not refused — split. The old Def-only check would have let this ride
+      // one write, which the core now rejects outright.
+      expect(ok, isTrue);
+      expect(notifier.state.error, isNull);
+      final writes = core.requests
+          .where((r) => r.command == 'write_save')
+          .toList();
+      expect(writes, hasLength(2));
+      expect(
+        (writes[0].payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.typed.setValue'],
+      );
+      expect(
+        (writes[1].payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.skills.set'],
+      );
+    },
+  );
+
+  test(
+    'saveAllPending splits the slot repair from an m_Id below a slot payload',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      // An m_Id that is not the slot's own leaf: narrower than the repair's
+      // refusal guard, so it is not refused — but the core counts it as a
+      // conflict, so it has to be split.
+      notifier.setPendingEdit(
+        'typed:payload-id',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {
+                'path': [
+                  'm_SavedPlayers',
+                  '[0]',
+                  'm_Inventory',
+                  'm_Slots',
+                  '[3]',
+                  'm_Payload',
+                  'm_Id',
+                ],
+                'value': 4,
+              },
+            },
+          ],
+        ),
+      );
+      notifier.setPendingEdit(
+        'inventory:repair',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.inventory.repairSlots',
+              'value': <String, Object?>{},
+            },
+          ],
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isTrue);
+      expect(notifier.state.error, isNull);
+      final writes = core.requests
+          .where((r) => r.command == 'write_save')
+          .toList();
+      expect(writes, hasLength(2));
+      expect(
+        (writes[0].payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.typed.setValue'],
+      );
+      expect(
+        (writes[1].payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.inventory.repairSlots'],
+      );
+    },
+  );
+
+  test(
+    'saveAllPending keeps the slot repair with a non-id slot edit in one write',
+    () async {
+      final core = _RecordingCoreService();
+      final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
+      await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+
+      // The repair only rewrites ids, so anything else inside a slot survives
+      // it untouched — the new split must not over-fire here.
+      notifier.setPendingEdit(
+        'typed:slot-count',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.typed.setValue',
+              'value': {
+                'path': [
+                  'm_SavedPlayers',
+                  '[0]',
+                  'm_Inventory',
+                  'm_Slots',
+                  '[3]',
+                  'm_SlotData',
+                  'm_ItemCount',
+                ],
+                'value': 7,
+              },
+            },
+          ],
+        ),
+      );
+      notifier.setPendingEdit(
+        'inventory:repair',
+        const PendingSaveEdit(
+          edits: [
+            {
+              'path': 'private.inventory.repairSlots',
+              'value': <String, Object?>{},
+            },
+          ],
+        ),
+      );
+
+      final ok = await notifier.saveAllPending();
+
+      expect(ok, isTrue);
+      final writes = core.requests
+          .where((r) => r.command == 'write_save')
+          .toList();
+      expect(writes, hasLength(1));
+      // The repair still runs last inside that write.
+      expect(
+        (writes.single.payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.typed.setValue', 'private.inventory.repairSlots'],
+      );
+    },
+  );
+
+  group('the same-target predicate the packer splits on', () {
+    Map<String, Object?> typedEdit(List<String> path) => {
+      'path': 'private.typed.setValue',
+      'value': {'path': path, 'value': 1},
+    };
+    Map<String, Object?> addItem(String? actorId) => {
+      'path': 'private.inventory.addItem',
+      'value': {
+        'path': '/Script/Angelscript.ItMi_Orenugget',
+        'count': 1,
+        'actorId': ?actorId,
+      },
+    };
+    const playerSlot = [
+      'm_SavedPlayers',
+      '[0]',
+      'm_Inventory',
+      'm_Slots',
+      '[3]',
+      'm_SlotData',
+      'm_ItemCount',
+    ];
+    List<String> npcSlot(String id) => [
+      'm_GenericData',
+      '{CharacterStates}',
+      'NPCCharacters',
+      'InventoryByGlobalId',
+      '{$id}',
+      'InventoryItems',
+      'm_Values',
+      'Items',
+      '[6]',
+      'm_Slots',
+      '[3]',
+      'm_SlotData',
+      'm_ItemCount',
+    ];
+
+    test('an inventory add only claims ITS actor\'s slots', () {
+      // The core allows an add for one actor beside a raw slot edit for
+      // another, so the packer must not split them. (Today saveAllPending
+      // refuses that combination outright, one refusal earlier — this pins the
+      // packing rule itself, which is what the core enforces.)
+      expect(
+        editsRewriteSameTarget(addItem(null), typedEdit(playerSlot)),
+        isTrue,
+      );
+      expect(
+        editsRewriteSameTarget(addItem(null), typedEdit(npcSlot('Lizard-1'))),
+        isFalse,
+      );
+      expect(
+        editsRewriteSameTarget(
+          addItem('Lizard-1'),
+          typedEdit(npcSlot('Lizard-1')),
+        ),
+        isTrue,
+      );
+      expect(
+        editsRewriteSameTarget(
+          addItem('Lizard-1'),
+          typedEdit(npcSlot('Lizard-2')),
+        ),
+        isFalse,
+      );
+      expect(
+        editsRewriteSameTarget(addItem('Lizard-1'), typedEdit(playerSlot)),
+        isFalse,
+      );
+    });
+
+    test('an actor key matches trimmed and case-insensitively', () {
+      expect(
+        editsRewriteSameTarget(
+          addItem('lizard-1'),
+          typedEdit(npcSlot(' LIZARD-1 ')),
+        ),
+        isTrue,
+      );
+    });
+
+    test('it holds in BOTH directions', () {
+      final revive = {
+        'path': 'private.npc.revive',
+        'value': {'id': 'Lizard-1'},
+      };
+      final typed = typedEdit([
+        'LongTermMemoryByGlobalId',
+        '{Lizard-1}',
+        'MemorizedEvents',
+      ]);
+      expect(editsRewriteSameTarget(revive, typed), isTrue);
+      expect(editsRewriteSameTarget(typed, revive), isTrue);
+    });
+
+    test('addressing a whole map collides with every entry in it', () {
+      final setEntry = {
+        'path': 'private.knowledge.setEntry',
+        'value': {'character': 'Diego', 'entry': 'Info_X', 'present': true},
+      };
+      expect(
+        structuredEditRewrites(setEntry, const [
+          'CharacterKnowledgeByUniqueName',
+        ]),
+        isTrue,
+      );
+      expect(
+        structuredEditRewrites(setEntry, const [
+          'CharacterKnowledgeByUniqueName',
+          '{Diego}',
+        ]),
+        isTrue,
+      );
+      expect(
+        structuredEditRewrites(setEntry, const [
+          'CharacterKnowledgeByUniqueName',
+          '{Xardas}',
+        ]),
+        isFalse,
+      );
+    });
+
+    test('a skill edit with no actor defends the hero\'s effects', () {
+      final skills = {
+        'path': 'private.skills.set',
+        'value': {'base': 'Melee_OneHanded', 'tier': 'Master'},
+      };
+      expect(
+        structuredEditRewrites(skills, const [
+          'ActiveEffectsByGlobalId',
+          '{Hero}',
+          'ActiveEffects',
+          '[0]',
+          'EffectSpec',
+          'Level',
+        ]),
+        isTrue,
+      );
+      expect(
+        structuredEditRewrites(skills, const [
+          'ActiveEffectsByGlobalId',
+          '{Lizard-1}',
+          'ActiveEffects',
+          '[0]',
+          'EffectSpec',
+          'Level',
+        ]),
+        isFalse,
+      );
+    });
+
+    test('two raw typed edits never count as a same-target pair', () {
+      // Only a STRUCTURED operation rewrites a target wholesale; two typed
+      // edits are ordered by the ordinal rule instead.
+      expect(
+        editsRewriteSameTarget(
+          typedEdit(playerSlot),
+          typedEdit(const [
+            'm_SavedPlayers',
+            '[0]',
+            'm_Inventory',
+            'm_Slots',
+            '[3]',
+            'm_Id',
+          ]),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Bug #1: a fresh inspection must reset the selected actor to the player so a
   // stale NPC GlobalId from the previous save can't drive the actor-aware tabs.
   // ---------------------------------------------------------------------------

--- a/apps/save-editor/test/editor_notifier_test.dart
+++ b/apps/save-editor/test/editor_notifier_test.dart
@@ -2853,6 +2853,23 @@ void main() {
         isFalse,
       );
 
+      // The core folds ASCII case only, so two names that differ outside ASCII
+      // stay two targets here as well.
+      expect(
+        structuredEditsShareATarget(
+          skill('HÄro', 'Ranged_Bow', 'Trained'),
+          skill('häro', 'Ranged_Bow', 'Untrained'),
+        ),
+        isFalse,
+      );
+      expect(
+        structuredEditsShareATarget(
+          skill('Häro', 'Ranged_Bow', 'Trained'),
+          skill('häro', 'Ranged_Bow', 'Untrained'),
+        ),
+        isTrue,
+      );
+
       // A glossary segment is keyed by the two asset names, as the core keys it.
       Map<String, Object?> segment(String document, String seg) => {
         'path': 'private.glossary.setSegment',

--- a/apps/save-editor/test/editor_notifier_test.dart
+++ b/apps/save-editor/test/editor_notifier_test.dart
@@ -2809,6 +2809,33 @@ void main() {
         isTrue,
       );
 
+      // The core reads an ABSENT or empty actor as the hero, and it decides that
+      // before folding, so a blank of spaces stays an actor of its own.
+      expect(
+        structuredEditsShareATarget(
+          skill('Hero', 'Ranged_Bow', 'Trained'),
+          {
+            'path': 'private.skills.set',
+            'value': {'base': 'Ranged_Bow', 'tier': 'Untrained'},
+          },
+        ),
+        isTrue,
+      );
+      expect(
+        structuredEditsShareATarget(
+          skill('Hero', 'Ranged_Bow', 'Trained'),
+          skill('', 'Ranged_Bow', 'Untrained'),
+        ),
+        isTrue,
+      );
+      expect(
+        structuredEditsShareATarget(
+          skill('Hero', 'Ranged_Bow', 'Trained'),
+          skill(' ', 'Ranged_Bow', 'Untrained'),
+        ),
+        isFalse,
+      );
+
       // Two skills of one character, and one skill of two characters, are two
       // targets — batching those is the point.
       expect(

--- a/apps/save-editor/test/editor_notifier_test.dart
+++ b/apps/save-editor/test/editor_notifier_test.dart
@@ -935,7 +935,10 @@ void main() {
     final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
     await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
     await pumpEventQueue();
-    // Two splicing edits → two sequential writes; the first commits.
+    // Batching packs peers into one write, so the two sub-writes this test needs
+    // come from an ordinary edit plus a `private.story.apply`, which is
+    // permanently exclusive. The revive commits (with the undo-note warning),
+    // the trailing story write fails.
     notifier.setPendingEdit(
       'npc.revive:A',
       const PendingSaveEdit(
@@ -947,21 +950,25 @@ void main() {
         ],
       ),
     );
-    notifier.setPendingEdit(
-      'npc.revive:B',
-      const PendingSaveEdit(
-        edits: [
-          {
-            'path': 'private.npc.revive',
-            'value': {'id': 'B'},
-          },
-        ],
+    notifier.setStoryStateEdit(
+      const StoryStateEdit(
+        id: 'Chapter',
+        present: true,
+        rawValue: 3,
+        expectedStored: true,
+        expectedRawValue: 2,
       ),
     );
 
     final ok = await notifier.saveAllPending();
 
     expect(ok, isFalse);
+    // Two sub-writes really were issued — otherwise the fake never reaches its
+    // failure branch and the assertion below would prove nothing.
+    expect(
+      core.requests.where((request) => request.command == 'write_save'),
+      hasLength(2),
+    );
     expect(notifier.state.error, contains('npc_placements.json'));
   });
 
@@ -988,8 +995,9 @@ void main() {
       final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
       await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
 
-      // Two splicing edits → two sequential writes. Keys sort so 'npc.revive:A'
-      // (first write, commits) precedes 'npc.revive:B' (second write, fails).
+      // An ordinary splicing edit plus a `private.story.apply`: story is
+      // permanently exclusive, so the batch is packed into exactly two
+      // sub-writes. The revive commits (first write), the story write fails.
       notifier.setPendingEdit(
         'npc.revive:A',
         const PendingSaveEdit(
@@ -1001,15 +1009,13 @@ void main() {
           ],
         ),
       );
-      notifier.setPendingEdit(
-        'npc.revive:B',
-        const PendingSaveEdit(
-          edits: [
-            {
-              'path': 'private.npc.revive',
-              'value': {'id': 'B'},
-            },
-          ],
+      notifier.setStoryStateEdit(
+        const StoryStateEdit(
+          id: 'Chapter',
+          present: true,
+          rawValue: 3,
+          expectedStored: true,
+          expectedRawValue: 2,
         ),
       );
 
@@ -1018,9 +1024,16 @@ void main() {
 
       expect(ok, isFalse);
       expect(notifier.state.error, isNotNull);
+      expect(
+        core.requests.where((request) => request.command == 'write_save'),
+        hasLength(2),
+      );
       // First write committed → its key is cleared; the failed second's key stays.
       expect(notifier.state.pendingEdits.containsKey('npc.revive:A'), isFalse);
-      expect(notifier.state.pendingEdits.containsKey('npc.revive:B'), isTrue);
+      expect(
+        notifier.state.pendingEdits.containsKey(storyStatePendingKey),
+        isTrue,
+      );
       // The committed edit changed the file, so the panes must be refreshed from
       // disk even though a later sub-write failed. refresh() begins with a
       // scan_save_dir, so exactly one ADDITIONAL scan proves the partial-commit
@@ -1049,6 +1062,8 @@ void main() {
       );
       final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
       await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
+      // Ordinary edit + exclusive `private.story.apply` = two sub-writes, so the
+      // fake's throw lands on a genuine SECOND write after the first committed.
       notifier.setPendingEdit(
         'npc.revive:A',
         const PendingSaveEdit(
@@ -1060,15 +1075,13 @@ void main() {
           ],
         ),
       );
-      notifier.setPendingEdit(
-        'npc.revive:B',
-        const PendingSaveEdit(
-          edits: [
-            {
-              'path': 'private.npc.revive',
-              'value': {'id': 'B'},
-            },
-          ],
+      notifier.setStoryStateEdit(
+        const StoryStateEdit(
+          id: 'Chapter',
+          present: true,
+          rawValue: 3,
+          expectedStored: true,
+          expectedRawValue: 2,
         ),
       );
 
@@ -1077,8 +1090,15 @@ void main() {
 
       expect(ok, isFalse);
       expect(notifier.state.error, contains('native worker died'));
+      expect(
+        core.requests.where((request) => request.command == 'write_save'),
+        hasLength(2),
+      );
       expect(notifier.state.pendingEdits.containsKey('npc.revive:A'), isFalse);
-      expect(notifier.state.pendingEdits.containsKey('npc.revive:B'), isTrue);
+      expect(
+        notifier.state.pendingEdits.containsKey(storyStatePendingKey),
+        isTrue,
+      );
       expect(core.refreshScans, scansBefore + 1);
       expect(notifier.state.saveProgress, isNull);
     },
@@ -1087,10 +1107,11 @@ void main() {
   test(
     'partial commit keeps the uncommitted add when several share one key',
     () async {
-      // Regression: several inventory adds queue under ONE pending key but each
-      // is its own sequential write_save. Commit tracking is per-EDIT, so when a
-      // later add fails the earlier committed add must not drag the still-unwritten
-      // add out of pending — the user must keep the failed one for retry.
+      // Regression: one pending key can still span several sequential
+      // write_saves — batching packs peers together, but an exclusive edit
+      // always starts a new sub-write. Commit tracking is per-EDIT, so when the
+      // later sub-write fails the earlier committed edit must not drag the
+      // still-unwritten one out of pending — the user must keep it for retry.
       final core = _FailSecondWriteCoreService(
         scanData: {
           'saves': [
@@ -1109,20 +1130,25 @@ void main() {
       final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
       await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
 
-      // Two adds under ONE key → two sequential splicing writes: the first
-      // commits, the second fails.
+      // An add and an exclusive `private.story.apply` under ONE key → two
+      // sequential writes: the add commits, the story write fails.
       notifier.setPendingEdit(
         'inventory:player',
-        const PendingSaveEdit(
+        PendingSaveEdit(
           edits: [
-            {
+            const <String, Object?>{
               'path': 'private.inventory.addItem',
               'value': {'path': '/Game/Item_A', 'count': 1},
             },
-            {
-              'path': 'private.inventory.addItem',
-              'value': {'path': '/Game/Item_B', 'count': 1},
-            },
+            storyStateApplyEdit(const [
+              StoryStateEdit(
+                id: 'Chapter',
+                present: true,
+                rawValue: 3,
+                expectedStored: true,
+                expectedRawValue: 2,
+              ),
+            ]),
           ],
         ),
       );
@@ -1131,15 +1157,25 @@ void main() {
 
       expect(ok, isFalse);
       expect(notifier.state.error, isNotNull);
-      // The key survives, carrying ONLY the second (uncommitted) add — the first
-      // committed and is gone; the second never wrote and stays for retry.
+      // The two edits of that one key really did split across two sub-writes.
+      final writes = core.requests
+          .where((request) => request.command == 'write_save')
+          .toList();
+      expect(writes, hasLength(2));
+      expect(
+        (writes.first.payload['edits'] as List).single,
+        containsPair('path', 'private.inventory.addItem'),
+      );
+      expect(
+        (writes.last.payload['edits'] as List).single,
+        containsPair('path', storyStateApplyPath),
+      );
+      // The key survives, carrying ONLY the uncommitted story edit — the add
+      // committed and is gone; the story edit never wrote and stays for retry.
       final pending = notifier.state.pendingEdits['inventory:player'];
       expect(pending, isNotNull);
       expect(pending!.edits, hasLength(1));
-      expect(pending.edits.single['value'], {
-        'path': '/Game/Item_B',
-        'count': 1,
-      });
+      expect(pending.edits.single['path'], storyStateApplyPath);
     },
   );
 
@@ -1192,6 +1228,8 @@ void main() {
       final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
       await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
 
+      // Ordinary edit + exclusive `private.story.apply` = two sub-writes; the
+      // first commits, the second fails.
       notifier.setPendingEdit(
         'npc.revive:A',
         const PendingSaveEdit(
@@ -1203,25 +1241,30 @@ void main() {
           ],
         ),
       );
-      notifier.setPendingEdit(
-        'npc.revive:B',
-        const PendingSaveEdit(
-          edits: [
-            {
-              'path': 'private.npc.revive',
-              'value': {'id': 'B'},
-            },
-          ],
+      notifier.setStoryStateEdit(
+        const StoryStateEdit(
+          id: 'Chapter',
+          present: true,
+          rawValue: 3,
+          expectedStored: true,
+          expectedRawValue: 2,
         ),
       );
 
       final ok = await notifier.saveAllPending();
 
       expect(ok, isFalse);
+      expect(
+        core.requests.where((request) => request.command == 'write_save'),
+        hasLength(2),
+      );
       // Slot switched to the only remaining save…
       expect(notifier.state.selectedPath, r'C:\tmp\saves\G1R-002.sav');
       // …so the uncommitted edit was dropped, NOT re-targeted at G1R-002.
-      expect(notifier.state.pendingEdits.containsKey('npc.revive:B'), isFalse);
+      expect(
+        notifier.state.pendingEdits.containsKey(storyStatePendingKey),
+        isFalse,
+      );
       expect(notifier.state.pendingEdits.containsKey('npc.revive:A'), isFalse);
     },
   );
@@ -1541,11 +1584,18 @@ void main() {
     final writes = core.requests
         .where((request) => request.command == 'write_save')
         .toList();
-    expect(writes, hasLength(2));
+    // Both intents are saved together. The requirement is the ORDER: the
+    // index-addressed All-data edit resolves against the pre-splice layout,
+    // so it must precede the structural relationship edit for the other NPC.
+    expect(writes, hasLength(1));
+    expect(
+      (writes.single.payload['edits'] as List).map((e) => (e as Map)['path']),
+      ['private.typed.setValue', 'private.npc.setRelationship'],
+    );
   });
 
   test(
-    'saveAllPending splits a splicing edit and a typed edit into separate writes',
+    'saveAllPending orders a typed edit ahead of a splicing edit in one write',
     () async {
       final core = _RecordingCoreService();
       final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
@@ -1580,39 +1630,26 @@ void main() {
       final ok = await notifier.saveAllPending();
 
       expect(ok, isTrue);
-      // No "must be saved on its own" guard fires anymore — the split replaces it.
+      // No "must be saved on its own" guard fires anymore — the ordering
+      // inside one write_save replaces it.
       expect(notifier.state.error, isNull);
       final writes = core.requests
           .where((r) => r.command == 'write_save')
           .toList();
-      // Two writes: the splicing removeItem on its own + the typed setValue batch.
-      expect(writes, hasLength(2));
-      // Each splicing edit is its own single-edit write.
-      final splicing = writes.firstWhere(
-        (w) => (w.payload['edits'] as List).any(
-          (e) => (e as Map)['path'] == 'private.inventory.removeItem',
-        ),
-      );
-      expect(splicing.payload['edits'], hasLength(1));
-      // The typed edit lands in its own (fixed) batch with no splicing peer.
-      final fixed = writes.firstWhere(
-        (w) => (w.payload['edits'] as List).any(
-          (e) => (e as Map)['path'] == 'private.typed.setValue',
-        ),
-      );
+      // One write; the fixed typed edit LEADS so it resolves against the layout
+      // the user saw, and the splicing removeItem follows it.
+      expect(writes, hasLength(1));
       expect(
-        (fixed.payload['edits'] as List).every(
-          (e) => (e as Map)['path'] == 'private.typed.setValue',
-        ),
-        isTrue,
+        (writes.single.payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.typed.setValue', 'private.inventory.removeItem'],
       );
       // All pending cleared after success.
       expect(notifier.state.pendingEdits, isEmpty);
     },
   );
 
-  test('saveAllPending splits a mixed batch: revive alone, addItem alone, '
-      'setValue batched — with backup only on the first write', () async {
+  test('saveAllPending orders a mixed batch fixed-first, splices after — '
+      'with the backup on the one write', () async {
     final core = _RecordingCoreService();
     final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
     await notifier.inspect(r'C:\tmp\saves\G1R-001.sav');
@@ -1658,38 +1695,29 @@ void main() {
     final writes = core.requests
         .where((r) => r.command == 'write_save')
         .toList();
-    // revive alone + addItem alone + the fixed setValue batch = three writes.
-    expect(writes, hasLength(3));
-
-    bool writeHas(_RecordedRequest w, String path) =>
-        (w.payload['edits'] as List).any((e) => (e as Map)['path'] == path);
-
-    final reviveWrite = writes.firstWhere(
-      (w) => writeHas(w, 'private.npc.revive'),
+    // All three ride ONE write, in the order that keeps every intent intact:
+    // the fixed setAttribute first (so a splice cannot retarget it), then the
+    // splicing addItem and revive.
+    expect(writes, hasLength(1));
+    expect(
+      (writes.single.payload['edits'] as List).map((e) => (e as Map)['path']),
+      [
+        'private.player.setAttribute',
+        'private.inventory.addItem',
+        'private.npc.revive',
+      ],
     );
-    expect(reviveWrite.payload['edits'], hasLength(1));
-    final addItemWrite = writes.firstWhere(
-      (w) => writeHas(w, 'private.inventory.addItem'),
-    );
-    expect(addItemWrite.payload['edits'], hasLength(1));
-    final fixedWrite = writes.firstWhere(
-      (w) => writeHas(w, 'private.player.setAttribute'),
-    );
-    expect(fixedWrite.payload['edits'], hasLength(1));
 
-    // Backup-once: exactly one write carries backup:true (the first), the
-    // rest backup:false — one pristine snapshot per Save.
+    // Backup-once: exactly one write carries backup:true — one pristine
+    // snapshot per Save.
     final backupTrue = writes.where((w) => w.payload['backup'] == true);
     expect(backupTrue, hasLength(1));
     expect(writes.first.payload['backup'], isTrue);
-    for (final w in writes.skip(1)) {
-      expect(w.payload['backup'], isFalse);
-    }
     expect(notifier.state.pendingEdits, isEmpty);
   });
 
   test(
-    'saveAllPending issues two writes for two distinct splicing edits',
+    'saveAllPending batches two distinct splicing edits into one ordered write',
     () async {
       final core = _RecordingCoreService();
       final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
@@ -1724,14 +1752,15 @@ void main() {
       final writes = core.requests
           .where((r) => r.command == 'write_save')
           .toList();
-      // Two separate single-edit writes — never batched together.
-      expect(writes, hasLength(2));
-      for (final w in writes) {
-        expect(w.payload['edits'], hasLength(1));
-      }
-      // Backup on the first write only.
-      expect(writes.first.payload['backup'], isTrue);
-      expect(writes.last.payload['backup'], isFalse);
+      // Neither splice is addressed by an index the other could shift, so both
+      // ride one write — in their stable pending-key order.
+      expect(writes, hasLength(1));
+      expect(
+        (writes.single.payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.knowledge.addCharacter', 'private.npc.revive'],
+      );
+      // Backup-once: the single write takes it.
+      expect(writes.single.payload['backup'], isTrue);
     },
   );
 
@@ -1797,11 +1826,12 @@ void main() {
       final writes = core.requests
           .where((request) => request.command == 'write_save')
           .toList();
-      expect(writes, hasLength(4));
-      final edits = [
-        for (final write in writes)
-          (write.payload['edits'] as List).single as Map,
-      ];
+      // The four splices ride ONE write, so the order INSIDE its payload is now
+      // the only thing keeping the glossary add ahead of the removal (an add
+      // needs a surviving SegmentUnlocked event as its byte template) and the
+      // other splices in their original relative position.
+      expect(writes, hasLength(1));
+      final edits = (writes.single.payload['edits'] as List).cast<Map>();
       expect(edits.map((edit) => edit['path']), [
         'private.glossary.setSegment',
         'private.inventory.addItem',
@@ -1814,7 +1844,7 @@ void main() {
   );
 
   test(
-    'saveAllPending puts syncPersistentDataList on the fixed-batch write only',
+    'saveAllPending sets syncPersistentDataList exactly once, on the backup write',
     () async {
       final core = _RecordingCoreService();
       final notifier = EditorNotifier(core, saveDir: r'C:\tmp\saves');
@@ -1846,21 +1876,18 @@ void main() {
       final writes = core.requests
           .where((r) => r.command == 'write_save')
           .toList();
-      expect(writes, hasLength(2));
-      // The fixed batch (public name) carries the sync flag; the splicing
-      // revive write must not.
-      final fixed = writes.firstWhere(
-        (w) => (w.payload['edits'] as List).any(
-          (e) => (e as Map)['path'] == 'public.m_PlayerSaveName',
-        ),
+      // Both edits ride one write; the flag is set exactly ONCE and lands on
+      // the write that also takes the backup, so the PersistentDataList.sav
+      // companion is only ever updated beside a restorable snapshot.
+      final synced = writes.where(
+        (w) => w.payload['syncPersistentDataList'] == true,
       );
-      expect(fixed.payload['syncPersistentDataList'], isTrue);
-      final splicing = writes.firstWhere(
-        (w) => (w.payload['edits'] as List).any(
-          (e) => (e as Map)['path'] == 'private.npc.revive',
-        ),
+      expect(synced, hasLength(1));
+      expect(synced.single.payload['backup'], isTrue);
+      expect(
+        (synced.single.payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['public.m_PlayerSaveName', 'private.npc.revive'],
       );
-      expect(splicing.payload.containsKey('syncPersistentDataList'), isFalse);
     },
   );
 
@@ -1966,11 +1993,18 @@ void main() {
 
       final ok = await notifier.saveAllPending();
       expect(ok, isTrue);
-      // Both saved: the NPC Def edit in the fixed batch, the hero skill trailing.
+      // Both saved. The packing rule only splits an ordinal-addressed edit that
+      // comes AFTER an ordinal-invalidating one; here the Def edit's `[0]`
+      // carries the ordinal and the skill edit (the invalidating producer) is
+      // ordered behind it, so nothing splits — they share ONE write, Def first.
       final writes = core.requests
           .where((r) => r.command == 'write_save')
           .toList();
-      expect(writes, hasLength(2));
+      expect(writes, hasLength(1));
+      expect(
+        (writes.single.payload['edits'] as List).map((e) => (e as Map)['path']),
+        ['private.typed.setValue', 'private.skills.set'],
+      );
     },
   );
 
@@ -2150,18 +2184,19 @@ void main() {
       final writes = core.requests
           .where((r) => r.command == 'write_save')
           .toList();
-      expect(writes, hasLength(2));
-      bool writeHas(_RecordedRequest w, String path) =>
-          (w.payload['edits'] as List).any((e) => (e as Map)['path'] == path);
-      final fixedIndex = writes.indexWhere(
-        (w) => writeHas(w, 'private.typed.setValue'),
+      // Both edits ride one write; the core applies a batch sequentially, so
+      // position in the payload is what orders them now.
+      expect(writes, hasLength(1));
+      final paths = (writes.single.payload['edits'] as List)
+          .map((e) => (e as Map)['path'])
+          .toList();
+      // The fixed Health edit is applied BEFORE the revive, so revive's HP
+      // (the last write to the NPC's HP) is final on disk.
+      expect(
+        paths.indexOf('private.typed.setValue'),
+        lessThan(paths.indexOf('private.npc.revive')),
       );
-      final reviveIndex = writes.indexWhere(
-        (w) => writeHas(w, 'private.npc.revive'),
-      );
-      // The fixed Health batch is issued BEFORE the revive write, so revive's
-      // HP (the last write to the NPC's HP) is final on disk.
-      expect(fixedIndex, lessThan(reviveIndex));
+      expect(paths, ['private.typed.setValue', 'private.npc.revive']);
     },
   );
 
@@ -2206,7 +2241,11 @@ void main() {
       final writes = core.requests
           .where((r) => r.command == 'write_save')
           .toList();
-      expect(writes, hasLength(2));
+      // The flag is set exactly once, on the write that also takes the backup.
+      expect(
+        writes.where((w) => w.payload['syncPersistentDataList'] == true),
+        hasLength(1),
+      );
       final synced = writes.singleWhere(
         (w) => w.payload['syncPersistentDataList'] == true,
       );

--- a/apps/save-editor/test/inventory_slot_repair_test.dart
+++ b/apps/save-editor/test/inventory_slot_repair_test.dart
@@ -127,11 +127,14 @@ void main() {
     expect(find.widgetWithText(FilledButton, 'Repair'), findsOneWidget);
   });
 
-  testWidgets('the repair is written last, after id-addressed edits', (
+  testWidgets('the repair is applied last, after id-addressed edits', (
     tester,
   ) async {
     // The repair rewrites every misaligned m_Id, so an NPC removal pinned to the
-    // id the UI showed has to reach the core FIRST or it would no longer match.
+    // id the UI showed has to be applied FIRST or it would no longer match.
+    // The two now batch into one write_save, which the core applies
+    // sequentially — so position inside that payload is what carries the
+    // requirement, and the repair must be the LAST edit in it.
     final core = _InventoryCoreService(misalignedSlots: 3, npcRemovable: true);
     await pumpApp(tester, core);
     await openPlayerInventory(tester);
@@ -155,9 +158,13 @@ void main() {
           .map((e) => e['path'])
           .toList();
     }).toList();
-    expect(writes.length, greaterThanOrEqualTo(2));
-    expect(writes.first, contains('private.inventory.removeItem'));
-    expect(writes.last, ['private.inventory.repairSlots']);
+    // Every edit of this Save, flattened in the exact order the core applies
+    // them across the (now single) write.
+    final applied = [for (final write in writes) ...write];
+    expect(applied, [
+      'private.inventory.removeItem',
+      'private.inventory.repairSlots',
+    ]);
   });
 
   testWidgets('without write capability the warning stays, the action goes', (

--- a/apps/save-editor/test/npc_relationship_action_test.dart
+++ b/apps/save-editor/test/npc_relationship_action_test.dart
@@ -46,7 +46,9 @@ void main() {
 
     notifier.setPendingNpcRelationship('Asghan-1', NpcRelationship.friend);
 
-    final pending = notifier.state.pendingEdits['npc.relationship:Asghan-1'];
+    // The registry key folds the id the way the core folds it, so two
+    // spellings of one NPC cannot sit here side by side.
+    final pending = notifier.state.pendingEdits['npc.relationship:asghan-1'];
     expect(pending, isNotNull);
     expect(pending!.edits.single, {
       'path': 'private.npc.setRelationship',

--- a/build.py
+++ b/build.py
@@ -548,6 +548,51 @@ def resolve_git_sha() -> str:
     return probe.stdout.strip() or "dev" if probe.returncode == 0 else "dev"
 
 
+def _git(args: list[str]) -> str | None:
+    """Run a git command in the repository root; None if git or the repo is absent."""
+    try:
+        probe = subprocess.run(
+            ["git", *args], cwd=ROOT, capture_output=True, text=True, check=False
+        )
+    except OSError:
+        return None
+    return probe.stdout if probe.returncode == 0 else None
+
+
+def discard_line_ending_only_churn(project: str) -> None:
+    """Restore tracked files a build rewrote with different line endings only.
+
+    `flutter build` regenerates the tracked l10n sources, and on Windows writes them
+    with CRLF where the repository stores LF. `git diff` reports nothing, because
+    `.gitattributes` marks them `text eol=lf` and Git normalises the difference
+    away — but `git status` still calls them modified and never stops, so a build
+    left behind a worktree that looked dirty and aborted any tooling that insists on
+    a clean branch.
+
+    A file is restored only when Git's own filtered hash of the working copy already
+    equals what the index holds, which means the two differ in nothing but line
+    endings. A genuinely regenerated file — a real translation change — hashes
+    differently and is left exactly where it is, for the developer to review and
+    commit.
+    """
+    project_dir = pdir(project).relative_to(ROOT).as_posix()
+    status = _git(["status", "--porcelain=v1", "-z", "--", project_dir])
+    if not status:
+        return
+    for entry in status.split("\0"):
+        # Worktree-modified, unstaged: "_M<path>". Anything staged or untracked is
+        # the developer's business, not ours.
+        if not entry.startswith(" M "):
+            continue
+        path = entry[3:]
+        indexed = _git(["rev-parse", f":{path}"])
+        working = _git(["hash-object", "--path", path, "--", path])
+        if indexed is None or working is None:
+            continue
+        if indexed.strip() == working.strip():
+            _git(["checkout", "--", path])
+
+
 # --------------------------------------------------------------------------- #
 # Build recipes                                                               #
 # --------------------------------------------------------------------------- #
@@ -638,6 +683,10 @@ def build_project(project: str, release: bool, dry: bool) -> None:
 
     if dry:
         return
+    # The build rewrote the generated l10n sources; put back the ones that differ in
+    # line endings alone, so a build does not leave a worktree that reads as dirty
+    # (see discard_line_ending_only_churn).
+    discard_line_ending_only_churn(project)
     rel = flutter_build_dir(project, release)
     if not rel.exists():
         raise SystemExit(f"missing flutter output: {rel}")

--- a/build.py
+++ b/build.py
@@ -569,11 +569,14 @@ def discard_line_ending_only_churn(project: str) -> None:
     left behind a worktree that looked dirty and aborted any tooling that insists on
     a clean branch.
 
-    A file is restored only when Git's own filtered hash of the working copy already
-    equals what the index holds, which means the two differ in nothing but line
-    endings. A genuinely regenerated file — a real translation change — hashes
-    differently and is left exactly where it is, for the developer to review and
-    commit.
+    A file is restored only when `git diff` reports nothing for it — the same
+    question, asked the way Git itself answers it. Normalisation applies, so a
+    line-ending-only difference shows as no diff, while anything Git would carry
+    into a commit shows up. That covers a changed file mode as well: an executable
+    bit is not part of a blob's contents, so comparing blob hashes would have missed
+    a `chmod +x` and thrown it away. A genuinely regenerated file — a real
+    translation change — is left exactly where it is, for the developer to review
+    and commit.
     """
     project_dir = pdir(project).relative_to(ROOT).as_posix()
     status = _git(["status", "--porcelain=v1", "-z", "--", project_dir])
@@ -585,12 +588,10 @@ def discard_line_ending_only_churn(project: str) -> None:
         if not entry.startswith(" M "):
             continue
         path = entry[3:]
-        indexed = _git(["rev-parse", f":{path}"])
-        working = _git(["hash-object", "--path", path, "--", path])
-        if indexed is None or working is None:
-            continue
-        if indexed.strip() == working.strip():
-            _git(["checkout", "--", path])
+        real_diff = _git(["diff", "--raw", "--", path])
+        if real_diff is None or real_diff.strip():
+            continue  # a difference Git would keep: contents, or the file mode
+        _git(["checkout", "--", path])
 
 
 # --------------------------------------------------------------------------- #

--- a/crates/gore-save/examples/json_timer.rs
+++ b/crates/gore-save/examples/json_timer.rs
@@ -12,7 +12,11 @@ fn main() {
     for i in 0..repeats {
         let start = std::time::Instant::now();
         last = gore_save::execute_json(&input);
-        eprintln!("run {i}: {:?}", start.elapsed());
+        eprintln!(
+            "run {i}: {:?}  parses={}",
+            start.elapsed(),
+            gore_save::properties::PARSE_COUNT.with(|c| { let n = c.get(); c.set(0); n })
+        );
     }
     println!("{last}");
 }

--- a/crates/gore-save/examples/json_timer.rs
+++ b/crates/gore-save/examples/json_timer.rs
@@ -1,0 +1,18 @@
+//! Scratch research driver: run one `execute_json` request from a file and print
+//! how long it took. Used to measure save-editor write latency. Not shipped.
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: json_timer <request.json>");
+    let input = std::fs::read_to_string(&path).expect("read request");
+    let repeats: usize = std::env::args()
+        .nth(2)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let mut last = String::new();
+    for i in 0..repeats {
+        let start = std::time::Instant::now();
+        last = gore_save::execute_json(&input);
+        eprintln!("run {i}: {:?}", start.elapsed());
+    }
+    println!("{last}");
+}

--- a/crates/gore-save/examples/parse_timer.rs
+++ b/crates/gore-save/examples/parse_timer.rs
@@ -39,33 +39,104 @@ fn main() {
     }
     println!("payload: {} bytes", payload.len());
 
+    println!(
+        "size_of: Property {} B, PropertyValue {} B, Descriptor {} B",
+        std::mem::size_of::<gore_save::properties::Property>(),
+        std::mem::size_of::<gore_save::properties::PropertyValue>(),
+        std::mem::size_of::<gore_save::properties::Descriptor>(),
+    );
+
+    let mut tally = Tally::default();
     for run in 0..3 {
         let start = Instant::now();
         let root = gore_save::properties::parse_private_root(&payload).expect("parse");
         let elapsed = start.elapsed();
-        let count = count_properties(&root.properties);
+        if run == 0 {
+            count_properties(&root.properties, &mut tally);
+        }
         println!(
-            "run {run}: {elapsed:?}  ({:.0} MB/s, {count} properties, {:.0} ns/property)",
+            "run {run}: {elapsed:?}  ({:.0} MB/s, {:.0} ns/property)",
             payload.len() as f64 / 1e6 / elapsed.as_secs_f64(),
-            elapsed.as_nanos() as f64 / count as f64
+            elapsed.as_nanos() as f64 / tally.properties.max(1) as f64
         );
+    }
+    let bytes = tally.properties * std::mem::size_of::<gore_save::properties::Property>();
+    println!(
+        "{} properties, {} strings, {} vectors, {} opaque bytes",
+        tally.properties, tally.strings, tally.vectors, tally.opaque_bytes
+    );
+    println!(
+        "~{:.0} MB of Property nodes, ~{} heap allocations",
+        bytes as f64 / 1e6,
+        tally.strings + tally.vectors
+    );
+}
+
+#[derive(Default, Debug)]
+struct Tally {
+    properties: usize,
+    strings: usize,
+    vectors: usize,
+    opaque_bytes: usize,
+}
+
+fn count_properties(properties: &[gore_save::properties::Property], tally: &mut Tally) {
+    use gore_save::properties::Descriptor;
+    tally.properties += properties.len();
+    tally.vectors += 1;
+    for property in properties {
+        // name + type_name
+        tally.strings += 2;
+        let Descriptor {
+            struct_type,
+            enum_type,
+            inner,
+            map,
+        } = &property.descriptor;
+        tally.strings += struct_type.iter().count() * 2 + enum_type.iter().count() * 3;
+        tally.strings += inner.iter().count() + map.iter().count() * 2;
+        count_value(&property.value, tally);
     }
 }
 
-fn count_properties(properties: &[gore_save::properties::Property]) -> usize {
-    use gore_save::properties::PropertyValue as V;
-    let mut total = properties.len();
-    for property in properties {
-        total += match &property.value {
-            V::Struct(gore_save::properties::StructValue::Properties(inner)) => {
-                count_properties(inner)
+fn count_value(value: &gore_save::properties::PropertyValue, tally: &mut Tally) {
+    use gore_save::properties::{PropertyValue as V, StructValue as S};
+    match value {
+        V::Str(_) | V::Name(_) | V::Object(_) | V::Enum(_) => tally.strings += 1,
+        V::SoftObject(_) => tally.strings += 3,
+        V::Opaque(bytes) => {
+            tally.vectors += 1;
+            tally.opaque_bytes += bytes.len();
+        }
+        V::Array { elements } | V::Set { elements, .. } => {
+            tally.vectors += 1;
+            for element in elements {
+                count_value(element, tally);
             }
-            V::ObjectInstances(instances) => instances
-                .iter()
-                .map(|instance| count_properties(&instance.properties))
-                .sum(),
-            _ => 0,
-        };
+        }
+        V::Map { entries, .. } => {
+            tally.vectors += 1;
+            for (key, entry) in entries {
+                count_value(key, tally);
+                count_value(entry, tally);
+            }
+        }
+        V::ObjectInstances(instances) => {
+            tally.vectors += 1;
+            for instance in instances {
+                tally.strings += 1;
+                count_properties(&instance.properties, tally);
+            }
+        }
+        V::Struct(S::Properties(inner)) => count_properties(inner, tally),
+        V::Struct(S::GameplayTagContainer(tags)) => {
+            tally.vectors += 1;
+            tally.strings += tags.len();
+        }
+        V::Struct(S::Instanced(Some(instanced))) => {
+            tally.strings += 1;
+            count_properties(&instanced.properties, tally);
+        }
+        _ => {}
     }
-    total
 }

--- a/crates/gore-save/examples/parse_timer.rs
+++ b/crates/gore-save/examples/parse_timer.rs
@@ -1,0 +1,71 @@
+//! Scratch research driver: time a typed parse of a real save's private payload.
+//! Read-only; writes nothing. Not shipped.
+
+use std::time::Instant;
+
+const PACKAGE_FILE_TAG: u32 = 0x9E2A83C1;
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: parse_timer <save.sav>");
+    let data = std::fs::read(&path).expect("read save");
+
+    let tag = PACKAGE_FILE_TAG.to_le_bytes();
+    let tag_at = (0..data.len() - 4)
+        .find(|&i| data[i..i + 4] == tag)
+        .expect("PACKAGE_FILE_TAG not found");
+    let mut p = tag_at + 8; // skip tag + header version
+    let max_chunk = u64::from_le_bytes(data[p..p + 8].try_into().unwrap()) as usize;
+    p += 9; // max chunk + algorithm id
+    let _sum_c = u64::from_le_bytes(data[p..p + 8].try_into().unwrap());
+    p += 8;
+    let sum_u = u64::from_le_bytes(data[p..p + 8].try_into().unwrap()) as usize;
+    p += 8;
+    let count = sum_u.div_ceil(max_chunk);
+    let mut table = Vec::with_capacity(count);
+    for _ in 0..count {
+        let c = u64::from_le_bytes(data[p..p + 8].try_into().unwrap()) as usize;
+        p += 8;
+        let u = u64::from_le_bytes(data[p..p + 8].try_into().unwrap()) as usize;
+        p += 8;
+        table.push((c, u));
+    }
+    let mut payload = Vec::with_capacity(sum_u);
+    let mut cursor = p;
+    for (c, u) in table {
+        payload.extend_from_slice(
+            &gore_oodle::decompress(&data[cursor..cursor + c], u).expect("decode"),
+        );
+        cursor += c;
+    }
+    println!("payload: {} bytes", payload.len());
+
+    for run in 0..3 {
+        let start = Instant::now();
+        let root = gore_save::properties::parse_private_root(&payload).expect("parse");
+        let elapsed = start.elapsed();
+        let count = count_properties(&root.properties);
+        println!(
+            "run {run}: {elapsed:?}  ({:.0} MB/s, {count} properties, {:.0} ns/property)",
+            payload.len() as f64 / 1e6 / elapsed.as_secs_f64(),
+            elapsed.as_nanos() as f64 / count as f64
+        );
+    }
+}
+
+fn count_properties(properties: &[gore_save::properties::Property]) -> usize {
+    use gore_save::properties::PropertyValue as V;
+    let mut total = properties.len();
+    for property in properties {
+        total += match &property.value {
+            V::Struct(gore_save::properties::StructValue::Properties(inner)) => {
+                count_properties(inner)
+            }
+            V::ObjectInstances(instances) => instances
+                .iter()
+                .map(|instance| count_properties(&instance.properties))
+                .sum(),
+            _ => 0,
+        };
+    }
+    total
+}

--- a/crates/gore-save/examples/phase_timer.rs
+++ b/crates/gore-save/examples/phase_timer.rs
@@ -1,0 +1,142 @@
+//! Scratch research driver: decompose the cost of one save write into phases and
+//! test whether the chunk codec parallelises. Read-only; writes nothing. Not shipped.
+
+use std::time::Instant;
+
+const PACKAGE_FILE_TAG: u32 = 0x9E2A83C1;
+const COMPRESSED_HEADER_V2: u32 = 0x2222_2222;
+
+struct Chunk {
+    off: usize,
+    csize: usize,
+    usize_: usize,
+}
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: phase_timer <save.sav>");
+    let threads: usize = std::env::args()
+        .nth(2)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(std::thread::available_parallelism().map(|v| v.get()).unwrap_or(8));
+    let data = std::fs::read(&path).expect("read save");
+
+    // Find the compressed-stream header by scanning for the package tag.
+    let tag = PACKAGE_FILE_TAG.to_le_bytes();
+    let tag_at = (0..data.len() - 4)
+        .find(|&i| data[i..i + 4] == tag)
+        .expect("PACKAGE_FILE_TAG not found");
+    let mut p = tag_at + 4;
+    let hdr_version = u32::from_le_bytes(data[p..p + 4].try_into().unwrap());
+    assert_eq!(hdr_version, COMPRESSED_HEADER_V2, "only v2 headers here");
+    p += 4;
+    let max_chunk = u64::from_le_bytes(data[p..p + 8].try_into().unwrap()) as usize;
+    p += 8;
+    let _alg = data[p];
+    p += 1;
+    let sum_c = u64::from_le_bytes(data[p..p + 8].try_into().unwrap()) as usize;
+    p += 8;
+    let sum_u = u64::from_le_bytes(data[p..p + 8].try_into().unwrap()) as usize;
+    p += 8;
+    let count = sum_u.div_ceil(max_chunk);
+    let mut table = Vec::with_capacity(count);
+    for _ in 0..count {
+        let c = u64::from_le_bytes(data[p..p + 8].try_into().unwrap()) as usize;
+        p += 8;
+        let u = u64::from_le_bytes(data[p..p + 8].try_into().unwrap()) as usize;
+        p += 8;
+        table.push((c, u));
+    }
+    let mut cursor = p;
+    let chunks: Vec<Chunk> = table
+        .iter()
+        .map(|&(c, u)| {
+            let ch = Chunk { off: cursor, csize: c, usize_: u };
+            cursor += c;
+            ch
+        })
+        .collect();
+
+    println!("file            : {} bytes", data.len());
+    println!("chunks          : {count}  (max chunk {max_chunk} bytes)");
+    println!("compressed total: {sum_c} bytes");
+    println!("plaintext total : {sum_u} bytes ({:.1} MB, ratio {:.1}:1)", sum_u as f64 / 1e6, sum_u as f64 / sum_c as f64);
+    println!();
+
+    // --- serial decompress ---
+    let t = Instant::now();
+    let plain: Vec<Vec<u8>> = chunks
+        .iter()
+        .map(|c| gore_oodle::decompress(&data[c.off..c.off + c.csize], c.usize_).expect("decode"))
+        .collect();
+    let serial_dec = t.elapsed();
+    println!("decompress all  serial   : {serial_dec:?}  ({:.0} MB/s)", sum_u as f64 / 1e6 / serial_dec.as_secs_f64());
+
+    // --- parallel decompress ---
+    let t = Instant::now();
+    let par_plain = par_map(&chunks, threads, |c| {
+        gore_oodle::decompress(&data[c.off..c.off + c.csize], c.usize_).expect("decode")
+    });
+    let par_dec = t.elapsed();
+    println!("decompress all  {threads:>2} threads: {par_dec:?}  ({:.0} MB/s, {:.1}x)", sum_u as f64 / 1e6 / par_dec.as_secs_f64(), serial_dec.as_secs_f64() / par_dec.as_secs_f64());
+    assert_eq!(plain, par_plain, "parallel decode must match serial");
+    println!();
+
+    // --- compress at each level, serial and parallel ---
+    for (name, level) in [
+        ("Fastest", gore_oodle::Level::Fastest),
+        ("Fast   ", gore_oodle::Level::Fast),
+        ("Default", gore_oodle::Level::Default),
+    ] {
+        let t = Instant::now();
+        let out: Vec<Vec<u8>> = plain.iter().map(|c| gore_oodle::compress(c, level).expect("encode")).collect();
+        let ser = t.elapsed();
+        let total: usize = out.iter().map(|c| c.len()).sum();
+
+        let t = Instant::now();
+        let out_par = par_map(&plain, threads, |c| gore_oodle::compress(c, level).expect("encode"));
+        let par = t.elapsed();
+        assert_eq!(out, out_par, "parallel encode must match serial");
+
+        let identical = out
+            .iter()
+            .zip(chunks.iter())
+            .filter(|(re, c)| re.as_slice() == &data[c.off..c.off + c.csize])
+            .count();
+        println!("    -> {identical}/{count} re-encoded chunks are BYTE-IDENTICAL to what is on disk");
+        println!(
+            "compress {name} serial: {ser:>10.3?} ({:>4.0} MB/s) | {threads:>2} threads: {par:>10.3?} ({:>4.0} MB/s, {:.1}x) | size {} ({:+.1}% vs disk)",
+            sum_u as f64 / 1e6 / ser.as_secs_f64(),
+            sum_u as f64 / 1e6 / par.as_secs_f64(),
+            ser.as_secs_f64() / par.as_secs_f64(),
+            total,
+            (total as f64 / sum_c as f64 - 1.0) * 100.0
+        );
+    }
+    println!();
+
+    // --- how many chunks does a typical in-place edit actually dirty? ---
+    let flat_len: usize = plain.iter().map(|c| c.len()).sum();
+    println!("a single in-place byte patch dirties 1 of {count} chunks ({:.2}% of {flat_len} plaintext bytes)", 100.0 / count as f64);
+
+    // --- cost of re-encoding only one chunk ---
+    let t = Instant::now();
+    let _ = gore_oodle::compress(&plain[count / 2], gore_oodle::Level::Default).expect("encode");
+    println!("re-encode ONE 128 KB chunk (Default): {:?}", t.elapsed());
+}
+
+fn par_map<T: Sync, R: Send>(items: &[T], threads: usize, f: impl Fn(&T) -> R + Sync) -> Vec<R> {
+    let n = items.len();
+    let mut out: Vec<Option<R>> = (0..n).map(|_| None).collect();
+    let chunk = n.div_ceil(threads);
+    std::thread::scope(|scope| {
+        let f = &f;
+        for (items_part, out_part) in items.chunks(chunk).zip(out.chunks_mut(chunk)) {
+            scope.spawn(move || {
+                for (item, slot) in items_part.iter().zip(out_part.iter_mut()) {
+                    *slot = Some(f(item));
+                }
+            });
+        }
+    });
+    out.into_iter().map(|v| v.unwrap()).collect()
+}

--- a/crates/gore-save/src/codec_backend.rs
+++ b/crates/gore-save/src/codec_backend.rs
@@ -99,6 +99,63 @@ impl CodecBackend for KrakenBackend {
         gore_oodle::compress(input, level_to_oodle(level))
             .map_err(|e| CoreError::Codec(e.to_string()))
     }
+
+    // A save's private stream is hundreds of independent chunks (916 x 128 KiB on a
+    // real 2.5 MB save), and the trait's default batch methods run them one at a
+    // time. Encoding is the write path's dominant cost, so fan the chunks across
+    // cores instead.
+    fn decompress_many(&self, chunks: &[CodecDecodeChunk<'_>]) -> Result<Vec<Vec<u8>>, CoreError> {
+        map_chunks_in_parallel(chunks, |chunk| {
+            self.decompress(chunk.input, chunk.expected_size)
+        })
+    }
+
+    fn compress_many(&self, chunks: &[CodecEncodeChunk<'_>]) -> Result<Vec<Vec<u8>>, CoreError> {
+        map_chunks_in_parallel(chunks, |chunk| self.compress(chunk.input, chunk.level))
+    }
+}
+
+/// Run one per-chunk codec job across worker threads.
+///
+/// Safe because `gore_oodle::compress`/`decompress` are pure functions of their
+/// arguments: the crate is `no_std`, holds no global or thread-local state, and
+/// allocates every scratch buffer per call — so concurrent calls cannot observe each
+/// other and each chunk's output is identical to what the serial path produced.
+///
+/// Results keep their input order (the chunk table and the payload are both emitted
+/// by index), and a failure surfaces as the LOWEST-index failing chunk, matching the
+/// serial `.collect()` this replaces.
+fn map_chunks_in_parallel<T, F>(items: &[T], job: F) -> Result<Vec<Vec<u8>>, CoreError>
+where
+    T: Sync,
+    F: Fn(&T) -> Result<Vec<u8>, CoreError> + Sync,
+{
+    let workers = std::thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(1)
+        .min(items.len());
+    // Also covers the empty stream (`minimal_gsav` declares zero chunks), where
+    // `items.chunks(0)` below would panic.
+    if workers <= 1 {
+        return items.iter().map(job).collect();
+    }
+    let stride = items.len().div_ceil(workers);
+    let mut results: Vec<Option<Result<Vec<u8>, CoreError>>> =
+        items.iter().map(|_| None).collect();
+    std::thread::scope(|scope| {
+        let job = &job;
+        for (inputs, slots) in items.chunks(stride).zip(results.chunks_mut(stride)) {
+            scope.spawn(move || {
+                for (item, slot) in inputs.iter().zip(slots.iter_mut()) {
+                    *slot = Some(job(item));
+                }
+            });
+        }
+    });
+    results
+        .into_iter()
+        .map(|slot| slot.expect("every slot is filled by the worker that owns it"))
+        .collect()
 }
 
 #[cfg(test)]
@@ -119,5 +176,69 @@ mod tests {
         assert!(probe.available);
         assert!(probe.can_decompress);
         assert!(probe.can_compress);
+    }
+
+    /// The batch methods fan chunks across threads. Their output must stay
+    /// byte-identical to the serial path and keep its order, because the chunk table
+    /// and the payload are written by index.
+    #[test]
+    fn batch_codec_matches_the_serial_path_chunk_for_chunk() {
+        let backend = KrakenBackend::default();
+        // Enough chunks that the fan-out actually splits, with distinct contents so a
+        // reordering bug cannot pass.
+        let inputs: Vec<Vec<u8>> = (0..64u32)
+            .map(|seed| (0..8192u32).map(|i| (i * 31 + seed * 7) as u8).collect())
+            .collect();
+
+        let encode: Vec<CodecEncodeChunk<'_>> = inputs
+            .iter()
+            .map(|input| CodecEncodeChunk { input, level: 6 })
+            .collect();
+        let batched = backend.compress_many(&encode).unwrap();
+        let serial: Vec<Vec<u8>> = inputs
+            .iter()
+            .map(|input| backend.compress(input, 6).unwrap())
+            .collect();
+        assert_eq!(batched, serial);
+
+        let decode: Vec<CodecDecodeChunk<'_>> = batched
+            .iter()
+            .zip(inputs.iter())
+            .map(|(compressed, original)| CodecDecodeChunk {
+                input: compressed,
+                expected_size: original.len(),
+            })
+            .collect();
+        assert_eq!(backend.decompress_many(&decode).unwrap(), inputs);
+    }
+
+    /// A save whose private stream declares no chunks reaches the batch methods with
+    /// an empty slice; the fan-out must not divide by zero or panic there.
+    #[test]
+    fn batch_codec_accepts_an_empty_chunk_list() {
+        let backend = KrakenBackend::default();
+        assert!(backend.compress_many(&[]).unwrap().is_empty());
+        assert!(backend.decompress_many(&[]).unwrap().is_empty());
+    }
+
+    /// A corrupt chunk must surface the same error the serial path surfaced: the one
+    /// belonging to the lowest failing index, not whichever worker finished first.
+    #[test]
+    fn batch_codec_reports_the_lowest_failing_chunk() {
+        let backend = KrakenBackend::default();
+        let good = backend.compress(&[7u8; 4096], 6).unwrap();
+        let chunks = vec![
+            CodecDecodeChunk { input: &good, expected_size: 4096 },
+            // Two different-length garbage chunks: whichever error wins is
+            // identifiable, so a race would show up as a flaky expected_size.
+            CodecDecodeChunk { input: b"not-a-kraken-stream", expected_size: 4096 },
+            CodecDecodeChunk { input: b"also-not-a-stream", expected_size: 8192 },
+        ];
+        let error = backend.decompress_many(&chunks).unwrap_err().to_string();
+        let serial = backend
+            .decompress(chunks[1].input, chunks[1].expected_size)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(error, serial);
     }
 }

--- a/crates/gore-save/src/factions.rs
+++ b/crates/gore-save/src/factions.rs
@@ -207,7 +207,7 @@ fn find_generic_instanced<'a>(
         target_key: &str,
     ) -> Option<(Vec<String>, &'a [Property])> {
         for p in props {
-            path.push(p.name.clone());
+            path.push(p.name.to_string());
             if p.name == "m_GenericData" {
                 if let PropertyValue::Map { entries, .. } = &p.value {
                     for (k, v) in entries {

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -319,13 +319,35 @@ impl<'a> Reader<'a> {
 
     pub(crate) fn fstring(&mut self) -> Result<String, CoreError> {
         let n = self.i32()?;
-        if n == 0 {
-            return Ok(String::new());
-        }
         if n > 0 {
             let raw = self.read(n as usize)?;
             let body = raw.strip_suffix(&[0]).unwrap_or(raw);
             return Ok(String::from_utf8_lossy(body).to_string());
+        }
+        self.fstring_after_length(n)
+    }
+
+    /// An FString read straight into the shared name table, with no owned `String`
+    /// in between. Property and type names repeat hundreds of thousands of times in
+    /// one payload, so this is the parser's hottest allocation by a wide margin.
+    pub(crate) fn prop_str(&mut self) -> Result<properties::PropStr, CoreError> {
+        let n = self.i32()?;
+        if n > 0 {
+            let raw = self.read(n as usize)?;
+            let body = raw.strip_suffix(&[0]).unwrap_or(raw);
+            return Ok(match std::str::from_utf8(body) {
+                Ok(text) => properties::PropStr::new(text),
+                Err(_) => properties::PropStr::new(&String::from_utf8_lossy(body)),
+            });
+        }
+        Ok(properties::PropStr::new(&self.fstring_after_length(n)?))
+    }
+
+    /// The empty and UTF-16 arms of [`Reader::fstring`], after its length has been
+    /// read. Rare next to the ASCII path both callers above take first.
+    fn fstring_after_length(&mut self, n: i32) -> Result<String, CoreError> {
+        if n == 0 {
+            return Ok(String::new());
         }
         // `-n` overflows (panic in debug, wrap in release) when n == i32::MIN
         // (0x80000000). Reject it via checked negation instead of aborting
@@ -7553,7 +7575,7 @@ fn summarize_memory_event_properties(
             .as_ref()
             .map(|(name, _)| name.as_str());
         let type_name = struct_type.map_or_else(
-            || property.type_name.clone(),
+            || property.type_name.to_string(),
             |name| format!("{} · {name}", property.type_name),
         );
         fields.push(json!({
@@ -11969,7 +11991,7 @@ fn misaligned_slot_containers(root: &properties::RootObject) -> Vec<(Vec<String>
         out: &mut Vec<(Vec<String>, usize)>,
     ) {
         for property in properties_ {
-            path.push(property.name.clone());
+            path.push(property.name.to_string());
             if property.name == "m_Slots" {
                 if let properties::PropertyValue::Array { elements } = &property.value {
                     let count = misaligned(elements);

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -12721,10 +12721,13 @@ fn reset_slot_payload_if_stateful(
 /// slot keeps its position, its `m_Id` and its `m_InventoryType`, and the array
 /// keeps its length, so no other slot moves.
 ///
-/// Each step re-parses: clearing the payload and the definition both change
-/// lengths, which invalidates the offsets recorded before them.
+/// `root` must be a parse of `payload` as it stands. Only clearing the payload state
+/// and the definition change lengths; zeroing the count does not, so it goes first
+/// and the whole slot is blanked from a single parse — one more only when the slot
+/// still carried state to reset.
 fn blank_inventory_slot(
     payload: &mut Vec<u8>,
+    root: &properties::RootObject,
     slots_path: &[String],
     index: usize,
 ) -> Result<(), CoreError> {
@@ -12735,25 +12738,24 @@ fn blank_inventory_slot(
         path
     };
 
-    {
-        let root = properties::parse_private_root(payload)?;
-        reset_slot_payload_if_stateful(payload, &root, slots_path, index)?;
-    }
+    let reset_moved_bytes = reset_slot_payload_if_stateful(payload, root, slots_path, index)?;
+    let reparsed = if reset_moved_bytes {
+        Some(properties::parse_private_root(payload)?)
+    } else {
+        None
+    };
+    let root = reparsed.as_ref().unwrap_or(root);
 
-    {
-        let root = properties::parse_private_root(payload)?;
-        let segs = properties::parse_path(&slot_path(&["m_SlotData", "m_ItemDefinition"]))?;
-        let chain = properties::resolve_chain(&root.properties, &segs)?;
-        let target = chain.target.clone();
-        let enclosing = chain.enclosing_size_fields.clone();
-        drop(root);
-        properties::patch_string(payload, &target, &enclosing, "")?;
-    }
+    // Fixed-size first, so it does not need its own view of the payload.
+    let count_segs = properties::parse_path(&slot_path(&["m_SlotData", "m_ItemCount"]))?;
+    let count_target = properties::resolve(&root.properties, &count_segs)?;
+    properties::patch_scalar(payload, count_target, properties::ScalarValue::Int(0))?;
 
-    let root = properties::parse_private_root(payload)?;
-    let segs = properties::parse_path(&slot_path(&["m_SlotData", "m_ItemCount"]))?;
-    let target = properties::resolve(&root.properties, &segs)?;
-    properties::patch_scalar(payload, target, properties::ScalarValue::Int(0))
+    let segs = properties::parse_path(&slot_path(&["m_SlotData", "m_ItemDefinition"]))?;
+    let chain = properties::resolve_chain(&root.properties, &segs)?;
+    let target = chain.target.clone();
+    let enclosing = chain.enclosing_size_fields.clone();
+    properties::patch_string(payload, &target, &enclosing, "")
 }
 
 fn apply_private_inventory_remove_item_to_payload(
@@ -12829,12 +12831,16 @@ fn apply_private_inventory_remove_item_to_payload(
         path
     };
     let mut patched = payload.clone();
-    blank_inventory_slot(&mut patched, &slots_path, index)?;
+    blank_inventory_slot(&mut patched, &root, &slots_path, index)?;
 
-    // 4. Re-align the container's ids with their positions. Blanking keeps them
-    //    aligned on its own; this repairs a container an earlier build left
-    //    misaligned (see normalize_slot_ids).
-    normalize_slot_ids(&mut patched, &slots_path)?;
+    // 4. Re-align the container's ids with their positions. Blanking never touches
+    //    an id, so whether any are out of step is already visible in the parse
+    //    above; the re-align only has to run for a container an earlier build left
+    //    misaligned (see normalize_slot_ids), and the proof below re-checks the
+    //    invariant on the bytes that land either way.
+    if !slot_ids_are_index_aligned(slots) {
+        normalize_slot_ids(&mut patched, &slots_path)?;
+    }
 
     // 5. Final proof: strict re-parse, and the targeted slot must be blank in
     //    the MainContainer specifically. The same item path may legitimately

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -9092,8 +9092,37 @@ fn path_has_name(path: &[properties::PathSeg], name: &str) -> bool {
 }
 
 fn path_has_key(path: &[properties::PathSeg], key: &str) -> bool {
-    path.iter()
-        .any(|segment| matches!(segment, properties::PathSeg::MapKey(found) if found == key))
+    path.iter().any(|segment| {
+        matches!(segment, properties::PathSeg::MapKey(found)
+            if found.trim().eq_ignore_ascii_case(key.trim()))
+    })
+}
+
+/// Whether a slot-reaching `path` belongs to the inventory `actor_id` names.
+///
+/// An NPC's inventory hangs under that character's own map entry, so its key
+/// settles it. The controlled player's hangs off `m_SavedPlayers`; a slot path that
+/// goes through there is the player's, and one that does not but names some
+/// character key belongs to somebody else. A path that fits neither description is
+/// treated as a conflict rather than waved through — a save with no
+/// `m_SavedPlayers` at all falls back to whatever `m_Inventory` exists, and there is
+/// nothing in the path to tell whose it is.
+///
+/// Container scope is deliberately NOT narrowed: which `Items[i]` a structured edit
+/// resolves to depends on the enum order inside the save, which is not visible here.
+fn slot_edit_targets_actor(path: &[properties::PathSeg], actor_id: Option<&str>) -> bool {
+    if !path_reaches_inventory_slot(path) {
+        return false;
+    }
+    match actor_id {
+        Some(id) => path_has_key(path, id),
+        None => {
+            path_has_name(path, "m_SavedPlayers")
+                || !path
+                    .iter()
+                    .any(|segment| matches!(segment, properties::PathSeg::MapKey(_)))
+        }
+    }
 }
 
 /// Whether `path` reaches a slot of an inventory container — the array itself, or an
@@ -9147,11 +9176,16 @@ fn structured_edit_rewrites(edit: &PrivateEdit, path: &[properties::PathSeg]) ->
             path_enters_map_entry(path, "CharacterKnowledgeByUniqueName", &edit.character)
         }
         // Claims a whole slot: the add fills a blank one and resets its payload, the
-        // removal blanks one.
-        PrivateEdit::InventoryAddItem(_) | PrivateEdit::InventoryRemoveItem(_) => {
-            path_reaches_inventory_slot(path)
+        // removal blanks one. Only in the inventory it targets — another actor's
+        // slots are a different subtree.
+        PrivateEdit::InventoryAddItem(add) => {
+            slot_edit_targets_actor(path, add.actor_id.as_deref())
         }
-        // Narrower: it only rewrites ids.
+        PrivateEdit::InventoryRemoveItem(remove) => {
+            slot_edit_targets_actor(path, remove.actor_id.as_deref())
+        }
+        // Narrower still: it only rewrites ids, but it does so across every
+        // container in the save, so it is not scoped to one actor.
         PrivateEdit::InventoryRepairSlots => matches!(
             path.last(),
             Some(properties::PathSeg::Name(name)) if name == "m_Id"
@@ -20694,6 +20728,72 @@ mod tests {
             properties::PropertyValue::Int(3),
             "the last edit in the batch must win"
         );
+    }
+
+    #[test]
+    fn an_inventory_write_only_conflicts_with_its_own_actors_slots() {
+        let player_slot = properties::parse_path(&[
+            "m_GenericData".to_string(),
+            "{PlayersSavedData}".to_string(),
+            "m_SavedPlayers".to_string(),
+            "[0]".to_string(),
+            "m_Inventory".to_string(),
+            "m_Values".to_string(),
+            "Items".to_string(),
+            "[1]".to_string(),
+            "m_Slots".to_string(),
+            "[2]".to_string(),
+            "m_SlotData".to_string(),
+            "m_ItemCount".to_string(),
+        ])
+        .unwrap();
+        let npc_slot = |id: &str| {
+            properties::parse_path(&[
+                "m_GenericData".to_string(),
+                "{CharacterStates}".to_string(),
+                "InventoriesByGlobalId".to_string(),
+                format!("{{{id}}}"),
+                "m_Inventory".to_string(),
+                "m_Values".to_string(),
+                "Items".to_string(),
+                "[1]".to_string(),
+                "m_Slots".to_string(),
+                "[2]".to_string(),
+                "m_SlotData".to_string(),
+                "m_ItemCount".to_string(),
+            ])
+            .unwrap()
+        };
+
+        let add_for = |actor: Option<&str>| {
+            PrivateEdit::InventoryAddItem(PrivateInventoryAddItemEdit {
+                path: "/Script/Angelscript.ItMi_Orenugget".to_string(),
+                count: 1,
+                actor_id: actor.map(str::to_string),
+            })
+        };
+
+        // The player's add collides with the player's slots, not an NPC's.
+        assert!(structured_edit_rewrites(&add_for(None), &player_slot));
+        assert!(!structured_edit_rewrites(&add_for(None), &npc_slot("Lizard-1")));
+
+        // An NPC's add collides with that NPC's slots, not another's nor the
+        // player's.
+        let for_lizard = add_for(Some("Lizard-1"));
+        assert!(structured_edit_rewrites(&for_lizard, &npc_slot("Lizard-1")));
+        assert!(!structured_edit_rewrites(&for_lizard, &npc_slot("Lizard-2")));
+        assert!(!structured_edit_rewrites(&for_lizard, &player_slot));
+
+        // A path that reaches no slot at all is unrelated either way.
+        let attribute = properties::parse_path(&[
+            "m_GenericData".to_string(),
+            "{CharacterStates}".to_string(),
+            "AttributesByGlobalId".to_string(),
+            "{Hero}".to_string(),
+            "Health".to_string(),
+        ])
+        .unwrap();
+        assert!(!structured_edit_rewrites(&add_for(None), &attribute));
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -9125,6 +9125,24 @@ fn slot_edit_targets_actor(path: &[properties::PathSeg], actor_id: Option<&str>)
     }
 }
 
+/// Whether `path` addresses the `CurrentState` of a quest entry — the leaf a
+/// glossary segment operation rewrites beside the hero's memory.
+///
+/// Which entry that is can only be read out of the save: the caller may leave
+/// `questStatePath` out entirely and let `resolve_glossary_quest_state_path`
+/// derive the leaf from the document and segment. This rule runs before anything
+/// is parsed, so it claims the shape of such a leaf rather than the one entry.
+/// Claiming too much costs a separate write; claiming too little would let one of
+/// the two writes disappear in silence.
+fn path_is_a_quest_current_state(path: &[properties::PathSeg]) -> bool {
+    let [.., quest, leaf] = path else {
+        return false;
+    };
+    matches!(leaf, properties::PathSeg::Name(name) if name == "CurrentState")
+        && matches!(quest, properties::PathSeg::MapKey(_))
+        && path_has_name(path, "QuestDataByClass")
+}
+
 /// Whether `path` writes a slot's `m_Id` — the field a slot is selected by, so a
 /// write to it renumbers slots exactly as a repair does.
 fn path_writes_a_slot_id(path: &[properties::PathSeg]) -> bool {
@@ -9163,14 +9181,11 @@ fn structured_edit_rewrites(edit: &PrivateEdit, path: &[properties::PathSeg]) ->
         PrivateEdit::SkillSet(skill) => {
             path_has_name(path, "ActiveEffects") && path_has_key(path, &skill.actor)
         }
-        // Adds or removes an unlock event in the hero's memory — and, when the
-        // caller supplied one, rewrites that quest's CurrentState as well.
-        PrivateEdit::GlossarySetSegment(glossary) => {
+        // Adds or removes an unlock event in the hero's memory, and rewrites the
+        // CurrentState of the quest leaf that stands for the same segment.
+        PrivateEdit::GlossarySetSegment(_) => {
             (path_has_name(path, "MemorizedEvents") && path_has_key(path, skills::HERO))
-                || glossary
-                    .quest_state_path
-                    .as_ref()
-                    .is_some_and(|quest| quest.as_slice() == path)
+                || path_is_a_quest_current_state(path)
         }
         // Strips memory events, death tags and the corpse entry.
         PrivateEdit::NpcRevive(_) => {
@@ -20882,9 +20897,11 @@ mod tests {
             quest_state_path: Some(quest_state.clone()),
         });
         assert!(structured_edit_rewrites(&with_quest, &quest_state));
-        assert!(!structured_edit_rewrites(&with_quest, &elsewhere));
 
-        // Without one, the quest state is not its business.
+        // Leaving the path out does not make the quest state someone else's
+        // business: the write then derives the very same leaf from the document
+        // and segment and rewrites it. Which leaf that is cannot be known here,
+        // before anything is parsed, so any quest's CurrentState is claimed.
         let without_quest = PrivateEdit::GlossarySetSegment(PrivateGlossarySetSegmentEdit {
             package: "/Script/Angelscript".to_string(),
             document_asset: "Document_Glossary_Meatbug".to_string(),
@@ -20892,7 +20909,25 @@ mod tests {
             unlocked: true,
             quest_state_path: None,
         });
-        assert!(!structured_edit_rewrites(&without_quest, &quest_state));
+        assert!(structured_edit_rewrites(&without_quest, &quest_state));
+        assert!(structured_edit_rewrites(&without_quest, &elsewhere));
+
+        // Another field of the same quest entry, and a CurrentState that is not a
+        // quest's, stay packable.
+        let sibling = properties::parse_path(&[
+            "QuestDataByClass".to_string(),
+            "{/Script/Angelscript.Quest_OldCamp_SLEEPER}".to_string(),
+            "m_Comment".to_string(),
+        ])
+        .unwrap();
+        let elsewhere_entirely = properties::parse_path(&[
+            "m_GenericData".to_string(),
+            "{Dialogue}".to_string(),
+            "CurrentState".to_string(),
+        ])
+        .unwrap();
+        assert!(!structured_edit_rewrites(&with_quest, &sibling));
+        assert!(!structured_edit_rewrites(&with_quest, &elsewhere_entirely));
 
         // The hero's memory events stay guarded either way.
         let hero_memory = properties::parse_path(&[
@@ -22912,12 +22947,14 @@ mod tests {
     }
 
     #[test]
-    fn glossary_set_segment_must_be_the_only_edit_in_a_write() {
+    fn glossary_set_segment_refuses_a_peer_write_to_the_quest_state_it_sets() {
         let (_dir, path, backend) = progression_fixture(
             "G1R-glossary-standalone.sav",
             glossary_progression_payload(),
         );
         let data = fs::read(path).unwrap();
+        // No questStatePath: the write derives the matching leaf from the
+        // document and segment and sets it, exactly as if one had been supplied.
         let glossary = Edit {
             path: "private.glossary.setSegment".to_string(),
             value: json!({
@@ -22937,9 +22974,23 @@ mod tests {
                 "value": "EQuestState::Available"
             }),
         };
-        // The peer resolves its quest by MAP KEY, which the glossary splice cannot
-        // move, so the two share one write.
-        let edited = apply_private_edits(&data, &[&glossary, &peer], Some(&backend)).unwrap();
+
+        // Sharing a write would set that CurrentState twice and report both edits
+        // as applied while one of them is discarded, whichever order they run in.
+        for pair in [[&glossary, &peer], [&peer, &glossary]] {
+            let error = apply_private_edits(&data, &pair, Some(&backend)).unwrap_err();
+            let CoreError::UnsupportedEdit(message) = &error else {
+                panic!("expected the pair to be refused, got {error:?}");
+            };
+            assert!(
+                message.contains("private.typed.setValue")
+                    && message.contains("private.glossary.setSegment"),
+                "the refusal has to name both edits, got {message:?}"
+            );
+        }
+
+        // Alone it goes through, and sets that leaf itself.
+        let edited = apply_private_edits(&data, &[&glossary], Some(&backend)).unwrap();
         let payload = decoded_private_payload_for_tests(&edited, &backend);
         assert!(
             find_subslice(&payload, b"DocumentSegment_Glossary_Meatbug_Entry2").is_some(),
@@ -22950,7 +23001,8 @@ mod tests {
             &root.properties,
             &properties::parse_path(&[
                 "QuestDataByClass".to_string(),
-                "{/Script/Angelscript.Quest_OldCamp_SLEEPER}".to_string(),
+                "{/Script/Angelscript.Quest_CreaturesGlossary_MeatbugGlossary_MeatbugEntry2}"
+                    .to_string(),
                 "CurrentState".to_string(),
             ])
             .unwrap(),
@@ -22958,7 +23010,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             state.value,
-            properties::PropertyValue::Enum("EQuestState::Available".to_string())
+            properties::PropertyValue::Enum("EQuestState::Succeeded".to_string())
         );
     }
 

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -10613,7 +10613,7 @@ fn decompress_private_payload_with_limit(
 /// provably structural. A `PayloadRoot` belongs to exactly ONE buffer — appliers that
 /// patch a scratch copy must give that copy its own.
 #[derive(Default)]
-struct PayloadRoot {
+pub(crate) struct PayloadRoot {
     root: Option<properties::RootObject>,
     /// A byte was written since `root` was parsed, so its decoded values are stale
     /// even though its offsets still hold.
@@ -10624,7 +10624,7 @@ impl PayloadRoot {
     /// The tree's structure only: offsets, sizes, names, keys and counts agree with
     /// `payload`, but its decoded values may predate an in-place write. Callers must
     /// read nothing else.
-    fn structural(&mut self, payload: &[u8]) -> Result<&properties::RootObject, CoreError> {
+    pub(crate) fn structural(&mut self, payload: &[u8]) -> Result<&properties::RootObject, CoreError> {
         if let Some(root) = &self.root {
             debug_assert!(
                 spine_still_describes(root, payload),
@@ -10638,7 +10638,7 @@ impl PayloadRoot {
     }
 
     /// The whole tree, decoded values included, agreeing with `payload`.
-    fn fresh(&mut self, payload: &[u8]) -> Result<&properties::RootObject, CoreError> {
+    pub(crate) fn fresh(&mut self, payload: &[u8]) -> Result<&properties::RootObject, CoreError> {
         if self.values_stale {
             self.root = None;
         }
@@ -10646,21 +10646,21 @@ impl PayloadRoot {
     }
 
     /// Record a patch that wrote over existing bytes without moving any.
-    fn note_in_place_write(&mut self) {
+    pub(crate) fn note_in_place_write(&mut self) {
         self.values_stale = true;
     }
 
     /// Drop the parse. Required after anything that can move a byte — every
     /// `patch_string` / `patch_value_bytes` / `patch_container` / splice, and every
     /// wholesale `*payload = patched`, whatever the observed length delta.
-    fn invalidate(&mut self) {
+    pub(crate) fn invalidate(&mut self) {
         self.root = None;
         self.values_stale = false;
     }
 
     /// Take over a tree that was parsed FROM the bytes being installed, so an
     /// applier's closing proof-parse doubles as the next edit's resolve parse.
-    fn adopt(&mut self, root: properties::RootObject) {
+    pub(crate) fn adopt(&mut self, root: properties::RootObject) {
         self.root = Some(root);
         self.values_stale = false;
     }
@@ -10704,11 +10704,13 @@ fn apply_private_edit_to_payload(
         PrivateEdit::TypedSetValue(edit) => {
             apply_private_typed_set_value_edit_to_payload_reusing(payload, edit, cache)
         }
-        // Re-parses for its own reads, but hands its closing proof parse to the next
-        // edit — the case that matters when several items are added in one write.
+        // Re-parse for their own reads, but hand their closing proof parse to the
+        // next edit — the case that matters when several items or skills go into one
+        // write.
         PrivateEdit::InventoryAddItem(edit) => {
             apply_private_inventory_add_item_to_payload_reusing(payload, edit, cache)
         }
+        PrivateEdit::SkillSet(edit) => skills::apply_skill_set(payload, edit, cache),
         // Everything else parses for itself and may move bytes, so the batch's parse
         // is dropped rather than handed to a later edit that would resolve against a
         // layout this one changed. A new variant lands here and inherits that.
@@ -10755,7 +10757,9 @@ fn apply_private_edit_to_payload_uncached(
         PrivateEdit::TypedContainer(edit) => {
             apply_private_typed_container_edit_to_payload(payload, edit)
         }
-        PrivateEdit::SkillSet(edit) => skills::apply_skill_set(payload, edit),
+        PrivateEdit::SkillSet(edit) => {
+            skills::apply_skill_set(payload, edit, &mut PayloadRoot::default())
+        }
         PrivateEdit::NpcRevive(edit) => npc::apply_revive(payload, &edit.id),
         PrivateEdit::NpcRelationship(edit) => {
             npc::apply_relationship(payload, &edit.id, edit.relationship)

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -12189,6 +12189,10 @@ fn apply_private_inventory_add_item_to_payload_reusing(
     })?;
     let mut patched = payload.clone();
     let mut needs_type_patch = false;
+    // `patched` starts out byte-for-byte the buffer `root` describes. Filling a free
+    // slot only writes to it when that slot still carried the previous item's state,
+    // so track whether anything moved and skip the re-parse below when nothing did.
+    let mut patched_matches_root = true;
     if let Some(free_index) = free_index {
         // A slot is picked as free on its empty definition alone, and an older
         // build could leave one blank while its payload still held the removed
@@ -12199,8 +12203,10 @@ fn apply_private_inventory_add_item_to_payload_reusing(
             path.extend_from_slice(&slots_suffix);
             path
         };
-        reset_slot_payload_if_stateful(&mut patched, &slots_path, free_index)?;
+        patched_matches_root =
+            !reset_slot_payload_if_stateful(&mut patched, root, &slots_path, free_index)?;
     } else {
+        patched_matches_root = false;
         let template_bytes = if let Some(source) = slots.iter().rposition(|slot| is_clean(slot)) {
             let layout = properties::container_layout(payload, chain.target)?;
             let range = layout.element_ranges.get(source).cloned().ok_or_else(|| {
@@ -12246,11 +12252,16 @@ fn apply_private_inventory_add_item_to_payload_reusing(
         suffix
     })?;
     {
-        let duplicated = properties::parse_private_root(&patched).map_err(|err| {
-            CoreError::Parse(format!(
-                "inventory slot duplication produced an inconsistent payload: {err}"
-            ))
-        })?;
+        let reparsed = if patched_matches_root {
+            None
+        } else {
+            Some(properties::parse_private_root(&patched).map_err(|err| {
+                CoreError::Parse(format!(
+                    "inventory slot duplication produced an inconsistent payload: {err}"
+                ))
+            })?)
+        };
+        let duplicated = reparsed.as_ref().unwrap_or(root);
         let definition_chain = properties::resolve_chain(&duplicated.properties, &definition_segs)
             .map_err(|err| {
                 CoreError::Parse(format!(
@@ -12654,20 +12665,23 @@ fn clean_payload_value_bytes(
 /// The payload shape varies by item, so rather than reset field by field, swap
 /// in the whole serialized payload of a state-free slot — the same struct type,
 /// and exactly the clean shape the game leaves behind.
+/// `root` must be a parse of `payload` as it stands. Returns whether the payload was
+/// actually written to — a caller holding its own parse can keep using it when this
+/// says no, since a slot with a state-free payload is left byte-for-byte alone.
 fn reset_slot_payload_if_stateful(
     payload: &mut Vec<u8>,
+    root: &properties::RootObject,
     slots_path: &[String],
     index: usize,
-) -> Result<(), CoreError> {
+) -> Result<bool, CoreError> {
     let mut path = slots_path.to_vec();
     path.push(format!("[{index}]"));
     path.push("m_Payload".to_string());
     let payload_segs = properties::parse_path(&path)?;
-    let root = properties::parse_private_root(payload)?;
     if !properties::resolve(&root.properties, &payload_segs).is_ok_and(property_carries_state) {
-        return Ok(());
+        return Ok(false);
     }
-    let clean = clean_payload_value_bytes(payload, &root, slots_path).ok_or_else(|| {
+    let clean = clean_payload_value_bytes(payload, root, slots_path).ok_or_else(|| {
         CoreError::UnsupportedEdit(
             "no inventory slot has a state-free payload to reset this slot with;              the edit would leave the old item's state behind"
                 .to_string(),
@@ -12676,8 +12690,8 @@ fn reset_slot_payload_if_stateful(
     let chain = properties::resolve_chain(&root.properties, &payload_segs)?;
     let target = chain.target.clone();
     let enclosing = chain.enclosing_size_fields.clone();
-    drop(root);
-    properties::patch_value_bytes(payload, &target, &enclosing, &clean)
+    properties::patch_value_bytes(payload, &target, &enclosing, &clean)?;
+    Ok(true)
 }
 
 /// Blank one inventory slot in place: drop the item-specific payload state,
@@ -12700,7 +12714,10 @@ fn blank_inventory_slot(
         path
     };
 
-    reset_slot_payload_if_stateful(payload, slots_path, index)?;
+    {
+        let root = properties::parse_private_root(payload)?;
+        reset_slot_payload_if_stateful(payload, &root, slots_path, index)?;
+    }
 
     {
         let root = properties::parse_private_root(payload)?;

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -8936,10 +8936,13 @@ fn apply_private_edits(
             ))),
         })
         .collect::<Result<Vec<_>, _>>()?;
-    // One StoryApply may contain many value-addressed story changes and applies
-    // them transactionally on its own scratch payload. Keep that transaction
-    // isolated from peer outer edits: its insert/remove branches can splice the
-    // StoryPropertyValues map and invalidate offsets/indices held by a peer.
+    // One StoryApply may contain many value-addressed story changes and applies them
+    // transactionally on its own scratch payload. It stays exclusive for TRANSACTION
+    // SCOPE, not for index shifting (the position rule below would already cover
+    // that): it takes its compare-and-set snapshot from the payload as it enters,
+    // which a peer ordered before it would have already changed, and it proves its
+    // own postconditions before committing, which a peer ordered after it could
+    // quietly undo.
     if edit_specs
         .iter()
         .any(|edit| matches!(edit, PrivateEdit::StoryApply(_)))
@@ -8950,132 +8953,146 @@ fn apply_private_edits(
                 .to_string(),
         ));
     }
-    // Structural edits (arrayRemove, arrayDuplicate, addItem, removeItem) change
-    // the length of array or set data; a second such edit in the same batch
-    // would silently target shifted offsets/indices.  Reject the batch
-    // instead of guessing the caller's intent.
-    let structural_array_edits = edit_specs
+    // A reset swaps the whole m_Inventory value for the start save's copy, so every
+    // container under it changes size — including the byte region the player-inventory
+    // scan (see `inventory_item_region`) searches, which is located positionally rather
+    // than through the typed tree. It is a once-per-save wholesale operation with
+    // nothing to gain from sharing a write.
+    if edit_specs
         .iter()
-        .filter(|edit| {
-            matches!(
-                edit,
-                PrivateEdit::TypedContainer(PrivateTypedContainerEdit {
-                    edit: properties::ContainerEdit::ArrayRemove(_)
-                        | properties::ContainerEdit::ArrayDuplicate(_),
-                    ..
-                }) | PrivateEdit::InventoryAddItem(_)
-                    | PrivateEdit::InventoryRemoveItem(_)
-                    | PrivateEdit::InventoryReset(_)
-                    | PrivateEdit::GlossarySetSegment(_)
-            )
-        })
-        .count();
-    if structural_array_edits > 1 {
-        return Err(CoreError::UnsupportedEdit(format!(
-            "a write may contain at most one structural array edit \
-             (arrayRemove/arrayDuplicate/addItem/removeItem); got {structural_array_edits} — \
-             indices shift after each structural change, submit them as \
-             separate writes"
-        )));
-    }
-    // A splicing structural edit inserts or removes bytes mid-payload and shifts
-    // every byte after the splice point:
-    //   - inventory addItem/removeItem splice the MainContainer slot array,
-    //   - inventory.reset replaces the whole m_Inventory value with a
-    //     differently-sized reference (start-save) copy,
-    //   - knowledge.addCharacter inserts a new entry into the
-    //     CharacterKnowledgeByUniqueName MapProperty, and
-    //   - npc.revive strips the authoritative State.Dead/KillBounty/Executed loose
-    //     tags from LooseTagsByGlobalId, removes defeat/kill memory events from
-    //     MemorizedEvents (own + cross-owner), drops the m_SavedInventories corpse
-    //     entry, and restores HP — each a separate re-parse/splice.
-    // Any peer edit in the same batch is unsafe: a later edit resolves its target
-    // against the pre-splice layout — an in-place setItemCount patches stale byte
-    // offsets, and a typed setValue re-resolves a now-shifted array index — so it
-    // can corrupt the save or hit the wrong slot. Require such an edit to stand alone.
-    let splicing_structural_edits = edit_specs
-        .iter()
-        .filter(|edit| {
-            matches!(
-                edit,
-                PrivateEdit::InventoryAddItem(_)
-                    | PrivateEdit::InventoryRemoveItem(_)
-                    | PrivateEdit::InventoryReset(_)
-                    | PrivateEdit::KnowledgeAddCharacter(_)
-                    | PrivateEdit::KnowledgeSetEntry(_)
-                    | PrivateEdit::NpcRevive(_)
-                    | PrivateEdit::NpcRelationship(_)
-                    | PrivateEdit::GlossarySetSegment(_)
-            )
-        })
-        .count();
-    if splicing_structural_edits >= 1 && edit_specs.len() > 1 {
+        .any(|edit| matches!(edit, PrivateEdit::InventoryReset(_)))
+        && edit_specs.len() != 1
+    {
         return Err(CoreError::UnsupportedEdit(
-            "a write containing private.inventory.addItem, private.inventory.removeItem, \
-             private.inventory.reset, private.knowledge.addCharacter, private.knowledge.setEntry, \
-             private.npc.revive, \
-             private.npc.setRelationship, or private.glossary.setSegment \
-             must contain no other edits — the structural splice (slot-array, map insert, or \
-             memory-event removal) shifts the byte offsets and array indices later edits \
-             resolve against; submit them as separate writes"
+            "private.inventory.reset replaces the whole inventory and must be the only \
+             edit in a write; save the other inventory changes separately"
                 .to_string(),
         ));
     }
-    // A private.skills.set that learns or unlearns splices the hero's
-    // ActiveEffects array (duplicate/remove an element). It is value-addressed
-    // (resolves by skill base and re-parses), so multiple skill edits batch
-    // safely among themselves, and peers whose paths resolve by NAME/map-key
-    // (hero attributes, game time, …) re-resolve correctly after the splice.
-    // But a peer that resolves by an ARRAY INDEX — an arrayRemove/arrayDuplicate,
-    // or a typed edit whose path steps through `[i]` (e.g. an All-Data edit under
-    // `.../ActiveEffects/[i]/…`) — would resolve against the post-splice layout
-    // and hit the wrong element. (Inventory/knowledge/npc splices already stand
-    // alone above.) Reject that mix; the skill edit's structurality isn't known
-    // until apply time, so guard conservatively.
-    let has_skill_edit = edit_specs
-        .iter()
-        .any(|edit| matches!(edit, PrivateEdit::SkillSet(_)));
-    if has_skill_edit {
-        let has_index_addressed_peer = edit_specs.iter().any(|edit| match edit {
-            PrivateEdit::TypedContainer(container) => {
-                matches!(
-                    container.edit,
-                    properties::ContainerEdit::ArrayRemove(_)
-                        | properties::ContainerEdit::ArrayDuplicate(_)
-                ) || container
-                    .path
-                    .iter()
-                    .any(|seg| matches!(seg, properties::PathSeg::Index(_)))
-            }
-            PrivateEdit::TypedSetValue(set_value) => set_value
-                .path
-                .iter()
-                .any(|seg| matches!(seg, properties::PathSeg::Index(_))),
-            _ => false,
-        });
-        if has_index_addressed_peer {
-            return Err(CoreError::UnsupportedEdit(
-                "a write containing private.skills.set (which can add or remove an \
-                 element in the hero's ActiveEffects array) must not also contain an \
-                 index-addressed edit — an arrayRemove/arrayDuplicate, or a typed \
-                 edit whose path steps through an array index (e.g. under \
-                 ActiveEffects/[i]); the skill splice shifts the indices those edits \
-                 resolve against, so submit them as separate writes"
-                    .to_string(),
-            ));
+    // Every `apply_*` re-parses the payload it is handed, so a batch can never carry a
+    // stale BYTE OFFSET from one edit into the next. What a batch CAN invalidate is a
+    // caller-supplied ORDINAL: an array index or slot id the caller read off an
+    // inspection taken before this write. Reject exactly that — an ordinal-carrying
+    // edit positioned AFTER an edit that can change how many elements a container
+    // holds, or renumber inventory slot ids — and let everything else share one write.
+    //
+    // Position is what makes this usable: a caller that wants both simply submits the
+    // index-addressed edit first, or orders its array removals index-descending.
+    if let Some(producer) = edit_specs.iter().position(may_invalidate_caller_ordinals) {
+        if let Some(consumer) = edit_specs[producer + 1..]
+            .iter()
+            .position(carries_caller_ordinal)
+            .map(|offset| producer + 1 + offset)
+        {
+            return Err(CoreError::UnsupportedEdit(format!(
+                "{} (edit {consumer}) addresses an element by index or slot id, but \
+                 {} (edit {producer}) earlier in the same write can change how many \
+                 elements a container holds, or renumber inventory slot ids — the index \
+                 would resolve against the changed layout and silently hit the wrong \
+                 element. Put the index-addressed edit first, or save it separately.",
+                edits[consumer].path, edits[producer].path
+            )));
         }
     }
     let mut private_payload = decompress_private_payload(data, &stream, backend)?;
+    // One parse shared by the whole batch. Every edit re-resolves its target, so the
+    // sequence still behaves exactly as separate writes did — it just stops re-parsing
+    // 120 MB per edit when nothing moved.
+    let mut root_cache = PayloadRoot::default();
     for edit in &edit_specs {
-        apply_private_edit_to_payload(&mut private_payload, edit)?;
+        apply_private_edit_to_payload(&mut private_payload, edit, &mut root_cache)?;
     }
-    let compressed_stream = rebuild_compressed_stream(&stream, &private_payload, backend)?;
+    let compressed_stream = rebuild_compressed_stream(&stream, data, &private_payload, backend)?;
     Ok(build_gsav(
         parts.version,
         parts.public_payload,
         &compressed_stream,
         parts.trailer,
     ))
+}
+
+/// True for an edit that can change the ELEMENT COUNT of a container (array length,
+/// set cardinality, map entry count) or RENUMBER inventory slot ids.
+///
+/// Those are the only two things that can invalidate a caller-supplied ordinal.
+/// Moving bytes does not: every `apply_*` re-parses the payload it is handed, so no
+/// edit inherits an offset from the one before it.
+fn may_invalidate_caller_ordinals(edit: &PrivateEdit) -> bool {
+    match edit {
+        // setAdd/setRemove change a set's cardinality; arrayRemove/arrayDuplicate
+        // change an array's length.
+        PrivateEdit::TypedContainer(_) => true,
+        // Appends a slot when no blank one is free, and renumbers ids on that path.
+        PrivateEdit::InventoryAddItem(_) => true,
+        // Blanks a slot in place and proves the length is unchanged — but then calls
+        // normalize_slot_ids, which rewrites every m_Id in the container.
+        PrivateEdit::InventoryRemoveItem(_) => true,
+        // Exists to rewrite misaligned m_Ids.
+        PrivateEdit::InventoryRepairSlots => true,
+        // Swaps the whole m_Inventory value for the start save's.
+        PrivateEdit::InventoryReset(_) => true,
+        // Map insert into CharacterKnowledgeByUniqueName.
+        PrivateEdit::KnowledgeAddCharacter(_) => true,
+        // May insert a character and set-add/set-remove an entry.
+        PrivateEdit::KnowledgeSetEntry(_) => true,
+        // Removes memory events across owners and drops the corpse map entry.
+        PrivateEdit::NpcRevive(_) => true,
+        // Inserts a missing relationship entry.
+        PrivateEdit::NpcRelationship(_) => true,
+        // Duplicates a template unlock event, or removes one.
+        PrivateEdit::GlossarySetSegment(_) => true,
+        // Learn duplicates an ActiveEffects element, unlearn removes one.
+        PrivateEdit::SkillSet(_) => true,
+        // Splices the StoryPropertyValues map. Already exclusive; listed so the
+        // classification is complete rather than relying on the other guard.
+        PrivateEdit::StoryApply(_) => true,
+
+        // Ordinal-stable below. A setValue resolves to a scalar, a string or a
+        // native struct; none of the three can add or drop a container element.
+        PrivateEdit::TypedSetValue(_) => false,
+        // Fixed-size boolean patches.
+        PrivateEdit::FactionsForgive(_) => false,
+        // Fresh whole-payload string scan, then a string patch.
+        PrivateEdit::FString(_) | PrivateEdit::PlayerName(_) | PrivateEdit::ProfileName(_) => false,
+        // Patch a fixed number of bytes in place; they cannot change any length.
+        PrivateEdit::PlayerAttribute(_)
+        | PrivateEdit::PlayerTransform(_)
+        | PrivateEdit::InventoryItemCount(_) => false,
+    }
+}
+
+/// True for an edit that carries a CALLER-SUPPLIED ordinal — an index, a slot id, or
+/// a positional assumption the caller derived from an inspection taken before this
+/// write.
+///
+/// Edits that re-derive their own indices at apply time (addItem's free slot,
+/// removeItem's path match, a skill's effect element, revive's events) are not
+/// consumers, however structural they are.
+fn carries_caller_ordinal(edit: &PrivateEdit) -> bool {
+    match edit {
+        PrivateEdit::TypedContainer(container) => {
+            matches!(
+                container.edit,
+                properties::ContainerEdit::ArrayRemove(_)
+                    | properties::ContainerEdit::ArrayDuplicate(_)
+            ) || container
+                .path
+                .iter()
+                .any(|seg| matches!(seg, properties::PathSeg::Index(_)))
+        }
+        PrivateEdit::TypedSetValue(set_value) => set_value
+            .path
+            .iter()
+            .any(|seg| matches!(seg, properties::PathSeg::Index(_))),
+        // A slot id is an index by invariant (m_Id == position), so a renumber
+        // retargets it. The player path carries an ordinal even without one: it
+        // locates the stack through a positional region scan over the whole payload
+        // rather than through the typed tree, so anything that resizes the inventory
+        // moves the window it searches.
+        PrivateEdit::InventoryItemCount(edit) => edit.slot_id.is_some() || edit.actor_id.is_none(),
+        PrivateEdit::InventoryRemoveItem(edit) => edit.slot_id.is_some(),
+        _ => false,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10011,29 +10028,60 @@ fn apply_private_typed_set_value_edit_to_payload(
     payload: &mut Vec<u8>,
     edit: &PrivateTypedSetValueEdit,
 ) -> Result<(), CoreError> {
-    let root = properties::parse_private_root(payload)?;
-    let resolved = properties::resolve_chain(&root.properties, &edit.path)?;
-    let value = coerce_typed_value(resolved.target, &edit.value)?;
-    let target = resolved.target.clone();
+    apply_private_typed_set_value_edit_to_payload_reusing(
+        payload,
+        edit,
+        &mut PayloadRoot::default(),
+    )
+}
+
+/// As above, but resolving through a [`PayloadRoot`] shared with the rest of the
+/// write, so a batch of typed edits parses the payload once instead of once each.
+///
+/// Reading only the STRUCTURE is enough here, and that is what makes the sharing
+/// sound: [`properties::resolve_chain`] matches names, map keys and array indices —
+/// none of which an in-place `patch_scalar` can touch, since it has no string arm and
+/// a map key is not a `Property` it could address — while [`coerce_typed_value`] reads
+/// the target's `type_name`, its `tag_flags` native-serialize bit, and its value's
+/// variant, which a same-sized scalar write cannot change either.
+fn apply_private_typed_set_value_edit_to_payload_reusing(
+    payload: &mut Vec<u8>,
+    edit: &PrivateTypedSetValueEdit,
+    cache: &mut PayloadRoot,
+) -> Result<(), CoreError> {
+    let (target, enclosing_size_fields, value) = {
+        let root = cache.structural(payload)?;
+        let resolved = properties::resolve_chain(&root.properties, &edit.path)?;
+        let value = coerce_typed_value(resolved.target, &edit.value)?;
+        (
+            resolved.target.clone(),
+            resolved.enclosing_size_fields.clone(),
+            value,
+        )
+    };
     match value {
-        TypedSetValue::Scalar(scalar) => properties::patch_scalar(payload, &target, scalar),
+        TypedSetValue::Scalar(scalar) => {
+            properties::patch_scalar(payload, &target, scalar)?;
+            // Same bytes in the same places: the tree still describes the payload,
+            // only the values it decoded are now a step behind.
+            cache.note_in_place_write();
+            Ok(())
+        }
         TypedSetValue::Text(text) => {
             // Length-changing patch: work on a scratch copy and prove with a
             // strict re-parse that every enclosing size field was fixed up, so
             // a bug cannot corrupt the caller's payload (or the save).
             let mut patched = payload.clone();
-            properties::patch_string(
-                &mut patched,
-                &target,
-                &resolved.enclosing_size_fields,
-                &text,
-            )?;
-            properties::parse_private_root(&patched).map_err(|err| {
+            properties::patch_string(&mut patched, &target, &enclosing_size_fields, &text)?;
+            let proof = properties::parse_private_root(&patched).map_err(|err| {
                 CoreError::Parse(format!(
                     "string patch produced an inconsistent payload: {err}"
                 ))
             })?;
             *payload = patched;
+            // That proof was parsed from exactly the bytes just installed, so it is
+            // also the next edit's resolve parse.
+            cache.adopt(proof);
             Ok(())
         }
         TypedSetValue::NativeStruct(bytes) => {
@@ -10041,18 +10089,14 @@ fn apply_private_typed_set_value_edit_to_payload(
             // proof as variable-length tag containers. The original payload is
             // untouched unless a strict full parse accepts the replacement.
             let mut patched = payload.clone();
-            properties::patch_value_bytes(
-                &mut patched,
-                &target,
-                &resolved.enclosing_size_fields,
-                &bytes,
-            )?;
-            properties::parse_private_root(&patched).map_err(|error| {
+            properties::patch_value_bytes(&mut patched, &target, &enclosing_size_fields, &bytes)?;
+            let proof = properties::parse_private_root(&patched).map_err(|error| {
                 CoreError::Parse(format!(
                     "native struct patch produced an inconsistent payload: {error}"
                 ))
             })?;
             *payload = patched;
+            cache.adopt(proof);
             Ok(())
         }
     }
@@ -10528,7 +10572,132 @@ fn decompress_private_payload_with_limit(
     Ok((out, chunks_to_decode))
 }
 
+/// The private payload parsed once and reused across the edits of a single write.
+///
+/// Parsing a real save's 120 MB payload costs about as much as the whole codec, and a
+/// batch of edits used to pay it once per edit. Reuse needs care, though, because
+/// [`properties::parse_private_root`] returns a tree carrying BOTH byte offsets and
+/// decoded values, and the two survive different things:
+///
+///  * STRUCTURE — names, type names, descriptors, `value_offset`, `value_size`,
+///    element counts, map keys. Survives an in-place [`properties::patch_scalar`],
+///    which writes exactly `value_size` bytes at `value_offset` and has no string arm.
+///  * VALUES — the decoded `PropertyValue`s. Any write to the payload makes them lie,
+///    and a caller that decides something from them (whether an inventory slot is a
+///    clean template, say) would decide it from the pre-edit save.
+///
+/// So [`PayloadRoot::fresh`] is the default and re-parses after any write, while
+/// [`PayloadRoot::structural`] is an explicit opt-in for a caller whose read set is
+/// provably structural. A `PayloadRoot` belongs to exactly ONE buffer — appliers that
+/// patch a scratch copy must give that copy its own.
+#[derive(Default)]
+struct PayloadRoot {
+    root: Option<properties::RootObject>,
+    /// A byte was written since `root` was parsed, so its decoded values are stale
+    /// even though its offsets still hold.
+    values_stale: bool,
+}
+
+impl PayloadRoot {
+    /// The tree's structure only: offsets, sizes, names, keys and counts agree with
+    /// `payload`, but its decoded values may predate an in-place write. Callers must
+    /// read nothing else.
+    fn structural(&mut self, payload: &[u8]) -> Result<&properties::RootObject, CoreError> {
+        if let Some(root) = &self.root {
+            debug_assert!(
+                spine_still_describes(root, payload),
+                "a cached payload parse outlived a patch that moved bytes"
+            );
+        } else {
+            self.root = Some(properties::parse_private_root(payload)?);
+            self.values_stale = false;
+        }
+        Ok(self.root.as_ref().expect("just parsed"))
+    }
+
+    /// The whole tree, decoded values included, agreeing with `payload`.
+    fn fresh(&mut self, payload: &[u8]) -> Result<&properties::RootObject, CoreError> {
+        if self.values_stale {
+            self.root = None;
+        }
+        self.structural(payload)
+    }
+
+    /// Record a patch that wrote over existing bytes without moving any.
+    fn note_in_place_write(&mut self) {
+        self.values_stale = true;
+    }
+
+    /// Drop the parse. Required after anything that can move a byte — every
+    /// `patch_string` / `patch_value_bytes` / `patch_container` / splice, and every
+    /// wholesale `*payload = patched`, whatever the observed length delta.
+    fn invalidate(&mut self) {
+        self.root = None;
+        self.values_stale = false;
+    }
+
+    /// Take over a tree that was parsed FROM the bytes being installed, so an
+    /// applier's closing proof-parse doubles as the next edit's resolve parse.
+    fn adopt(&mut self, root: properties::RootObject) {
+        self.root = Some(root);
+        self.values_stale = false;
+    }
+}
+
+/// Debug-only check that a cached tree still describes `payload`'s layout. Compares
+/// the top-level spine, which is what a missing [`PayloadRoot::invalidate`] would
+/// break: a length change anywhere shifts every offset after it.
+#[cfg(debug_assertions)]
+fn spine_still_describes(root: &properties::RootObject, payload: &[u8]) -> bool {
+    let Ok(fresh) = properties::parse_private_root(payload) else {
+        return false;
+    };
+    fresh.consumed == root.consumed
+        && fresh.properties.len() == root.properties.len()
+        && fresh
+            .properties
+            .iter()
+            .zip(root.properties.iter())
+            .all(|(fresh, cached)| {
+                fresh.name == cached.name
+                    && fresh.type_name == cached.type_name
+                    && fresh.value_offset == cached.value_offset
+                    && fresh.value_size == cached.value_size
+            })
+}
+
+#[cfg(not(debug_assertions))]
+fn spine_still_describes(_root: &properties::RootObject, _payload: &[u8]) -> bool {
+    true
+}
+
 fn apply_private_edit_to_payload(
+    payload: &mut Vec<u8>,
+    edit: &PrivateEdit,
+    cache: &mut PayloadRoot,
+) -> Result<(), CoreError> {
+    match edit {
+        // The one edit that reuses the batch's parse: it resolves by name, key and
+        // index and patches a scalar in place, so nothing it reads can go stale.
+        PrivateEdit::TypedSetValue(edit) => {
+            apply_private_typed_set_value_edit_to_payload_reusing(payload, edit, cache)
+        }
+        // Re-parses for its own reads, but hands its closing proof parse to the next
+        // edit — the case that matters when several items are added in one write.
+        PrivateEdit::InventoryAddItem(edit) => {
+            apply_private_inventory_add_item_to_payload_reusing(payload, edit, cache)
+        }
+        // Everything else parses for itself and may move bytes, so the batch's parse
+        // is dropped rather than handed to a later edit that would resolve against a
+        // layout this one changed. A new variant lands here and inherits that.
+        edit => {
+            cache.invalidate();
+            apply_private_edit_to_payload_uncached(payload, edit)
+        }
+    }
+}
+
+fn apply_private_edit_to_payload_uncached(
     payload: &mut Vec<u8>,
     edit: &PrivateEdit,
 ) -> Result<(), CoreError> {
@@ -11920,14 +12089,32 @@ fn apply_private_inventory_add_item_to_payload(
     payload: &mut Vec<u8>,
     edit: &PrivateInventoryAddItemEdit,
 ) -> Result<(), CoreError> {
+    apply_private_inventory_add_item_to_payload_reusing(
+        payload,
+        edit,
+        &mut PayloadRoot::default(),
+    )
+}
+
+/// As above, but resolving through a [`PayloadRoot`] shared with the rest of the write
+/// so several adds in one write do not each re-parse the payload from scratch.
+fn apply_private_inventory_add_item_to_payload_reusing(
+    payload: &mut Vec<u8>,
+    edit: &PrivateInventoryAddItemEdit,
+    cache: &mut PayloadRoot,
+) -> Result<(), CoreError> {
     // 1. Typed parse + locate the MainContainer by enum value in m_Keys.
-    let root = properties::parse_private_root(payload).map_err(|err| {
+    //    `fresh`, not `structural`: picking a clean template slot reads DECODED
+    //    values (see property_carries_state), so a tree that predates an in-place
+    //    write by an earlier edit in the batch could call a dirty slot clean and let
+    //    the new item inherit its state.
+    let root = cache.fresh(payload).map_err(|err| {
         CoreError::Parse(format!(
             "private.inventory.addItem requires a typed-parsable private payload: {err}"
         ))
     })?;
     let inventory_path =
-        resolve_inventory_path(&root, edit.actor_id.as_deref()).ok_or_else(|| {
+        resolve_inventory_path(root, edit.actor_id.as_deref()).ok_or_else(|| {
             CoreError::Parse(
                 "private payload has no m_Inventory property; cannot add an item".to_string(),
             )
@@ -11937,7 +12124,7 @@ fn apply_private_inventory_add_item_to_payload(
         segments.extend_from_slice(suffix);
         properties::parse_path(&segments)
     };
-    let slots_suffix = main_container_slots_suffix(&root, &inventory_path)?;
+    let slots_suffix = main_container_slots_suffix(root, &inventory_path)?;
     let main_index = main_container_index_from_suffix(&slots_suffix);
     let slots_segs = child_segments(&slots_suffix)?;
     let chain = properties::resolve_chain(&root.properties, &slots_segs)?;
@@ -12003,7 +12190,7 @@ fn apply_private_inventory_add_item_to_payload(
             payload[range].to_vec()
         } else {
             needs_type_patch = true;
-            donor_slot_template_bytes(payload, &root, &inventory_path, main_index)?.ok_or_else(
+            donor_slot_template_bytes(payload, root, &inventory_path, main_index)?.ok_or_else(
                 || {
                     CoreError::UnsupportedEdit(
                         "no inventory container has a clean (state-free) slot to use as a \
@@ -12166,6 +12353,9 @@ fn apply_private_inventory_add_item_to_payload(
         ));
     }
     *payload = patched;
+    // The proof parse above was taken from exactly these bytes, so the next edit in
+    // the batch can resolve against it instead of parsing the payload again.
+    cache.adopt(reparsed);
     Ok(())
 }
 
@@ -13387,8 +13577,21 @@ fn find_item_count_value_offset(
         .and_then(|(count_idx, _)| i32_value_offset_at(payload, refs, count_idx))
 }
 
+/// How many previous chunks are decoded at once while looking for carry-over
+/// candidates. The backend parallelises within a window; the window bound keeps the
+/// comparison from holding a second full copy of a 120 MB payload in memory.
+const CARRY_OVER_WINDOW: usize = 64;
+
+/// Rebuild the private stream around an edited payload.
+///
+/// `source` is the file the `template` was parsed from, so the previous stream's
+/// compressed bytes are still addressable. Most edits touch a handful of bytes, and
+/// re-encoding the ~900 untouched chunks of a real save is the single most expensive
+/// thing a write does — so chunks whose plaintext did not change keep the bytes they
+/// already had (see [`carry_over_unchanged_chunks`]).
 fn rebuild_compressed_stream(
     template: &CompressedStream,
+    source: &[u8],
     private_payload: &[u8],
     backend: &dyn codec_backend::CodecBackend,
 ) -> Result<Vec<u8>, CoreError> {
@@ -13412,46 +13615,165 @@ fn rebuild_compressed_stream(
         .iter()
         .map(|chunk| chunk.len() as u64)
         .collect::<Vec<_>>();
-    let encode_chunks = payload_chunks
+    let carried = carry_over_unchanged_chunks(
+        template,
+        source,
+        max_chunk_size,
+        &payload_chunks,
+        backend,
+    );
+    let dirty = (0..payload_chunks.len())
+        .filter(|index| carried[*index].is_none())
+        .collect::<Vec<_>>();
+
+    let encode_chunks = dirty
         .iter()
-        .map(|chunk| codec_backend::CodecEncodeChunk {
-            input: chunk,
+        .map(|&index| codec_backend::CodecEncodeChunk {
+            input: payload_chunks[index],
             level: 6,
         })
         .collect::<Vec<_>>();
-    let compressed_chunks = backend.compress_many(&encode_chunks)?;
-    if compressed_chunks.len() != payload_chunks.len() {
+    let encoded_chunks = backend.compress_many(&encode_chunks)?;
+    if encoded_chunks.len() != dirty.len() {
         return Err(CoreError::Codec(format!(
             "codec backend compressed {} chunks, expected {}",
-            compressed_chunks.len(),
-            payload_chunks.len()
+            encoded_chunks.len(),
+            dirty.len()
         )));
     }
-    let decode_chunks = compressed_chunks
+    // Post-compress validation covers every chunk this write emits, as it always has:
+    // the carried-over ones were proved by the decode-and-compare that selected them,
+    // so only the freshly encoded ones still need decoding here.
+    let decode_chunks = encoded_chunks
         .iter()
-        .zip(payload_chunks.iter())
-        .map(|(compressed, original)| codec_backend::CodecDecodeChunk {
+        .zip(dirty.iter())
+        .map(|(compressed, &index)| codec_backend::CodecDecodeChunk {
             input: compressed,
-            expected_size: original.len(),
+            expected_size: payload_chunks[index].len(),
         })
         .collect::<Vec<_>>();
     let roundtrip_chunks = backend.decompress_many(&decode_chunks)?;
-    if roundtrip_chunks.len() != payload_chunks.len() {
+    if roundtrip_chunks.len() != dirty.len() {
         return Err(CoreError::Codec(format!(
             "codec backend post-compress validation decoded {} chunks, expected {}",
             roundtrip_chunks.len(),
-            payload_chunks.len()
+            dirty.len()
         )));
     }
-    for (roundtrip, original) in roundtrip_chunks.iter().zip(payload_chunks.iter()) {
-        if roundtrip != original {
+    for (roundtrip, &index) in roundtrip_chunks.iter().zip(dirty.iter()) {
+        if roundtrip != payload_chunks[index] {
             return Err(CoreError::Codec(
                 "codec backend failed post-compress validation".to_string(),
             ));
         }
     }
 
+    let mut encoded = encoded_chunks.into_iter();
+    let mut compressed_chunks = Vec::with_capacity(payload_chunks.len());
+    for reused in carried {
+        compressed_chunks.push(match reused {
+            Some(bytes) => bytes.to_vec(),
+            None => encoded
+                .next()
+                .expect("one encoded chunk per index without carry-over bytes"),
+        });
+    }
+
     build_compressed_stream_v2(template, &compressed_chunks, &uncompressed_sizes)
+}
+
+/// Pick out the chunks whose compressed bytes can be carried over from `source`
+/// unchanged.
+///
+/// A previous chunk qualifies only when it describes exactly the same plaintext window
+/// as the new chunk at its index — real saves use a uniform 128 KiB table, but the
+/// parser accepts ragged ones (see [`parse_compressed_stream`]), so the alignment is
+/// checked rather than assumed — and when decoding it reproduces that new chunk
+/// byte-for-byte.
+///
+/// That decode is what makes the carry-over safe: the emitted bytes are proved to
+/// decode to the plaintext they claim, which is exactly what the post-compress
+/// validation proves for a re-encoded chunk. A chunk that fails any test simply goes
+/// back through the encoder, so a ragged or damaged source stream costs speed, never
+/// correctness.
+fn carry_over_unchanged_chunks<'a>(
+    template: &CompressedStream,
+    source: &'a [u8],
+    max_chunk_size: usize,
+    payload_chunks: &[&[u8]],
+    backend: &dyn codec_backend::CodecBackend,
+) -> Vec<Option<&'a [u8]>> {
+    let candidates = aligned_previous_chunks(template, source, max_chunk_size, payload_chunks);
+    let mut carried = vec![None; payload_chunks.len()];
+    let candidate_indices = (0..payload_chunks.len())
+        .filter(|index| candidates[*index].is_some())
+        .collect::<Vec<_>>();
+    for window in candidate_indices.chunks(CARRY_OVER_WINDOW) {
+        let decode_chunks = window
+            .iter()
+            .map(|&index| codec_backend::CodecDecodeChunk {
+                input: candidates[index].expect("windows only hold candidate indices"),
+                expected_size: payload_chunks[index].len(),
+            })
+            .collect::<Vec<_>>();
+        // A previous chunk that will not decode is simply not reused; the payload it
+        // would have described was already decoded successfully by the caller.
+        let Ok(decoded) = backend.decompress_many(&decode_chunks) else {
+            continue;
+        };
+        if decoded.len() != window.len() {
+            continue;
+        }
+        for (plain, &index) in decoded.iter().zip(window.iter()) {
+            if plain.as_slice() == payload_chunks[index] {
+                carried[index] = candidates[index];
+            }
+        }
+    }
+    carried
+}
+
+/// The previous stream's compressed bytes for each new chunk index, but only where the
+/// two tables line up: the previous chunk must start at `index * max_chunk_size` in
+/// plaintext (i.e. every chunk before it was full) and hold as many plaintext bytes as
+/// the new chunk at that index.
+fn aligned_previous_chunks<'a>(
+    template: &CompressedStream,
+    source: &'a [u8],
+    max_chunk_size: usize,
+    payload_chunks: &[&[u8]],
+) -> Vec<Option<&'a [u8]>> {
+    let mut candidates = vec![None; payload_chunks.len()];
+    let mut plain_offset = 0usize;
+    for (index, chunk) in template.chunks.iter().enumerate() {
+        let starts_where_the_new_chunk_does = index
+            .checked_mul(max_chunk_size)
+            .is_some_and(|expected| expected == plain_offset);
+        let Some(next_offset) = plain_offset.checked_add(chunk.uncompressed_size as usize) else {
+            break;
+        };
+        plain_offset = next_offset;
+        if !starts_where_the_new_chunk_does {
+            continue;
+        }
+        let Some(new_chunk) = payload_chunks.get(index) else {
+            continue;
+        };
+        if new_chunk.len() as u64 != chunk.uncompressed_size {
+            continue;
+        }
+        let Some(end) = chunk
+            .compressed_offset
+            .checked_add(chunk.compressed_size as usize)
+        else {
+            continue;
+        };
+        let Some(bytes) = source.get(chunk.compressed_offset..end) else {
+            continue;
+        };
+        candidates[index] = Some(bytes);
+    }
+    candidates
 }
 
 fn build_compressed_stream_v2(
@@ -15736,6 +16058,25 @@ mod tests {
         out
     }
 
+    /// First offset at which `needle` occurs in `haystack`, for asserting that a
+    /// string an edit was supposed to write really reached the payload.
+    fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack
+            .windows(needle.len())
+            .position(|window| window == needle)
+    }
+
+    /// The private payload of a written test save, decoded with the same fake
+    /// backend that wrote it.
+    fn decoded_private_payload_for_tests(
+        file_bytes: &[u8],
+        backend: &dyn codec_backend::CodecBackend,
+    ) -> Vec<u8> {
+        let parts = split_gsav(file_bytes).unwrap();
+        let stream = parse_compressed_stream(file_bytes, 13 + parts.public_payload.len()).unwrap();
+        decompress_private_payload(file_bytes, &stream, backend).unwrap()
+    }
+
     fn compressed_stream_with_one_chunk(compressed: &[u8], uncompressed_size: usize) -> Vec<u8> {
         compressed_stream_with_chunks(&[(compressed.to_vec(), uncompressed_size as u64)])
     }
@@ -15807,6 +16148,58 @@ mod tests {
             let mut out = b"CMP:".to_vec();
             out.extend_from_slice(input);
             Ok(out)
+        }
+    }
+
+    /// Same trivial `CMP:` framing as [`PrefixCodecBackend`], but it counts how many
+    /// chunks were handed to the encoder, so a test can pin down that a write only
+    /// re-encodes what it actually changed.
+    struct CountingCodecBackend {
+        compressed_chunks: Mutex<usize>,
+    }
+
+    impl CountingCodecBackend {
+        fn new() -> Self {
+            Self {
+                compressed_chunks: Mutex::new(0),
+            }
+        }
+
+        fn compressed_chunks(&self) -> usize {
+            *self.compressed_chunks.lock().unwrap()
+        }
+
+        fn seed(plain: &[u8]) -> Vec<u8> {
+            let mut out = b"CMP:".to_vec();
+            out.extend_from_slice(plain);
+            out
+        }
+    }
+
+    impl codec_backend::CodecBackend for CountingCodecBackend {
+        fn probe(&self) -> Result<codec_backend::CodecBackendProbe, CoreError> {
+            Ok(codec_backend::CodecBackendProbe {
+                backend: "counting_test_codec".to_string(),
+                available: true,
+                can_decompress: true,
+                can_compress: true,
+                status: "ready".to_string(),
+                profile: None,
+                resolution_mode: None,
+                details: json!({}),
+            })
+        }
+
+        fn decompress(&self, input: &[u8], _expected_size: usize) -> Result<Vec<u8>, CoreError> {
+            input
+                .strip_prefix(b"CMP:")
+                .map(|payload| payload.to_vec())
+                .ok_or_else(|| CoreError::Codec("unexpected test compressed payload".to_string()))
+        }
+
+        fn compress(&self, input: &[u8], _level: u8) -> Result<Vec<u8>, CoreError> {
+            *self.compressed_chunks.lock().unwrap() += 1;
+            Ok(Self::seed(input))
         }
     }
 
@@ -18834,6 +19227,78 @@ mod tests {
         assert_eq!(value["private"]["inventory"]["items"][0]["count"], 99);
     }
 
+    /// Re-encoding every chunk is what makes a write slow: a real save is ~900 chunks
+    /// and a scalar edit dirties one of them. A write must therefore hand the encoder
+    /// only the chunks whose plaintext changed and carry the rest over verbatim.
+    #[test]
+    fn write_save_reencodes_only_the_chunks_an_edit_touched() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("G1R-001.sav");
+        let output_path = dir.path().join("G1R-001-edited.sav");
+
+        // The edited property sits at the very end, so an in-place patch of it can only
+        // dirty the trailing chunk.
+        let mut payload = fstring("/Script/Test.Save");
+        payload.push(0);
+        payload.extend_from_slice(&private_str_property("m_Filler", &"x".repeat(400)));
+        payload.extend_from_slice(&int_property("m_Gold", 250));
+        payload.extend_from_slice(&fstring("None"));
+        payload.extend_from_slice(&0u32.to_le_bytes());
+
+        // A full leading chunk plus a shorter tail, so the rebuild's own
+        // `chunks(max_chunk_size)` split lines up with this table.
+        let split = payload.len().div_ceil(2);
+        let (head, tail) = payload.split_at(split);
+        let head_compressed = CountingCodecBackend::seed(head);
+        let tail_compressed = CountingCodecBackend::seed(tail);
+        let stream = compressed_stream_with_chunks(&[
+            (head_compressed.clone(), head.len() as u64),
+            (tail_compressed, tail.len() as u64),
+        ]);
+        fs::write(
+            &path,
+            build_gsav(2, &public_payload("Slot A"), &stream, &[0, 0, 0, 0]),
+        )
+        .unwrap();
+
+        let backend = CountingCodecBackend::new();
+        write_save_with_codec_backend(
+            &path,
+            &[json!({
+                "path": "private.typed.setValue",
+                "value": { "path": ["m_Gold"], "value": 999 }
+            })],
+            false,
+            Some(&output_path),
+            Some(&backend),
+        )
+        .unwrap();
+
+        assert_eq!(
+            backend.compressed_chunks(),
+            1,
+            "only the chunk holding the edited property may be re-encoded"
+        );
+
+        // The untouched chunk keeps the exact bytes it had, so the written stream is a
+        // mix of carried-over and freshly encoded chunks.
+        let written = fs::read(&output_path).unwrap();
+        let parts = split_gsav(&written).unwrap();
+        let rebuilt = parse_compressed_stream(&written, 13 + parts.public_payload.len()).unwrap();
+        assert_eq!(rebuilt.chunks.len(), 2);
+        let head_range = rebuilt.chunks[0].compressed_offset
+            ..rebuilt.chunks[0].compressed_offset + rebuilt.chunks[0].compressed_size as usize;
+        assert_eq!(&written[head_range], head_compressed.as_slice());
+
+        // ... and the mixed stream still decodes to the edited payload.
+        let decoded = decompress_private_payload(&written, &rebuilt, &backend).unwrap();
+        let root = properties::parse_private_root(&decoded).unwrap();
+        assert_eq!(
+            root.properties.last().map(|property| &property.value),
+            Some(&properties::PropertyValue::Int(999))
+        );
+    }
+
     #[test]
     fn inspect_save_decodes_private_stream_with_codec_backend() {
         let dir = tempdir().unwrap();
@@ -19902,7 +20367,7 @@ mod tests {
         .unwrap_err();
         assert!(
             err.to_string()
-                .contains("at most one structural array edit"),
+                .contains("addresses an element by index or slot id"),
             "unexpected error: {err}"
         );
         assert!(
@@ -19927,12 +20392,119 @@ mod tests {
     }
 
     #[test]
-    fn write_save_rejects_inventory_structural_edit_with_peer() {
+    fn array_remove_retargets_a_later_index_addressed_edit() {
+        // The hazard the ordinal guard exists to stop, proven with the guard out of
+        // the way: removing element 0 shifts every later slot down one, so a queued
+        // edit on [1] — an index the caller derived from the PRE-write inspection,
+        // where [1] was the Apple — lands on whatever moved into that position.
+        let mut payload = typed_inventory_private_payload(
+            &[],
+            &[
+                inv_item_slot(
+                    0,
+                    INV_MAIN_LABEL,
+                    "/Script/Angelscript.ItMi_Orenugget",
+                    3,
+                    &inv_empty_payload_map(),
+                ),
+                inv_item_slot(
+                    1,
+                    INV_MAIN_LABEL,
+                    "/Script/Angelscript.ItFo_Apple",
+                    1,
+                    &inv_empty_payload_map(),
+                ),
+                inv_item_slot(
+                    2,
+                    INV_MAIN_LABEL,
+                    "/Script/Angelscript.ItFo_Cheese",
+                    7,
+                    &inv_empty_payload_map(),
+                ),
+            ],
+        );
+        let slots = inv_slots_prefix(1);
+        let count_segs = |index: usize| {
+            let mut path = slots.clone();
+            path.extend([
+                format!("[{index}]"),
+                "m_SlotData".to_string(),
+                "m_ItemCount".to_string(),
+            ]);
+            properties::parse_path(&path).unwrap()
+        };
+        let count_at = |payload: &[u8], index: usize| {
+            let root = properties::parse_private_root(payload).unwrap();
+            match properties::resolve(&root.properties, &count_segs(index))
+                .unwrap()
+                .value
+            {
+                properties::PropertyValue::Int(value) => value,
+                ref other => panic!("m_ItemCount is not an Int: {other:?}"),
+            }
+        };
+
+        apply_private_edit_to_payload(
+            &mut payload,
+            &PrivateEdit::TypedContainer(PrivateTypedContainerEdit {
+                path: properties::parse_path(&slots).unwrap(),
+                edit: properties::ContainerEdit::ArrayRemove(0),
+            }),
+            &mut PayloadRoot::default(),
+        )
+        .unwrap();
+        apply_private_edit_to_payload(
+            &mut payload,
+            &PrivateEdit::TypedSetValue(PrivateTypedSetValueEdit {
+                // The caller meant the Apple.
+                path: count_segs(1),
+                value: json!(99),
+            }),
+            &mut PayloadRoot::default(),
+        )
+        .unwrap();
+
+        assert_eq!(count_at(&payload, 0), 1, "the Apple is left untouched");
+        assert_eq!(count_at(&payload, 1), 99, "the Cheese was silently retargeted");
+    }
+
+    #[test]
+    fn private_edits_apply_in_submitted_order() {
+        // The ordinal guard is position-based and callers order their edits
+        // deliberately (array removals index-descending, glossary unlocks before
+        // removals, a slot repair last), so submission order is part of the contract.
+        // Anything that sorted or grouped the batch would break those rules silently.
+        let mut payload = fstring("/Script/Test.Save");
+        payload.push(0);
+        payload.extend_from_slice(&int_property("m_Gold", 1));
+        payload.extend_from_slice(&fstring("None"));
+        payload.extend_from_slice(&0u32.to_le_bytes());
+
+        let gold = |value: i32| {
+            PrivateEdit::TypedSetValue(PrivateTypedSetValueEdit {
+                path: properties::parse_path(&["m_Gold".to_string()]).unwrap(),
+                value: json!(value),
+            })
+        };
+        let mut cache = PayloadRoot::default();
+        apply_private_edit_to_payload(&mut payload, &gold(2), &mut cache).unwrap();
+        apply_private_edit_to_payload(&mut payload, &gold(3), &mut cache).unwrap();
+
+        let root = properties::parse_private_root(&payload).unwrap();
+        assert_eq!(
+            root.properties[0].value,
+            properties::PropertyValue::Int(3),
+            "the last edit in the batch must win"
+        );
+    }
+
+    #[test]
+    fn write_save_rejects_an_index_addressed_peer_after_a_length_change() {
         // An inventory add/remove must stand alone: a peer edit in the same
         // write resolves against the pre-splice layout and would be corrupted.
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
-        let private_payload = inventory_payload_for_add_item_tests();
+        let private_payload = typed_inventory_private_payload(&[], &default_main_slots());
         let seed_compressed = b"seed-peer".to_vec();
         let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
         fs::write(
@@ -19945,16 +20517,24 @@ mod tests {
             seed_uncompressed: private_payload,
         };
 
+        // The add appends a slot, so the queued edit's `[1]` — an index the caller
+        // read off the PRE-write inspection — would resolve against a different array.
+        let mut count_path = inv_slots_prefix(1);
+        count_path.extend([
+            "[1]".to_string(),
+            "m_SlotData".to_string(),
+            "m_ItemCount".to_string(),
+        ]);
         let err = write_save_with_codec_backend(
             &path,
             &[
                 json!({
                     "path": "private.inventory.addItem",
-                    "value": { "path": "/Script/Angelscript.ItMi_Orenugget", "count": 1 }
+                    "value": { "path": "/Script/Angelscript.ItFo_Cheese", "count": 1 }
                 }),
                 json!({
                     "path": "private.typed.setValue",
-                    "value": { "path": ["m_MaxQuick"], "value": 9 }
+                    "value": { "path": count_path, "value": 9 }
                 }),
             ],
             false,
@@ -19962,8 +20542,10 @@ mod tests {
             Some(&backend),
         )
         .unwrap_err();
+        assert!(matches!(err, CoreError::UnsupportedEdit(_)), "got: {err}");
         assert!(
-            err.to_string().contains("must contain no other edits"),
+            err.to_string()
+                .contains("addresses an element by index or slot id"),
             "unexpected error: {err}"
         );
     }
@@ -20000,7 +20582,8 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.to_string().contains("must contain no other edits"),
+            err.to_string()
+                .contains("must be the only edit in a write"),
             "unexpected error: {err}"
         );
     }
@@ -20063,7 +20646,7 @@ mod tests {
             seed_uncompressed: private_payload,
         };
 
-        let err = write_save_with_codec_backend(
+        let response = write_save_with_codec_backend(
             &path,
             &[
                 json!({
@@ -20071,24 +20654,28 @@ mod tests {
                     "value": { "value": "OC_TEST_BrandNew" }
                 }),
                 json!({
-                    "path": "private.typed.setValue",
-                    "value": { "path": ["m_MaxQuick"], "value": 9 }
+                    "path": "private.knowledge.addCharacter",
+                    "value": { "value": "OC_TEST_SecondNew" }
                 }),
             ],
             false,
             None,
             Some(&backend),
         )
-        .unwrap_err();
-        assert!(
-            err.to_string().contains("must contain no other edits"),
-            "unexpected error: {err}"
-        );
-        // The error must call out the map-insert case, not only inventory.
-        assert!(
-            err.to_string().contains("private.knowledge.addCharacter"),
-            "error should mention the knowledge op: {err}"
-        );
+        .unwrap();
+        assert_eq!(response["editsApplied"], 2);
+
+        // Each insert re-parses the map it is handed, so neither carries an ordinal
+        // the other could shift.
+        let written = fs::read(&path).unwrap();
+        let payload = decoded_private_payload_for_tests(&written, &backend);
+        for expected in [b"OC_TEST_BrandNew".as_slice(), b"OC_TEST_SecondNew".as_slice()] {
+            assert!(
+                find_subslice(&payload, expected).is_some(),
+                "inserted character is missing from the written payload: {}",
+                String::from_utf8_lossy(expected)
+            );
+        }
     }
 
     #[test]
@@ -21875,8 +22462,29 @@ mod tests {
                 "value": "EQuestState::Available"
             }),
         };
-        let err = apply_private_edits(&data, &[&glossary, &peer], Some(&backend)).unwrap_err();
-        assert!(matches!(err, CoreError::UnsupportedEdit(_)));
+        // The peer resolves its quest by MAP KEY, which the glossary splice cannot
+        // move, so the two share one write.
+        let edited = apply_private_edits(&data, &[&glossary, &peer], Some(&backend)).unwrap();
+        let payload = decoded_private_payload_for_tests(&edited, &backend);
+        assert!(
+            find_subslice(&payload, b"DocumentSegment_Glossary_Meatbug_Entry2").is_some(),
+            "the unlocked segment is missing from the written payload"
+        );
+        let root = properties::parse_private_root(&payload).unwrap();
+        let state = properties::resolve(
+            &root.properties,
+            &properties::parse_path(&[
+                "QuestDataByClass".to_string(),
+                "{/Script/Angelscript.Quest_OldCamp_SLEEPER}".to_string(),
+                "CurrentState".to_string(),
+            ])
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            state.value,
+            properties::PropertyValue::Enum("EQuestState::Available".to_string())
+        );
     }
 
     #[test]
@@ -25341,12 +25949,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_private_inventory_add_item_rejects_two_in_batch() {
-        // Two addItem edits in one batch must be rejected as structural edits
-        // (array-length changes) for the same reason as two arrayDuplicate ops.
+    fn parse_private_inventory_add_item_accepts_two_in_batch() {
+        // Two addItem edits share one write: each re-derives its own free slot from
+        // the payload it is handed, so neither depends on an index the other moved.
         let dir = tempdir().unwrap();
         let path = dir.path().join("G1R-001.sav");
-        let private_payload = inventory_payload_for_add_item_tests();
+        let private_payload = typed_inventory_private_payload(&[], &default_main_slots());
         let seed_compressed = b"seed-2add".to_vec();
         let stream = compressed_stream_with_one_chunk(&seed_compressed, private_payload.len());
         fs::write(
@@ -25359,13 +25967,13 @@ mod tests {
             seed_uncompressed: private_payload,
         };
 
-        let err = write_save_with_codec_backend(
+        let response = write_save_with_codec_backend(
             &path,
             &[
                 json!({
                     "path": "private.inventory.addItem",
                     "value": {
-                        "path": "/Script/Angelscript.ItMi_Orenugget",
+                        "path": "/Script/Angelscript.ItFo_Cheese",
                         "count": 1
                     }
                 }),
@@ -25381,16 +25989,23 @@ mod tests {
             None,
             Some(&backend),
         )
-        .unwrap_err();
-        assert!(
-            matches!(err, CoreError::UnsupportedEdit(_)),
-            "expected UnsupportedEdit for two addItem in batch, got: {err}"
-        );
-        assert!(
-            err.to_string()
-                .contains("at most one structural array edit"),
-            "unexpected error message: {err}"
-        );
+        .unwrap();
+        assert_eq!(response["editsApplied"], 2);
+
+        // Each add re-derives its own free slot at apply time, so neither carries an
+        // ordinal the other could invalidate.
+        let written = fs::read(&path).unwrap();
+        let payload = decoded_private_payload_for_tests(&written, &backend);
+        for expected in [
+            b"/Script/Angelscript.ItFo_Cheese".as_slice(),
+            b"/Script/Angelscript.ItAt_Lurker_01".as_slice(),
+        ] {
+            assert!(
+                find_subslice(&payload, expected).is_some(),
+                "batched add is missing from the written payload: {}",
+                String::from_utf8_lossy(expected)
+            );
+        }
     }
 
     #[test]
@@ -25447,7 +26062,7 @@ mod tests {
         );
         assert!(
             err.to_string()
-                .contains("at most one structural array edit"),
+                .contains("addresses an element by index or slot id"),
             "unexpected error message: {err}"
         );
     }
@@ -26598,7 +27213,7 @@ mod tests {
             seed_uncompressed: private_payload,
         };
 
-        let err = write_save_with_codec_backend(
+        let response = write_save_with_codec_backend(
             &path,
             &[
                 json!({
@@ -26614,16 +27229,23 @@ mod tests {
             None,
             Some(&backend),
         )
-        .unwrap_err();
-        assert!(
-            matches!(err, CoreError::UnsupportedEdit(_)),
-            "expected UnsupportedEdit for two removeItem in batch, got: {err}"
-        );
-        assert!(
-            err.to_string()
-                .contains("at most one structural array edit"),
-            "unexpected error message: {err}"
-        );
+        .unwrap();
+        assert_eq!(response["editsApplied"], 2);
+
+        // Each removal matches its own item path against the payload it is handed,
+        // so the first one's slot renumbering cannot retarget the second.
+        let written = fs::read(&path).unwrap();
+        let payload = decoded_private_payload_for_tests(&written, &backend);
+        for gone in [
+            b"/Script/Angelscript.ItMi_Orenugget".as_slice(),
+            b"/Script/Angelscript.ItFo_Apple".as_slice(),
+        ] {
+            assert!(
+                find_subslice(&payload, gone).is_none(),
+                "removed item is still in the written payload: {}",
+                String::from_utf8_lossy(gone)
+            );
+        }
     }
 
     #[test]
@@ -26644,7 +27266,7 @@ mod tests {
             seed_uncompressed: private_payload,
         };
 
-        let err = write_save_with_codec_backend(
+        let response = write_save_with_codec_backend(
             &path,
             &[
                 json!({
@@ -26660,15 +27282,18 @@ mod tests {
             None,
             Some(&backend),
         )
-        .unwrap_err();
+        .unwrap();
+        assert_eq!(response["editsApplied"], 2);
+
+        let written = fs::read(&path).unwrap();
+        let payload = decoded_private_payload_for_tests(&written, &backend);
         assert!(
-            matches!(err, CoreError::UnsupportedEdit(_)),
-            "expected UnsupportedEdit for addItem + removeItem, got: {err}"
+            find_subslice(&payload, b"/Script/Angelscript.ItFo_Cheese").is_some(),
+            "the added item is missing from the written payload"
         );
         assert!(
-            err.to_string()
-                .contains("at most one structural array edit"),
-            "unexpected error message: {err}"
+            find_subslice(&payload, b"/Script/Angelscript.ItMi_Orenugget").is_none(),
+            "the removed item is still in the written payload"
         );
     }
 

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -12189,10 +12189,11 @@ fn apply_private_inventory_add_item_to_payload_reusing(
     })?;
     let mut patched = payload.clone();
     let mut needs_type_patch = false;
+    let ids_already_aligned;
     // `patched` starts out byte-for-byte the buffer `root` describes. Filling a free
     // slot only writes to it when that slot still carried the previous item's state,
     // so track whether anything moved and skip the re-parse below when nothing did.
-    let mut patched_matches_root = true;
+    let patched_matches_root;
     if let Some(free_index) = free_index {
         // A slot is picked as free on its empty definition alone, and an older
         // build could leave one blank while its payload still held the removed
@@ -12335,17 +12336,37 @@ fn apply_private_inventory_add_item_to_payload_reusing(
             id_target,
             properties::ScalarValue::Int(new_id),
         )?;
+        // Whether the ids need re-aligning is decidable from THIS parse: the two
+        // writes above are fixed-size, so every other slot still holds the id it
+        // shows here, and the edited one was just set to its own index. Deciding it
+        // now saves the whole-payload parse the re-align would otherwise open with,
+        // and the proof below re-checks the invariant on the bytes that land.
+        let slots_after = properties::resolve(&retargeted.properties, &slots_segs)?;
+        let properties::PropertyValue::Array {
+            elements: slots_after,
+        } = &slots_after.value
+        else {
+            return Err(CoreError::Parse(
+                "MainContainer m_Slots is not a plain slot array after the edit".to_string(),
+            ));
+        };
+        ids_already_aligned = slots_after.iter().enumerate().all(|(index, slot)| {
+            index == new_index
+                || i32::try_from(index).is_ok_and(|expected| slot_id(slot) == Some(expected))
+        });
     }
 
     // 5. Re-align the edited container's slot ids with their indices. The append
     //    above keeps the invariant on its own for a healthy save; this also
     //    repairs a MainContainer an earlier build left misaligned.
-    let slots_path = {
-        let mut path = inventory_path.clone();
-        path.extend_from_slice(&slots_suffix);
-        path
-    };
-    normalize_slot_ids(&mut patched, &slots_path)?;
+    if !ids_already_aligned {
+        let slots_path = {
+            let mut path = inventory_path.clone();
+            path.extend_from_slice(&slots_suffix);
+            path
+        };
+        normalize_slot_ids(&mut patched, &slots_path)?;
+    }
 
     // 6. Final proof: strict re-parse AND the new slot must exist in the
     //    MainContainer itself with the requested path and count. A global

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -9072,6 +9072,20 @@ fn segment_after_name<'a>(
     Some(path.get(at + 1))
 }
 
+/// Whether `path` descends into `map`'s entry for `key` — or into the map as a
+/// whole, which collides with every entry in it.
+fn path_enters_map_entry(path: &[properties::PathSeg], map: &str, key: &str) -> bool {
+    match segment_after_name(path, map) {
+        None => false,
+        Some(None) => true,
+        Some(Some(properties::PathSeg::MapKey(found))) => {
+            found.trim().eq_ignore_ascii_case(key.trim())
+        }
+        // Addressed some other way; too unclear to call safe.
+        Some(Some(_)) => true,
+    }
+}
+
 fn path_has_name(path: &[properties::PathSeg], name: &str) -> bool {
     path.iter()
         .any(|segment| matches!(segment, properties::PathSeg::Name(found) if found == name))
@@ -9107,15 +9121,7 @@ fn structured_edit_rewrites(edit: &PrivateEdit, path: &[properties::PathSeg]) ->
     match edit {
         // Patches or appends a modifier under this NPC's relationship entry.
         PrivateEdit::NpcRelationship(relationship) => {
-            match segment_after_name(path, "RelationshipByGlobalId") {
-                None => false,
-                // An edit of the whole map collides with every structured write.
-                Some(None) => true,
-                Some(Some(properties::PathSeg::MapKey(key))) => {
-                    key.trim().eq_ignore_ascii_case(relationship.id.trim())
-                }
-                Some(Some(_)) => true,
-            }
+            path_enters_map_entry(path, "RelationshipByGlobalId", &relationship.id)
         }
         // Learning or unlearning rewrites this actor's effect elements.
         PrivateEdit::SkillSet(skill) => {
@@ -9131,9 +9137,14 @@ fn structured_edit_rewrites(edit: &PrivateEdit, path: &[properties::PathSeg]) ->
                 || path_has_name(path, "LooseTagsByGlobalId")
                 || path_has_name(path, "m_SavedInventories")
         }
-        // Inserts an entry into the knowledge map.
-        PrivateEdit::KnowledgeAddCharacter(_) | PrivateEdit::KnowledgeSetEntry(_) => {
-            path_has_name(path, "CharacterKnowledgeByUniqueName")
+        // Insert or update ONE character's knowledge entry. Another character's
+        // entry is a different map value, and every applier re-resolves its target
+        // by key, so the two do not collide.
+        PrivateEdit::KnowledgeAddCharacter(name) => {
+            path_enters_map_entry(path, "CharacterKnowledgeByUniqueName", name)
+        }
+        PrivateEdit::KnowledgeSetEntry(edit) => {
+            path_enters_map_entry(path, "CharacterKnowledgeByUniqueName", &edit.character)
         }
         // Claims a whole slot: the add fills a blank one and resets its payload, the
         // removal blanks one.
@@ -20683,6 +20694,49 @@ mod tests {
             properties::PropertyValue::Int(3),
             "the last edit in the batch must win"
         );
+    }
+
+    #[test]
+    fn a_keyed_structured_write_only_conflicts_with_its_own_entry() {
+        // Two characters are two map values, and every applier re-resolves its
+        // target by key, so a write to one cannot disturb the other. Same for a
+        // relationship: only that NPC's entry is rewritten.
+        let entry_path = |map: &str, key: &str| {
+            properties::parse_path(&[
+                map.to_string(),
+                format!("{{{key}}}"),
+                "Entries".to_string(),
+            ])
+            .unwrap()
+        };
+
+        let add = PrivateEdit::KnowledgeAddCharacter("OC_TEST_New".to_string());
+        assert!(structured_edit_rewrites(
+            &add,
+            &entry_path("CharacterKnowledgeByUniqueName", "OC_TEST_New")
+        ));
+        assert!(!structured_edit_rewrites(
+            &add,
+            &entry_path("CharacterKnowledgeByUniqueName", "OC_STT_Diego")
+        ));
+        // Addressing the map itself collides with every entry in it.
+        assert!(structured_edit_rewrites(
+            &add,
+            &properties::parse_path(&["CharacterKnowledgeByUniqueName".to_string()]).unwrap()
+        ));
+
+        let relationship = PrivateEdit::NpcRelationship(PrivateNpcRelationshipEdit {
+            id: "OC_GRD_Orry_254".to_string(),
+            relationship: npc::PersonalRelationship::Friend,
+        });
+        assert!(structured_edit_rewrites(
+            &relationship,
+            &entry_path("RelationshipByGlobalId", "OC_GRD_Orry_254")
+        ));
+        assert!(!structured_edit_rewrites(
+            &relationship,
+            &entry_path("RelationshipByGlobalId", "OC_GRD_Someone_Else")
+        ));
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -9156,9 +9156,14 @@ fn structured_edit_rewrites(edit: &PrivateEdit, path: &[properties::PathSeg]) ->
         PrivateEdit::SkillSet(skill) => {
             path_has_name(path, "ActiveEffects") && path_has_key(path, &skill.actor)
         }
-        // Adds or removes an unlock event in the hero's memory.
-        PrivateEdit::GlossarySetSegment(_) => {
-            path_has_name(path, "MemorizedEvents") && path_has_key(path, skills::HERO)
+        // Adds or removes an unlock event in the hero's memory — and, when the
+        // caller supplied one, rewrites that quest's CurrentState as well.
+        PrivateEdit::GlossarySetSegment(glossary) => {
+            (path_has_name(path, "MemorizedEvents") && path_has_key(path, skills::HERO))
+                || glossary
+                    .quest_state_path
+                    .as_ref()
+                    .is_some_and(|quest| quest.as_slice() == path)
         }
         // Strips memory events, death tags and the corpse entry.
         PrivateEdit::NpcRevive(_) => {
@@ -20794,6 +20799,55 @@ mod tests {
         ])
         .unwrap();
         assert!(!structured_edit_rewrites(&add_for(None), &attribute));
+    }
+
+    #[test]
+    fn a_glossary_write_also_guards_the_quest_state_it_rewrites() {
+        // Unlocking a segment can carry a quest-state path, and then it rewrites
+        // that CurrentState too. A raw edit of the same leaf must not share the
+        // write in either order.
+        let quest_state = properties::parse_path(&[
+            "QuestDataByClass".to_string(),
+            "{/Script/Angelscript.Quest_OldCamp_SLEEPER}".to_string(),
+            "CurrentState".to_string(),
+        ])
+        .unwrap();
+        let elsewhere = properties::parse_path(&[
+            "QuestDataByClass".to_string(),
+            "{/Script/Angelscript.Quest_Something_Else}".to_string(),
+            "CurrentState".to_string(),
+        ])
+        .unwrap();
+
+        let with_quest = PrivateEdit::GlossarySetSegment(PrivateGlossarySetSegmentEdit {
+            package: "/Script/Angelscript".to_string(),
+            document_asset: "Document_Glossary_Meatbug".to_string(),
+            segment_asset: "DocumentSegment_Glossary_Meatbug_Entry2".to_string(),
+            unlocked: true,
+            quest_state_path: Some(quest_state.clone()),
+        });
+        assert!(structured_edit_rewrites(&with_quest, &quest_state));
+        assert!(!structured_edit_rewrites(&with_quest, &elsewhere));
+
+        // Without one, the quest state is not its business.
+        let without_quest = PrivateEdit::GlossarySetSegment(PrivateGlossarySetSegmentEdit {
+            package: "/Script/Angelscript".to_string(),
+            document_asset: "Document_Glossary_Meatbug".to_string(),
+            segment_asset: "DocumentSegment_Glossary_Meatbug_Entry2".to_string(),
+            unlocked: true,
+            quest_state_path: None,
+        });
+        assert!(!structured_edit_rewrites(&without_quest, &quest_state));
+
+        // The hero's memory events stay guarded either way.
+        let hero_memory = properties::parse_path(&[
+            "LongTermMemoryByGlobalId".to_string(),
+            "{Hero}".to_string(),
+            "MemorizedEvents".to_string(),
+            "[3]".to_string(),
+        ])
+        .unwrap();
+        assert!(structured_edit_rewrites(&without_quest, &hero_memory));
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -8991,6 +8991,25 @@ fn apply_private_edits(
                 .to_string(),
         ));
     }
+    // Ordering cannot rescue a batch whose edits address the SAME thing: a structured
+    // operation rewrites its target wholesale, so one of the two silently loses while
+    // the write reports both as applied. Reject those pairs whichever way round they
+    // come (see `structured_edit_rewrites`).
+    for (structured_at, structured) in edit_specs.iter().enumerate() {
+        for (typed_at, typed) in edit_specs.iter().enumerate() {
+            let Some(path) = raw_typed_path(typed) else {
+                continue;
+            };
+            if structured_edit_rewrites(structured, path) {
+                return Err(CoreError::UnsupportedEdit(format!(
+                    "{} (edit {typed_at}) edits something {} (edit {structured_at}) \
+                     rewrites as a whole, so one of the two would silently be \
+                     discarded whichever order they run in; save them separately",
+                    edits[typed_at].path, edits[structured_at].path
+                )));
+            }
+        }
+    }
     // Every `apply_*` re-parses the payload it is handed, so a batch can never carry a
     // stale BYTE OFFSET from one edit into the next. What a batch CAN invalidate is a
     // caller-supplied ORDINAL: an array index or slot id the caller read off an
@@ -9031,6 +9050,103 @@ fn apply_private_edits(
         &compressed_stream,
         parts.trailer,
     ))
+}
+
+/// The path a raw `private.typed.*` edit addresses, if this is one.
+fn raw_typed_path(edit: &PrivateEdit) -> Option<&[properties::PathSeg]> {
+    match edit {
+        PrivateEdit::TypedSetValue(edit) => Some(&edit.path),
+        PrivateEdit::TypedContainer(edit) => Some(&edit.path),
+        _ => None,
+    }
+}
+
+/// The segment following the first `Name(name)` in `path`, if any.
+fn segment_after_name<'a>(
+    path: &'a [properties::PathSeg],
+    name: &str,
+) -> Option<Option<&'a properties::PathSeg>> {
+    let at = path.iter().position(
+        |segment| matches!(segment, properties::PathSeg::Name(found) if found == name),
+    )?;
+    Some(path.get(at + 1))
+}
+
+fn path_has_name(path: &[properties::PathSeg], name: &str) -> bool {
+    path.iter()
+        .any(|segment| matches!(segment, properties::PathSeg::Name(found) if found == name))
+}
+
+fn path_has_key(path: &[properties::PathSeg], key: &str) -> bool {
+    path.iter()
+        .any(|segment| matches!(segment, properties::PathSeg::MapKey(found) if found == key))
+}
+
+/// Whether `path` reaches a slot of an inventory container — the array itself, or an
+/// element of it.
+fn path_reaches_inventory_slot(path: &[properties::PathSeg]) -> bool {
+    match segment_after_name(path, "m_Slots") {
+        // Addressing the whole slot array.
+        Some(None) => true,
+        Some(Some(properties::PathSeg::Index(_))) => true,
+        _ => false,
+    }
+}
+
+/// Whether a raw typed edit at `path` addresses something the structured `edit`
+/// rewrites as a whole.
+///
+/// Ordering cannot make such a pair safe, which is why this is checked separately
+/// from the ordinal rule below: a structured operation resolves its own target and
+/// rewrites or recreates it wholesale, so whichever of the two runs second discards
+/// the other's work — silently, with the write reporting both as applied. The editor
+/// refuses these combinations before it ever calls in; a caller coming straight
+/// through `execute_json` does not go through the editor, so the core refuses them
+/// too.
+fn structured_edit_rewrites(edit: &PrivateEdit, path: &[properties::PathSeg]) -> bool {
+    match edit {
+        // Patches or appends a modifier under this NPC's relationship entry.
+        PrivateEdit::NpcRelationship(relationship) => {
+            match segment_after_name(path, "RelationshipByGlobalId") {
+                None => false,
+                // An edit of the whole map collides with every structured write.
+                Some(None) => true,
+                Some(Some(properties::PathSeg::MapKey(key))) => {
+                    key.trim().eq_ignore_ascii_case(relationship.id.trim())
+                }
+                Some(Some(_)) => true,
+            }
+        }
+        // Learning or unlearning rewrites this actor's effect elements.
+        PrivateEdit::SkillSet(skill) => {
+            path_has_name(path, "ActiveEffects") && path_has_key(path, &skill.actor)
+        }
+        // Adds or removes an unlock event in the hero's memory.
+        PrivateEdit::GlossarySetSegment(_) => {
+            path_has_name(path, "MemorizedEvents") && path_has_key(path, skills::HERO)
+        }
+        // Strips memory events, death tags and the corpse entry.
+        PrivateEdit::NpcRevive(_) => {
+            path_has_name(path, "MemorizedEvents")
+                || path_has_name(path, "LooseTagsByGlobalId")
+                || path_has_name(path, "m_SavedInventories")
+        }
+        // Inserts an entry into the knowledge map.
+        PrivateEdit::KnowledgeAddCharacter(_) | PrivateEdit::KnowledgeSetEntry(_) => {
+            path_has_name(path, "CharacterKnowledgeByUniqueName")
+        }
+        // Claims a whole slot: the add fills a blank one and resets its payload, the
+        // removal blanks one.
+        PrivateEdit::InventoryAddItem(_) | PrivateEdit::InventoryRemoveItem(_) => {
+            path_reaches_inventory_slot(path)
+        }
+        // Narrower: it only rewrites ids.
+        PrivateEdit::InventoryRepairSlots => matches!(
+            path.last(),
+            Some(properties::PathSeg::Name(name)) if name == "m_Id"
+        ) && path_reaches_inventory_slot(&path[..path.len().saturating_sub(1)]),
+        _ => false,
+    }
 }
 
 /// True for an edit that can change the ELEMENT COUNT of a container (array length,
@@ -20570,7 +20686,7 @@ mod tests {
     }
 
     #[test]
-    fn write_save_rejects_an_index_addressed_peer_after_a_length_change() {
+    fn write_save_rejects_a_raw_slot_edit_beside_an_inventory_add() {
         // An inventory add/remove must stand alone: a peer edit in the same
         // write resolves against the pre-splice layout and would be corrupted.
         let dir = tempdir().unwrap();
@@ -20588,8 +20704,9 @@ mod tests {
             seed_uncompressed: private_payload,
         };
 
-        // The add appends a slot, so the queued edit's `[1]` — an index the caller
-        // read off the PRE-write inspection — would resolve against a different array.
+        // The add claims a whole slot and resets its payload, so a raw edit into a
+        // slot cannot share the write with it in either order: whichever runs second
+        // discards the other's work while both are reported as applied.
         let mut count_path = inv_slots_prefix(1);
         count_path.extend([
             "[1]".to_string(),
@@ -20615,9 +20732,33 @@ mod tests {
         .unwrap_err();
         assert!(matches!(err, CoreError::UnsupportedEdit(_)), "got: {err}");
         assert!(
-            err.to_string()
-                .contains("addresses an element by index or slot id"),
+            err.to_string().contains("rewrites as a whole"),
             "unexpected error: {err}"
+        );
+
+        // The same pair is refused with the raw edit FIRST: ordering cannot make a
+        // same-target conflict safe, which is what the positional ordinal rule alone
+        // would have missed.
+        let reversed = write_save_with_codec_backend(
+            &path,
+            &[
+                json!({
+                    "path": "private.typed.setValue",
+                    "value": { "path": count_path, "value": 9 }
+                }),
+                json!({
+                    "path": "private.inventory.addItem",
+                    "value": { "path": "/Script/Angelscript.ItFo_Cheese", "count": 1 }
+                }),
+            ],
+            false,
+            None,
+            Some(&backend),
+        )
+        .unwrap_err();
+        assert!(
+            reversed.to_string().contains("rewrites as a whole"),
+            "unexpected error: {reversed}"
         );
     }
 

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -12240,18 +12240,19 @@ fn apply_private_inventory_add_item_to_payload_reusing(
         )?;
     }
 
-    // 4. Retarget the duplicate: definition path first (length-changing, so
-    //    re-resolve from a fresh parse), then the fixed-size count and id.
+    // 4. Retarget the slot. The count and the id are fixed-size writes, so they go
+    //    first and cost no parse of their own; the item definition changes a length
+    //    and so comes last. Only a borrowed template needs its m_InventoryType fixed
+    //    too, and that second length-changing patch is the one case that pays for
+    //    another parse.
     let slot_segment = format!("[{new_index}]");
-    let definition_segs = child_segments(&{
+    let slot_child_segs = |leaf: &[&str]| -> Result<Vec<properties::PathSeg>, CoreError> {
         let mut suffix = slots_suffix.clone();
-        suffix.extend([
-            slot_segment.clone(),
-            "m_SlotData".to_string(),
-            "m_ItemDefinition".to_string(),
-        ]);
-        suffix
-    })?;
+        suffix.push(slot_segment.clone());
+        suffix.extend(leaf.iter().map(|segment| (*segment).to_string()));
+        child_segments(&suffix)
+    };
+    let definition_segs = slot_child_segs(&["m_SlotData", "m_ItemDefinition"])?;
     {
         let reparsed = if patched_matches_root {
             None
@@ -12262,8 +12263,43 @@ fn apply_private_inventory_add_item_to_payload_reusing(
                 ))
             })?)
         };
-        let duplicated = reparsed.as_ref().unwrap_or(root);
-        let definition_chain = properties::resolve_chain(&duplicated.properties, &definition_segs)
+        let current = reparsed.as_ref().unwrap_or(root);
+
+        let count_segs = slot_child_segs(&["m_SlotData", "m_ItemCount"])?;
+        let id_segs = slot_child_segs(&["m_Id"])?;
+        let count_target = properties::resolve(&current.properties, &count_segs)?;
+        let id_target = properties::resolve(&current.properties, &id_segs)?;
+        properties::patch_scalar(
+            &mut patched,
+            count_target,
+            properties::ScalarValue::Int(edit.count),
+        )?;
+        properties::patch_scalar(
+            &mut patched,
+            id_target,
+            properties::ScalarValue::Int(new_id),
+        )?;
+
+        // Whether the ids need re-aligning is decidable from this same parse: the
+        // two writes above are fixed-size, so every other slot still holds the id it
+        // shows here, and the edited one was just set to its own index. Deciding it
+        // now saves the whole-payload parse the re-align would otherwise open with,
+        // and the proof below re-checks the invariant on the bytes that land.
+        let slots_now = properties::resolve(&current.properties, &slots_segs)?;
+        let properties::PropertyValue::Array {
+            elements: slots_now,
+        } = &slots_now.value
+        else {
+            return Err(CoreError::Parse(
+                "MainContainer m_Slots is not a plain slot array after the edit".to_string(),
+            ));
+        };
+        ids_already_aligned = slots_now.iter().enumerate().all(|(index, slot)| {
+            index == new_index
+                || i32::try_from(index).is_ok_and(|expected| slot_id(slot) == Some(expected))
+        });
+
+        let definition_chain = properties::resolve_chain(&current.properties, &definition_segs)
             .map_err(|err| {
                 CoreError::Parse(format!(
                     "duplicated inventory slot is missing m_SlotData.m_ItemDefinition: {err}"
@@ -12277,19 +12313,15 @@ fn apply_private_inventory_add_item_to_payload_reusing(
         )?;
     }
     if needs_type_patch {
-        // A borrowed template carries the donor container's m_InventoryType;
-        // fix it to MainContainer (length-changing, so re-resolve and patch on
-        // its own before the fixed-size scalar writes below).
+        // A borrowed template carries the donor container's m_InventoryType; fix it
+        // to MainContainer. Length-changing, and it follows the definition patch, so
+        // it re-resolves from a fresh parse.
         let reparsed = properties::parse_private_root(&patched).map_err(|err| {
             CoreError::Parse(format!(
                 "inventory item definition patch produced an inconsistent payload: {err}"
             ))
         })?;
-        let type_segs = child_segments(&{
-            let mut suffix = slots_suffix.clone();
-            suffix.extend([slot_segment.clone(), "m_InventoryType".to_string()]);
-            suffix
-        })?;
+        let type_segs = slot_child_segs(&["m_InventoryType"])?;
         let type_chain =
             properties::resolve_chain(&reparsed.properties, &type_segs).map_err(|err| {
                 CoreError::Parse(format!(
@@ -12302,58 +12334,6 @@ fn apply_private_inventory_add_item_to_payload_reusing(
             &type_chain.enclosing_size_fields,
             MAIN_CONTAINER_ENUM_LABEL,
         )?;
-    }
-    {
-        let retargeted = properties::parse_private_root(&patched).map_err(|err| {
-            CoreError::Parse(format!(
-                "inventory item definition patch produced an inconsistent payload: {err}"
-            ))
-        })?;
-        let count_segs = child_segments(&{
-            let mut suffix = slots_suffix.clone();
-            suffix.extend([
-                slot_segment.clone(),
-                "m_SlotData".to_string(),
-                "m_ItemCount".to_string(),
-            ]);
-            suffix
-        })?;
-        let id_segs = child_segments(&{
-            let mut suffix = slots_suffix.clone();
-            suffix.extend([slot_segment.clone(), "m_Id".to_string()]);
-            suffix
-        })?;
-        let count_target = properties::resolve(&retargeted.properties, &count_segs)?;
-        let id_target = properties::resolve(&retargeted.properties, &id_segs)?;
-        // Fixed-size scalar patches: no offsets shift between the two writes.
-        properties::patch_scalar(
-            &mut patched,
-            count_target,
-            properties::ScalarValue::Int(edit.count),
-        )?;
-        properties::patch_scalar(
-            &mut patched,
-            id_target,
-            properties::ScalarValue::Int(new_id),
-        )?;
-        // Whether the ids need re-aligning is decidable from THIS parse: the two
-        // writes above are fixed-size, so every other slot still holds the id it
-        // shows here, and the edited one was just set to its own index. Deciding it
-        // now saves the whole-payload parse the re-align would otherwise open with,
-        // and the proof below re-checks the invariant on the bytes that land.
-        let slots_after = properties::resolve(&retargeted.properties, &slots_segs)?;
-        let properties::PropertyValue::Array {
-            elements: slots_after,
-        } = &slots_after.value
-        else {
-            return Err(CoreError::Parse(
-                "MainContainer m_Slots is not a plain slot array after the edit".to_string(),
-            ));
-        };
-        ids_already_aligned = slots_after.iter().enumerate().all(|(index, slot)| {
-            index == new_index
-                || i32::try_from(index).is_ok_and(|expected| slot_id(slot) == Some(expected))
-        });
     }
 
     // 5. Re-align the edited container's slot ids with their indices. The append

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -9125,6 +9125,13 @@ fn slot_edit_targets_actor(path: &[properties::PathSeg], actor_id: Option<&str>)
     }
 }
 
+/// Whether `path` writes a slot's `m_Id` — the field a slot is selected by, so a
+/// write to it renumbers slots exactly as a repair does.
+fn path_writes_a_slot_id(path: &[properties::PathSeg]) -> bool {
+    matches!(path.last(), Some(properties::PathSeg::Name(name)) if name == "m_Id")
+        && path_reaches_inventory_slot(&path[..path.len() - 1])
+}
+
 /// Whether `path` reaches a slot of an inventory container — the array itself, or an
 /// element of it.
 fn path_reaches_inventory_slot(path: &[properties::PathSeg]) -> bool {
@@ -9191,10 +9198,7 @@ fn structured_edit_rewrites(edit: &PrivateEdit, path: &[properties::PathSeg]) ->
         }
         // Narrower still: it only rewrites ids, but it does so across every
         // container in the save, so it is not scoped to one actor.
-        PrivateEdit::InventoryRepairSlots => matches!(
-            path.last(),
-            Some(properties::PathSeg::Name(name)) if name == "m_Id"
-        ) && path_reaches_inventory_slot(&path[..path.len().saturating_sub(1)]),
+        PrivateEdit::InventoryRepairSlots => path_writes_a_slot_id(path),
         _ => false,
     }
 }
@@ -9235,9 +9239,10 @@ fn may_invalidate_caller_ordinals(edit: &PrivateEdit) -> bool {
         // classification is complete rather than relying on the other guard.
         PrivateEdit::StoryApply(_) => true,
 
-        // Ordinal-stable below. A setValue resolves to a scalar, a string or a
-        // native struct; none of the three can add or drop a container element.
-        PrivateEdit::TypedSetValue(_) => false,
+        // A setValue resolves to a scalar, a string or a native struct, so it can
+        // add or drop no container element — but writing a slot's m_Id renumbers
+        // slots, which is the other half of what invalidates a caller's ordinal.
+        PrivateEdit::TypedSetValue(edit) => path_writes_a_slot_id(&edit.path),
         // Fixed-size boolean patches.
         PrivateEdit::FactionsForgive(_) => false,
         // Fresh whole-payload string scan, then a string patch.
@@ -20799,6 +20804,56 @@ mod tests {
         ])
         .unwrap();
         assert!(!structured_edit_rewrites(&add_for(None), &attribute));
+    }
+
+    #[test]
+    fn writing_a_slot_id_invalidates_a_later_slot_selector() {
+        // A slot is selected by its m_Id, so a raw write to that field renumbers
+        // slots just as a repair does. A count edit pinned to a slot id afterwards
+        // would pick whichever slot now carries it — the wrong stack, when two hold
+        // the same item.
+        let slot_id_path = properties::parse_path(&[
+            "m_GenericData".to_string(),
+            "{CharacterStates}".to_string(),
+            "InventoriesByGlobalId".to_string(),
+            "{Lizard-1}".to_string(),
+            "m_Inventory".to_string(),
+            "m_Values".to_string(),
+            "Items".to_string(),
+            "[1]".to_string(),
+            "m_Slots".to_string(),
+            "[0]".to_string(),
+            "m_Id".to_string(),
+        ])
+        .unwrap();
+        let renumber = PrivateEdit::TypedSetValue(PrivateTypedSetValueEdit {
+            path: slot_id_path.clone(),
+            value: json!(5),
+        });
+        assert!(may_invalidate_caller_ordinals(&renumber));
+
+        // A count edit pinned to a slot id is the consumer it would retarget.
+        let pinned_count = PrivateEdit::InventoryItemCount(PrivateInventoryItemCountEdit {
+            id: None,
+            path: Some("/Script/Angelscript.ItMi_Orenugget".to_string()),
+            count: 3,
+            actor_id: Some("Lizard-1".to_string()),
+            slot_id: Some(5),
+            container_type: None,
+        });
+        assert!(carries_caller_ordinal(&pinned_count));
+
+        // An ordinary value write is still ordinal-stable.
+        let mut count_path = slot_id_path;
+        count_path.pop();
+        count_path.push(properties::PathSeg::Name("m_SlotData".to_string()));
+        count_path.push(properties::PathSeg::Name("m_ItemCount".to_string()));
+        assert!(!may_invalidate_caller_ordinals(&PrivateEdit::TypedSetValue(
+            PrivateTypedSetValueEdit {
+                path: count_path,
+                value: json!(3),
+            }
+        )));
     }
 
     #[test]

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -5221,7 +5221,7 @@ fn npc_relationship_set_writable(root: &properties::RootObject) -> bool {
     let supported_value = value.type_name == "StructProperty"
         && value
             .struct_type
-            .as_ref()
+            .as_deref()
             .is_some_and(|(kind, _)| kind == "CharacterStateSaveGameData_Relationship");
     property.type_name == "MapProperty"
         && supported_key
@@ -7572,7 +7572,7 @@ fn summarize_memory_event_properties(
         let struct_type = property
             .descriptor
             .struct_type
-            .as_ref()
+            .as_deref()
             .map(|(name, _)| name.as_str());
         let type_name = struct_type.map_or_else(
             || property.type_name.to_string(),
@@ -9849,7 +9849,7 @@ fn coerce_native_struct_value(
     let descriptor = property
         .descriptor
         .struct_type
-        .as_ref()
+        .as_deref()
         .map(|(name, _)| name.as_str())
         .ok_or_else(|| {
             CoreError::UnsupportedEdit(

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -14117,6 +14117,11 @@ mod tests {
     use std::sync::Mutex;
     use tempfile::tempdir;
 
+    /// Serializes the tests that drive the process-wide parsed-root cache. It holds
+    /// exactly ONE entry, so two of them running at once evict each other's and the
+    /// loser sees a re-parse where it asserted a hit.
+    static REAL_SAVE_CACHE_TESTS: Mutex<()> = Mutex::new(());
+
     /// The parsed-root cache must hand back the SAME allocation for repeated
     /// reads of an unchanged save — proof that clicking around the editor
     /// (open a character, then its inventory, …) no longer re-decodes/re-parses
@@ -14128,6 +14133,9 @@ mod tests {
             eprintln!("GORE_SAVE not set; skipping");
             return;
         };
+        let _serialized = REAL_SAVE_CACHE_TESTS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let path = Path::new(&path);
         let backend = codec_backend::KrakenBackend::default();
         let a = decode_private_root_cached(path, &backend).expect("first parse");
@@ -14194,6 +14202,9 @@ mod tests {
             eprintln!("GORE_SAVE not set; skipping");
             return;
         };
+        let _serialized = REAL_SAVE_CACHE_TESTS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let path = Path::new(&path);
         let backend = codec_backend::KrakenBackend::default();
         // Start cold.
@@ -14204,20 +14215,30 @@ mod tests {
             "payload": { "path": path.to_string_lossy(), "includePrivate": true }
         })
         .to_string();
-        let resp: serde_json::Value = serde_json::from_str(&execute_json(&req)).unwrap();
-        assert_eq!(resp["ok"], json!(true), "inspect failed: {resp}");
-        // The first private read after inspect must be a cache HIT. A re-parse of
-        // the whole payload takes seconds (in this debug/test profile); a hit is
-        // sub-millisecond. The generous threshold makes this a robust proof that
-        // inspect seeded the cache rather than a flaky micro-benchmark.
-        let t = SystemTime::now();
-        let a = decode_private_root_cached(path, &backend).unwrap();
-        let elapsed = t.elapsed().unwrap();
+        // Check the cache entry itself rather than how long the next read takes. The
+        // cache holds exactly ONE entry and the rest of the suite runs in parallel,
+        // seeding it with its own temp saves, so a timing threshold cannot tell
+        // "inspect did not seed" apart from "a foreign test evicted it a moment
+        // later". Retry the seed so an eviction costs a repeat, not a red build.
+        let mut seeded = false;
+        for _ in 0..8 {
+            invalidate_decoded_payload_cache(path);
+            let resp: serde_json::Value = serde_json::from_str(&execute_json(&req)).unwrap();
+            assert_eq!(resp["ok"], json!(true), "inspect failed: {resp}");
+            let guard = PARSED_ROOT_CACHE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if guard.as_ref().is_some_and(|entry| entry.path == path) {
+                seeded = true;
+                break;
+            }
+        }
         assert!(
-            elapsed < std::time::Duration::from_millis(200),
-            "first read after inspect took {elapsed:?} — inspect did not seed the \
-             parsed-root cache (a re-parse takes seconds)"
+            seeded,
+            "inspect_save never left its parse in the parsed-root cache, so the first \
+             private read after a load re-parses the whole payload"
         );
+        let a = decode_private_root_cached(path, &backend).unwrap();
         // And it is the SAME cached allocation on a repeat read.
         let b = decode_private_root_cached(path, &backend).unwrap();
         assert!(

--- a/crates/gore-save/src/lib.rs
+++ b/crates/gore-save/src/lib.rs
@@ -9010,6 +9010,26 @@ fn apply_private_edits(
             }
         }
     }
+    // The same applies to two STRUCTURED edits that resolve the same target: each
+    // replaces whatever is there, so the second discards the first's work while the
+    // write reports both. They are not addressed by a path, so the rule above never
+    // sees them — compare the targets themselves.
+    let targets: Vec<Option<(&str, String)>> =
+        edit_specs.iter().map(structured_edit_target).collect();
+    for (first_at, first) in targets.iter().enumerate() {
+        let Some(first) = first else { continue };
+        for (second_at, second) in targets.iter().enumerate().skip(first_at + 1) {
+            if second.as_ref() != Some(first) {
+                continue;
+            }
+            return Err(CoreError::UnsupportedEdit(format!(
+                "{} (edit {first_at}) and {} (edit {second_at}) rewrite the same {}, \
+                 so one of the two would silently be discarded whichever order they \
+                 run in; save them separately",
+                edits[first_at].path, edits[second_at].path, first.0
+            )));
+        }
+    }
     // Every `apply_*` re-parses the payload it is handed, so a batch can never carry a
     // stale BYTE OFFSET from one edit into the next. What a batch CAN invalidate is a
     // caller-supplied ORDINAL: an array index or slot id the caller read off an
@@ -9158,6 +9178,46 @@ fn path_reaches_inventory_slot(path: &[properties::PathSeg]) -> bool {
         Some(None) => true,
         Some(Some(properties::PathSeg::Index(_))) => true,
         _ => false,
+    }
+}
+
+/// What a structured edit rewrites as a whole, for the operations that resolve
+/// their target from a key and then replace what they find there. Two edits
+/// naming the same one cannot share a write in either order.
+///
+/// Only the declarative operations belong here, not the ones that ADD to what is
+/// there: two `addItem` calls for one actor fill two different slots and two
+/// skill edits for one actor touch two different skills, which is exactly what a
+/// batch is for. The description is what the user reads in the refusal.
+fn structured_edit_target(edit: &PrivateEdit) -> Option<(&'static str, String)> {
+    fn key(parts: [&str; 2]) -> String {
+        parts
+            .iter()
+            .map(|part| part.trim().to_ascii_lowercase())
+            .collect::<Vec<_>>()
+            .join("\u{1f}")
+    }
+    match edit {
+        PrivateEdit::NpcRelationship(relationship) => Some((
+            "relationship of that NPC",
+            key([relationship.id.as_str(), ""]),
+        )),
+        PrivateEdit::SkillSet(skill) => Some((
+            "skill of that character",
+            key([skill.actor.as_str(), skill.base.as_str()]),
+        )),
+        PrivateEdit::KnowledgeSetEntry(entry) => Some((
+            "knowledge entry of that character",
+            key([entry.character.as_str(), entry.entry.as_str()]),
+        )),
+        PrivateEdit::GlossarySetSegment(glossary) => Some((
+            "glossary segment",
+            key([
+                glossary.document_asset.as_str(),
+                glossary.segment_asset.as_str(),
+            ]),
+        )),
+        _ => None,
     }
 }
 
@@ -22944,6 +23004,95 @@ mod tests {
         let error = apply_private_glossary_set_segment_to_payload(&mut payload, &edit).unwrap_err();
         assert!(matches!(error, CoreError::Validation(_)));
         assert_eq!(payload, before);
+    }
+
+    #[test]
+    fn two_structured_edits_for_one_target_are_refused_but_peers_still_batch() {
+        let relationship = |id: &str, value: &str| PrivateEdit::NpcRelationship(
+            PrivateNpcRelationshipEdit {
+                id: id.to_string(),
+                relationship: npc::PersonalRelationship::parse(value).unwrap(),
+            },
+        );
+        let skill = |actor: &str, base: &str, tier: &str| {
+            PrivateEdit::SkillSet(skills::SkillSetEdit {
+                actor: actor.to_string(),
+                base: base.to_string(),
+                tier: tier.to_string(),
+            })
+        };
+
+        // Each of the two replaces that NPC's relationship, so one of them would
+        // vanish without a word. The id is matched as the appliers match it.
+        assert_eq!(
+            structured_edit_target(&relationship("Diego", "friend")),
+            structured_edit_target(&relationship(" diego ", "enemy")),
+        );
+
+        // Two skills of one character are two different targets — that is what a
+        // batch is for — and so are one skill of two characters.
+        assert_ne!(
+            structured_edit_target(&skill("Hero", "Skill_OneHanded", "Tier2")),
+            structured_edit_target(&skill("Hero", "Skill_Bow", "Tier2")),
+        );
+        assert_ne!(
+            structured_edit_target(&skill("Hero", "Skill_Bow", "Tier2")),
+            structured_edit_target(&skill("Diego", "Skill_Bow", "Tier2")),
+        );
+        assert_eq!(
+            structured_edit_target(&skill("Hero", "Skill_Bow", "Tier1")),
+            structured_edit_target(&skill("Hero", "Skill_Bow", "Tier3")),
+        );
+
+        // Adding two items to one inventory is not a target collision at all.
+        let add = |path: &str| {
+            PrivateEdit::InventoryAddItem(PrivateInventoryAddItemEdit {
+                path: path.to_string(),
+                count: 1,
+                actor_id: None,
+            })
+        };
+        assert!(structured_edit_target(&add("/Script/Angelscript.ItFo_Cheese")).is_none());
+
+        // And end to end: the same segment twice is refused by name, two
+        // different segments of one document still share the write.
+        let (_dir, path, backend) = progression_fixture(
+            "G1R-glossary-pair.sav",
+            glossary_progression_payload(),
+        );
+        let data = fs::read(path).unwrap();
+        let segment = |segment: &str, unlocked: bool| Edit {
+            path: "private.glossary.setSegment".to_string(),
+            value: json!({
+                "documentClass": "/Script/Angelscript.Document_Glossary_Meatbug",
+                "segmentClass": segment,
+                "unlocked": unlocked,
+            }),
+        };
+        let entry2 = segment(
+            "/Script/Angelscript.DocumentSegment_Glossary_Meatbug_Entry2",
+            true,
+        );
+        let entry2_again = segment(
+            "/Script/Angelscript.DocumentSegment_Glossary_Meatbug_Entry2",
+            false,
+        );
+        let unlock = segment(
+            "/Script/Angelscript.DocumentSegment_Glossary_Meatbug_Unlock",
+            false,
+        );
+
+        let error = apply_private_edits(&data, &[&entry2, &entry2_again], Some(&backend))
+            .unwrap_err();
+        let CoreError::UnsupportedEdit(message) = &error else {
+            panic!("expected the pair to be refused, got {error:?}");
+        };
+        assert!(
+            message.contains("glossary segment"),
+            "the refusal has to say what the two share, got {message:?}"
+        );
+        apply_private_edits(&data, &[&entry2, &unlock], Some(&backend))
+            .expect("two different segments of one document still share a write");
     }
 
     #[test]

--- a/crates/gore-save/src/npc.rs
+++ b/crates/gore-save/src/npc.rs
@@ -1481,8 +1481,8 @@ pub fn apply_relationship(
     }
 
     // Refuse accidental map entries for non-characters/typos.
-    let root = parse_private_root(payload)?;
-    let attributes = find_character_map(&root, ATTRIBUTES_TYPE)
+    let checked = parse_private_root(payload)?;
+    let attributes = find_character_map(&checked, ATTRIBUTES_TYPE)
         .ok_or_else(|| CoreError::Parse(format!("no {ATTRIBUTES_TYPE} map found in save")))?;
     if lookup_entry(attributes, id).is_none() {
         return Err(CoreError::InvalidRequest(format!(
@@ -1495,8 +1495,14 @@ pub fn apply_relationship(
     // retains Weight 1000 after SaveGame load. Reparse after every splice
     // because Friend/Neutral/Enemy have different byte lengths.
     let mut missing_entry = false;
+    // The check above parsed the payload nobody has written to yet, so the first
+    // pass reuses it; every later pass follows a splice and needs its own.
+    let mut unwritten = Some(checked);
     loop {
-        let root = parse_private_root(payload)?;
+        let root = match unwritten.take() {
+            Some(root) => root,
+            None => parse_private_root(payload)?,
+        };
         let Some((map_path, map_property)) = find_property_by_name(&root, RELATIONSHIP_MAP) else {
             return Err(CoreError::Parse(format!(
                 "{RELATIONSHIP_MAP} map not found in save"

--- a/crates/gore-save/src/npc.rs
+++ b/crates/gore-save/src/npc.rs
@@ -778,7 +778,7 @@ fn find_character_map_path<'a>(
         path: &mut Vec<String>,
     ) -> Option<&'a [(PropertyValue, PropertyValue)]> {
         for p in props {
-            path.push(p.name.clone());
+            path.push(p.name.to_string());
             if let PropertyValue::Map { entries, .. } = &p.value {
                 if map_value_struct_type(p) == Some(struct_type) {
                     return Some(entries);
@@ -884,14 +884,14 @@ fn collect_attribute_rows(
         }
         PropertyValue::Struct(StructValue::Properties(inner)) => {
             for p in inner {
-                path.push(p.name.clone());
+                path.push(p.name.to_string());
                 collect_attribute_rows(&p.value, path, out);
                 path.pop();
             }
         }
         PropertyValue::Struct(StructValue::Instanced(Some(i))) => {
             for p in &i.properties {
-                path.push(p.name.clone());
+                path.push(p.name.to_string());
                 collect_attribute_rows(&p.value, path, out);
                 path.pop();
             }
@@ -907,7 +907,7 @@ fn collect_attribute_rows(
             for (idx, o) in objs.iter().enumerate() {
                 path.push(format!("[{idx}]"));
                 for p in &o.properties {
-                    path.push(p.name.clone());
+                    path.push(p.name.to_string());
                     collect_attribute_rows(&p.value, path, out);
                     path.pop();
                 }
@@ -1116,7 +1116,7 @@ pub fn npc_inventory_path(root: &RootObject, global_id: &str) -> Option<Vec<Stri
     let container = entry_props(value)?.first()?;
     // The entry is addressed by its map key; then descend to the container prop.
     path.push(map_key_segment(global_id));
-    path.push(container.name.clone());
+    path.push(container.name.to_string());
     Some(path)
 }
 

--- a/crates/gore-save/src/npc.rs
+++ b/crates/gore-save/src/npc.rs
@@ -1500,14 +1500,14 @@ pub fn apply_relationship(
     // retains Weight 1000 after SaveGame load. Reparse after every splice
     // because Friend/Neutral/Enemy have different byte lengths.
     let mut missing_entry = false;
-    // The check above parsed the payload nobody has written to yet, so the first
-    // pass reuses it; every later pass follows a splice and needs its own.
-    let mut unwritten = Some(checked);
-    loop {
-        let root = match unwritten.take() {
-            Some(root) => root,
-            None => parse_private_root(payload)?,
-        };
+    // One pass over the modifiers: the scan below collects EVERY mismatch and
+    // settles whether a strong override already exists, so the parse taken for the
+    // existence check above serves the whole edit. The writes then run back to
+    // front — the append copies the existing bytes verbatim and adds at the end, so
+    // it cannot move a mismatch, and the mismatches themselves are patched
+    // descending — which is what makes one parse enough.
+    'entry: {
+        let root = &checked;
         let Some((map_path, map_property)) = find_property_by_name(&root, RELATIONSHIP_MAP) else {
             return Err(CoreError::Parse(format!(
                 "{RELATIONSHIP_MAP} map not found in save"
@@ -1521,7 +1521,7 @@ pub fn apply_relationship(
             .find(|(key, _)| map_key_to_string(key).as_deref() == Some(id))
         else {
             missing_entry = true;
-            break;
+            break 'entry;
         };
         let Some(entry_properties) = entry_props(entry_value) else {
             return Err(CoreError::Parse(format!(
@@ -1535,7 +1535,7 @@ pub fn apply_relationship(
                 "{RELATIONSHIP_MAP}[{id:?}] has no {ACTIVE_RELATIONSHIP_MODIFIERS} array"
             )));
         };
-        let mut next_mismatch = None;
+        let mut mismatches: Vec<usize> = Vec::new();
         let mut found_strong_override = false;
         match &array_property.value {
             PropertyValue::ObjectInstances(modifiers) => {
@@ -1556,8 +1556,7 @@ pub fn apply_relationship(
                         found_strong_override = true;
                     }
                     if current != relationship.enum_label() {
-                        next_mismatch = Some(index);
-                        break;
+                        mismatches.push(index);
                     }
                 }
             }
@@ -1569,26 +1568,32 @@ pub fn apply_relationship(
             }
         }
 
-        if let Some(index) = next_mismatch {
-            let mut path = map_path;
+        // Resolve every mismatch against this parse before anything is written.
+        let mut mismatch_targets = Vec::new();
+        for index in &mismatches {
+            let mut path = map_path.clone();
             path.push(format!("{{{id}}}"));
             path.push(ACTIVE_RELATIONSHIP_MODIFIERS.to_string());
             path.push(format!("[{index}]"));
             path.push("Relationship".to_string());
             let chain = resolve_chain(&root.properties, &parse_path(&path)?)?;
-            let target = chain.target.clone();
-            let enclosing = chain.enclosing_size_fields.clone();
-            patch_string(payload, &target, &enclosing, relationship.enum_label())?;
-            continue;
+            mismatch_targets.push((chain.target.clone(), chain.enclosing_size_fields));
         }
 
         if found_strong_override {
-            break;
+            // Nothing to append: patch the mismatches back to front and stop.
+            for (target, enclosing) in mismatch_targets.into_iter().rev() {
+                patch_string(payload, &target, &enclosing, relationship.enum_label())?;
+            }
+            break 'entry;
         }
 
         // The map entry exists but has only unrelated modifiers or a weak
         // legacy `_Story_Permanent` override. Append the strong, indefinite
-        // `_Story` representation while preserving every existing object.
+        // `_Story` representation while preserving every existing object. The
+        // append goes first: it rewrites the array body starting from the same
+        // offset with the existing bytes unchanged, so the mismatch targets below
+        // still sit where this parse said they do.
         let mut path = map_path;
         path.push(format!("{{{id}}}"));
         path.push(ACTIVE_RELATIONSHIP_MODIFIERS.to_string());
@@ -1632,13 +1637,19 @@ pub fn apply_relationship(
             }
             _ => unreachable!("array encoding validated above"),
         }
-        // Reparse and verify the newly appended object before finishing.
+
+        // Back to front, so the append above and each patch leave the targets still
+        // to come exactly where this parse found them.
+        for (target, enclosing) in mismatch_targets.into_iter().rev() {
+            patch_string(payload, &target, &enclosing, relationship.enum_label())?;
+        }
     }
 
     if missing_entry {
-        // No entry existed: append a fully-formed inline map key/value pair.
-        let root = parse_private_root(payload)?;
-        let (map_path, map_property) = find_property_by_name(&root, RELATIONSHIP_MAP)
+        // No entry existed: append a fully-formed inline map key/value pair. Nothing
+        // has been written at this point, so the existence check's parse still holds.
+        let root = &checked;
+        let (map_path, map_property) = find_property_by_name(root, RELATIONSHIP_MAP)
             .ok_or_else(|| CoreError::Parse(format!("{RELATIONSHIP_MAP} map not found in save")))?;
         let PropertyValue::Map { entries, .. } = &map_property.value else {
             return Err(CoreError::Parse(format!("{RELATIONSHIP_MAP} is not a map")));
@@ -1678,18 +1689,6 @@ pub fn apply_relationship(
     Ok(())
 }
 
-/// REVIVE NPC `id` in a decoded private payload, in place — restore a KILLED NPC
-/// to its alive state by undoing all persisted death state.
-///
-/// 1. Scan every `LongTermMemoryByGlobalId` owner and remove only defeat/kill
-///    events that refer to this NPC.
-/// 2. Strip the authoritative `State.Dead`, kill-bounty, and execution-bounty
-///    loose tags while preserving unrelated tags.
-/// 3. Remove the NPC's lootable corpse entry from `m_SavedInventories`.
-/// 4. Restore Health to MaxHealth.
-///
-/// Each structural step reparses before continuing, so shifted offsets and
-/// indices are never reused. An already-alive NPC with full HP is a clean no-op.
 /// One planned change to the payload, resolved from a single parse.
 ///
 /// Reviving touches four unrelated places in the save, and each used to re-parse
@@ -1774,6 +1773,19 @@ impl ReviveEdit {
     }
 }
 
+/// REVIVE NPC `id` in a decoded private payload, in place — restore a KILLED NPC
+/// to its alive state by undoing all persisted death state.
+///
+/// 1. Scan every `LongTermMemoryByGlobalId` owner and remove only defeat/kill
+///    events that refer to this NPC.
+/// 2. Strip the authoritative `State.Dead`, kill-bounty, and execution-bounty
+///    loose tags while preserving unrelated tags.
+/// 3. Remove the NPC's lootable corpse entry from `m_SavedInventories`.
+/// 4. Restore Health to MaxHealth.
+///
+/// Everything is planned against ONE parse and applied back to front, so no step
+/// reuses an offset a later one moved. An already-alive NPC with full HP is a clean
+/// no-op.
 pub fn apply_revive(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreError> {
     let root = parse_private_root(payload)?;
 

--- a/crates/gore-save/src/npc.rs
+++ b/crates/gore-save/src/npc.rs
@@ -1263,13 +1263,12 @@ fn is_corpse_key_for(key: &str, id: &str) -> bool {
 /// path to the `m_SavedInventories` MapProperty; [`resolve_chain`] re-resolves it
 /// for the enclosing size fields. The payload is re-parsed before each splice so
 /// offsets and indices stay fresh.
-fn remove_corpse_inventory(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreError> {
-    let root = parse_private_root(payload)?;
-    let Some((path, map_prop)) = find_property_by_name(&root, SAVED_INVENTORIES_MAP) else {
-        return Ok(()); // no corpse map => nothing to remove
+fn plan_corpse_removal(root: &RootObject, id: &str) -> Result<Option<ReviveEdit>, CoreError> {
+    let Some((path, map_prop)) = find_property_by_name(root, SAVED_INVENTORIES_MAP) else {
+        return Ok(None); // no corpse map => nothing to remove
     };
     let PropertyValue::Map { entries, .. } = &map_prop.value else {
-        return Ok(());
+        return Ok(None);
     };
     let entry_indices: Vec<usize> = entries
         .iter()
@@ -1282,19 +1281,16 @@ fn remove_corpse_inventory(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreEr
         .map(|(index, _)| index)
         .collect();
     if entry_indices.is_empty() {
-        return Ok(()); // no corpse for this NPC (e.g. an alive NPC) => done
+        return Ok(None); // no corpse for this NPC (e.g. an alive NPC) => done
     }
 
     let segs = parse_path(&path)?;
     let chain = resolve_chain(&root.properties, &segs)?;
-    let target = chain.target.clone();
-    let enclosing = chain.enclosing_size_fields.clone();
-    patch_container(
-        payload,
-        &target,
-        &enclosing,
-        &ContainerEdit::MapRemoveMany(entry_indices),
-    )
+    Ok(Some(ReviveEdit::RemoveMapEntries {
+        target: chain.target.clone(),
+        enclosing: chain.enclosing_size_fields,
+        indices: entry_indices,
+    }))
 }
 
 /// Strip the death loose tags ([`DEAD_LOOSE_TAGS`]: `State.Dead`,
@@ -1309,29 +1305,32 @@ fn remove_corpse_inventory(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreEr
 /// [`patch_map_value_tag_container`] (not [`patch_tag_container`], which would clobber
 /// the key). The payload is re-parsed before each removal so offsets stay fresh.
 /// No-op (Ok) if the map / entry is absent or carries none of the tags.
-fn remove_dead_loose_tags(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreError> {
-    let root = parse_private_root(payload)?;
-    let Some((path, map_prop)) = find_property_by_name(&root, LOOSE_TAGS_MAP) else {
-        return Ok(()); // no loose-tags map => nothing to strip
+fn plan_dead_loose_tag_removal(
+    root: &RootObject,
+    id: &str,
+) -> Result<Option<ReviveEdit>, CoreError> {
+    let Some((path, map_prop)) = find_property_by_name(root, LOOSE_TAGS_MAP) else {
+        return Ok(None); // no loose-tags map => nothing to strip
     };
     let PropertyValue::Map { entries, .. } = &map_prop.value else {
-        return Ok(());
+        return Ok(None);
     };
     let Some(entry_index) = entries
         .iter()
         .position(|(k, _v)| map_key_to_string(k).as_deref() == Some(id))
     else {
-        return Ok(()); // no entry for this NPC => nothing to strip
+        return Ok(None); // no entry for this NPC => nothing to strip
     };
     // Enclosing size fields for the MAP property (ancestors); the map's own size
     // field is handled inside patch_map_value_tag_container, which strips every
     // listed tag from this one view of the container.
     let segs = parse_path(&path)?;
     let chain = resolve_chain(&root.properties, &segs)?;
-    let target = chain.target.clone();
-    let enclosing = chain.enclosing_size_fields.clone();
-    patch_map_value_tag_container(payload, &target, &enclosing, entry_index, DEAD_LOOSE_TAGS)?;
-    Ok(())
+    Ok(Some(ReviveEdit::RemoveTags {
+        target: chain.target.clone(),
+        enclosing: chain.enclosing_size_fields,
+        entry_index,
+    }))
 }
 
 /// Restore NPC `id`'s `Health` to its `MaxHealth` `BaseValue` (both `BaseValue` and
@@ -1341,8 +1340,7 @@ fn remove_dead_loose_tags(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreErr
 ///
 /// Errors if the NPC has no `Health` attribute or no `MaxHealth` `BaseValue` to
 /// revive to.
-fn restore_hp_to_max(payload: &mut [u8], id: &str) -> Result<(), CoreError> {
-    let root = parse_private_root(payload)?;
+fn plan_hp_restore(root: &RootObject, id: &str) -> Result<Vec<ReviveEdit>, CoreError> {
     let (base_path, current_path, max_hp, needs_patch) = {
         let rows = npc_attributes(&root, id)?;
         let health = rows
@@ -1370,16 +1368,23 @@ fn restore_hp_to_max(payload: &mut [u8], id: &str) -> Result<(), CoreError> {
     };
 
     if !needs_patch {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let base_segs = parse_path(&base_path)?;
     let base_target = resolve_chain(&root.properties, &base_segs)?.target.clone();
     let cur_segs = parse_path(&current_path)?;
     let cur_target = resolve_chain(&root.properties, &cur_segs)?.target.clone();
-    patch_scalar(payload, &base_target, ScalarValue::Float(max_hp))?;
-    patch_scalar(payload, &cur_target, ScalarValue::Float(max_hp))?;
-    Ok(())
+    Ok(vec![
+        ReviveEdit::SetFloat {
+            target: base_target,
+            value: max_hp,
+        },
+        ReviveEdit::SetFloat {
+            target: cur_target,
+            value: max_hp,
+        },
+    ])
 }
 
 fn relationship_name_property(name: &str, value: &str) -> Vec<u8> {
@@ -1685,49 +1690,133 @@ pub fn apply_relationship(
 ///
 /// Each structural step reparses before continuing, so shifted offsets and
 /// indices are never reused. An already-alive NPC with full HP is a clean no-op.
+/// One planned change to the payload, resolved from a single parse.
+///
+/// Reviving touches four unrelated places in the save, and each used to re-parse
+/// because the one before it had spliced. It does not have to: a splice only moves
+/// bytes AFTER itself, so a change whose target sits earlier is untouched by one
+/// already applied. Planning every change against one parse and then applying them
+/// back to front therefore needs exactly one parse — and `patch_container` reads
+/// each enclosing size field from the current bytes, so the size cascade stays
+/// correct as the payload shrinks underneath it.
+enum ReviveEdit {
+    RemoveArrayElements {
+        target: Property,
+        enclosing: Vec<usize>,
+        indices: Vec<usize>,
+    },
+    RemoveMapEntries {
+        target: Property,
+        enclosing: Vec<usize>,
+        indices: Vec<usize>,
+    },
+    RemoveTags {
+        target: Property,
+        enclosing: Vec<usize>,
+        entry_index: usize,
+    },
+    SetFloat {
+        target: Property,
+        value: f32,
+    },
+}
+
+impl ReviveEdit {
+    /// The byte range this change reads and writes within.
+    fn range(&self) -> core::ops::Range<usize> {
+        let target = match self {
+            ReviveEdit::RemoveArrayElements { target, .. }
+            | ReviveEdit::RemoveMapEntries { target, .. }
+            | ReviveEdit::RemoveTags { target, .. }
+            | ReviveEdit::SetFloat { target, .. } => target,
+        };
+        target.value_offset..target.value_offset + target.value_size.max(1)
+    }
+
+    fn apply(self, payload: &mut Vec<u8>) -> Result<(), CoreError> {
+        match self {
+            ReviveEdit::RemoveArrayElements {
+                target,
+                enclosing,
+                indices,
+            } => patch_container(
+                payload,
+                &target,
+                &enclosing,
+                &ContainerEdit::ArrayRemoveMany(indices),
+            ),
+            ReviveEdit::RemoveMapEntries {
+                target,
+                enclosing,
+                indices,
+            } => patch_container(
+                payload,
+                &target,
+                &enclosing,
+                &ContainerEdit::MapRemoveMany(indices),
+            ),
+            ReviveEdit::RemoveTags {
+                target,
+                enclosing,
+                entry_index,
+            } => patch_map_value_tag_container(
+                payload,
+                &target,
+                &enclosing,
+                entry_index,
+                DEAD_LOOSE_TAGS,
+            )
+            .map(|_| ()),
+            ReviveEdit::SetFloat { target, value } => {
+                patch_scalar(payload, &target, ScalarValue::Float(value))
+            }
+        }
+    }
+}
+
 pub fn apply_revive(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreError> {
-    // ── Phase 1: strip every kill/defeat memory event across ALL owners ──────
-    // One parse serves every removal. Each owner's matching events are dropped in a
-    // single splice pass, and the owners themselves are processed back to front in
-    // the payload, so no splice can move an array still to be patched — the reason
-    // this no longer needs a re-parse per event. (patch_container reads each
-    // enclosing size field from the current bytes, so the cascade stays right as
-    // the payload shrinks underneath it.)
     let root = parse_private_root(payload)?;
-    let mut owners = Vec::new();
+
+    // Everything reviving has to change, planned against this one parse: the
+    // kill/defeat memory events across every owner, the authoritative death tags,
+    // the lootable-corpse entries, and the health restore.
+    let mut edits = Vec::new();
     for (owner_id, indices) in kill_memories_to_remove(&root, id) {
         let path = memorized_events_array_path(&root, &owner_id).ok_or_else(|| {
             CoreError::Parse(format!(
                 "memory owner {owner_id:?} has no MemorizedEvents array to revive"
             ))
         })?;
-        let segs = parse_path(&path)?;
-        let chain = resolve_chain(&root.properties, &segs)?;
-        owners.push((
-            chain.target.clone(),
-            chain.enclosing_size_fields.clone(),
+        let chain = resolve_chain(&root.properties, &parse_path(&path)?)?;
+        edits.push(ReviveEdit::RemoveArrayElements {
+            target: chain.target.clone(),
+            enclosing: chain.enclosing_size_fields,
             indices,
-        ));
+        });
     }
-    owners.sort_by_key(|(target, _, _)| std::cmp::Reverse(target.value_offset));
-    for (target, enclosing, indices) in owners {
-        patch_container(
-            payload,
-            &target,
-            &enclosing,
-            &ContainerEdit::ArrayRemoveMany(indices),
-        )?;
-    }
+    edits.extend(plan_dead_loose_tag_removal(&root, id)?);
+    edits.extend(plan_corpse_removal(&root, id)?);
+    edits.extend(plan_hp_restore(&root, id)?);
     drop(root);
 
-    // ── Phase 2: strip the authoritative death loose tags (the native gate) ──
-    remove_dead_loose_tags(payload, id)?;
-
-    // ── Phase 3: remove the lootable-corpse entry (its own re-parse/splice) ──
-    remove_corpse_inventory(payload, id)?;
-
-    // ── Phase 4: restore HP to max (no-op if already full) ───────────────────
-    restore_hp_to_max(payload, id)
+    // Back to front, so no change moves a target still to be applied. The ranges
+    // must not overlap for that to hold; they never do (the four live in different
+    // maps), but a save that made them overlap would be corrupted silently, so it
+    // is checked rather than assumed.
+    edits.sort_by_key(|edit| core::cmp::Reverse(edit.range().start));
+    for pair in edits.windows(2) {
+        let (later, earlier) = (pair[0].range(), pair[1].range());
+        if earlier.end > later.start {
+            return Err(CoreError::Parse(format!(
+                "revive would edit overlapping byte ranges ({:?} and {:?}); refusing",
+                earlier, later
+            )));
+        }
+    }
+    for edit in edits {
+        edit.apply(payload)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/gore-save/src/npc.rs
+++ b/crates/gore-save/src/npc.rs
@@ -207,7 +207,7 @@ pub(crate) fn char_key(global_id: &str) -> String {
 /// type name). `None` for non-map / non-struct-valued maps.
 fn map_value_struct_type(prop: &Property) -> Option<&str> {
     let (_key, value) = prop.descriptor.map.as_deref()?;
-    value.struct_type.as_ref().map(|(ty, _pkg)| ty.as_str())
+    value.struct_type.as_deref().map(|(ty, _pkg)| ty.as_str())
 }
 
 /// Find the character-state map of `struct_type` and return its entries keyed by

--- a/crates/gore-save/src/npc.rs
+++ b/crates/gore-save/src/npc.rs
@@ -1187,30 +1187,36 @@ fn memory_owners(root: &RootObject) -> Vec<(String, &PropertyValue)> {
 ///
 /// Re-scanning from scratch each call (rather than caching indices across the
 /// splicing removal loop) is what keeps the loop correct as removals shift indices.
-fn next_kill_memory_to_remove(root: &RootObject, id: &str) -> Option<(String, usize)> {
+fn kill_memories_to_remove(root: &RootObject, id: &str) -> Vec<(String, Vec<usize>)> {
+    let mut out = Vec::new();
     for (owner_id, memory) in memory_owners(root) {
         let Some(PropertyValue::Array { elements }) = struct_member(memory, "MemorizedEvents")
         else {
             continue;
         };
         let is_own = owner_id == id;
-        let found = elements.iter().position(|element| {
-            if is_own {
-                // Own defeat/kill residue only — an event about a DIFFERENT
-                // character (this NPC killed/executed someone else) is real
-                // memory and must be preserved across revive.
-                event_has_any_tag(element, REVIVE_EVENT_TAGS)
-                    && affected_character_id(element).map_or(true, |a| a == id)
-            } else {
-                event_has_any_tag(element, KILL_EVENT_TAGS)
-                    && affected_character_id(element) == Some(id)
-            }
-        });
-        if let Some(index) = found {
-            return Some((owner_id, index));
+        let found: Vec<usize> = elements
+            .iter()
+            .enumerate()
+            .filter(|(_, element)| {
+                if is_own {
+                    // Own defeat/kill residue only — an event about a DIFFERENT
+                    // character (this NPC killed/executed someone else) is real
+                    // memory and must be preserved across revive.
+                    event_has_any_tag(element, REVIVE_EVENT_TAGS)
+                        && affected_character_id(element).map_or(true, |a| a == id)
+                } else {
+                    event_has_any_tag(element, KILL_EVENT_TAGS)
+                        && affected_character_id(element) == Some(id)
+                }
+            })
+            .map(|(index, _)| index)
+            .collect();
+        if !found.is_empty() {
+            out.push((owner_id, found));
         }
     }
-    None
+    out
 }
 
 /// The typed path (from the private root) to NPC `id`'s `MemorizedEvents` array:
@@ -1258,33 +1264,37 @@ fn is_corpse_key_for(key: &str, id: &str) -> bool {
 /// for the enclosing size fields. The payload is re-parsed before each splice so
 /// offsets and indices stay fresh.
 fn remove_corpse_inventory(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreError> {
-    loop {
-        let root = parse_private_root(payload)?;
-        let Some((path, map_prop)) = find_property_by_name(&root, SAVED_INVENTORIES_MAP) else {
-            return Ok(()); // no corpse map => nothing to remove
-        };
-        let PropertyValue::Map { entries, .. } = &map_prop.value else {
-            return Ok(());
-        };
-        let Some(entry_index) = entries.iter().position(|(k, _v)| {
+    let root = parse_private_root(payload)?;
+    let Some((path, map_prop)) = find_property_by_name(&root, SAVED_INVENTORIES_MAP) else {
+        return Ok(()); // no corpse map => nothing to remove
+    };
+    let PropertyValue::Map { entries, .. } = &map_prop.value else {
+        return Ok(());
+    };
+    let entry_indices: Vec<usize> = entries
+        .iter()
+        .enumerate()
+        .filter(|(_, (k, _v))| {
             map_key_to_string(k)
                 .as_deref()
                 .is_some_and(|k| is_corpse_key_for(k, id))
-        }) else {
-            return Ok(()); // no corpse for this NPC (e.g. an alive NPC) => done
-        };
-
-        let segs = parse_path(&path)?;
-        let chain = resolve_chain(&root.properties, &segs)?;
-        let target = chain.target.clone();
-        let enclosing = chain.enclosing_size_fields.clone();
-        patch_container(
-            payload,
-            &target,
-            &enclosing,
-            &ContainerEdit::MapRemove { entry_index },
-        )?;
+        })
+        .map(|(index, _)| index)
+        .collect();
+    if entry_indices.is_empty() {
+        return Ok(()); // no corpse for this NPC (e.g. an alive NPC) => done
     }
+
+    let segs = parse_path(&path)?;
+    let chain = resolve_chain(&root.properties, &segs)?;
+    let target = chain.target.clone();
+    let enclosing = chain.enclosing_size_fields.clone();
+    patch_container(
+        payload,
+        &target,
+        &enclosing,
+        &ContainerEdit::MapRemoveMany(entry_indices),
+    )
 }
 
 /// Strip the death loose tags ([`DEAD_LOOSE_TAGS`]: `State.Dead`,
@@ -1300,36 +1310,27 @@ fn remove_corpse_inventory(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreEr
 /// the key). The payload is re-parsed before each removal so offsets stay fresh.
 /// No-op (Ok) if the map / entry is absent or carries none of the tags.
 fn remove_dead_loose_tags(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreError> {
-    for tag in DEAD_LOOSE_TAGS {
-        loop {
-            let root = parse_private_root(payload)?;
-            let Some((path, map_prop)) = find_property_by_name(&root, LOOSE_TAGS_MAP) else {
-                return Ok(()); // no loose-tags map => nothing to strip
-            };
-            let PropertyValue::Map { entries, .. } = &map_prop.value else {
-                return Ok(());
-            };
-            let Some(entry_index) = entries
-                .iter()
-                .position(|(k, _v)| map_key_to_string(k).as_deref() == Some(id))
-            else {
-                break; // no entry for this NPC => move to next tag (will also break)
-            };
-            // Enclosing size fields for the MAP property (ancestors); the map's own
-            // size field is handled inside patch_map_value_tag_container.
-            let segs = parse_path(&path)?;
-            let chain = resolve_chain(&root.properties, &segs)?;
-            let target = chain.target.clone();
-            let enclosing = chain.enclosing_size_fields.clone();
-            let removed =
-                patch_map_value_tag_container(payload, &target, &enclosing, entry_index, tag)?;
-            if !removed {
-                break; // this tag is gone => next tag
-            }
-            // Re-parse and re-scan in case the same tag appears more than once
-            // (defensive; a container normally holds each tag at most once).
-        }
-    }
+    let root = parse_private_root(payload)?;
+    let Some((path, map_prop)) = find_property_by_name(&root, LOOSE_TAGS_MAP) else {
+        return Ok(()); // no loose-tags map => nothing to strip
+    };
+    let PropertyValue::Map { entries, .. } = &map_prop.value else {
+        return Ok(());
+    };
+    let Some(entry_index) = entries
+        .iter()
+        .position(|(k, _v)| map_key_to_string(k).as_deref() == Some(id))
+    else {
+        return Ok(()); // no entry for this NPC => nothing to strip
+    };
+    // Enclosing size fields for the MAP property (ancestors); the map's own size
+    // field is handled inside patch_map_value_tag_container, which strips every
+    // listed tag from this one view of the container.
+    let segs = parse_path(&path)?;
+    let chain = resolve_chain(&root.properties, &segs)?;
+    let target = chain.target.clone();
+    let enclosing = chain.enclosing_size_fields.clone();
+    patch_map_value_tag_container(payload, &target, &enclosing, entry_index, DEAD_LOOSE_TAGS)?;
     Ok(())
 }
 
@@ -1341,8 +1342,8 @@ fn remove_dead_loose_tags(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreErr
 /// Errors if the NPC has no `Health` attribute or no `MaxHealth` `BaseValue` to
 /// revive to.
 fn restore_hp_to_max(payload: &mut [u8], id: &str) -> Result<(), CoreError> {
+    let root = parse_private_root(payload)?;
     let (base_path, current_path, max_hp, needs_patch) = {
-        let root = parse_private_root(payload)?;
         let rows = npc_attributes(&root, id)?;
         let health = rows
             .iter()
@@ -1372,7 +1373,6 @@ fn restore_hp_to_max(payload: &mut [u8], id: &str) -> Result<(), CoreError> {
         return Ok(());
     }
 
-    let root = parse_private_root(payload)?;
     let base_segs = parse_path(&base_path)?;
     let base_target = resolve_chain(&root.properties, &base_segs)?.target.clone();
     let cur_segs = parse_path(&current_path)?;
@@ -1681,14 +1681,15 @@ pub fn apply_relationship(
 /// indices are never reused. An already-alive NPC with full HP is a clean no-op.
 pub fn apply_revive(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreError> {
     // ── Phase 1: strip every kill/defeat memory event across ALL owners ──────
-    // Re-parse/re-scan/splice loop: each removal shifts later indices and offsets,
-    // so we locate the next matching event afresh every iteration. The scan returns
-    // the owner it found so we splice the correct owner's MemorizedEvents array.
-    loop {
-        let root = parse_private_root(payload)?;
-        let Some((owner_id, index)) = next_kill_memory_to_remove(&root, id) else {
-            break;
-        };
+    // One parse serves every removal. Each owner's matching events are dropped in a
+    // single splice pass, and the owners themselves are processed back to front in
+    // the payload, so no splice can move an array still to be patched — the reason
+    // this no longer needs a re-parse per event. (patch_container reads each
+    // enclosing size field from the current bytes, so the cascade stays right as
+    // the payload shrinks underneath it.)
+    let root = parse_private_root(payload)?;
+    let mut owners = Vec::new();
+    for (owner_id, indices) in kill_memories_to_remove(&root, id) {
         let path = memorized_events_array_path(&root, &owner_id).ok_or_else(|| {
             CoreError::Parse(format!(
                 "memory owner {owner_id:?} has no MemorizedEvents array to revive"
@@ -1696,15 +1697,22 @@ pub fn apply_revive(payload: &mut Vec<u8>, id: &str) -> Result<(), CoreError> {
         })?;
         let segs = parse_path(&path)?;
         let chain = resolve_chain(&root.properties, &segs)?;
-        let target = chain.target.clone();
-        let enclosing = chain.enclosing_size_fields.clone();
+        owners.push((
+            chain.target.clone(),
+            chain.enclosing_size_fields.clone(),
+            indices,
+        ));
+    }
+    owners.sort_by_key(|(target, _, _)| std::cmp::Reverse(target.value_offset));
+    for (target, enclosing, indices) in owners {
         patch_container(
             payload,
             &target,
             &enclosing,
-            &ContainerEdit::ArrayRemove(index),
+            &ContainerEdit::ArrayRemoveMany(indices),
         )?;
     }
+    drop(root);
 
     // ── Phase 2: strip the authoritative death loose tags (the native gate) ──
     remove_dead_loose_tags(payload, id)?;

--- a/crates/gore-save/src/properties.rs
+++ b/crates/gore-save/src/properties.rs
@@ -27,12 +27,181 @@
 
 use crate::{CoreError, Reader};
 use serde_json::{Value, json};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 
 pub const TAG_FLAG_NATIVE_SERIALIZE: u8 = 0x08;
 pub const TAG_FLAG_BOOL_TRUE: u8 = 0x10;
 
 const MAX_DEPTH: usize = 96;
+
+/// An interned property or type name.
+///
+/// A real save's payload parses into ~1.4 million properties, and the names on them
+/// are drawn from a few thousand distinct strings — `"IntProperty"` alone appears
+/// hundreds of thousands of times. Allocating one `String` per occurrence made the
+/// allocator the parser's dominant cost, so names are shared instead: equal text is
+/// stored once per thread and handed out as a cheap pointer clone.
+///
+/// It compares and reads like a `&str` (`Deref`, `PartialEq<&str>`, `Display`), so
+/// call sites treat it as the string it is.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PropStr(Arc<str>);
+
+/// A small non-cryptographic hasher for the name table.
+///
+/// The table is looked up several million times per parse and holds nothing but
+/// short, internal, non-attacker-chosen strings, so the default SipHash costs more
+/// than the allocation interning is there to avoid. This is the usual
+/// multiply-and-rotate word hash.
+#[derive(Default, Clone, Copy)]
+struct NameHasher(u64);
+
+impl std::hash::Hasher for NameHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        const SEED: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+        let mut hash = self.0;
+        let mut chunks = bytes.chunks_exact(8);
+        for chunk in &mut chunks {
+            let word = u64::from_le_bytes(chunk.try_into().expect("chunks_exact(8)"));
+            hash = (hash.rotate_left(5) ^ word).wrapping_mul(SEED);
+        }
+        let mut tail = 0u64;
+        for (index, byte) in chunks.remainder().iter().enumerate() {
+            tail |= u64::from(*byte) << (index * 8);
+        }
+        self.0 = (hash.rotate_left(5) ^ tail).wrapping_mul(SEED);
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+struct NameHasherBuilder;
+
+impl std::hash::BuildHasher for NameHasherBuilder {
+    type Hasher = NameHasher;
+    fn build_hasher(&self) -> NameHasher {
+        NameHasher::default()
+    }
+}
+
+thread_local! {
+    /// Names seen on this thread. Bounded so a save full of unique strings cannot
+    /// grow it without limit; past the cap new names simply are not shared.
+    static INTERNED_NAMES: std::cell::RefCell<HashSet<Arc<str>, NameHasherBuilder>> =
+        std::cell::RefCell::new(HashSet::with_hasher(NameHasherBuilder));
+}
+
+const MAX_INTERNED_NAMES: usize = 1 << 16;
+
+impl PropStr {
+    /// Intern `text`, reusing the copy this thread already holds when there is one.
+    pub fn new(text: &str) -> Self {
+        INTERNED_NAMES.with(|names| {
+            let mut names = names.borrow_mut();
+            if let Some(shared) = names.get(text) {
+                return PropStr(shared.clone());
+            }
+            let shared: Arc<str> = Arc::from(text);
+            if names.len() < MAX_INTERNED_NAMES {
+                names.insert(shared.clone());
+            }
+            PropStr(shared)
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for PropStr {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for PropStr {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::borrow::Borrow<str> for PropStr {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PropStr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for PropStr {
+    fn from(value: &str) -> Self {
+        PropStr::new(value)
+    }
+}
+
+impl From<String> for PropStr {
+    fn from(value: String) -> Self {
+        PropStr::new(&value)
+    }
+}
+
+impl From<&PropStr> for String {
+    fn from(value: &PropStr) -> Self {
+        value.0.to_string()
+    }
+}
+
+impl PartialEq<str> for PropStr {
+    fn eq(&self, other: &str) -> bool {
+        &*self.0 == other
+    }
+}
+
+impl PartialEq<&str> for PropStr {
+    fn eq(&self, other: &&str) -> bool {
+        &*self.0 == *other
+    }
+}
+
+impl PartialEq<String> for PropStr {
+    fn eq(&self, other: &String) -> bool {
+        &*self.0 == other.as_str()
+    }
+}
+
+impl PartialEq<PropStr> for str {
+    fn eq(&self, other: &PropStr) -> bool {
+        self == &*other.0
+    }
+}
+
+impl PartialEq<PropStr> for &str {
+    fn eq(&self, other: &PropStr) -> bool {
+        *self == &*other.0
+    }
+}
+
+impl PartialEq<PropStr> for String {
+    fn eq(&self, other: &PropStr) -> bool {
+        self.as_str() == &*other.0
+    }
+}
+
+impl serde::Serialize for PropStr {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RootObject {
@@ -46,8 +215,8 @@ pub struct RootObject {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Property {
-    pub name: String,
-    pub type_name: String,
+    pub name: PropStr,
+    pub type_name: PropStr,
     pub descriptor: Descriptor,
     pub array_index: u32,
     pub tag_flags: u8,
@@ -70,9 +239,9 @@ impl Property {
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Descriptor {
     /// StructProperty: (struct_type, package)
-    pub struct_type: Option<(String, String)>,
+    pub struct_type: Option<(PropStr, PropStr)>,
     /// EnumProperty: (enum_type, package, underlying_type)
-    pub enum_type: Option<(String, String, String)>,
+    pub enum_type: Option<(PropStr, PropStr, PropStr)>,
     /// Array/Set inner type, Map key/value types (with nested descriptors).
     pub inner: Option<Box<InnerDescriptor>>,
     pub map: Option<Box<(InnerDescriptor, InnerDescriptor)>>,
@@ -80,9 +249,9 @@ pub struct Descriptor {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct InnerDescriptor {
-    pub type_name: String,
-    pub struct_type: Option<(String, String)>,
-    pub enum_type: Option<(String, String, String)>,
+    pub type_name: PropStr,
+    pub struct_type: Option<(PropStr, PropStr)>,
+    pub enum_type: Option<(PropStr, PropStr, PropStr)>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -165,7 +334,7 @@ pub enum StructValue {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct InstancedStruct {
-    pub actual_type: String,
+    pub actual_type: PropStr,
     /// Absolute offset of the u32 `data_size` field preceding the body.
     /// Length-changing edits inside this struct must adjust it.
     pub data_size_offset: usize,
@@ -527,7 +696,7 @@ fn walk_search(
             display.push_str(" › ");
         }
         display.push_str(&p.name);
-        path.push(p.name.clone());
+        path.push(p.name.to_string());
         let addressable =
             ancestors_addressable && name_counts.get(p.name.as_str()).copied() == Some(1);
 
@@ -537,7 +706,7 @@ fn walk_search(
                 ctx.record(PropertyHit {
                     path: path.clone(),
                     display: display.clone(),
-                    type_name: p.type_name.clone(),
+                    type_name: p.type_name.to_string(),
                     value_display,
                     editable: addressable && scalar_editable(&p.value),
                 });
@@ -878,7 +1047,7 @@ fn walk_browse_properties(
             display.push_str(" › ");
         }
         display.push_str(&property.name);
-        path.push(property.name.clone());
+        path.push(property.name.to_string());
         let addressable =
             ancestors_addressable && name_counts.get(property.name.as_str()).copied() == Some(1);
         let kind = property_kind(&property.value);
@@ -903,7 +1072,7 @@ fn walk_browse_properties(
                 ordinal,
                 path: path.clone(),
                 display: display.clone(),
-                type_name: property.type_name.clone(),
+                type_name: property.type_name.to_string(),
                 struct_type: struct_type.map(str::to_string),
                 kind: kind.to_string(),
                 value_display,
@@ -1256,7 +1425,7 @@ pub fn find_path_in_properties<'a>(
         path: &mut Vec<String>,
     ) -> Option<&'a Property> {
         for p in props {
-            path.push(p.name.clone());
+            path.push(p.name.to_string());
             if p.name == name {
                 return Some(p);
             }
@@ -1637,7 +1806,7 @@ pub fn container_layout(payload: &[u8], property: &Property) -> Result<Container
     }
     Ok(ContainerLayout {
         kind,
-        inner_type: inner.type_name.clone(),
+        inner_type: inner.type_name.to_string(),
         count_offset,
         count,
         element_ranges,
@@ -2349,19 +2518,19 @@ pub(crate) fn read_property_list(r: &mut Reader, depth: usize) -> Result<Vec<Pro
     }
     let mut out = Vec::new();
     loop {
-        let name = r.fstring()?;
+        let name = r.prop_str()?;
         if name == "None" {
             return Ok(out);
         }
-        let type_name = r.fstring()?;
+        let type_name = r.prop_str()?;
         out.push(read_property(r, name, type_name, depth)?);
     }
 }
 
 fn read_property(
     r: &mut Reader,
-    name: String,
-    type_name: String,
+    name: PropStr,
+    type_name: PropStr,
     depth: usize,
 ) -> Result<Property, CoreError> {
     let descriptor = read_descriptor(r, &type_name)?;
@@ -2433,21 +2602,21 @@ fn read_descriptor(r: &mut Reader, type_name: &str) -> Result<Descriptor, CoreEr
     Ok(descriptor)
 }
 
-fn read_struct_descriptor(r: &mut Reader) -> Result<(String, String), CoreError> {
+fn read_struct_descriptor(r: &mut Reader) -> Result<(PropStr, PropStr), CoreError> {
     let _count = r.u32()?;
-    let struct_type = r.fstring()?;
+    let struct_type = r.prop_str()?;
     let _package_count = r.u32()?;
-    let package = r.fstring()?;
+    let package = r.prop_str()?;
     Ok((struct_type, package))
 }
 
-fn read_enum_descriptor(r: &mut Reader) -> Result<(String, String, String), CoreError> {
+fn read_enum_descriptor(r: &mut Reader) -> Result<(PropStr, PropStr, PropStr), CoreError> {
     let _count = r.u32()?;
-    let enum_type = r.fstring()?;
+    let enum_type = r.prop_str()?;
     let _package_count = r.u32()?;
-    let package = r.fstring()?;
+    let package = r.prop_str()?;
     let _underlying_count = r.u32()?;
-    let underlying = r.fstring()?;
+    let underlying = r.prop_str()?;
     Ok((enum_type, package, underlying))
 }
 
@@ -2457,7 +2626,7 @@ fn read_inner_descriptor(r: &mut Reader) -> Result<InnerDescriptor, CoreError> {
 }
 
 fn read_inner_descriptor_body(r: &mut Reader) -> Result<InnerDescriptor, CoreError> {
-    let type_name = r.fstring()?;
+    let type_name = r.prop_str()?;
     let mut inner = InnerDescriptor {
         type_name: type_name.clone(),
         struct_type: None,
@@ -2684,7 +2853,7 @@ fn read_struct_value(
             Ok(StructValue::GameplayTagContainer(tags))
         }
         "InstancedStruct" => {
-            let actual_type = r.fstring()?;
+            let actual_type = r.prop_str()?;
             let data_size_offset = r.abs_pos();
             let data_size = r.u32()? as usize;
             let body_base = r.abs_pos();
@@ -3745,8 +3914,8 @@ mod tests {
     fn exhaustive_browser_marks_unaddressable_and_duplicate_map_keys_read_only() {
         fn leaf(name: &str, value: i32) -> PropertyValue {
             PropertyValue::Struct(StructValue::Properties(vec![Property {
-                name: name.to_string(),
-                type_name: "IntProperty".to_string(),
+                name: name.into(),
+                type_name: "IntProperty".into(),
                 descriptor: Descriptor::default(),
                 array_index: 0,
                 tag_flags: 0,
@@ -3759,8 +3928,8 @@ mod tests {
             class: "/Script/Test.Save".to_string(),
             flag: 0,
             properties: vec![Property {
-                name: "Values".to_string(),
-                type_name: "MapProperty".to_string(),
+                name: "Values".into(),
+                type_name: "MapProperty".into(),
                 descriptor: Descriptor::default(),
                 array_index: 0,
                 tag_flags: 0,

--- a/crates/gore-save/src/properties.rs
+++ b/crates/gore-save/src/properties.rs
@@ -2436,8 +2436,20 @@ pub fn count_properties(props: &[Property]) -> PropertyCounts {
     acc
 }
 
+thread_local! {
+    /// How many whole-payload parses this thread has done.
+    ///
+    /// A parse costs about half a second on a real save and allocates a tree of a
+    /// few hundred megabytes, so how often an edit re-parses is the number that
+    /// decides how long a write takes — and unlike wall-clock time it is exactly
+    /// reproducible. `crates/gore-save/examples/json_timer.rs` reports it beside the
+    /// elapsed time. Counting costs one thread-local increment per parse.
+    pub static PARSE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 /// Parse a full decompressed private payload (strict: every byte accounted for).
 pub fn parse_private_root(payload: &[u8]) -> Result<RootObject, CoreError> {
+    PARSE_COUNT.with(|c| c.set(c.get() + 1));
     parse_private_root_at(payload, 0)
 }
 

--- a/crates/gore-save/src/properties.rs
+++ b/crates/gore-save/src/properties.rs
@@ -93,9 +93,19 @@ thread_local! {
     /// grow it without limit; past the cap new names simply are not shared.
     static INTERNED_NAMES: std::cell::RefCell<HashSet<Arc<str>, NameHasherBuilder>> =
         std::cell::RefCell::new(HashSet::with_hasher(NameHasherBuilder));
+    /// Bytes of text the table above is holding on to.
+    static INTERNED_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
+/// What the shared table may keep. A count alone does not bound memory: the table
+/// lives for the life of the thread, and a malformed or modded save could fill it
+/// with tens of thousands of very long names and pin them there long after the save
+/// was closed. Real property names are short and few, so a name that busts either
+/// limit is simply not shared — it is still returned, and it is released with the
+/// tree that holds it, exactly as before interning existed.
 const MAX_INTERNED_NAMES: usize = 1 << 16;
+const MAX_INTERNED_BYTES: usize = 4 << 20;
+const MAX_INTERNED_NAME_LEN: usize = 256;
 
 impl PropStr {
     /// Intern `text`, reusing the copy this thread already holds when there is one.
@@ -106,8 +116,14 @@ impl PropStr {
                 return PropStr(shared.clone());
             }
             let shared: Arc<str> = Arc::from(text);
-            if names.len() < MAX_INTERNED_NAMES {
-                names.insert(shared.clone());
+            if text.len() <= MAX_INTERNED_NAME_LEN && names.len() < MAX_INTERNED_NAMES {
+                INTERNED_BYTES.with(|held| {
+                    let next = held.get().saturating_add(text.len());
+                    if next <= MAX_INTERNED_BYTES {
+                        held.set(next);
+                        names.insert(shared.clone());
+                    }
+                });
             }
             PropStr(shared)
         })
@@ -3025,6 +3041,27 @@ fn read_array_value(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The shared name table lives as long as the thread, so it must not be able to
+    /// pin an unbounded amount of text: a name past the length limit is handed back
+    /// like any other, but is not retained for sharing.
+    #[test]
+    fn the_name_table_does_not_retain_outsized_names() {
+        let short = "IntProperty";
+        assert_eq!(
+            PropStr::new(short).as_str().as_ptr(),
+            PropStr::new(short).as_str().as_ptr(),
+            "an ordinary name is stored once and shared"
+        );
+
+        let outsized = "X".repeat(MAX_INTERNED_NAME_LEN + 1);
+        assert_eq!(PropStr::new(&outsized).as_str(), outsized);
+        assert_ne!(
+            PropStr::new(&outsized).as_str().as_ptr(),
+            PropStr::new(&outsized).as_str().as_ptr(),
+            "an outsized name is not kept in the table"
+        );
+    }
 
     fn fstring(value: &str) -> Vec<u8> {
         let mut out = Vec::new();

--- a/crates/gore-save/src/properties.rs
+++ b/crates/gore-save/src/properties.rs
@@ -54,8 +54,28 @@ pub struct PropStr(Arc<str>);
 /// short, internal, non-attacker-chosen strings, so the default SipHash costs more
 /// than the allocation interning is there to avoid. This is the usual
 /// multiply-and-rotate word hash.
-#[derive(Default, Clone, Copy)]
+///
+/// The names come out of the save file, so they are chosen by whoever wrote it —
+/// and a fixed hash that anyone can read here would let a crafted save drop
+/// thousands of names into one bucket and turn the millions of lookups a parse
+/// makes into a quadratic hang, long before the size caps could bite. The state is
+/// therefore started from a value drawn once per process, which no save can know.
+/// This is not a cryptographic hash and does not pretend to be; it is that unknown
+/// starting point that makes collisions impossible to work out ahead of time.
+#[derive(Clone, Copy)]
 struct NameHasher(u64);
+
+/// Drawn once per process from the standard library's randomly seeded hasher, so
+/// no dependency is needed to get an unpredictable value.
+fn name_hash_seed() -> u64 {
+    use std::hash::{BuildHasher, Hasher};
+    static SEED: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *SEED.get_or_init(|| {
+        let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
+        hasher.write_u8(0);
+        hasher.finish()
+    })
+}
 
 impl std::hash::Hasher for NameHasher {
     fn finish(&self) -> u64 {
@@ -78,13 +98,19 @@ impl std::hash::Hasher for NameHasher {
     }
 }
 
-#[derive(Default, Clone, Copy)]
-struct NameHasherBuilder;
+#[derive(Clone, Copy)]
+struct NameHasherBuilder(u64);
+
+impl NameHasherBuilder {
+    fn new() -> Self {
+        NameHasherBuilder(name_hash_seed())
+    }
+}
 
 impl std::hash::BuildHasher for NameHasherBuilder {
     type Hasher = NameHasher;
     fn build_hasher(&self) -> NameHasher {
-        NameHasher::default()
+        NameHasher(self.0)
     }
 }
 
@@ -92,7 +118,7 @@ thread_local! {
     /// Names seen on this thread. Bounded so a save full of unique strings cannot
     /// grow it without limit; past the cap new names simply are not shared.
     static INTERNED_NAMES: std::cell::RefCell<HashSet<Arc<str>, NameHasherBuilder>> =
-        std::cell::RefCell::new(HashSet::with_hasher(NameHasherBuilder));
+        std::cell::RefCell::new(HashSet::with_hasher(NameHasherBuilder::new()));
     /// Bytes of text the table above is holding on to.
     static INTERNED_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
@@ -3041,6 +3067,44 @@ fn read_array_value(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The names being hashed come out of the save file, so the table has to be
+    /// keyed by something the file's author cannot know: without that, collisions
+    /// can be worked out in advance and a crafted save turns every lookup of a
+    /// parse into a linear scan. The seed is what supplies that, so this pins that
+    /// it genuinely reaches the hash rather than sitting unused beside it.
+    #[test]
+    fn the_name_hash_depends_on_the_per_process_seed() {
+        use std::hash::{BuildHasher, Hash, Hasher};
+
+        fn hash_with(seed: u64, text: &str) -> u64 {
+            let mut hasher = NameHasherBuilder(seed).build_hasher();
+            text.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let name = "GameplayTagContainer";
+        assert_eq!(
+            hash_with(1, name),
+            hash_with(1, name),
+            "the same seed has to keep hashing a name the same way"
+        );
+        assert_ne!(
+            hash_with(1, name),
+            hash_with(2, name),
+            "a different seed has to move the name somewhere else"
+        );
+        assert_ne!(
+            name_hash_seed(),
+            0,
+            "the drawn seed has to be a real value, not a zero standing in for one"
+        );
+        assert_eq!(
+            name_hash_seed(),
+            name_hash_seed(),
+            "the seed is drawn once, so the table cannot lose track of its own keys"
+        );
+    }
 
     /// The shared name table lives as long as the thread, so it must not be able to
     /// pin an unbounded amount of text: a name past the length limit is handed back

--- a/crates/gore-save/src/properties.rs
+++ b/crates/gore-save/src/properties.rs
@@ -238,10 +238,12 @@ impl Property {
 /// Type descriptors serialized between the property type and the value header.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Descriptor {
-    /// StructProperty: (struct_type, package)
-    pub struct_type: Option<(PropStr, PropStr)>,
+    /// StructProperty: (struct_type, package). Boxed like the others: a payload
+    /// parses into over a million properties and most carry no descriptor at all,
+    /// so what this costs when absent is what matters.
+    pub struct_type: Option<Box<(PropStr, PropStr)>>,
     /// EnumProperty: (enum_type, package, underlying_type)
-    pub enum_type: Option<(PropStr, PropStr, PropStr)>,
+    pub enum_type: Option<Box<(PropStr, PropStr, PropStr)>>,
     /// Array/Set inner type, Map key/value types (with nested descriptors).
     pub inner: Option<Box<InnerDescriptor>>,
     pub map: Option<Box<(InnerDescriptor, InnerDescriptor)>>,
@@ -250,8 +252,8 @@ pub struct Descriptor {
 #[derive(Debug, Clone, PartialEq)]
 pub struct InnerDescriptor {
     pub type_name: PropStr,
-    pub struct_type: Option<(PropStr, PropStr)>,
-    pub enum_type: Option<(PropStr, PropStr, PropStr)>,
+    pub struct_type: Option<Box<(PropStr, PropStr)>>,
+    pub enum_type: Option<Box<(PropStr, PropStr, PropStr)>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1054,7 +1056,7 @@ fn walk_browse_properties(
         let struct_type = property
             .descriptor
             .struct_type
-            .as_ref()
+            .as_deref()
             .map(|(name, _)| name.as_str());
         let value_display = browse_value_preview(&property.value);
         let addressable_editable = addressable && browse_value_editable(&property.value);
@@ -1841,7 +1843,7 @@ pub fn tag_container_layout(
     let struct_type = property
         .descriptor
         .struct_type
-        .as_ref()
+        .as_deref()
         .map(|(name, _)| name.as_str());
     if struct_type != Some("GameplayTagContainer") {
         return Err(CoreError::InvalidRequest(format!(
@@ -2363,7 +2365,7 @@ pub fn patch_map_value_tag_container(
     let value_is_tag_container = value_desc.type_name == "StructProperty"
         && value_desc
             .struct_type
-            .as_ref()
+            .as_deref()
             .map(|(name, _)| name.as_str())
             == Some("GameplayTagContainer");
     if !value_is_tag_container {
@@ -2663,10 +2665,10 @@ fn read_descriptor(r: &mut Reader, type_name: &str) -> Result<Descriptor, CoreEr
     let mut descriptor = Descriptor::default();
     match type_name {
         "StructProperty" => {
-            descriptor.struct_type = Some(read_struct_descriptor(r)?);
+            descriptor.struct_type = Some(Box::new(read_struct_descriptor(r)?));
         }
         "EnumProperty" => {
-            descriptor.enum_type = Some(read_enum_descriptor(r)?);
+            descriptor.enum_type = Some(Box::new(read_enum_descriptor(r)?));
         }
         "ArrayProperty" | "SetProperty" => {
             descriptor.inner = Some(Box::new(read_inner_descriptor(r)?));
@@ -2715,8 +2717,8 @@ fn read_inner_descriptor_body(r: &mut Reader) -> Result<InnerDescriptor, CoreErr
         enum_type: None,
     };
     match type_name.as_str() {
-        "StructProperty" => inner.struct_type = Some(read_struct_descriptor(r)?),
-        "EnumProperty" => inner.enum_type = Some(read_enum_descriptor(r)?),
+        "StructProperty" => inner.struct_type = Some(Box::new(read_struct_descriptor(r)?)),
+        "EnumProperty" => inner.enum_type = Some(Box::new(read_enum_descriptor(r)?)),
         _ => {}
     }
     Ok(inner)
@@ -2758,7 +2760,7 @@ fn read_sized_value(
         "StructProperty" => {
             let (struct_type, _) = descriptor
                 .struct_type
-                .as_ref()
+                .as_deref()
                 .ok_or_else(|| CoreError::Parse("StructProperty missing descriptor".into()))?;
             Ok(PropertyValue::Struct(read_struct_value(
                 r,
@@ -2851,7 +2853,7 @@ fn read_inline_value(
         "StructProperty" => {
             let (struct_type, _) = inner
                 .struct_type
-                .as_ref()
+                .as_deref()
                 .ok_or_else(|| CoreError::Parse("inline struct missing descriptor".into()))?;
             // Inline structs carry no tag_flags; decide native-vs-proplist by type.
             Ok(PropertyValue::Struct(read_struct_value(

--- a/crates/gore-save/src/properties.rs
+++ b/crates/gore-save/src/properties.rs
@@ -1938,6 +1938,11 @@ pub enum ContainerEdit {
     SetRemove(String),
     /// Remove an ArrayProperty element by index.
     ArrayRemove(usize),
+    /// Remove several ArrayProperty elements in one splice pass. The indices are
+    /// resolved against ONE layout, so a caller stripping many elements neither
+    /// re-parses between them nor has to reason about how each removal shifts the
+    /// next. Duplicates are ignored; order does not matter.
+    ArrayRemoveMany(Vec<usize>),
     /// Duplicate an ArrayProperty element in place (copy inserted right after
     /// the source element).
     ArrayDuplicate(usize),
@@ -1950,6 +1955,9 @@ pub enum ContainerEdit {
     /// The bytes must be schema-valid for this map's key/value descriptors; the
     /// caller validates via the re-parse it performs afterwards.
     MapInsert { entry_bytes: Vec<u8> },
+    /// Remove several MapProperty entries in one splice pass, like
+    /// [`ContainerEdit::ArrayRemoveMany`].
+    MapRemoveMany(Vec<usize>),
     /// Remove the (key+value) entry at `entry_index` from a MapProperty (the
     /// entry's whole byte range is spliced out, the count decremented). The index
     /// is into [`map_layout`]'s `entry_ranges` (entry order == on-disk order).
@@ -1995,7 +2003,9 @@ pub fn patch_container(
     // rejects MapProperty, so resolve the Array/Set layout lazily and skip it
     // for the map path. The shared size-chain fixup below runs for both.
     let layout = match edit {
-        ContainerEdit::MapInsert { .. } | ContainerEdit::MapRemove { .. } => None,
+        ContainerEdit::MapInsert { .. }
+        | ContainerEdit::MapRemove { .. }
+        | ContainerEdit::MapRemoveMany(_) => None,
         _ => Some(container_layout(payload, target)?),
     };
     let require_kind = |wanted: ContainerKind, op: &str| {
@@ -2010,10 +2020,12 @@ pub fn patch_container(
             )))
         }
     };
-    // Each edit is one splice: either remove a byte range or insert bytes at a
-    // position. `count_delta` is +1 or -1.
-    let (remove_range, insert_at, insert_bytes, count_delta): (
-        Option<core::ops::Range<usize>>,
+    // Each edit is one splice pass: either remove byte ranges or insert bytes at a
+    // position. Removals are a LIST so an edit can drop several elements resolved
+    // from one layout; they are spliced back to front below, which leaves every
+    // range before the one being removed exactly where it was.
+    let (remove_ranges, insert_at, insert_bytes, count_delta): (
+        Vec<core::ops::Range<usize>>,
         usize,
         Vec<u8>,
         i64,
@@ -2036,7 +2048,7 @@ pub fn patch_container(
                 )));
             }
             let end = target.value_offset + target.value_size;
-            (None, end, encode_fstring_value(value), 1)
+            (Vec::new(), end, encode_fstring_value(value), 1)
         }
         ContainerEdit::SetRemove(value) => {
             require_kind(ContainerKind::Set, "setRemove")?;
@@ -2047,7 +2059,7 @@ pub fn patch_container(
             let index = set_element_position(elements, value, fold_case)
                 .ok_or_else(|| CoreError::Parse(format!("set does not contain {value:?}")))?;
             let range = layout.element_ranges[index].clone();
-            (Some(range.clone()), range.start, Vec::new(), -1)
+            (vec![range.clone()], range.start, Vec::new(), -1)
         }
         ContainerEdit::ArrayRemove(index) => {
             require_kind(ContainerKind::Array, "arrayRemove")?;
@@ -2058,7 +2070,7 @@ pub fn patch_container(
                     layout.count
                 ))
             })?;
-            (Some(range.clone()), range.start, Vec::new(), -1)
+            (vec![range.clone()], range.start, Vec::new(), -1)
         }
         ContainerEdit::ArrayDuplicate(index) => {
             require_kind(ContainerKind::Array, "arrayDuplicate")?;
@@ -2070,14 +2082,35 @@ pub fn patch_container(
                 ))
             })?;
             let bytes = payload[range.clone()].to_vec();
-            (None, range.end, bytes, 1)
+            (Vec::new(), range.end, bytes, 1)
         }
         ContainerEdit::ArrayInsertBytes(bytes) => {
             require_kind(ContainerKind::Array, "arrayInsertBytes")?;
             // Append after the last element; for an empty array this is the end
             // of the value (right after the count u32).
             let end = target.value_offset + target.value_size;
-            (None, end, bytes.clone(), 1)
+            (Vec::new(), end, bytes.clone(), 1)
+        }
+        ContainerEdit::ArrayRemoveMany(indices) => {
+            require_kind(ContainerKind::Array, "arrayRemoveMany")?;
+            let layout = layout.as_ref().expect("array edit resolves a layout");
+            let ranges = distinct_element_ranges(indices, &layout.element_ranges, layout.count)?;
+            let start = ranges.first().map_or(target.value_offset, |range| range.start);
+            let removed = ranges.len() as i64;
+            (ranges, start, Vec::new(), -removed)
+        }
+        ContainerEdit::MapRemoveMany(indices) => {
+            if target.type_name != "MapProperty" {
+                return Err(CoreError::InvalidRequest(format!(
+                    "mapRemoveMany requires a MapProperty target, got {}",
+                    target.type_name
+                )));
+            }
+            let map = map_layout(payload, target)?;
+            let ranges = distinct_element_ranges(indices, &map.entry_ranges, map.count)?;
+            let start = ranges.first().map_or(target.value_offset, |range| range.start);
+            let removed = ranges.len() as i64;
+            (ranges, start, Vec::new(), -removed)
         }
         ContainerEdit::MapInsert { entry_bytes } => {
             if target.type_name != "MapProperty" {
@@ -2087,7 +2120,7 @@ pub fn patch_container(
                 )));
             }
             let insert_at = target.value_offset + target.value_size; // end of map body
-            (None, insert_at, entry_bytes.clone(), 1)
+            (Vec::new(), insert_at, entry_bytes.clone(), 1)
         }
         ContainerEdit::MapRemove { entry_index } => {
             if target.type_name != "MapProperty" {
@@ -2103,7 +2136,7 @@ pub fn patch_container(
                     map.count
                 ))
             })?;
-            (Some(range.clone()), range.start, Vec::new(), -1)
+            (vec![range.clone()], range.start, Vec::new(), -1)
         }
     };
     // The entry/element count lives at `count_offset`; its current value comes
@@ -2111,7 +2144,9 @@ pub fn patch_container(
     // Both are computed before any mutation (offsets stay valid until the
     // splice), preserving the "failed patch leaves payload untouched" rule.
     let (count, count_offset) = match edit {
-        ContainerEdit::MapInsert { .. } | ContainerEdit::MapRemove { .. } => {
+        ContainerEdit::MapInsert { .. }
+        | ContainerEdit::MapRemove { .. }
+        | ContainerEdit::MapRemoveMany(_) => {
             let map = map_layout(payload, target)?;
             (map.count, map.count_offset)
         }
@@ -2120,7 +2155,7 @@ pub fn patch_container(
             (layout.count, layout.count_offset)
         }
     };
-    let removed = remove_range.as_ref().map_or(0, |r| r.len());
+    let removed: usize = remove_ranges.iter().map(|range| range.len()).sum();
     let delta = insert_bytes.len() as i64 - removed as i64;
     let new_count = u32::try_from(count as i64 + count_delta)
         .map_err(|_| CoreError::Parse("container count underflow".to_string()))?;
@@ -2157,16 +2192,40 @@ pub fn patch_container(
     for (offset, value) in writes {
         payload[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
     }
-    match remove_range {
-        Some(range) => {
+    if remove_ranges.is_empty() {
+        payload.splice(insert_at..insert_at, insert_bytes);
+    } else {
+        // Back to front: removing a later range cannot move an earlier one.
+        for range in remove_ranges.into_iter().rev() {
             payload.splice(range, core::iter::empty());
-        }
-        None => {
-            payload.splice(insert_at..insert_at, insert_bytes);
         }
     }
     Ok(())
 }
+
+/// The byte ranges of `indices` within `ranges`, de-duplicated and sorted ascending
+/// so a caller can splice them back to front.
+fn distinct_element_ranges(
+    indices: &[usize],
+    ranges: &[core::ops::Range<usize>],
+    count: usize,
+) -> Result<Vec<core::ops::Range<usize>>, CoreError> {
+    let mut wanted = indices.to_vec();
+    wanted.sort_unstable();
+    wanted.dedup();
+    wanted
+        .into_iter()
+        .map(|index| {
+            ranges.get(index).cloned().ok_or_else(|| {
+                CoreError::InvalidRequest(format!(
+                    "container index {index} out of bounds ({count} elements)"
+                ))
+            })
+        })
+        .collect()
+}
+
+
 
 /// Add or remove one tag in a native `GameplayTagContainer` value, applied by
 /// [`patch_tag_container`].
@@ -2288,8 +2347,8 @@ pub fn patch_map_value_tag_container(
     map_property: &Property,
     enclosing_size_fields: &[usize],
     entry_index: usize,
-    tag: &str,
-) -> Result<bool, CoreError> {
+    tags: &[&str],
+) -> Result<usize, CoreError> {
     if map_property.type_name != "MapProperty" {
         return Err(CoreError::InvalidRequest(format!(
             "patch_map_value_tag_container requires a MapProperty target, got {}",
@@ -2351,12 +2410,19 @@ pub fn patch_map_value_tag_container(
         }
         (count, ranges)
     };
-    let Some((_t, range)) = tag_ranges.into_iter().find(|(t, _)| t == tag) else {
-        return Ok(false); // tag not present => nothing to remove
-    };
-
-    let delta = -(range.len() as i64);
-    let new_count = u32::try_from(count as i64 - 1)
+    // Every requested tag that is present, in container order, so they can be
+    // spliced back to front from this one view of the container.
+    let ranges: Vec<core::ops::Range<usize>> = tag_ranges
+        .into_iter()
+        .filter(|(name, _)| tags.contains(&name.as_str()))
+        .map(|(_, range)| range)
+        .collect();
+    if ranges.is_empty() {
+        return Ok(0); // none of them present => nothing to remove
+    }
+    let first_start = ranges[0].start;
+    let delta = -(ranges.iter().map(|range| range.len()).sum::<usize>() as i64);
+    let new_count = u32::try_from(count as i64 - ranges.len() as i64)
         .map_err(|_| CoreError::Parse("tag container count underflow".to_string()))?;
 
     // Compute every size-field rewrite up front; mutate only once all are valid.
@@ -2368,7 +2434,7 @@ pub fn patch_map_value_tag_container(
             .map_err(|_| CoreError::Parse("map size would leave the u32 range".to_string()))?,
     ));
     for &offset in enclosing_size_fields {
-        if offset + 4 > range.start {
+        if offset + 4 > first_start {
             return Err(CoreError::Parse(format!(
                 "enclosing size field at 0x{offset:x} does not precede the patch target"
             )));
@@ -2381,13 +2447,17 @@ pub fn patch_map_value_tag_container(
         })?;
         writes.push((offset, updated));
     }
-    // The count field precedes the spliced range, so writing it first is safe.
+    // The count field precedes every spliced range, so writing it first is safe.
     writes.push((count_offset, new_count));
     for (offset, value) in writes {
         payload[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
     }
-    payload.splice(range, core::iter::empty());
-    Ok(true)
+    let removed = ranges.len();
+    // Back to front: removing a later tag cannot move an earlier one.
+    for range in ranges.into_iter().rev() {
+        payload.splice(range, core::iter::empty());
+    }
+    Ok(removed)
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -3440,10 +3510,10 @@ mod tests {
             &target,
             &chain.enclosing_size_fields,
             1, // Npc-B
-            "State.Dead",
+            &["State.Dead"],
         )
         .unwrap();
-        assert!(removed);
+        assert_eq!(removed, 1);
 
         assert_eq!(reparse_loose_tags(&payload, "Npc-A"), vec!["State.Aggro"]);
         assert_eq!(
@@ -3468,10 +3538,10 @@ mod tests {
             &target,
             &chain.enclosing_size_fields,
             0,
-            "State.Dead",
+            &["State.Dead"],
         )
         .unwrap();
-        assert!(!removed, "tag absent => no removal");
+        assert_eq!(removed, 0, "tag absent => no removal");
         assert_eq!(payload, before, "no-op leaves payload byte-identical");
     }
 

--- a/crates/gore-save/src/skills/mod.rs
+++ b/crates/gore-save/src/skills/mod.rs
@@ -357,13 +357,14 @@ pub fn apply_skill_set(payload: &mut Vec<u8>, edit: &SkillSetEdit) -> Result<(),
         Some(idx) => {
             if want_untrained && !has_untrained {
                 // Unlearn: no `_Untrained` class exists, so remove the element.
-                container_edit(payload, &array_path, ContainerEdit::ArrayRemove(idx))
-            } else if element_class_at(payload, &array_path, idx)?.as_deref()
+                container_edit(payload, &root, &array_path, ContainerEdit::ArrayRemove(idx))?;
+                Ok(())
+            } else if element_class_at(&root, &array_path, idx)?.as_deref()
                 == Some(target_class.as_str())
             {
                 Ok(()) // already the requested class
             } else {
-                retarget_def(payload, &array_path, idx, &target_class)
+                retarget_def(payload, &root, &array_path, idx, &target_class)
             }
         }
         None => {
@@ -380,35 +381,36 @@ pub fn apply_skill_set(payload: &mut Vec<u8>, edit: &SkillSetEdit) -> Result<(),
             // element.
             match same_category_donor.or(any_donor) {
                 Some(donor_idx) => {
-                    container_edit(
+                    let cloned = container_edit(
                         payload,
+                        &root,
                         &array_path,
                         ContainerEdit::ArrayDuplicate(donor_idx),
                     )?;
                     // ArrayDuplicate inserts the copy right after the source.
-                    retarget_def(payload, &array_path, donor_idx + 1, &target_class)
+                    retarget_def(payload, &cloned, &array_path, donor_idx + 1, &target_class)
                 }
                 None => {
-                    container_edit(
+                    let appended = container_edit(
                         payload,
+                        &root,
                         &array_path,
                         ContainerEdit::ArrayInsertBytes(donor::donor_template()),
                     )?;
                     // ArrayInsertBytes appends at the end of the array.
-                    retarget_def(payload, &array_path, element_count, &target_class)
+                    retarget_def(payload, &appended, &array_path, element_count, &target_class)
                 }
             }
         }
     }
 }
 
-/// Re-parse the payload and read the class string of the element at `index`.
+/// The class string of the element at `index`, read from an existing parse.
 fn element_class_at(
-    payload: &[u8],
+    root: &properties::RootObject,
     array_path: &[String],
     index: usize,
 ) -> Result<Option<String>, CoreError> {
-    let root = properties::parse_private_root(payload)?;
     let segs = properties::parse_path(array_path)?;
     let resolved = properties::resolve_chain(&root.properties, &segs)?;
     let PropertyValue::Array { elements } = &resolved.target.value else {
@@ -422,12 +424,14 @@ fn element_class_at(
 
 /// Apply a structural container edit to the array at `array_path`, validating on
 /// a scratch copy before committing (mirrors the generic typed container apply).
+/// `root` must describe `payload` as it stands. Returns the proof parse, which
+/// describes the bytes just installed, so the next step needs no parse of its own.
 fn container_edit(
     payload: &mut Vec<u8>,
+    root: &properties::RootObject,
     array_path: &[String],
     edit: ContainerEdit,
-) -> Result<(), CoreError> {
-    let root = properties::parse_private_root(payload)?;
+) -> Result<properties::RootObject, CoreError> {
     let segs = properties::parse_path(array_path)?;
     let resolved = properties::resolve_chain(&root.properties, &segs)?;
     let target = resolved.target.clone();
@@ -438,19 +442,21 @@ fn container_edit(
         &resolved.enclosing_size_fields,
         &edit,
     )?;
-    properties::parse_private_root(&patched).map_err(|err| {
+    let proof = properties::parse_private_root(&patched).map_err(|err| {
         CoreError::Parse(format!(
             "skill container edit produced an inconsistent payload: {err}"
         ))
     })?;
     *payload = patched;
-    Ok(())
+    Ok(proof)
 }
 
 /// Retarget the `EffectSpec/Def` ObjectProperty of the array element at `index`
 /// to `new_class` (a length-changing string patch), validating on a scratch copy.
+/// `root` must describe `payload` as it stands.
 fn retarget_def(
     payload: &mut Vec<u8>,
+    root: &properties::RootObject,
     array_path: &[String],
     index: usize,
     new_class: &str,
@@ -460,7 +466,6 @@ fn retarget_def(
     def_path.push("EffectSpec".to_string());
     def_path.push("Def".to_string());
 
-    let root = properties::parse_private_root(payload)?;
     let segs = properties::parse_path(&def_path)?;
     let resolved = properties::resolve_chain(&root.properties, &segs)?;
     let target = resolved.target.clone();

--- a/crates/gore-save/src/skills/mod.rs
+++ b/crates/gore-save/src/skills/mod.rs
@@ -307,9 +307,16 @@ impl SkillSetEdit {
 /// - not learned, `tier != Untrained` → clone a donor element (or the embedded
 ///   template on an empty array) and retarget its `Def`.
 /// - otherwise a no-op.
-pub fn apply_skill_set(payload: &mut Vec<u8>, edit: &SkillSetEdit) -> Result<(), CoreError> {
-    let root = properties::parse_private_root(payload)?;
-    let (base_path, elements) = locate_active_effects(&root, &edit.actor).ok_or_else(|| {
+pub(crate) fn apply_skill_set(
+    payload: &mut Vec<u8>,
+    edit: &SkillSetEdit,
+    cache: &mut crate::PayloadRoot,
+) -> Result<(), CoreError> {
+    // `fresh`, not `structural`: the decision below reads decoded Def strings off
+    // the tree, so a parse that predates an in-place write by an earlier edit in
+    // the batch could pick the wrong element.
+    let root = cache.fresh(payload)?;
+    let (base_path, elements) = locate_active_effects(root, &edit.actor).ok_or_else(|| {
         CoreError::UnsupportedEdit(format!(
             "actor {:?} has no ActiveEffects array to edit skills in",
             edit.actor
@@ -352,19 +359,23 @@ pub fn apply_skill_set(payload: &mut Vec<u8>, edit: &SkillSetEdit) -> Result<(),
         p
     };
     let element_count = elements.len();
+    // Read the existing element's class here, while the tree is still in hand; the
+    // borrow of the cache ends with this block so the writes below can hand it their
+    // proof parses.
+    let existing_class = existing
+        .and_then(|idx| elements.get(idx))
+        .and_then(element_class)
+        .map(str::to_string);
 
     match existing {
         Some(idx) => {
             if want_untrained && !has_untrained {
                 // Unlearn: no `_Untrained` class exists, so remove the element.
-                container_edit(payload, &root, &array_path, ContainerEdit::ArrayRemove(idx))?;
-                Ok(())
-            } else if element_class_at(&root, &array_path, idx)?.as_deref()
-                == Some(target_class.as_str())
-            {
+                container_edit(payload, cache, &array_path, ContainerEdit::ArrayRemove(idx))
+            } else if existing_class.as_deref() == Some(target_class.as_str()) {
                 Ok(()) // already the requested class
             } else {
-                retarget_def(payload, &root, &array_path, idx, &target_class)
+                retarget_def(payload, cache, &array_path, idx, &target_class)
             }
         }
         None => {
@@ -381,82 +392,62 @@ pub fn apply_skill_set(payload: &mut Vec<u8>, edit: &SkillSetEdit) -> Result<(),
             // element.
             match same_category_donor.or(any_donor) {
                 Some(donor_idx) => {
-                    let cloned = container_edit(
+                    container_edit(
                         payload,
-                        &root,
+                        cache,
                         &array_path,
                         ContainerEdit::ArrayDuplicate(donor_idx),
                     )?;
                     // ArrayDuplicate inserts the copy right after the source.
-                    retarget_def(payload, &cloned, &array_path, donor_idx + 1, &target_class)
+                    retarget_def(payload, cache, &array_path, donor_idx + 1, &target_class)
                 }
                 None => {
-                    let appended = container_edit(
+                    container_edit(
                         payload,
-                        &root,
+                        cache,
                         &array_path,
                         ContainerEdit::ArrayInsertBytes(donor::donor_template()),
                     )?;
                     // ArrayInsertBytes appends at the end of the array.
-                    retarget_def(payload, &appended, &array_path, element_count, &target_class)
+                    retarget_def(payload, cache, &array_path, element_count, &target_class)
                 }
             }
         }
     }
 }
 
-/// The class string of the element at `index`, read from an existing parse.
-fn element_class_at(
-    root: &properties::RootObject,
-    array_path: &[String],
-    index: usize,
-) -> Result<Option<String>, CoreError> {
-    let segs = properties::parse_path(array_path)?;
-    let resolved = properties::resolve_chain(&root.properties, &segs)?;
-    let PropertyValue::Array { elements } = &resolved.target.value else {
-        return Ok(None);
-    };
-    Ok(elements
-        .get(index)
-        .and_then(element_class)
-        .map(str::to_string))
-}
-
-/// Apply a structural container edit to the array at `array_path`, validating on
-/// a scratch copy before committing (mirrors the generic typed container apply).
-/// `root` must describe `payload` as it stands. Returns the proof parse, which
-/// describes the bytes just installed, so the next step needs no parse of its own.
+/// Resolves through `cache` and hands it the proof parse afterwards, so a run of
+/// skill edits in one write parses the payload once per edit rather than per step.
 fn container_edit(
     payload: &mut Vec<u8>,
-    root: &properties::RootObject,
+    cache: &mut crate::PayloadRoot,
     array_path: &[String],
     edit: ContainerEdit,
-) -> Result<properties::RootObject, CoreError> {
-    let segs = properties::parse_path(array_path)?;
-    let resolved = properties::resolve_chain(&root.properties, &segs)?;
-    let target = resolved.target.clone();
+) -> Result<(), CoreError> {
+    let (target, enclosing) = {
+        let root = cache.fresh(payload)?;
+        let segs = properties::parse_path(array_path)?;
+        let resolved = properties::resolve_chain(&root.properties, &segs)?;
+        (resolved.target.clone(), resolved.enclosing_size_fields)
+    };
     let mut patched = payload.clone();
-    properties::patch_container(
-        &mut patched,
-        &target,
-        &resolved.enclosing_size_fields,
-        &edit,
-    )?;
+    properties::patch_container(&mut patched, &target, &enclosing, &edit)?;
     let proof = properties::parse_private_root(&patched).map_err(|err| {
         CoreError::Parse(format!(
             "skill container edit produced an inconsistent payload: {err}"
         ))
     })?;
     *payload = patched;
-    Ok(proof)
+    cache.adopt(proof);
+    Ok(())
 }
 
 /// Retarget the `EffectSpec/Def` ObjectProperty of the array element at `index`
 /// to `new_class` (a length-changing string patch), validating on a scratch copy.
-/// `root` must describe `payload` as it stands.
+/// Resolves through `cache` and hands it the proof parse afterwards.
 fn retarget_def(
     payload: &mut Vec<u8>,
-    root: &properties::RootObject,
+    cache: &mut crate::PayloadRoot,
     array_path: &[String],
     index: usize,
     new_class: &str,
@@ -466,22 +457,23 @@ fn retarget_def(
     def_path.push("EffectSpec".to_string());
     def_path.push("Def".to_string());
 
-    let segs = properties::parse_path(&def_path)?;
-    let resolved = properties::resolve_chain(&root.properties, &segs)?;
-    let target = resolved.target.clone();
+    let (target, enclosing) = {
+        let root = cache.fresh(payload)?;
+        let segs = properties::parse_path(&def_path)?;
+        let resolved = properties::resolve_chain(&root.properties, &segs)?;
+        (resolved.target.clone(), resolved.enclosing_size_fields)
+    };
     let mut patched = payload.clone();
-    properties::patch_string(
-        &mut patched,
-        &target,
-        &resolved.enclosing_size_fields,
-        new_class,
-    )?;
-    properties::parse_private_root(&patched).map_err(|err| {
+    properties::patch_string(&mut patched, &target, &enclosing, new_class)?;
+    let proof = properties::parse_private_root(&patched).map_err(|err| {
         CoreError::Parse(format!(
             "skill Def retarget produced an inconsistent payload: {err}"
         ))
     })?;
     *payload = patched;
+    // The proof describes exactly the bytes just installed, so the next edit in the
+    // batch resolves against it instead of parsing the payload again.
+    cache.adopt(proof);
     Ok(())
 }
 

--- a/crates/gore-save/src/story.rs
+++ b/crates/gore-save/src/story.rs
@@ -1439,8 +1439,8 @@ mod tests {
 
     fn property(name: &str, type_name: &str, value: PropertyValue) -> Property {
         Property {
-            name: name.to_string(),
-            type_name: type_name.to_string(),
+            name: name.into(),
+            type_name: type_name.into(),
             descriptor: Descriptor::default(),
             array_index: 0,
             tag_flags: 0,

--- a/crates/gore-save/src/story.rs
+++ b/crates/gore-save/src/story.rs
@@ -933,7 +933,7 @@ fn unique_story_map_value<'a>(
         || value_descriptor.type_name != "StructProperty"
         || !value_descriptor
             .struct_type
-            .as_ref()
+            .as_deref()
             .is_some_and(|(name, package)| {
                 name == expected_value_struct && package == expected_value_package
             })
@@ -941,7 +941,7 @@ fn unique_story_map_value<'a>(
     {
         let actual_struct = value_descriptor
             .struct_type
-            .as_ref()
+            .as_deref()
             .map(|(name, package)| format!("{name}@{package}"))
             .unwrap_or_else(|| "<missing>".to_string());
         return Err(CoreError::Parse(format!(


### PR DESCRIPTION
Saving in the editor was slow enough to be the thing you noticed most: eight
changed values took eleven seconds, adding six items took nearly a minute. This
makes a save take about as long as the game itself needs.

Measured on a real 2.5 MB save (`G1R-011`), before → after:

| Operation | before | after |
|---|---|---|
| 1 attribute | 3.49 s | **0.72 s** |
| 8 attributes | 10.71 s | **0.73 s** |
| slot repair | 3.71 s | **0.96 s** |
| revive an NPC | 14.91 s | **1.48 s** |
| forgive a guild | 4.57 s | **1.40 s** |
| remove an item | 8.88 s | **1.57 s** |
| add an item | 8.93 s | **1.53 s** |
| set a skill | 6.81 s | **1.59 s** |
| add knowledge | 5.07 s | **1.76 s** |
| set a relationship | 7.37 s | **1.88 s** |
| 3 skills | 18.80 s | **4.71 s** |
| 3 items added | 26.8 s *(3 writes)* | **3.76 s** |
| 3 NPCs revived | 44.7 s *(3 writes)* | **3.48 s** |
| 8 attributes + 2 items | 28.6 s *(3 writes)* | **2.91 s** |
| 6 items added | 53.6 s *(6 writes)* | **8.17 s** |

The italic rows were *refused* by the old batch guard, so the editor had to
split them into that many separate writes. That is the before number.

## Where the time went

A 2.5 MB save holds a 120 MB payload in 916 Oodle chunks. Every write
re-encoded all 916 of them on one thread, and every edit re-parsed the whole
payload — some operations more than once each. Reviving an NPC parsed it eleven
times.

## What changed

**Every write got cheaper.** Chunks now compress and decompress across cores,
and a chunk whose plaintext did not change keeps the bytes it already had (915
of 916 for a scalar edit). Property and type names are interned, and the parsed
property node lost 64 bytes, which takes a parse from 610 ms to 385 ms.

**A Save is one write.** The old rule refused to batch any splicing edit with
anything else. But every `apply_*` re-parses what it is handed, so a batch can
never carry a stale byte offset — only a *caller-supplied ordinal*, an index or
slot id read off an inspection taken before the write. Rejecting exactly that,
positioned after an edit that can change an element count, lets the editor send
one write instead of one per edit. It also closes a hole the old guards left
open: `arrayRemove` followed by an index-addressed `setValue` passed all four of
them and silently patched the wrong element.

**Each operation parses once or twice.** Four patterns did it: fixed-size writes
go before length-changing ones; a step reports whether it wrote anything, so the
caller's parse survives when it did not; a closing proof parse is handed to the
next edit, since it describes exactly the bytes just installed; and changes are
applied back to front, which works because a splice only moves bytes after
itself and the size cascade is read from the current bytes. That last one is
what lets a whole revive come off a single parse.

## How it is checked

Every performance change had to produce **byte-identical saves**: the
`writtenSha1` of real edits was recorded first and had to match afterwards. That
caught two real mistakes during the work.

`crates/gore-save/examples/` gains three read-only measurement drivers — the
crate had no benchmark of any kind before — and `json_timer` reports the parse
count beside the elapsed time, because wall-clock swings by a factor of two
under load while the parse count does not.

Tests: 393 unit + 8 real-save integration (Rust), 522 (Dart). The tests that
asserted a write *count* now assert the order inside the single payload, which
is stronger — order is the only thing protecting those rules once everything
shares a write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the save write path and edit batching/ordering — incorrect packing could silently apply edits to the wrong targets. Mitigated by mirrored core refusal rules and byte-identical SHA1 checks, but still a critical data path.
> 
> **Overview**
> **Saving is dramatically faster** — mixed edits that used to take tens of seconds now finish in about one to a few seconds. A save with eight changed values drops from ~11s to ~1s.
> 
> The editor no longer issues one `write_save` per splicing edit. Compatible pending edits are **packed into as few writes as the core will accept**, ordered so index/slot-id edits resolve against the layout the user saw. Same-target and ordinal-invalidating pairs are split (or refused) by rules that mirror the Rust core, so batching cannot silently retarget the wrong element.
> 
> On the core side, each write is cheaper too: Oodle chunks compress/decompress across cores, unchanged chunks keep their existing bytes, property names are interned, and operations re-parse the payload far less often. Also fixes a bug where removing an item then editing another in the same list could change the wrong one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c6eb009bc6b707f72f90a14452d99b08332c065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->