### PR TITLE
fix(release): bind appcast public keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,7 @@ jobs:
           --title gore-save-editor
           --version ${{ steps.version.outputs.version }}
           --installer dist/gore-save-editor/gore-save-editor-${{ steps.version.outputs.version }}-setup.exe
+          --public-key apps/save-editor/dsa_pub.pem
           --notes dist/gore-save-editor/RELEASE_NOTES.md
           --release-tag gore-save-editor-v${{ steps.version.outputs.version }}
           --output dist/gore-save-editor/appcast-windows.xml
@@ -257,6 +258,7 @@ jobs:
           --title gore-mod-studio
           --version ${{ steps.version.outputs.version }}
           --installer dist/gore-mod-studio/gore-mod-studio-${{ steps.version.outputs.version }}-setup.exe
+          --public-key apps/mod-studio/dsa_pub.pem
           --notes dist/gore-mod-studio/RELEASE_NOTES.md
           --release-tag gore-mod-studio-v${{ steps.version.outputs.version }}
           --output dist/gore-mod-studio/appcast-windows.xml
@@ -376,6 +378,7 @@ jobs:
           --title gore-mod-manager
           --version ${{ steps.version.outputs.version }}
           --installer dist/gore-mod-manager/gore-mod-manager-${{ steps.version.outputs.version }}-setup.exe
+          --public-key apps/mod-manager/dsa_pub.pem
           --notes dist/gore-mod-manager/RELEASE_NOTES.md
           --release-tag gore-mod-manager-v${{ steps.version.outputs.version }}
           --output dist/gore-mod-manager/appcast-windows.xml

--- a/scripts/appcast.py
+++ b/scripts/appcast.py
@@ -9,6 +9,7 @@ of the matching per-project release tag (e.g. gore-save-editor-v1.2.3).
 Usage:
     python scripts/appcast.py --title gore-save-editor --version 0.1.1 \
         --installer dist/gore-save-editor-0.1.1-setup.exe \
+        --public-key apps/save-editor/dsa_pub.pem \
         --notes dist/RELEASE_NOTES.md \
         --release-tag gore-save-editor-v0.1.1 \
         --output dist/appcast-windows.xml
@@ -17,14 +18,15 @@ Environment:
     WINSPARKLE_DSA_PRIV_KEY_B64   base64-encoded DSA private key PEM.
                                   Required: WinSparkle rejects unsigned
                                   updates once a public key is embedded.
-                                  gore-save and gore-mod share one keypair,
-                                  so the same secret signs both feeds.
+                                  All three apps currently share one keypair,
+                                  so the same secret signs every feed.
 """
 
 from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import os
 import subprocess
 import sys
@@ -53,19 +55,64 @@ def sign_dsa(installer: Path) -> str:
     with tempfile.TemporaryDirectory() as tmp:
         key_path = Path(tmp) / "dsa_priv.pem"
         key_path.write_text(key_pem, encoding="utf-8")
-        digest = subprocess.run(
-            ["openssl", "dgst", "-sha1", "-binary"],
-            input=installer.read_bytes(),
-            capture_output=True,
-            check=True,
-        )
+        digest = _sha1_digest(installer.read_bytes())
         result = subprocess.run(
             ["openssl", "dgst", "-sha1", "-sign", str(key_path)],
-            input=digest.stdout,
+            input=digest,
             capture_output=True,
             check=True,
         )
     return base64.b64encode(result.stdout).decode()
+
+
+def _sha1_digest(payload: bytes) -> bytes:
+    return subprocess.run(
+        ["openssl", "dgst", "-sha1", "-binary"],
+        input=payload,
+        capture_output=True,
+        check=True,
+    ).stdout
+
+
+def verify_dsa(installer: Path, signature: str, public_key: Path) -> None:
+    """Fail unless *signature* is accepted by the key embedded in the app.
+
+    This mirrors WinSparkle's two-stage verification: the DSA signature covers
+    SHA1(SHA1(installer)). A stale or wrong CI secret must stop the release
+    before an appcast that every installed client rejects can be uploaded.
+    """
+    if not public_key.is_file():
+        sys.exit(f"WinSparkle public key not found: {public_key}")
+    try:
+        signature_bytes = base64.b64decode(signature, validate=True)
+    except (ValueError, binascii.Error) as error:
+        raise SystemExit(f"invalid base64 DSA signature: {error}") from error
+    if not signature_bytes:
+        sys.exit("empty DSA signature")
+
+    digest = _sha1_digest(installer.read_bytes())
+    with tempfile.TemporaryDirectory() as tmp:
+        signature_path = Path(tmp) / "installer.dsa"
+        signature_path.write_bytes(signature_bytes)
+        verified = subprocess.run(
+            [
+                "openssl",
+                "dgst",
+                "-sha1",
+                "-verify",
+                str(public_key),
+                "-signature",
+                str(signature_path),
+            ],
+            input=digest,
+            capture_output=True,
+            check=False,
+        )
+    if verified.returncode != 0:
+        sys.exit(
+            "DSA signature does not match the WinSparkle public key "
+            f"embedded by this release: {public_key}"
+        )
 
 
 def notes_to_html(notes_path: Path | None) -> str:
@@ -125,6 +172,12 @@ def main() -> int:
                         help="channel title (the product name)")
     parser.add_argument("--version", required=True)
     parser.add_argument("--installer", required=True, type=Path)
+    parser.add_argument(
+        "--public-key",
+        required=True,
+        type=Path,
+        help="WinSparkle DSA public key embedded in this app",
+    )
     parser.add_argument("--notes", type=Path)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--release-tag", required=True,
@@ -136,6 +189,7 @@ def main() -> int:
         sys.exit(f"installer not found: {args.installer}")
 
     signature = sign_dsa(args.installer)
+    verify_dsa(args.installer, signature, args.public_key)
     xml = build_appcast(
         title=args.title,
         version=args.version,

--- a/scripts/check_release_workflow.py
+++ b/scripts/check_release_workflow.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import posixpath
 import re
 import sys
-from typing import Iterable, Sequence
+from typing import Iterable, Mapping, Sequence
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -83,6 +84,12 @@ class ProductContract:
     feed_command: str | None = None
 
 
+@dataclass(frozen=True)
+class AppcastKeyContract:
+    runner_rc: str
+    public_key: str
+
+
 def _app_version_command(app_dir: str, tag_prefix: str) -> str:
     return "\n".join(
         (
@@ -144,6 +151,22 @@ def _release_notes_command(changelog: str, output_dir: str) -> str:
     )
 
 
+APPCAST_KEYS: dict[str, AppcastKeyContract] = {
+    "gore-save-editor": AppcastKeyContract(
+        runner_rc="apps/save-editor/windows/runner/Runner.rc",
+        public_key="apps/save-editor/dsa_pub.pem",
+    ),
+    "gore-mod-studio": AppcastKeyContract(
+        runner_rc="apps/mod-studio/windows/runner/Runner.rc",
+        public_key="apps/mod-studio/dsa_pub.pem",
+    ),
+    "gore-mod-manager": AppcastKeyContract(
+        runner_rc="apps/mod-manager/windows/runner/Runner.rc",
+        public_key="apps/mod-manager/dsa_pub.pem",
+    ),
+}
+
+
 PRODUCTS: dict[str, ProductContract] = {
     "gore-save-editor": ProductContract(
         tag_prefix="gore-save-editor-v",
@@ -173,6 +196,7 @@ PRODUCTS: dict[str, ProductContract] = {
             "--version ${{ steps.version.outputs.version }} "
             "--installer dist/gore-save-editor/"
             "gore-save-editor-${{ steps.version.outputs.version }}-setup.exe "
+            f"--public-key {APPCAST_KEYS['gore-save-editor'].public_key} "
             "--notes dist/gore-save-editor/RELEASE_NOTES.md "
             "--release-tag gore-save-editor-v${{ steps.version.outputs.version }} "
             "--output dist/gore-save-editor/appcast-windows.xml"
@@ -217,6 +241,7 @@ PRODUCTS: dict[str, ProductContract] = {
             "--version ${{ steps.version.outputs.version }} "
             "--installer dist/gore-mod-studio/"
             "gore-mod-studio-${{ steps.version.outputs.version }}-setup.exe "
+            f"--public-key {APPCAST_KEYS['gore-mod-studio'].public_key} "
             "--notes dist/gore-mod-studio/RELEASE_NOTES.md "
             "--release-tag gore-mod-studio-v${{ steps.version.outputs.version }} "
             "--output dist/gore-mod-studio/appcast-windows.xml"
@@ -265,6 +290,7 @@ PRODUCTS: dict[str, ProductContract] = {
             "--version ${{ steps.version.outputs.version }} "
             "--installer dist/gore-mod-manager/"
             "gore-mod-manager-${{ steps.version.outputs.version }}-setup.exe "
+            f"--public-key {APPCAST_KEYS['gore-mod-manager'].public_key} "
             "--notes dist/gore-mod-manager/RELEASE_NOTES.md "
             "--release-tag gore-mod-manager-v${{ steps.version.outputs.version }} "
             "--output dist/gore-mod-manager/appcast-windows.xml"
@@ -1209,15 +1235,47 @@ def validate_workflows(ci_text: str, release_text: str) -> list[str]:
         return [str(error)]
 
 
+def validate_appcast_key_resources(
+    runner_resources: Mapping[str, str],
+) -> list[str]:
+    """Bind each signed appcast key to the exact key embedded by Runner.rc."""
+    problems: list[str] = []
+    for product, contract in APPCAST_KEYS.items():
+        runner_text = runner_resources.get(product)
+        if runner_text is None:
+            problems.append(f"{contract.runner_rc}: missing Runner.rc contract input")
+            continue
+        resource_lines = [
+            " ".join(line.split())
+            for line in runner_text.splitlines()
+            if re.match(r"^\s*DSAPub(?:\s|$)", line)
+        ]
+        relative_key = posixpath.relpath(
+            contract.public_key, posixpath.dirname(contract.runner_rc)
+        )
+        expected = f'DSAPub DSAPEM "{relative_key}"'
+        if resource_lines != [expected]:
+            problems.append(
+                f"{contract.runner_rc}: {product} WinSparkle DSA resource must "
+                f"bind exactly to {contract.public_key} as {expected!r}"
+            )
+    return problems
+
+
 def main() -> int:
     try:
         ci_text = CI_PATH.read_text(encoding="utf-8")
         release_text = RELEASE_PATH.read_text(encoding="utf-8")
+        runner_resources = {
+            product: (ROOT / contract.runner_rc).read_text(encoding="utf-8")
+            for product, contract in APPCAST_KEYS.items()
+        }
     except OSError as error:
         print(f"release workflow check could not read its inputs: {error}", file=sys.stderr)
         return 1
 
     problems = validate_workflows(ci_text, release_text)
+    problems.extend(validate_appcast_key_resources(runner_resources))
     if problems:
         for problem in problems:
             print(problem, file=sys.stderr)

--- a/scripts/test_appcast.py
+++ b/scripts/test_appcast.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from appcast import main, sign_dsa, verify_dsa
+
+
+class AppcastSignatureTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._keys = tempfile.TemporaryDirectory(prefix="gore-appcast-keys-")
+        cls.keys = Path(cls._keys.name)
+        cls.private_key, cls.public_key = cls._generate_keypair("release")
+        _, cls.other_public_key = cls._generate_keypair("other")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._keys.cleanup()
+
+    @classmethod
+    def _generate_keypair(cls, name: str) -> tuple[Path, Path]:
+        parameters = cls.keys / f"{name}-parameters.pem"
+        private_key = cls.keys / f"{name}-private.pem"
+        public_key = cls.keys / f"{name}-public.pem"
+        subprocess.run(
+            [
+                "openssl",
+                "genpkey",
+                "-genparam",
+                "-algorithm",
+                "DSA",
+                "-pkeyopt",
+                "dsa_paramgen_bits:1024",
+                "-out",
+                str(parameters),
+            ],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            [
+                "openssl",
+                "genpkey",
+                "-paramfile",
+                str(parameters),
+                "-out",
+                str(private_key),
+            ],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            [
+                "openssl",
+                "pkey",
+                "-in",
+                str(private_key),
+                "-pubout",
+                "-out",
+                str(public_key),
+            ],
+            capture_output=True,
+            check=True,
+        )
+        return private_key, public_key
+
+    def setUp(self) -> None:
+        self._files = tempfile.TemporaryDirectory(prefix="gore-appcast-test-")
+        self.files = Path(self._files.name)
+        self.installer = self.files / "gore-mod-manager-0.1.0-setup.exe"
+        self.installer.write_bytes(b"test installer payload\0")
+        private_key_b64 = base64.b64encode(self.private_key.read_bytes()).decode()
+        self.environment = mock.patch.dict(
+            os.environ,
+            {"WINSPARKLE_DSA_PRIV_KEY_B64": private_key_b64},
+        )
+        self.environment.start()
+
+    def tearDown(self) -> None:
+        self.environment.stop()
+        self._files.cleanup()
+
+    def test_generated_signature_matches_embedded_public_key(self) -> None:
+        signature = sign_dsa(self.installer)
+
+        verify_dsa(self.installer, signature, self.public_key)
+
+    def test_wrong_public_key_is_refused(self) -> None:
+        signature = sign_dsa(self.installer)
+
+        with self.assertRaisesRegex(SystemExit, "does not match"):
+            verify_dsa(self.installer, signature, self.other_public_key)
+
+    def test_changed_installer_is_refused(self) -> None:
+        signature = sign_dsa(self.installer)
+        self.installer.write_bytes(b"different payload")
+
+        with self.assertRaisesRegex(SystemExit, "does not match"):
+            verify_dsa(self.installer, signature, self.public_key)
+
+    def test_invalid_signature_inputs_are_refused(self) -> None:
+        cases = (("not base64!", "invalid base64"), ("", "empty DSA signature"))
+        for signature, message in cases:
+            with self.subTest(signature=signature):
+                with self.assertRaisesRegex(SystemExit, message):
+                    verify_dsa(self.installer, signature, self.public_key)
+
+    def test_missing_public_key_is_refused(self) -> None:
+        signature = sign_dsa(self.installer)
+
+        with self.assertRaisesRegex(SystemExit, "public key not found"):
+            verify_dsa(self.installer, signature, self.files / "missing.pem")
+
+    def test_key_mismatch_publishes_no_appcast(self) -> None:
+        output = self.files / "appcast-windows.xml"
+        arguments = [
+            "appcast.py",
+            "--title",
+            "gore-mod-manager",
+            "--version",
+            "0.1.0",
+            "--installer",
+            str(self.installer),
+            "--public-key",
+            str(self.other_public_key),
+            "--release-tag",
+            "gore-mod-manager-v0.1.0",
+            "--output",
+            str(output),
+        ]
+
+        with mock.patch("sys.argv", arguments):
+            with self.assertRaisesRegex(SystemExit, "does not match"):
+                main()
+        self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_release_workflow.py
+++ b/scripts/test_check_release_workflow.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+import posixpath
 import re
 import unittest
 
-from check_release_workflow import PRODUCTS, PUBLISH_GUARD, validate_workflows
+from check_release_workflow import (
+    APPCAST_KEYS,
+    PRODUCTS,
+    PUBLISH_GUARD,
+    validate_appcast_key_resources,
+    validate_workflows,
+)
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -55,6 +62,10 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         cls.release = (ROOT / ".github" / "workflows" / "release.yml").read_text(
             encoding="utf-8"
         )
+        cls.runner_resources = {
+            product: (ROOT / contract.runner_rc).read_text(encoding="utf-8")
+            for product, contract in APPCAST_KEYS.items()
+        }
 
     def assert_invalid(
         self,
@@ -74,6 +85,9 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
 
     def test_current_workflows_pass(self) -> None:
         self.assertEqual(validate_workflows(self.ci, self.release), [])
+        self.assertEqual(
+            validate_appcast_key_resources(self.runner_resources), []
+        )
 
     def test_ci_must_be_reusable_and_read_only(self) -> None:
         without_call = replace_once(self.ci, "  workflow_call:\n", "")
@@ -422,6 +436,35 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
                     "gh release upload changed-appcast",
                 )
                 self.assert_invalid(release=changed, mentions="feed command changed")
+
+    def test_all_appcasts_are_bound_to_their_embedded_public_key(self) -> None:
+        for product, contract in APPCAST_KEYS.items():
+            with self.subTest(product=product):
+                changed = mutate_job(
+                    self.release,
+                    product,
+                    f"--public-key {contract.public_key}",
+                    "--public-key apps/changed/dsa_pub.pem",
+                )
+                self.assert_invalid(release=changed, mentions="appcast command changed")
+
+    def test_runner_resources_are_bound_to_the_workflow_public_keys(self) -> None:
+        for product, contract in APPCAST_KEYS.items():
+            with self.subTest(product=product):
+                relative_key = posixpath.relpath(
+                    contract.public_key, posixpath.dirname(contract.runner_rc)
+                )
+                changed = dict(self.runner_resources)
+                changed[product] = replace_once(
+                    changed[product],
+                    f'DSAPEM                  "{relative_key}"',
+                    'DSAPEM                  "../../changed.pem"',
+                )
+                problems = validate_appcast_key_resources(changed)
+                self.assertTrue(
+                    any(contract.runner_rc in problem for problem in problems),
+                    f"changed {product} Runner.rc unexpectedly passed: {problems}",
+                )
 
     def test_duplicate_and_unsupported_yaml_shapes_fail_closed(self) -> None:
         duplicate = mutate_job(


### PR DESCRIPTION
## Summary
- verify every generated appcast DSA signature against the product's pinned public key before XML publication
- bind each release workflow and embedded Runner resource to the same canonical public key
- fail release-contract checks when a workflow or Runner key path drifts

## Validation
- `python -m unittest discover -s scripts -p test_*.py` (44/44)
- `python -m ruff check scripts/appcast.py scripts/check_release_workflow.py scripts/test_appcast.py scripts/test_check_release_workflow.py`
- `python -m py_compile scripts/appcast.py scripts/check_release_workflow.py scripts/test_appcast.py scripts/test_check_release_workflow.py`
- `python scripts/check_release_workflow.py`
- `git diff --check origin/main...HEAD`

No installer execution, release publication, game operation, or real-install mutation was performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 54affcf4ad507224bc34184d7b4426c7bc84eba2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->