### PR TITLE
chore(manager): define early alpha contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,6 +399,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           make_latest: "false"
+          prerelease: "true"
           files: |
             dist/gore-mod-manager/*.zip
             dist/gore-mod-manager/gore-mod-manager-${{ steps.version.outputs.version }}-setup.exe

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -15,7 +15,7 @@ sections are part of `about.hbs`, so `cargo-about` regeneration preserves them.
 ## Overview
 
 - **Apache License 2.0** — 221 crate(s)
-- **MIT License** — 79 crate(s)
+- **MIT License** — 80 crate(s)
 - **BSD 3-Clause "New" or "Revised" License** — 5 crate(s)
 - **BSD 2-Clause "Simplified" License** — 4 crate(s)
 - **University of Illinois/NCSA Open Source License** — 1 crate(s)
@@ -7092,6 +7092,7 @@ Used by:
 - [gore-catalog 0.0.0](https://crates.io/crates/gore-catalog)
 - [gore-ffi 0.0.0](https://crates.io/crates/gore-ffi)
 - [gore-fmod 0.0.0](https://crates.io/crates/gore-fmod)
+- [gore-generation 0.0.0](https://crates.io/crates/gore-generation)
 - [gore-loc 0.0.0](https://crates.io/crates/gore-loc)
 - [gore-mcp 0.0.0](https://crates.io/crates/gore-mcp)
 - [gore-mod 0.0.0](https://crates.io/crates/gore-mod)
@@ -7757,6 +7758,78 @@ Microsoft states that licensed Visual Studio users may redistribute these
 unmodified files subject to the applicable Visual Studio license terms. See
 [Redistributing Visual C++ files](https://learn.microsoft.com/en-us/cpp/windows/redistributing-visual-cpp-files?view=msvc-170).
 These files are not covered by GORE's MIT License.
+
+### WinSparkle 0.8.1 updater
+
+The installed GORE Mod Manager Windows package includes WinSparkle 0.8.1 via
+the `auto_updater_windows` dependency. The portable package omits the updater
+binaries, but carries this notice with the other third-party attributions.
+
+The following WinSparkle license and attribution text is reproduced from
+`packages/auto_updater_windows/windows/WinSparkle-0.8.1/COPYING` in the pinned
+dependency package. The contents are split into two blocks so the OpenSSL
+attribution remains explicit.
+
+#### WinSparkle license
+
+```
+Copyright (c) 2009-2023 Vaclav Slavik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+#### OpenSSL attribution from WinSparkle COPYING
+
+```
+This product includes software developed by the OpenSSL Project
+for use in the OpenSSL Toolkit (http://www.openssl.org/).
+```
+
+#### Expat license
+
+The following text is reproduced from
+`packages/auto_updater_windows/windows/WinSparkle-0.8.1/COPYING.expat` in the
+pinned dependency package.
+
+```
+Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper
+Copyright (c) 2001-2017 Expat maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
 
 ### BSD 2-Clause - embedded diagnostics helper
 

--- a/about.hbs
+++ b/about.hbs
@@ -48,6 +48,78 @@ unmodified files subject to the applicable Visual Studio license terms. See
 [Redistributing Visual C++ files](https://learn.microsoft.com/en-us/cpp/windows/redistributing-visual-cpp-files?view=msvc-170).
 These files are not covered by GORE's MIT License.
 
+### WinSparkle 0.8.1 updater
+
+The installed GORE Mod Manager Windows package includes WinSparkle 0.8.1 via
+the `auto_updater_windows` dependency. The portable package omits the updater
+binaries, but carries this notice with the other third-party attributions.
+
+The following WinSparkle license and attribution text is reproduced from
+`packages/auto_updater_windows/windows/WinSparkle-0.8.1/COPYING` in the pinned
+dependency package. The contents are split into two blocks so the OpenSSL
+attribution remains explicit.
+
+#### WinSparkle license
+
+```
+Copyright (c) 2009-2023 Vaclav Slavik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+#### OpenSSL attribution from WinSparkle COPYING
+
+```
+This product includes software developed by the OpenSSL Project
+for use in the OpenSSL Toolkit (http://www.openssl.org/).
+```
+
+#### Expat license
+
+The following text is reproduced from
+`packages/auto_updater_windows/windows/WinSparkle-0.8.1/COPYING.expat` in the
+pinned dependency package.
+
+```
+Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper
+Copyright (c) 2001-2017 Expat maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
 ### BSD 2-Clause - embedded diagnostics helper
 
 Used by the embedded `gore-as-diagnostics-hook.dll`:

--- a/apps/mod-manager/CHANGELOG.md
+++ b/apps/mod-manager/CHANGELOG.md
@@ -8,4 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.1.0] - 2026-07-03
 
-- Initial release: mod library, load order, conflict detection, declarative apply.
+- Early Alpha release, published as a GitHub prerelease rather than a stable
+  general-use build.
+- Mod library, load order, conflict detection, and declarative Apply/Undeploy.
+- Windows installer with WinSparkle update checks; the portable zip remains
+  self-contained and updater-free.
+- Documented that uninstalling removes the app and its UI preferences but does
+  not undeploy mods or erase the shared imported library, loadout, and GORE
+  configuration.
+- Included WinSparkle 0.8.1, Expat, and OpenSSL attributions in the shipped
+  third-party notices.

--- a/apps/mod-manager/CHANGELOG.md
+++ b/apps/mod-manager/CHANGELOG.md
@@ -13,8 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Mod library, load order, conflict detection, and declarative Apply/Undeploy.
 - Windows installer with WinSparkle update checks; the portable zip remains
   self-contained and updater-free.
-- Documented that uninstalling removes the app and its UI preferences but does
-  not undeploy mods or erase the shared imported library, loadout, and GORE
-  configuration.
+- Documented that uninstalling removes the app and its normal
+  `%LOCALAPPDATA%` UI preferences, while an `%APPDATA%` fallback needs manual
+  cleanup; uninstall does not undeploy mods or erase the shared imported
+  library, loadout, and GORE configuration.
 - Included WinSparkle 0.8.1, Expat, and OpenSSL attributions in the shipped
   third-party notices.

--- a/apps/mod-manager/README.md
+++ b/apps/mod-manager/README.md
@@ -1,7 +1,9 @@
 # GORE Mod Manager
 
-> **Development status:** work in progress — not yet ready for general use. For
-> stable modding today, use the [`gore` CLI](../../docs/guide/README.md).
+> **Early Alpha:** this is a public preview, published as a GitHub prerelease.
+> Use it on a test installation, keep your own backups, and expect rough edges.
+> For the established expert workflow, use the
+> [`gore` CLI](../../docs/guide/README.md).
 
 A Windows app for running **many** mods at once. Where
 [Mod Studio](../mod-studio/README.md) *authors* a single mod, Mod Manager owns
@@ -11,7 +13,8 @@ whole enabled set to your install. It consumes the mod bundles Mod Studio (or
 
 It is a GUI over the same engine as [`gore mgr`](../../docs/guide/mod-manager.md),
 through the `dart:ffi` bridge (`gore_ffi.dll`), and shares that CLI's library
-and loadout files. Auto-updates on launch (WinSparkle).
+and loadout files. Installer builds can check for updates through WinSparkle;
+portable builds are deliberately updater-free.
 
 ## What it can do
 
@@ -40,6 +43,27 @@ and loadout files. Auto-updates on launch (WinSparkle).
   [`gore` CLI](../../docs/guide/README.md).
 - Edit **save files** — that's the [Save Editor](../save-editor/README.md).
 - Download mods (no Nexus API integration) — import files you already have.
+
+## Packages, updates, and persistent data
+
+- The **installer** adds an uninstaller and enables best-effort WinSparkle
+  update checks after launch. Updates download the next installer and update
+  the existing install location in place.
+- The **portable zip** has no installer, uninstaller, or updater binaries.
+  Extract it to a normal writable folder, run `gore_manager.exe`, and replace
+  that extracted app folder manually when updating. “Portable” describes the
+  app package; user data is not stored beside the executable.
+- Both packages share `%LOCALAPPDATA%\gore\mod-manager\` for the imported mod
+  library and loadout, plus `%LOCALAPPDATA%\gore\config.json` for shared GORE
+  settings such as the selected game. `%APPDATA%` is the fallback when
+  `%LOCALAPPDATA%` is unavailable. Manager-only UI preferences live under
+  `%LOCALAPPDATA%\gore\gore-manager\`.
+- Before uninstalling or deleting a portable copy, use **Undeploy** if Manager
+  has applied mods. Removing the app does not undo a deployment in the game
+  directory. The installer uninstaller removes the installed app and
+  Manager-only UI preferences; it intentionally preserves the shared config,
+  imported library, and loadout. Delete `%LOCALAPPDATA%\gore\mod-manager\`
+  manually only if you also want to discard that retained library and loadout.
 
 ## Build / run
 

--- a/apps/mod-manager/README.md
+++ b/apps/mod-manager/README.md
@@ -53,17 +53,20 @@ portable builds are deliberately updater-free.
   Extract it to a normal writable folder, run `gore_manager.exe`, and replace
   that extracted app folder manually when updating. “Portable” describes the
   app package; user data is not stored beside the executable.
-- Both packages share `%LOCALAPPDATA%\gore\mod-manager\` for the imported mod
-  library and loadout, plus `%LOCALAPPDATA%\gore\config.json` for shared GORE
-  settings such as the selected game. `%APPDATA%` is the fallback when
-  `%LOCALAPPDATA%` is unavailable. Manager-only UI preferences live under
-  `%LOCALAPPDATA%\gore\gore-manager\`.
+- Both packages normally share `%LOCALAPPDATA%\gore\mod-manager\` for the
+  imported mod library and loadout, `%LOCALAPPDATA%\gore\config.json` for
+  shared GORE settings such as the selected game, and
+  `%LOCALAPPDATA%\gore\gore-manager\` for Manager-only UI preferences. If
+  `%LOCALAPPDATA%` is unavailable, the app uses the same relative paths under
+  `%APPDATA%` instead.
 - Before uninstalling or deleting a portable copy, use **Undeploy** if Manager
   has applied mods. Removing the app does not undo a deployment in the game
-  directory. The installer uninstaller removes the installed app and
-  Manager-only UI preferences; it intentionally preserves the shared config,
-  imported library, and loadout. Delete `%LOCALAPPDATA%\gore\mod-manager\`
-  manually only if you also want to discard that retained library and loadout.
+  directory. The installer uninstaller removes the installed app and its
+  normal `%LOCALAPPDATA%` UI preferences; it intentionally preserves the
+  shared config, imported library, and loadout. In the `%APPDATA%` fallback
+  case, remove `%APPDATA%\gore\gore-manager\` manually to discard UI
+  preferences. Delete the active data root's `gore\mod-manager\` directory
+  manually only if you also want to discard the retained library and loadout.
 
 ## Build / run
 

--- a/scripts/check_release_workflow.py
+++ b/scripts/check_release_workflow.py
@@ -77,6 +77,7 @@ class ProductContract:
     upload_name: str
     upload_paths: str
     make_latest: str
+    prerelease: str | None
     publish_files: str
     publish_body: str
     artifact_verify_command: str | None = None
@@ -185,6 +186,7 @@ PRODUCTS: dict[str, ProductContract] = {
             "dist/gore-save-editor/appcast-windows.xml"
         ),
         make_latest='"true"',
+        prerelease=None,
         publish_files=(
             "dist/gore-save-editor/*.zip\n"
             "dist/gore-save-editor/*.exe\n"
@@ -230,6 +232,7 @@ PRODUCTS: dict[str, ProductContract] = {
             "dist/gore-mod-studio/appcast-windows.xml"
         ),
         make_latest='"false"',
+        prerelease=None,
         publish_files=(
             "dist/gore-mod-studio/*.zip\n"
             "dist/gore-mod-studio/gore-mod-studio-"
@@ -275,6 +278,7 @@ PRODUCTS: dict[str, ProductContract] = {
             "dist/gore-mod-manager/appcast-windows.xml"
         ),
         make_latest='"false"',
+        prerelease='"true"',
         publish_files=(
             "dist/gore-mod-manager/*.zip\n"
             "dist/gore-mod-manager/gore-mod-manager-"
@@ -318,6 +322,7 @@ PRODUCTS: dict[str, ProductContract] = {
         upload_name="gore-cli-windows-x64",
         upload_paths="dist/gore-cli/*.zip",
         make_latest='"false"',
+        prerelease=None,
         publish_files="dist/gore-cli/*.zip",
         publish_body="dist/gore-cli/RELEASE_NOTES.md",
     ),
@@ -1024,17 +1029,26 @@ def _validate_product_steps(
             problems.append(f"{context}: release action changed")
         if with_field is not None:
             with_fields = _mapping(with_field, f"{context} publish.with")
+            expected_fields = {"make_latest", "files", "body_path"}
+            if contract.prerelease is not None:
+                expected_fields.add("prerelease")
             _expect_keys(
                 with_fields,
-                {"make_latest", "files", "body_path"},
+                expected_fields,
                 f"{context} publish.with",
                 problems,
             )
             latest = with_fields.get("make_latest")
+            prerelease = with_fields.get("prerelease")
             files = with_fields.get("files")
             body = with_fields.get("body_path")
             if latest is None or _scalar(latest, context) != contract.make_latest:
                 problems.append(f"{context}: make_latest changed")
+            if contract.prerelease is not None and (
+                prerelease is None
+                or _scalar(prerelease, context) != contract.prerelease
+            ):
+                problems.append(f"{context}: prerelease flag changed")
             if files is None or _scalar(files, context) != contract.publish_files:
                 problems.append(f"{context}: published release files changed")
             if body is None or _scalar(body, context) != contract.publish_body:

--- a/scripts/test_check_release_workflow.py
+++ b/scripts/test_check_release_workflow.py
@@ -416,6 +416,33 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
                 )
                 self.assert_invalid(release=changed)
 
+    def test_only_manager_versioned_releases_are_prereleases(self) -> None:
+        missing = mutate_job(
+            self.release,
+            "gore-mod-manager",
+            '          prerelease: "true"\n',
+            "",
+        )
+        self.assert_invalid(release=missing, mentions="prerelease flag changed")
+
+        false = mutate_job(
+            self.release,
+            "gore-mod-manager",
+            'prerelease: "true"',
+            'prerelease: "false"',
+        )
+        self.assert_invalid(release=false, mentions="prerelease flag changed")
+
+        for product in ("gore-save-editor", "gore-mod-studio", "gore-cli"):
+            with self.subTest(product=product):
+                changed = mutate_job(
+                    self.release,
+                    product,
+                    '          make_latest: ',
+                    '          prerelease: "true"\n          make_latest: ',
+                )
+                self.assert_invalid(release=changed, mentions="field set changed")
+
     def test_all_appcast_generation_and_feed_commands_are_pinned(self) -> None:
         for product, contract in PRODUCTS.items():
             if contract.appcast_command is None or contract.feed_command is None:

--- a/scripts/test_verify_mod_manager_release.py
+++ b/scripts/test_verify_mod_manager_release.py
@@ -70,8 +70,14 @@ class _ReleaseFixture:
             path.write_bytes(name.encode())
 
         (self.root / "LICENSE").write_text("MIT\n", encoding="utf-8")
-        (self.root / "THIRD_PARTY_LICENSES.md").write_text(
-            "Third party\n", encoding="utf-8"
+        source_notices = (ROOT / "about.hbs").read_text(encoding="utf-8")
+        notices = verifier._winsparkle_notice_section(source_notices)
+        assert notices is not None
+        notices += f"\n\n{verifier.WINSPARKLE_NOTICE_END}\n"
+        (self.root / "about.hbs").write_text(notices, encoding="utf-8")
+        (self.root / "THIRD_PARTY_LICENSES.md").write_text(notices, encoding="utf-8")
+        (self.root / "apps" / "mod-manager" / "pubspec.lock").write_text(
+            verifier.AUTO_UPDATER_WINDOWS_LOCK_STANZA + "\n", encoding="utf-8"
         )
         self.setup = self.root / "apps" / "mod-manager" / "installer" / "setup.iss"
         self.setup.parent.mkdir(parents=True)
@@ -215,6 +221,80 @@ class ModManagerReleaseContractTest(unittest.TestCase):
                     self.assert_problem(problems, expected)
                 finally:
                     fixture.close()
+
+    def test_notice_source_and_generated_file_require_winsparkle_markers(self) -> None:
+        for relative in verifier.THIRD_PARTY_NOTICE_FILES:
+            for label, marker in verifier.THIRD_PARTY_NOTICE_MARKERS.items():
+                with self.subTest(file=relative, marker=label):
+                    fixture = self.fixture()
+                    path = fixture.root / relative
+                    text = path.read_text(encoding="utf-8")
+                    path.write_text(text.replace(marker, "", 1), encoding="utf-8")
+                    problems = verifier.verify_release(
+                        fixture.root, VERSION, version_info_reader=fixture.metadata
+                    )
+                    self.assert_problem(problems, f"{relative} is missing {label}")
+
+    def test_exact_notice_sections_reject_non_marker_license_clause_drift(self) -> None:
+        clauses = (
+            (
+                "WinSparkle license",
+                "of the Software, and to permit persons to whom the Software is furnished to do",
+            ),
+            (
+                "WinSparkle license",
+                "OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE",
+            ),
+            (
+                "Expat license",
+                "without limitation the rights to use, copy, modify, merge, publish,",
+            ),
+        )
+        for _, clause in clauses:
+            self.assertFalse(
+                any(clause in marker for marker in verifier.THIRD_PARTY_NOTICE_MARKERS.values())
+            )
+        for relative in verifier.THIRD_PARTY_NOTICE_FILES:
+            for heading, clause in clauses:
+                with self.subTest(file=relative, clause=clause):
+                    fixture = self.fixture()
+                    path = fixture.root / relative
+                    text = path.read_text(encoding="utf-8")
+                    self.assertIn(clause, text)
+                    path.write_text(text.replace(clause, "", 1), encoding="utf-8")
+                    problems = verifier.verify_release(
+                        fixture.root, VERSION, version_info_reader=fixture.metadata
+                    )
+                    self.assert_problem(
+                        problems,
+                        f"{relative} exact WinSparkle 0.8.1 notice section changed",
+                    )
+                    self.assert_problem(
+                        problems, f"{relative} exact upstream {heading} block changed"
+                    )
+
+    def test_winsparkle_notices_are_bound_to_pinned_dependency_source(self) -> None:
+        mutations = (
+            (
+                "56dc406f6e0f6ccf01d70d2fbc88f7ca1c3ebf9a",
+                "0000000000000000000000000000000000000000",
+            ),
+            ('version: "1.0.1"', 'version: "1.0.2"'),
+            ("packages/auto_updater_windows", "packages/changed_updater_windows"),
+        )
+        for old, new in mutations:
+            with self.subTest(changed=old):
+                fixture = self.fixture()
+                lock = fixture.root / "apps" / "mod-manager" / "pubspec.lock"
+                text = lock.read_text(encoding="utf-8")
+                self.assertIn(old, text)
+                lock.write_text(text.replace(old, new, 1), encoding="utf-8")
+                problems = verifier.verify_release(
+                    fixture.root, VERSION, version_info_reader=fixture.metadata
+                )
+                self.assert_problem(
+                    problems, "auto_updater_windows dependency pin changed"
+                )
 
     def test_windows_path_collisions_and_traversal_fail(self) -> None:
         cases = (

--- a/scripts/verify_mod_manager_release.py
+++ b/scripts/verify_mod_manager_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import ctypes
+import hashlib
 import os
 from pathlib import Path
 import re
@@ -88,6 +89,61 @@ EXPECTED_INSTALLER_FILES = (
     'Source: "..\\..\\..\\THIRD_PARTY_LICENSES.md"; DestDir: "{app}"; Flags: ignoreversion',
 )
 
+THIRD_PARTY_NOTICE_FILES = ("about.hbs", "THIRD_PARTY_LICENSES.md")
+WINSPARKLE_NOTICE_START = "### WinSparkle 0.8.1 updater"
+WINSPARKLE_NOTICE_END = "### BSD 2-Clause - embedded diagnostics helper"
+# These hashes come from the exact local dependency package at the pinned
+# resolved ref below. Its original files are COPYING (SHA-256
+# d236b139330d1456b8f392f8d10453e86c9a9375ec939566b234b9363a56535e) and
+# COPYING.expat (SHA-256
+# 7e043c766b1772d1ccc47751c7334db4feb1f2f9a7fd5055df60a6fde420a2f5);
+# rendered blocks use LF and no edge blanks.
+WINSPARKLE_NOTICE_SHA256 = (
+    "d5221ccb51b03d603fcd7d92b4b284fdf1e4609956b65600eb59048312a6be5d"
+)
+WINSPARKLE_UPSTREAM_BLOCK_SHA256 = {
+    "WinSparkle license": (
+        "06f49858020bdc0ac014b0591dd9e8b4ff6e3d547576777b0a5e73f27a4e9c97"
+    ),
+    "OpenSSL attribution from WinSparkle COPYING": (
+        "0be450ce884e718e17497338a2f39f7efa3096cc513d7c7683c77efe8cf2f516"
+    ),
+    "Expat license": (
+        "4c76c8c281d86ab08dadc05f47b15b827ef18fd3035090f167ffab81cccd7069"
+    ),
+}
+AUTO_UPDATER_WINDOWS_LOCK_STANZA = "\n".join(
+    (
+        "  auto_updater_windows:",
+        '    dependency: "direct overridden"',
+        "    description:",
+        '      path: "packages/auto_updater_windows"',
+        "      ref: swiftpm-support",
+        '      resolved-ref: "56dc406f6e0f6ccf01d70d2fbc88f7ca1c3ebf9a"',
+        '      url: "https://github.com/dh0er/auto_updater.git"',
+        "    source: git",
+        '    version: "1.0.1"',
+    )
+)
+THIRD_PARTY_NOTICE_MARKERS = {
+    "WinSparkle 0.8.1 heading": "### WinSparkle 0.8.1 updater",
+    "WinSparkle COPYING source": (
+        "`packages/auto_updater_windows/windows/WinSparkle-0.8.1/COPYING`"
+    ),
+    "WinSparkle copyright": "Copyright (c) 2009-2023 Vaclav Slavik",
+    "WinSparkle OpenSSL attribution": (
+        "This product includes software developed by the OpenSSL Project\n"
+        "for use in the OpenSSL Toolkit (http://www.openssl.org/)."
+    ),
+    "WinSparkle COPYING.expat source": (
+        "`packages/auto_updater_windows/windows/WinSparkle-0.8.1/COPYING.expat`"
+    ),
+    "WinSparkle Expat copyright": (
+        "Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper\n"
+        "Copyright (c) 2001-2017 Expat maintainers"
+    ),
+}
+
 _WINDOWS_FORBIDDEN_CHARS = set('<>:"\\|?*')
 _WINDOWS_RESERVED = re.compile(r"^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$", re.I)
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
@@ -95,6 +151,98 @@ _FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
 
 class ContractError(ValueError):
     pass
+
+
+def _normalise_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _winsparkle_notice_section(text: str) -> str | None:
+    text = _normalise_newlines(text)
+    if text.count(WINSPARKLE_NOTICE_START) != 1:
+        return None
+    start = text.index(WINSPARKLE_NOTICE_START)
+    end = text.find(WINSPARKLE_NOTICE_END, start)
+    if end < 0:
+        return None
+    return text[start:end].rstrip("\n")
+
+
+def _markdown_code_block(section: str, heading: str) -> str | None:
+    match = re.search(
+        rf"(?ms)^#### {re.escape(heading)}\n.*?^```\n(.*?)\n^```$", section
+    )
+    return None if match is None else match.group(1)
+
+
+def _auto_updater_windows_lock_contract(root: Path) -> list[str]:
+    relative = "apps/mod-manager/pubspec.lock"
+    path = root / relative
+    if path.is_symlink() or not path.is_file():
+        return [f"release notices: missing or non-regular file: {relative}"]
+    try:
+        text = _normalise_newlines(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError) as error:
+        return [f"release notices: cannot read {relative}: {error}"]
+    stanzas = re.findall(
+        r"(?ms)^  auto_updater_windows:\n.*?(?=^  [A-Za-z0-9_-]+:\n|\Z)", text
+    )
+    if len(stanzas) != 1 or stanzas[0].rstrip("\n") != AUTO_UPDATER_WINDOWS_LOCK_STANZA:
+        return [
+            "release notices: auto_updater_windows dependency pin changed; "
+            "reverify WinSparkle notices against the new resolved source"
+        ]
+    return []
+
+
+def _third_party_notice_contract(root: Path) -> list[str]:
+    problems: list[str] = []
+    sections: dict[str, str] = {}
+    for relative in THIRD_PARTY_NOTICE_FILES:
+        path = root / relative
+        if path.is_symlink() or not path.is_file():
+            problems.append(f"release notices: missing or non-regular file: {relative}")
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            problems.append(f"release notices: cannot read {relative}: {error}")
+            continue
+        for label, marker in THIRD_PARTY_NOTICE_MARKERS.items():
+            if marker not in text:
+                problems.append(f"release notices: {relative} is missing {label}")
+        section = _winsparkle_notice_section(text)
+        if section is None:
+            problems.append(
+                f"release notices: {relative} has no unique bounded WinSparkle section"
+            )
+            continue
+        sections[relative] = section
+        digest = hashlib.sha256(section.encode("utf-8")).hexdigest()
+        if digest != WINSPARKLE_NOTICE_SHA256:
+            problems.append(
+                f"release notices: {relative} exact WinSparkle 0.8.1 notice "
+                "section changed"
+            )
+        for heading, expected_digest in WINSPARKLE_UPSTREAM_BLOCK_SHA256.items():
+            block = _markdown_code_block(section, heading)
+            block_digest = (
+                None
+                if block is None
+                else hashlib.sha256(block.encode("utf-8")).hexdigest()
+            )
+            if block_digest != expected_digest:
+                problems.append(
+                    f"release notices: {relative} exact upstream {heading} "
+                    "block changed"
+                )
+    if len(sections) == len(THIRD_PARTY_NOTICE_FILES) and len(set(sections.values())) != 1:
+        problems.append(
+            "release notices: about.hbs and THIRD_PARTY_LICENSES.md WinSparkle "
+            "sections differ"
+        )
+    problems.extend(_auto_updater_windows_lock_contract(root))
+    return problems
 
 
 def _windows_path(name: str, *, directory: bool) -> str:
@@ -564,6 +712,7 @@ def verify_release(
 ) -> list[str]:
     if VERSION_RE.fullmatch(version) is None:
         return [f"version must be plain X.Y.Z, got {version!r}"]
+    notice_problems = _third_party_notice_contract(root)
     dist = root / "dist" / "gore-mod-manager"
     portable_name = f"gore-mod-manager-{version}-windows-x64.zip"
     installer_name = f"gore-mod-manager-{version}-setup.exe"
@@ -571,8 +720,10 @@ def verify_release(
     installer = dist / installer_name
 
     problems: list[str] = []
+    problems.extend(notice_problems)
     if not dist.is_dir():
-        return [f"release output directory missing: {dist}"]
+        problems.append(f"release output directory missing: {dist}")
+        return problems
     package_entries = [
         (path.name, path.is_dir())
         for path in dist.iterdir()


### PR DESCRIPTION
## Summary

- publish versioned Mod Manager releases as GitHub prereleases while leaving other products unchanged
- ship and fail-closed verify exact WinSparkle 0.8.1, OpenSSL, and Expat notices from the pinned updater dependency
- document Early Alpha status plus truthful installer, portable, updater, uninstall, and persistent-data behavior

## Validation

- `python -m unittest discover -s scripts -p "test_*.py" -v` — 48 passed
- `python scripts/check_docs_links.py` — 41 files, no broken links
- `python scripts/check_release_workflow.py`
- `actionlint .github/workflows/release.yml`
- `cargo about generate --frozen` reproduces `THIRD_PARTY_LICENSES.md` byte-for-byte
- independent frozen-diff review: CLEAN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation, license attribution, and release metadata. The only behavioral change is marking Mod Manager GitHub releases as prereleases, with fail-closed notice verification around that contract.
> 
> **Overview**
> Defines the **Early Alpha** contract for Mod Manager: versioned GitHub releases are now published as **prereleases** (other products unchanged), with the release-workflow checker enforcing that only Manager carries `prerelease: "true"`.
> 
> Adds exact **WinSparkle 0.8.1** / OpenSSL / Expat attributions to `about.hbs` and `THIRD_PARTY_LICENSES.md`, and extends `verify_mod_manager_release.py` to fail closed if those notice sections drift or the pinned `auto_updater_windows` lock changes.
> 
> Updates README/CHANGELOG to document Early Alpha status plus installer vs portable updater behavior, uninstall cleanup, and where library/loadout/UI data live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258e36607154321b607ef5259e6619ca5f7fa070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->