### PR TITLE
feat(manager): serialize loadout state

### DIFF
--- a/apps/mod-manager/lib/core/core_service.dart
+++ b/apps/mod-manager/lib/core/core_service.dart
@@ -26,7 +26,7 @@ typedef _FreeV2Native = Void Function(Pointer<Void>);
 typedef _FreeV2Dart = void Function(Pointer<Void>);
 
 const _transportAbiV2 = 2;
-const _protocolAbi = 1;
+const _protocolAbi = 2;
 const _maxRequestBytes = 64 * 1024 * 1024;
 const _maxResponseBytes = 64 * 1024 * 1024;
 const _maxCoreInfoBytes = 64 * 1024;

--- a/apps/mod-manager/lib/core/mgr_ffi.dart
+++ b/apps/mod-manager/lib/core/mgr_ffi.dart
@@ -34,16 +34,51 @@ class MgrFfi {
   /// The mod library plus the current loadout order.
   Future<(List<ModEntryMetaView>, LoadoutView)> libraryList() async {
     final r = await _call('mgr_library_list', const {});
-    final mods = [
-      for (final m in _maps(r['mods'])) ModEntryMetaView.fromJson(m),
-    ];
-    final loadout = r['loadout'];
-    return (
-      mods,
-      loadout is Map
-          ? LoadoutView.fromJson(loadout.cast<String, Object?>())
-          : const LoadoutView(),
-    );
+    final rawMods = r['mods'];
+    final rawLoadout = r['loadout'];
+    if (rawMods is! List || rawLoadout is! Map) {
+      throw MgrFfiException('mgr_library_list: malformed store snapshot');
+    }
+    final mods = <ModEntryMetaView>[];
+    final modIds = <String>{};
+    for (final raw in rawMods) {
+      if (raw is! Map ||
+          raw['id'] is! String ||
+          raw['kind'] is! String ||
+          raw['name'] is! String ||
+          raw['components'] is! List ||
+          (raw['components']! as List).any(
+            (component) => component is! Map || component['type'] is! String,
+          )) {
+        throw MgrFfiException('mgr_library_list: malformed library entry');
+      }
+      final parsed = raw.cast<String, Object?>();
+      final id = parsed['id']! as String;
+      if (id.isEmpty || !modIds.add(id)) {
+        throw MgrFfiException('mgr_library_list: invalid library id set');
+      }
+      mods.add(ModEntryMetaView.fromJson(parsed));
+    }
+    final loadoutMap = rawLoadout.cast<String, Object?>();
+    final format = loadoutMap['format'];
+    if (format is! int || format != 1 || loadoutMap['entries'] is! List) {
+      throw MgrFfiException('mgr_library_list: malformed loadout');
+    }
+    final entries = loadoutMap['entries']! as List;
+    final loadoutIds = <String>{};
+    for (final raw in entries) {
+      if (raw is! Map ||
+          raw['id'] is! String ||
+          (raw['id']! as String).isEmpty ||
+          raw['enabled'] is! bool ||
+          !loadoutIds.add(raw['id']! as String)) {
+        throw MgrFfiException('mgr_library_list: malformed loadout entry');
+      }
+    }
+    if (loadoutIds.length != modIds.length || !loadoutIds.containsAll(modIds)) {
+      throw MgrFfiException('mgr_library_list: inconsistent store snapshot');
+    }
+    return (mods, LoadoutView.fromJson(loadoutMap));
   }
 
   /// Import a mod file/folder into the library; returns its library entry.

--- a/apps/mod-manager/lib/library/domain/library_notifier.dart
+++ b/apps/mod-manager/lib/library/domain/library_notifier.dart
@@ -7,9 +7,9 @@ import 'models.dart';
 /// The mod library plus its loadout, as shown in the Mods tab.
 ///
 /// Immutable; every mutation returns a fresh instance via [copyWith]. The
-/// [loadout] is always reconciled against [mods] (see
-/// [LibraryNotifier.refresh]) so the UI can trust that every library mod has
-/// exactly one loadout entry and vice versa.
+/// Native returns [mods] and [loadout] from one locked, reconciled store
+/// snapshot, so the UI can trust that every library mod has exactly one
+/// loadout entry and vice versa.
 class LibraryState {
   const LibraryState({
     this.mods = const [],
@@ -29,8 +29,8 @@ class LibraryState {
   /// starts.
   final String? error;
 
-  /// True only after the native library and persisted loadout were read and
-  /// reconciled successfully. Mutations and Apply stay fail-closed otherwise.
+  /// True only after Native returned one locked, reconciled library/loadout
+  /// snapshot. Mutations and Apply stay fail-closed otherwise.
   final bool authoritative;
 
   LibraryState copyWith({
@@ -70,11 +70,8 @@ class LibraryNotifier extends StateNotifier<LibraryState> {
 
   final MgrFfi _mgr;
 
-  /// Reload the library and loadout, reconciling the two so that:
-  ///  * every library mod id appears exactly once in the loadout,
-  ///  * ids present in the loadout but no longer in the library are dropped,
-  ///  * library ids missing from the loadout are appended at the end,
-  ///    disabled, preserving the stored order for the rest.
+  /// Reload the authoritative library and loadout snapshot. Reconciliation and
+  /// any necessary persistence happen inside Native under the store lock.
   Future<void> refresh() async {
     await _runRefresh();
   }
@@ -132,24 +129,12 @@ class LibraryNotifier extends StateNotifier<LibraryState> {
   /// Refresh without its own busy/error framing — for use inside another
   /// mutation/refresh lane so the whole operation is one busy span.
   ///
-  /// Reconciling only fixes the *in-memory* loadout; the on-disk loadout that
-  /// `mgr_apply`/`mgr_status` read is untouched. So when reconciliation
-  /// actually changed something (a stale entry dropped, a new library mod
-  /// appended), persist the result via `mgr_set_loadout` so the on-disk
-  /// loadout matches what the UI shows. The delta check makes this idempotent:
-  /// a loadout that already agrees with the library persists nothing, so the
-  /// follow-up refresh after a persist can't loop.
+  /// This read lane never writes a loadout back. Native owns the locked
+  /// reconciliation transaction; a Dart read-then-write would race CLI or
+  /// another Manager process.
   Future<void> _refreshInline() async {
     final (mods, loadout) = await _mgr.libraryList();
-    final reconciled = _reconcile(mods, loadout);
-    if (!_sameEntries(loadout.entries, reconciled.entries)) {
-      await _mgr.setLoadout(reconciled);
-    }
-    state = state.copyWith(
-      mods: mods,
-      loadout: reconciled,
-      authoritative: true,
-    );
+    state = state.copyWith(mods: mods, loadout: loadout, authoritative: true);
   }
 
   /// Explicit read lane. It remains available while state is unknown because
@@ -208,38 +193,6 @@ class LibraryNotifier extends StateNotifier<LibraryState> {
     MgrFfiException() => error.message,
     _ => error.toString(),
   };
-
-  /// True when two loadout entry lists carry the same ids, enabled flags, and
-  /// order — the delta gate for persisting a reconciled loadout.
-  static bool _sameEntries(List<LoadoutEntryView> a, List<LoadoutEntryView> b) {
-    if (a.length != b.length) return false;
-    for (var i = 0; i < a.length; i++) {
-      if (a[i].id != b[i].id || a[i].enabled != b[i].enabled) return false;
-    }
-    return true;
-  }
-
-  /// See [refresh] for the reconciliation contract.
-  static LoadoutView _reconcile(
-    List<ModEntryMetaView> mods,
-    LoadoutView loadout,
-  ) {
-    final known = {for (final m in mods) m.id};
-    final seen = <String>{};
-    final kept = <LoadoutEntryView>[
-      for (final e in loadout.entries)
-        if (known.contains(e.id) && seen.add(e.id)) e,
-    ];
-    // Append any library mods that had no loadout entry, disabled, in library
-    // order.
-    for (final m in mods) {
-      if (!seen.contains(m.id)) {
-        kept.add(LoadoutEntryView(id: m.id, enabled: false));
-        seen.add(m.id);
-      }
-    }
-    return LoadoutView(format: loadout.format, entries: kept);
-  }
 }
 
 /// The library + loadout, kicked off with an initial refresh.

--- a/apps/mod-manager/test/app/theme_toggle_test.dart
+++ b/apps/mod-manager/test/app/theme_toggle_test.dart
@@ -7,6 +7,7 @@ import 'package:gore_manager/core/core_service.dart';
 import 'package:gore_manager/core/providers.dart';
 import 'package:gore_manager/home_page.dart';
 import 'package:gore_manager/l10n/app_localizations.dart';
+import 'package:gore_manager/library/domain/library_notifier.dart';
 
 /// A settings store that starts light and records every write so the test can
 /// assert the theme-mode toggle both flips the provider and persists.
@@ -52,11 +53,16 @@ Widget _app(FakeGoreCoreFfiService fake, _RecordingSettingsStore store) {
 }
 
 void main() {
-  testWidgets('the app-bar theme toggle flips and persists themeModeProvider',
-      (tester) async {
+  testWidgets('the app-bar theme toggle flips and persists themeModeProvider', (
+    tester,
+  ) async {
     final fake = FakeGoreCoreFfiService(
       responses: {
-        'mgr_library_list': {'ok': true, 'mods': [], 'loadout': {'entries': []}},
+        'mgr_library_list': {
+          'ok': true,
+          'mods': [],
+          'loadout': {'format': 1, 'entries': []},
+        },
         'mgr_analyze': {'ok': true, 'conflicts': []},
         'mgr_status': {
           'ok': true,
@@ -73,6 +79,8 @@ void main() {
     );
     // Default theme mode is light; the toggle shows the "go dark" icon.
     expect(container.read(themeModeProvider), ThemeMode.light);
+    expect(container.read(libraryProvider).authoritative, isTrue);
+    expect(container.read(libraryProvider).error, isNull);
     expect(find.byIcon(Icons.dark_mode), findsOneWidget);
 
     await tester.tap(find.byIcon(Icons.dark_mode));
@@ -94,7 +102,11 @@ void main() {
   testWidgets('the app-bar info button opens the about dialog', (tester) async {
     final fake = FakeGoreCoreFfiService(
       responses: {
-        'mgr_library_list': {'ok': true, 'mods': [], 'loadout': {'entries': []}},
+        'mgr_library_list': {
+          'ok': true,
+          'mods': [],
+          'loadout': {'format': 1, 'entries': []},
+        },
         'mgr_analyze': {'ok': true, 'conflicts': []},
         'mgr_status': {
           'ok': true,
@@ -107,6 +119,11 @@ void main() {
     await tester.pumpAndSettle();
 
     final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(HomePage)),
+    );
+    expect(container.read(libraryProvider).authoritative, isTrue);
+    expect(container.read(libraryProvider).error, isNull);
     // Before tapping, only the app-bar title carries the product name.
     expect(find.text('GORE Mod Manager'), findsOneWidget);
 

--- a/apps/mod-manager/test/core/core_bootstrap_test.dart
+++ b/apps/mod-manager/test/core/core_bootstrap_test.dart
@@ -30,7 +30,7 @@ class _Probe implements CoreBootstrapProbe {
 }
 
 String _coreInfo({
-  int abi = 1,
+  int abi = 2,
   Object? commands,
   String version = '0.1.0',
   Map<String, Object?> extra = const {},
@@ -181,7 +181,7 @@ void main() {
 
     final olderProtocol = _Probe(
       states: {'old.dll': CoreCandidateState.present},
-      inspections: {'old.dll': _currentEvidence(coreInfo: _coreInfo(abi: 0))},
+      inspections: {'old.dll': _currentEvidence(coreInfo: _coreInfo(abi: 1))},
     );
     final protocol = _blocked(
       inspectCoreCandidates(
@@ -190,7 +190,7 @@ void main() {
       ),
     );
     expect(protocol.reason, CoreBootstrapFailureReason.protocolAbiMismatch);
-    expect(protocol.observedProtocolAbi, 0);
+    expect(protocol.observedProtocolAbi, 1);
     expect(
       protocol.compatibilityDirection,
       CoreCompatibilityDirection.coreTooOld,

--- a/apps/mod-manager/test/core/core_unavailable_app_test.dart
+++ b/apps/mod-manager/test/core/core_unavailable_app_test.dart
@@ -138,7 +138,7 @@ void main() {
       reason: CoreBootstrapFailureReason.protocolAbiMismatch,
       candidatePath: r'C:\app\gore_ffi.dll',
       observedTransportAbi: 2,
-      observedProtocolAbi: 2,
+      observedProtocolAbi: 3,
       coreVersion: '9.0.0',
       detail:
           'unsafe\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e'

--- a/apps/mod-manager/test/core/mgr_ffi_test.dart
+++ b/apps/mod-manager/test/core/mgr_ffi_test.dart
@@ -219,6 +219,46 @@ void main() {
       expect(loadout.entries[1].enabled, isFalse);
     });
 
+    test('malformed native store snapshots fail closed', () async {
+      final malformed = <Map<String, Object?>>[
+        {
+          'ok': true,
+          'mods': 7,
+          'loadout': const {'format': 1, 'entries': []},
+        },
+        {'ok': true, 'mods': const [], 'loadout': null},
+        {
+          'ok': true,
+          'mods': const [42],
+          'loadout': const {'format': 1, 'entries': []},
+        },
+        {
+          'ok': true,
+          'mods': const [],
+          'loadout': const {'format': 1.0, 'entries': []},
+        },
+        {
+          'ok': true,
+          'mods': const [],
+          'loadout': const {
+            'format': 1,
+            'entries': [
+              {'id': 'mod-a', 'enabled': 'yes'},
+            ],
+          },
+        },
+      ];
+      for (final response in malformed) {
+        final fake = FakeGoreCoreFfiService(
+          responses: {'mgr_library_list': response},
+        );
+        await expectLater(
+          MgrFfi(fake).libraryList(),
+          throwsA(isA<MgrFfiException>()),
+        );
+      }
+    });
+
     test(
       'older DLL coverage is inferred conservatively from component facts',
       () {

--- a/apps/mod-manager/test/home_page_actionable_status_test.dart
+++ b/apps/mod-manager/test/home_page_actionable_status_test.dart
@@ -74,6 +74,7 @@ class _HomeCore implements GoreCoreFfiService {
           'ok': true,
           'mods': mods,
           'loadout': {
+            'format': 1,
             'entries': [
               {'id': 'a', 'enabled': true},
               {'id': 'b', 'enabled': true},

--- a/apps/mod-manager/test/home_page_game_path_status_test.dart
+++ b/apps/mod-manager/test/home_page_game_path_status_test.dart
@@ -104,7 +104,7 @@ class _StatefulFake implements GoreCoreFfiService {
         return {
           'ok': true,
           'mods': _mods,
-          'loadout': {'entries': _loadout},
+          'loadout': {'format': 1, 'entries': _loadout},
         };
       case 'mgr_set_loadout':
         final lo = payload['loadout'] as Map<String, Object?>?;
@@ -202,7 +202,7 @@ void main() {
         'mgr_library_list': {
           'ok': true,
           'mods': [],
-          'loadout': {'entries': []},
+          'loadout': {'format': 1, 'entries': []},
         },
         'mgr_analyze': {'ok': true, 'conflicts': []},
         'mgr_status': {

--- a/apps/mod-manager/test/library/library_notifier_test.dart
+++ b/apps/mod-manager/test/library/library_notifier_test.dart
@@ -15,7 +15,12 @@ Map<String, Object?> _libraryList({
     'ok': true,
     'mods': [
       for (final id in ids)
-        {'id': id, 'kind': 'goremod', 'name': id.toUpperCase()},
+        {
+          'id': id,
+          'kind': 'goremod',
+          'name': id.toUpperCase(),
+          'components': const [],
+        },
     ],
     'loadout': {
       'format': 1,
@@ -125,18 +130,16 @@ Future<LibraryNotifier> _settled(FakeGoreCoreFfiService fake) async {
 }
 
 void main() {
-  group('LibraryNotifier.refresh reconciliation', () {
+  group('LibraryNotifier native-authoritative refresh', () {
     test(
-      'new library mod missing from loadout is appended disabled at end',
+      'uses the reconciled native snapshot without writing it back',
       () async {
-        // Loadout only knows mod-a; library has mod-a and a brand-new mod-b.
         final fake = FakeGoreCoreFfiService(
           responses: {
             'mgr_library_list': _libraryList(
-              loadout: [('mod-a', true)],
+              loadout: [('mod-a', true), ('mod-b', false)],
               mods: ['mod-a', 'mod-b'],
             ),
-            // Reconcile appends mod-b, so the notifier persists the result.
             'mgr_set_loadout': {'ok': true},
           },
         );
@@ -148,18 +151,20 @@ void main() {
         expect(entries[1].enabled, isFalse);
         expect(n.state.error, isNull);
         expect(n.state.busy, isFalse);
+        expect(
+          fake.calls.where((call) => call.command == 'mgr_set_loadout'),
+          isEmpty,
+        );
       },
     );
 
-    test('loadout entry for a vanished mod is dropped', () async {
-      // Loadout references mod-x which is no longer in the library.
+    test('accepts a native snapshot with a stale id already removed', () async {
       final fake = FakeGoreCoreFfiService(
         responses: {
           'mgr_library_list': _libraryList(
-            loadout: [('mod-a', true), ('mod-x', true)],
+            loadout: [('mod-a', true)],
             mods: ['mod-a'],
           ),
-          // Reconcile drops the vanished mod-x, so the result is persisted.
           'mgr_set_loadout': {'ok': true},
         },
       );
@@ -167,37 +172,27 @@ void main() {
       expect(n.state.loadout.entries.map((e) => e.id), ['mod-a']);
     });
 
-    test('a reconcile delta is persisted back via mgr_set_loadout', () async {
-      // On-disk loadout has a stale entry (mod-x, gone from the library) and
-      // is missing a present library mod (mod-b). Reconciliation drops mod-x
-      // and appends mod-b disabled; that reconciled loadout must be written
-      // back so the on-disk loadout matches the UI.
-      final fake = FakeGoreCoreFfiService(
-        responses: {
-          'mgr_library_list': _libraryList(
-            loadout: [('mod-a', true), ('mod-x', true)],
-            mods: ['mod-a', 'mod-b'],
-          ),
-          'mgr_set_loadout': {'ok': true},
-        },
-      );
-      final n = await _settled(fake);
+    test(
+      'refresh is read-only even when mgr_set_loadout is available',
+      () async {
+        final fake = FakeGoreCoreFfiService(
+          responses: {
+            'mgr_library_list': _libraryList(
+              loadout: [('mod-a', true), ('mod-b', false)],
+              mods: ['mod-a', 'mod-b'],
+            ),
+            'mgr_set_loadout': {'ok': true},
+          },
+        );
+        final n = await _settled(fake);
 
-      final setCall = fake.calls.firstWhere(
-        (c) => c.command == 'mgr_set_loadout',
-      );
-      expect(setCall.payload, {
-        'loadout': {
-          'format': 1,
-          'entries': [
-            {'id': 'mod-a', 'enabled': true},
-            {'id': 'mod-b', 'enabled': false},
-          ],
-        },
-      });
-      // The in-memory loadout matches what was persisted.
-      expect(n.state.loadout.entries.map((e) => e.id), ['mod-a', 'mod-b']);
-    });
+        expect(
+          fake.calls.where((c) => c.command == 'mgr_set_loadout'),
+          isEmpty,
+        );
+        expect(n.state.loadout.entries.map((e) => e.id), ['mod-a', 'mod-b']);
+      },
+    );
 
     test(
       'an already-consistent loadout is not re-persisted (no loop)',
@@ -320,10 +315,9 @@ void main() {
             'entry': {'id': 'mod-new', 'kind': 'foreign_pak', 'name': 'New'},
           },
           'mgr_library_list': _libraryList(
-            loadout: [('mod-a', true)],
+            loadout: [('mod-a', true), ('mod-new', false)],
             mods: ['mod-a', 'mod-new'],
           ),
-          // The post-import refresh appends mod-new, so it is persisted.
           'mgr_set_loadout': {'ok': true},
         },
       );
@@ -429,6 +423,27 @@ void main() {
   });
 
   group('LibraryNotifier errors', () {
+    test(
+      'a malformed native snapshot revokes authority and clears stale data',
+      () async {
+        final fake = FakeGoreCoreFfiService(
+          responses: {
+            'mgr_library_list': {
+              'ok': true,
+              'mods': [42],
+              'loadout': const {'format': 1, 'entries': []},
+            },
+          },
+        );
+        final n = LibraryNotifier(MgrFfi(fake));
+        await n.refresh();
+        expect(n.state.authoritative, isFalse);
+        expect(n.state.mods, isEmpty);
+        expect(n.state.loadout.entries, isEmpty);
+        expect(n.state.error, contains('malformed'));
+      },
+    );
+
     test('an FFI error lands in state.error and clears busy', () async {
       final fake = FakeGoreCoreFfiService(
         responses: {

--- a/apps/mod-manager/test/library/widgets_test.dart
+++ b/apps/mod-manager/test/library/widgets_test.dart
@@ -157,7 +157,6 @@ class _RemoveCore implements GoreCoreFfiService {
         'loadout': {
           'format': 1,
           'entries': [
-            if (partialFailure) {'id': 'mod-a', 'enabled': true},
             {'id': 'mod-b', 'enabled': true},
           ],
         },

--- a/apps/mod-studio/lib/core/core_service.dart
+++ b/apps/mod-studio/lib/core/core_service.dart
@@ -24,7 +24,7 @@ typedef GoreCoreExecuteV2 =
 typedef _FreeV2Native = Void Function(Pointer<Void>);
 typedef GoreCoreFreeV2 = void Function(Pointer<Void>);
 
-const goreCoreAbi = 1;
+const goreCoreAbi = 2;
 const goreCoreTransportAbiV2 = 2;
 const goreCoreTransportMaxRequestBytes = 64 * 1024 * 1024;
 const goreCoreTransportMaxResponseBytes = 64 * 1024 * 1024;
@@ -163,7 +163,7 @@ class GoreCoreInfo {
     requiredStudioCoreCommands.where((command) => !commands.contains(command)),
   );
 
-  /// Strictly parses the stable ABI-1 response. Bounds are deliberately small because this runs
+  /// Strictly parses the current protocol response. Bounds are deliberately small because this runs
   /// synchronously during startup, before a native library is trusted for normal work.
   factory GoreCoreInfo.parseResponse(String response) {
     if (response.length > _maxCoreInfoResponseBytes ||

--- a/apps/mod-studio/test/core/core_service_test.dart
+++ b/apps/mod-studio/test/core/core_service_test.dart
@@ -151,6 +151,7 @@ void main() {
             'message': 'unknown command: core_info',
           },
         });
+        final oldAbi = _coreInfoResponse(abi: 1);
         final wrongAbi = _coreInfoResponse(abi: goreCoreAbi + 1);
         final missingAuthoring = _coreInfoResponse(
           commands: requiredStudioCoreCommands
@@ -211,6 +212,7 @@ void main() {
 
         final decisions = [
           missingCoreInfo,
+          oldAbi,
           wrongAbi,
           missingAuthoring,
           missingVoice,

--- a/crates/gore-ffi/src/lib.rs
+++ b/crates/gore-ffi/src/lib.rs
@@ -275,7 +275,7 @@ pub use transport::{
 };
 
 /// Increment only when the current JSON command/response protocol changes incompatibly.
-const CORE_PROTOCOL_ABI: u32 = 1;
+const CORE_PROTOCOL_ABI: u32 = 2;
 
 /// Every command understood by [`dispatch`], kept in bytewise ascending order so capability
 /// negotiation is deterministic across builds and platforms.
@@ -2028,7 +2028,7 @@ mod tests {
             v,
             json!({
                 "ok": true,
-                "abi": 1,
+                "abi": 2,
                 "version": env!("CARGO_PKG_VERSION"),
                 "commands": [
                     "audio_extract",

--- a/crates/gore-ffi/src/lib.rs
+++ b/crates/gore-ffi/src/lib.rs
@@ -188,8 +188,8 @@
 //! - `script_compile_install_state_v1` is a bounded, strictly read-only native preflight for the
 //!   shipping-game process and every known compile/recovery artifact. It returns display-only
 //!   paths and never creates, removes, renames, repairs, launches, or writes anything.
-//! - `mgr_preflight_v1` accepts one explicit game root plus optional native Manager path
-//!   overrides and returns seven fixed-order, bounded first-run findings. It never falls back to
+//! - `mgr_preflight_v1` accepts one explicit game root plus an optional paired native Manager
+//!   Store override and returns seven fixed-order, bounded first-run findings. It never falls back to
 //!   config/Steam discovery, reconciles imports, probes by writing, repairs recovery state, or
 //!   claims that Apply is ready; all returned paths are display-only evidence.
 //! - `authoring_store_inspect_revision3_installed_dataasset_v1` accepts only one exact managed
@@ -1517,23 +1517,41 @@ fn mod_undeploy(payload: Value) -> Value {
 }
 
 // ── mod-manager (`mgr_*`) commands ─────────────────────────────────────────────
-// Every mgr command accepts OPTIONAL `library_dir` / `loadout_path` string overrides so tests
-// (and callers wanting an isolated store) can point at temp dirs; when absent the shared
-// per-user layout from `gore_mod::mgr::paths` is used, so every gore tool sees one library.
-
-/// The library dir to use: `payload.library_dir` if given, else the shared default.
-fn mgr_library_dir(payload: &Value) -> PathBuf {
-    match payload.get("library_dir").and_then(Value::as_str) {
-        Some(p) => PathBuf::from(p),
-        None => gore_mod::mgr::paths::library_dir(),
+// Store-backed mgr commands use either the shared Store or one explicit `library_dir` /
+// `loadout_path` pair. A lone override cannot identify which two roots belong together and could
+// otherwise reconcile a custom file against unrelated shared state.
+fn mgr_store_paths_from_options(
+    library: Option<&str>,
+    loadout: Option<&str>,
+) -> Result<(PathBuf, PathBuf), String> {
+    match (library, loadout) {
+        (None, None) => Ok((
+            gore_mod::mgr::paths::library_dir(),
+            gore_mod::mgr::paths::loadout_path(),
+        )),
+        (Some(library), Some(loadout)) => {
+            Ok((PathBuf::from(library), PathBuf::from(loadout)))
+        }
+        _ => Err(
+            "library_dir and loadout_path overrides must be supplied together so they identify one manager store"
+                .to_string(),
+        ),
     }
 }
 
-/// The loadout file to use: `payload.loadout_path` if given, else the shared default.
-fn mgr_loadout_path(payload: &Value) -> PathBuf {
-    match payload.get("loadout_path").and_then(Value::as_str) {
-        Some(p) => PathBuf::from(p),
-        None => gore_mod::mgr::paths::loadout_path(),
+fn mgr_store_paths(payload: &Value) -> Result<(PathBuf, PathBuf), String> {
+    let path = |key: &str| match payload.get(key) {
+        None => Ok(None),
+        Some(Value::String(path)) => Ok(Some(path.as_str())),
+        Some(_) => Err(format!("'{key}' must be a string")),
+    };
+    mgr_store_paths_from_options(path("library_dir")?, path("loadout_path")?)
+}
+
+fn mgr_store_paths_or_error(payload: &Value) -> Result<(PathBuf, PathBuf), Value> {
+    match mgr_store_paths(payload) {
+        Ok(paths) => Ok(paths),
+        Err(message) => Err(err("BAD_REQUEST", message)),
     }
 }
 
@@ -1572,11 +1590,14 @@ fn mgr_entry_wire_value(entry: &gore_mod::mgr::ModEntryMeta) -> Value {
     value
 }
 
-/// `{library_dir?, loadout_path?}` → `{ok, mods:[ModEntryMeta], loadout:Loadout}`. Raw library +
+/// `{library_dir?, loadout_path?}` → `{ok, mods:[ModEntryMeta], loadout:Loadout}`. Overrides are a
+/// pair. Raw library +
 /// loadout from one strict, natively reconciled Store snapshot.
 fn mgr_library_list(payload: Value) -> Value {
-    let lib = mgr_library_dir(&payload);
-    let lo_path = mgr_loadout_path(&payload);
+    let (lib, lo_path) = match mgr_store_paths_or_error(&payload) {
+        Ok(paths) => paths,
+        Err(error) => return error,
+    };
     let store = match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
         Ok(store) => store,
         Err(e) => return err("IO", e.to_string()),
@@ -1588,7 +1609,7 @@ fn mgr_library_list(payload: Value) -> Value {
     })
 }
 
-/// `{path, library_dir?, loadout_path?}` →
+/// `{path, library_dir?, loadout_path?}` → (Store overrides are a pair)
 /// `{ok, entry:ModEntryMeta, disposition, matched_by}` — import a source into the
 /// library AND register it in the loadout (disabled) if not already present. Mirrors
 /// `gore mgr import`: without this, a GUI-imported mod is invisible to apply/status/analyze (which
@@ -1597,7 +1618,10 @@ fn mgr_import(payload: Value) -> Value {
     let Some(path) = payload.get("path").and_then(Value::as_str) else {
         return err("BAD_REQUEST", "missing 'path'");
     };
-    let lib = mgr_library_dir(&payload);
+    let (lib, lo_path) = match mgr_store_paths_or_error(&payload) {
+        Ok(paths) => paths,
+        Err(error) => return error,
+    };
     let outcome = match gore_mod::mgr::import::import_detailed(&lib, std::path::Path::new(path)) {
         Ok(outcome) => outcome,
         Err(error @ gore_mod::mgr::import::ImportError::DuplicateAmbiguous { .. }) => {
@@ -1622,7 +1646,6 @@ fn mgr_import(payload: Value) -> Value {
     let entry = &outcome.entry;
     // Library publication and loadout registration remain two explicit commits. Import has
     // released Library before Store acquires its canonical composite roots and reconciles state.
-    let lo_path = mgr_loadout_path(&payload);
     // Surface a loadout read/write failure instead of returning ok: apply/status/analyze read the
     // on-disk loadout, so a swallowed error here would leave the imported mod invisible to them. A
     // missing loadout file loads as an empty default (not an error), so first-time imports still
@@ -1644,17 +1667,20 @@ fn mgr_import(payload: Value) -> Value {
     })
 }
 
-/// `{id, library_dir?}` → `{ok, removed:bool}` — delete a library entry (absent id → removed:false).
+/// `{id, library_dir?, loadout_path?}` → `{ok, removed:bool}` — delete a library entry and its
+/// paired loadout slot (absent id → removed:false).
 fn mgr_remove(payload: Value) -> Value {
     let Some(id) = payload.get("id").and_then(Value::as_str) else {
         return err("BAD_REQUEST", "missing 'id'");
     };
-    let lib = mgr_library_dir(&payload);
+    let (lib, lo_path) = match mgr_store_paths_or_error(&payload) {
+        Ok(paths) => paths,
+        Err(error) => return error,
+    };
     let removed = match gore_mod::mgr::import::remove(&lib, id) {
         Ok(removed) => removed,
         Err(e) => return err("BAD_REQUEST", e.to_string()),
     };
-    let lo_path = mgr_loadout_path(&payload);
     if let Err(e) = gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
         return err(
             "IO",
@@ -1664,7 +1690,8 @@ fn mgr_remove(payload: Value) -> Value {
     json!({"ok": true, "removed": removed})
 }
 
-/// `{loadout:Loadout, loadout_path?}` → `{ok}` — persist the loadout.
+/// `{loadout:Loadout, library_dir?, loadout_path?}` → `{ok}` — persist the loadout; Store path
+/// overrides are a pair.
 const MAX_MGR_SET_LOADOUT_REQUEST_BYTES: usize = 1024 * 1024 + 64 * 1024;
 
 #[derive(serde::Deserialize)]
@@ -1713,16 +1740,13 @@ fn mgr_set_loadout_raw(input: &str) -> Value {
     if encoded_loadout.len() > 1024 * 1024 {
         return err("BAD_REQUEST", "loadout exceeds its 1048576-byte limit");
     }
-    let lib = request
-        .payload
-        .library_dir
-        .map(PathBuf::from)
-        .unwrap_or_else(gore_mod::mgr::paths::library_dir);
-    let lo_path = request
-        .payload
-        .loadout_path
-        .map(PathBuf::from)
-        .unwrap_or_else(gore_mod::mgr::paths::loadout_path);
+    let (lib, lo_path) = match mgr_store_paths_from_options(
+        request.payload.library_dir.as_deref(),
+        request.payload.loadout_path.as_deref(),
+    ) {
+        Ok(paths) => paths,
+        Err(message) => return err("BAD_REQUEST", message),
+    };
     match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
         Ok(mut store) => match store.replace_loadout(request.payload.loadout) {
             Ok(()) => json!({"ok": true}),
@@ -1732,11 +1756,14 @@ fn mgr_set_loadout_raw(input: &str) -> Value {
     }
 }
 
-/// `{library_dir?, loadout_path?}` → `{ok, conflicts:[Conflict]}` — pure conflict analysis of the
+/// `{library_dir?, loadout_path?}` → `{ok, conflicts:[Conflict]}` — paired Store overrides; pure
+/// conflict analysis of the
 /// enabled loadout against the library.
 fn mgr_analyze(payload: Value) -> Value {
-    let lib = mgr_library_dir(&payload);
-    let lo_path = mgr_loadout_path(&payload);
+    let (lib, lo_path) = match mgr_store_paths_or_error(&payload) {
+        Ok(paths) => paths,
+        Err(error) => return error,
+    };
     let store = match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
         Ok(store) => store,
         Err(e) => return err("ANALYZE_FAILED", e.to_string()),
@@ -1745,14 +1772,17 @@ fn mgr_analyze(payload: Value) -> Value {
     json!({"ok": true, "conflicts": serde_json::to_value(&conflicts).unwrap_or(Value::Null)})
 }
 
-/// `{game_root, library_dir?, loadout_path?}` → `{ok, report:ApplyReport}` — realize the enabled
+/// `{game_root, library_dir?, loadout_path?}` → `{ok, report:ApplyReport}` — paired Store overrides;
+/// realize the enabled
 /// loadout into one manager deployment. A studio deploy in the way maps to STUDIO_DEPLOY_ACTIVE.
 fn mgr_apply(payload: Value) -> Value {
     let Some(game_root) = payload.get("game_root").and_then(Value::as_str) else {
         return err("BAD_REQUEST", "missing 'game_root'");
     };
-    let lib = mgr_library_dir(&payload);
-    let lo_path = mgr_loadout_path(&payload);
+    let (lib, lo_path) = match mgr_store_paths_or_error(&payload) {
+        Ok(paths) => paths,
+        Err(error) => return error,
+    };
     let store = match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
         Ok(store) => store,
         Err(e) => return err("APPLY_FAILED", e.to_string()),
@@ -1773,15 +1803,18 @@ fn mgr_apply(payload: Value) -> Value {
     }
 }
 
-/// `{game_root, library_dir?, loadout_path?}` → `{ok, status:ManagerStatus}` — diff deployed vs
+/// `{game_root, library_dir?, loadout_path?}` → `{ok, status:ManagerStatus}` — paired Store
+/// overrides; diff deployed vs
 /// target loadout. `library_dir` lets status fingerprint each enabled mod's current content so a
 /// same-id re-import (update) is reported as changes-pending rather than in-sync.
 fn mgr_status(payload: Value) -> Value {
     let Some(game_root) = payload.get("game_root").and_then(Value::as_str) else {
         return err("BAD_REQUEST", "missing 'game_root'");
     };
-    let lib = mgr_library_dir(&payload);
-    let lo_path = mgr_loadout_path(&payload);
+    let (lib, lo_path) = match mgr_store_paths_or_error(&payload) {
+        Ok(paths) => paths,
+        Err(error) => return error,
+    };
     let store = match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
         Ok(store) => store,
         Err(e) => return err("STATUS_FAILED", e.to_string()),
@@ -2582,6 +2615,152 @@ mod tests {
         // A missing loadout file is the fresh default (format 1, no entries).
         assert_eq!(v["loadout"]["format"], 1);
         assert_eq!(v["loadout"]["entries"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn mgr_store_path_overrides_must_be_paired() {
+        let default = mgr_store_paths_from_options(None, None).unwrap();
+        assert_eq!(default.0, gore_mod::mgr::paths::library_dir());
+        assert_eq!(default.1, gore_mod::mgr::paths::loadout_path());
+        assert!(mgr_store_paths_from_options(Some("library"), None).is_err());
+        assert!(mgr_store_paths_from_options(None, Some("loadout.json")).is_err());
+        assert_eq!(
+            mgr_store_paths_from_options(Some("library"), Some("loadout.json")).unwrap(),
+            (PathBuf::from("library"), PathBuf::from("loadout.json")),
+        );
+
+        let malformed = mgr_library_list(json!({
+            "library_dir": 7,
+            "loadout_path": "loadout.json",
+        }));
+        assert_eq!(malformed["error"]["code"], "BAD_REQUEST");
+
+        let temp = tempfile::tempdir().unwrap();
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("tests::mgr_unpaired_store_override_worker")
+            .arg("--ignored")
+            .arg("--nocapture")
+            .env("GORE_FFI_UNPAIRED_STORE_ROOT", temp.path())
+            .env("LOCALAPPDATA", temp.path().join("data"))
+            .env("APPDATA", temp.path().join("data"))
+            .env("XDG_DATA_HOME", temp.path().join("data"))
+            .env("HOME", temp.path().join("home"))
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    #[ignore = "worker process with isolated shared Manager paths"]
+    fn mgr_unpaired_store_override_worker() {
+        let root = PathBuf::from(std::env::var_os("GORE_FFI_UNPAIRED_STORE_ROOT").unwrap());
+        let default_library = gore_mod::mgr::paths::library_dir();
+        let default_loadout = gore_mod::mgr::paths::loadout_path();
+        let custom_library = root.join("custom-library");
+        let custom_loadout = root.join("custom-loadout.json");
+
+        write_mgr_library_entry(&default_library, "default-mod");
+        write_mgr_library_entry(&custom_library, "custom-mod");
+        let default_loadout_bytes =
+            br#"{"format":1,"entries":[{"id":"default-mod","enabled":true}]}"#;
+        let custom_loadout_bytes =
+            br#"{"format":1,"entries":[{"id":"custom-mod","enabled":true}]}"#;
+        std::fs::create_dir_all(default_loadout.parent().unwrap()).unwrap();
+        std::fs::write(&default_loadout, default_loadout_bytes).unwrap();
+        std::fs::write(&custom_loadout, custom_loadout_bytes).unwrap();
+
+        let default_library_before = mgr_visible_library_snapshot(&default_library);
+        let custom_library_before = mgr_visible_library_snapshot(&custom_library);
+        let replacement = json!({"format":1,"entries":[]});
+        for payload in [
+            json!({
+                "library_dir": custom_library,
+                "loadout": replacement,
+            }),
+            json!({
+                "loadout_path": custom_loadout,
+                "loadout": replacement,
+            }),
+        ] {
+            let request = json!({"command":"mgr_set_loadout", "payload":payload});
+            let response: Value =
+                serde_json::from_str(&execute_json(&request.to_string())).unwrap();
+            assert_eq!(response["error"]["code"], "BAD_REQUEST", "{response}");
+            assert!(response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("must be supplied together"));
+            assert_eq!(
+                std::fs::read(&default_loadout).unwrap(),
+                default_loadout_bytes
+            );
+            assert_eq!(
+                std::fs::read(&custom_loadout).unwrap(),
+                custom_loadout_bytes
+            );
+            assert_eq!(
+                mgr_visible_library_snapshot(&default_library),
+                default_library_before
+            );
+            assert_eq!(
+                mgr_visible_library_snapshot(&custom_library),
+                custom_library_before
+            );
+        }
+
+        let missing_source = root.join("missing.pak");
+        let import = mgr_import(json!({
+            "path": missing_source,
+            "library_dir": custom_library,
+        }));
+        assert_eq!(import["error"]["code"], "BAD_REQUEST", "{import}");
+
+        let remove = mgr_remove(json!({
+            "id": "custom-mod",
+            "library_dir": custom_library,
+        }));
+        assert_eq!(remove["error"]["code"], "BAD_REQUEST", "{remove}");
+        assert_eq!(
+            mgr_visible_library_snapshot(&custom_library),
+            custom_library_before
+        );
+        assert_eq!(
+            std::fs::read(&default_loadout).unwrap(),
+            default_loadout_bytes
+        );
+        assert_eq!(
+            std::fs::read(&custom_loadout).unwrap(),
+            custom_loadout_bytes
+        );
+
+        let preflight = crate::mgr_preflight::mgr_preflight_v1_raw(
+            &json!({
+                "command":"mgr_preflight_v1",
+                "payload":{
+                    "game_root":root.join("game"),
+                    "loadout_path":custom_loadout,
+                }
+            })
+            .to_string(),
+        );
+        assert_eq!(
+            preflight["error"]["code"], "MGR_PREFLIGHT_BAD_REQUEST",
+            "{preflight}"
+        );
+        assert!(preflight["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("must be supplied together"));
+
+        for root in [
+            default_library,
+            custom_library,
+            default_loadout.parent().unwrap().to_path_buf(),
+            custom_loadout.parent().unwrap().to_path_buf(),
+        ] {
+            assert!(!root.join(".gore-manager-library.lock").exists());
+        }
     }
 
     #[test]

--- a/crates/gore-ffi/src/lib.rs
+++ b/crates/gore-ffi/src/lib.rs
@@ -493,7 +493,10 @@ fn probe_dispatch_command(input: &str) -> Result<Option<String>, DispatchProbeEr
             if command.len() > MAX_DISPATCH_COMMAND_BYTES {
                 return Err(DispatchProbeError::CommandTooLong);
             }
-            if command == mgr_preflight::COMMAND || revision3_store_raw_route(&command).is_some() {
+            if command == mgr_preflight::COMMAND
+                || command == "mgr_set_loadout"
+                || revision3_store_raw_route(&command).is_some()
+            {
                 return Ok(Some(command));
             }
             last_command = Some(command);
@@ -818,6 +821,9 @@ fn dispatch(input: &str) -> Value {
     if command == mgr_preflight::COMMAND {
         return mgr_preflight::mgr_preflight_v1_raw(input);
     }
+    if command == "mgr_set_loadout" {
+        return mgr_set_loadout_raw(input);
+    }
     // These security-sensitive Store routes see the original wire before any generic
     // payload `Value` exists. Route-local parsers enforce their smaller envelope caps before
     // decoding nested strings.
@@ -847,7 +853,6 @@ fn dispatch(input: &str) -> Value {
         "mgr_library_list" => mgr_library_list(payload),
         "mgr_import" => mgr_import(payload),
         "mgr_remove" => mgr_remove(payload),
-        "mgr_set_loadout" => mgr_set_loadout(payload),
         "mgr_analyze" => mgr_analyze(payload),
         "mgr_apply" => mgr_apply(payload),
         "mgr_status" => mgr_status(payload),
@@ -1568,22 +1573,18 @@ fn mgr_entry_wire_value(entry: &gore_mod::mgr::ModEntryMeta) -> Value {
 }
 
 /// `{library_dir?, loadout_path?}` → `{ok, mods:[ModEntryMeta], loadout:Loadout}`. Raw library +
-/// loadout, unreconciled (the UI reconciles ids against the library itself).
+/// loadout from one strict, natively reconciled Store snapshot.
 fn mgr_library_list(payload: Value) -> Value {
     let lib = mgr_library_dir(&payload);
     let lo_path = mgr_loadout_path(&payload);
-    let mods = match gore_mod::mgr::import::list(&lib) {
-        Ok(m) => m,
+    let store = match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
+        Ok(store) => store,
         Err(e) => return err("IO", e.to_string()),
-    };
-    let loadout = match gore_mod::mgr::loadout::load(&lo_path) {
-        Ok(l) => l,
-        Err(e) => return err("BAD_REQUEST", e.to_string()),
     };
     json!({
         "ok": true,
-        "mods": Value::Array(mods.iter().map(mgr_entry_wire_value).collect()),
-        "loadout": serde_json::to_value(&loadout).unwrap_or(Value::Null),
+        "mods": Value::Array(store.mods().iter().map(mgr_entry_wire_value).collect()),
+        "loadout": serde_json::to_value(store.loadout()).unwrap_or(Value::Null),
     })
 }
 
@@ -1619,37 +1620,21 @@ fn mgr_import(payload: Value) -> Value {
         Err(error) => return err("IMPORT_FAILED", error.to_string()),
     };
     let entry = &outcome.entry;
-    // Register the new mod in the loadout (disabled) so enable/apply can find it. Skip if an entry
-    // with this id already exists (a re-import / update): keep its current enabled state + order.
+    // Library publication and loadout registration remain two explicit commits. Import has
+    // released Library before Store acquires its canonical composite roots and reconciles state.
     let lo_path = mgr_loadout_path(&payload);
     // Surface a loadout read/write failure instead of returning ok: apply/status/analyze read the
     // on-disk loadout, so a swallowed error here would leave the imported mod invisible to them. A
     // missing loadout file loads as an empty default (not an error), so first-time imports still
     // register normally.
-    match gore_mod::mgr::loadout::load(&lo_path) {
-        Ok(mut lo) => {
-            if !lo.entries.iter().any(|e| e.id == entry.id) {
-                lo.entries.push(gore_mod::mgr::LoadoutEntry {
-                    id: entry.id.clone(),
-                    enabled: false,
-                });
-                if let Err(e) = gore_mod::mgr::loadout::save(&lo_path, &lo) {
-                    return err(
-                        "IO",
-                        format!("imported '{}' into the library but failed to register it in the loadout: {e}", entry.id),
-                    );
-                }
-            }
-        }
-        Err(e) => {
-            return err(
-                "IO",
-                format!(
-                    "imported '{}' into the library but failed to read the loadout: {e}",
-                    entry.id
-                ),
-            )
-        }
+    if let Err(e) = gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
+        return err(
+            "IO",
+            format!(
+                "imported '{}' into the library but failed to reconcile the loadout: {e}",
+                entry.id
+            ),
+        );
     }
     json!({
         "ok": true,
@@ -1669,51 +1654,80 @@ fn mgr_remove(payload: Value) -> Value {
         Ok(removed) => removed,
         Err(e) => return err("BAD_REQUEST", e.to_string()),
     };
-    // Keep the persisted loadout in sync (mirror `gore mgr remove`): a removed mod must not
-    // linger as an enabled loadout entry, or a later `mgr_apply` — which reads the on-disk
-    // loadout, not the GUI's in-memory reconcile — fails loading the deleted mod's metadata.
     let lo_path = mgr_loadout_path(&payload);
-    // Surface a loadout read/write failure instead of returning ok: a dropped save error would let
-    // the persisted loadout keep an enabled reference to the now-removed mod, so a later
-    // apply/status/analyze (which read the on-disk loadout) would fail or act on a stale target. A
-    // missing loadout file loads as an empty default (not an error).
-    match gore_mod::mgr::loadout::load(&lo_path) {
-        Ok(mut lo) => {
-            let before = lo.entries.len();
-            lo.entries.retain(|e| e.id != id);
-            if lo.entries.len() != before {
-                if let Err(e) = gore_mod::mgr::loadout::save(&lo_path, &lo) {
-                    return err(
-                        "IO",
-                        format!(
-                            "removed '{id}' from the library but failed to update the loadout: {e}"
-                        ),
-                    );
-                }
-            }
-        }
-        Err(e) => {
-            return err(
-                "IO",
-                format!("removed '{id}' from the library but failed to read the loadout: {e}"),
-            )
-        }
+    if let Err(e) = gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
+        return err(
+            "IO",
+            format!("removed '{id}' from the library but failed to reconcile the loadout: {e}"),
+        );
     }
     json!({"ok": true, "removed": removed})
 }
 
 /// `{loadout:Loadout, loadout_path?}` → `{ok}` — persist the loadout.
-fn mgr_set_loadout(payload: Value) -> Value {
-    let loadout: gore_mod::mgr::Loadout = match payload.get("loadout").cloned() {
-        Some(v) => match serde_json::from_value(v) {
-            Ok(l) => l,
-            Err(e) => return err("BAD_REQUEST", format!("invalid loadout: {e}")),
-        },
-        None => return err("BAD_REQUEST", "missing 'loadout'"),
+const MAX_MGR_SET_LOADOUT_REQUEST_BYTES: usize = 1024 * 1024 + 64 * 1024;
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MgrSetLoadoutRawRequest {
+    command: String,
+    payload: MgrSetLoadoutRawPayload,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MgrSetLoadoutRawPayload {
+    loadout: gore_mod::mgr::Loadout,
+    #[serde(default)]
+    library_dir: Option<String>,
+    #[serde(default)]
+    loadout_path: Option<String>,
+}
+
+fn mgr_set_loadout_raw(input: &str) -> Value {
+    if input.len() > MAX_MGR_SET_LOADOUT_REQUEST_BYTES {
+        return err(
+            "BAD_REQUEST",
+            "mgr_set_loadout request exceeds its bounded size",
+        );
+    }
+    let request: MgrSetLoadoutRawRequest = match serde_json::from_str(input) {
+        Ok(request) => request,
+        Err(error) => {
+            return err(
+                "BAD_REQUEST",
+                format!("invalid mgr_set_loadout request: {error}"),
+            )
+        }
     };
-    let lo_path = mgr_loadout_path(&payload);
-    match gore_mod::mgr::loadout::save(&lo_path, &loadout) {
-        Ok(()) => json!({"ok": true}),
+    if request.command != "mgr_set_loadout" {
+        return err("BAD_REQUEST", "invalid mgr_set_loadout command");
+    }
+    if let Err(error) = request.payload.loadout.validate() {
+        return err("BAD_REQUEST", format!("invalid loadout: {error}"));
+    }
+    let encoded_loadout = match serde_json::to_vec_pretty(&request.payload.loadout) {
+        Ok(encoded) => encoded,
+        Err(error) => return err("BAD_REQUEST", format!("invalid loadout: {error}")),
+    };
+    if encoded_loadout.len() > 1024 * 1024 {
+        return err("BAD_REQUEST", "loadout exceeds its 1048576-byte limit");
+    }
+    let lib = request
+        .payload
+        .library_dir
+        .map(PathBuf::from)
+        .unwrap_or_else(gore_mod::mgr::paths::library_dir);
+    let lo_path = request
+        .payload
+        .loadout_path
+        .map(PathBuf::from)
+        .unwrap_or_else(gore_mod::mgr::paths::loadout_path);
+    match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
+        Ok(mut store) => match store.replace_loadout(request.payload.loadout) {
+            Ok(()) => json!({"ok": true}),
+            Err(e) => err("IO", e.to_string()),
+        },
         Err(e) => err("IO", e.to_string()),
     }
 }
@@ -1723,16 +1737,11 @@ fn mgr_set_loadout(payload: Value) -> Value {
 fn mgr_analyze(payload: Value) -> Value {
     let lib = mgr_library_dir(&payload);
     let lo_path = mgr_loadout_path(&payload);
-    let mods = match gore_mod::mgr::import::list(&lib) {
-        Ok(m) => m,
+    let store = match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
+        Ok(store) => store,
         Err(e) => return err("ANALYZE_FAILED", e.to_string()),
     };
-    let loadout = match gore_mod::mgr::loadout::load(&lo_path) {
-        Ok(l) => l,
-        Err(e) => return err("ANALYZE_FAILED", e.to_string()),
-    };
-    let refs: Vec<&gore_mod::mgr::ModEntryMeta> = mods.iter().collect();
-    let conflicts = gore_mod::mgr::analyze::analyze(&refs, &loadout);
+    let conflicts = store.analyze();
     json!({"ok": true, "conflicts": serde_json::to_value(&conflicts).unwrap_or(Value::Null)})
 }
 
@@ -1744,11 +1753,11 @@ fn mgr_apply(payload: Value) -> Value {
     };
     let lib = mgr_library_dir(&payload);
     let lo_path = mgr_loadout_path(&payload);
-    let loadout = match gore_mod::mgr::loadout::load(&lo_path) {
-        Ok(l) => l,
+    let store = match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
+        Ok(store) => store,
         Err(e) => return err("APPLY_FAILED", e.to_string()),
     };
-    match gore_mod::mgr::apply::apply_loadout(std::path::Path::new(game_root), &lib, &loadout) {
+    match store.apply(std::path::Path::new(game_root)) {
         Ok(report) => {
             json!({"ok": true, "report": serde_json::to_value(&report).unwrap_or(Value::Null)})
         }
@@ -1773,11 +1782,11 @@ fn mgr_status(payload: Value) -> Value {
     };
     let lib = mgr_library_dir(&payload);
     let lo_path = mgr_loadout_path(&payload);
-    let loadout = match gore_mod::mgr::loadout::load(&lo_path) {
-        Ok(l) => l,
+    let store = match gore_mod::mgr::store::StoreSnapshot::open(&lib, &lo_path) {
+        Ok(store) => store,
         Err(e) => return err("STATUS_FAILED", e.to_string()),
     };
-    match gore_mod::mgr::status::status(std::path::Path::new(game_root), &lib, &loadout) {
+    match store.status(std::path::Path::new(game_root)) {
         Ok(status) => {
             json!({"ok": true, "status": serde_json::to_value(&status).unwrap_or(Value::Null)})
         }
@@ -2361,6 +2370,26 @@ mod tests {
         serde_json::from_str(&execute_json(&req.to_string())).unwrap()
     }
 
+    fn write_mgr_library_entry(library: &std::path::Path, id: &str) {
+        let entry = library.join(id);
+        std::fs::create_dir_all(&entry).unwrap();
+        let meta = gore_mod::mgr::ModEntryMeta {
+            id: id.into(),
+            kind: gore_mod::mgr::ModKind::ForeignPak,
+            name: id.into(),
+            version: String::new(),
+            author: String::new(),
+            imported_at: "2026-01-01T00:00:00Z".into(),
+            source: String::new(),
+            components: Vec::new(),
+        };
+        std::fs::write(
+            entry.join(gore_mod::mgr::META_FILE),
+            serde_json::to_vec(&meta).unwrap(),
+        )
+        .unwrap();
+    }
+
     /// Build a real goremod bundle (one item override → a UE4SS Lua component) under `root` and
     /// return its dir, so `mgr_import` has a genuine bundle to ingest.
     fn write_goremod_bundle(root: &std::path::Path, name: &str) -> PathBuf {
@@ -2495,12 +2524,16 @@ mod tests {
         };
         rec.loc_skipped
             .push("'itfo_cheese': this install's cache declares no 'english' language".into());
-        rec.loc_shadowed
-            .push("'itfo_cheese': 'german' was written and 'german_new' is what the game reads".into());
+        rec.loc_shadowed.push(
+            "'itfo_cheese': 'german' was written and 'german_new' is what the game reads".into(),
+        );
 
         let v = super::deploy_response(rec);
         assert_eq!(v["ok"], true, "resp: {v}");
-        assert_eq!(v["record"]["mod_name"], "Test", "the record still travels: {v}");
+        assert_eq!(
+            v["record"]["mod_name"], "Test",
+            "the record still travels: {v}"
+        );
         assert!(
             v["record"].get("loc_skipped").is_none(),
             "and still without the run-specific lists in it: {v}"
@@ -2508,15 +2541,31 @@ mod tests {
         // Two fields, not one total: a skipped edit was never written and the spec has to change,
         // a shadowed edit landed and is merely not the one displayed. One edit can raise both.
         assert_eq!(v["loc_skipped"].as_array().unwrap().len(), 1, "{v}");
-        assert!(v["loc_skipped"][0].as_str().unwrap().contains("itfo_cheese"), "{v}");
+        assert!(
+            v["loc_skipped"][0]
+                .as_str()
+                .unwrap()
+                .contains("itfo_cheese"),
+            "{v}"
+        );
         assert_eq!(v["loc_shadowed"].as_array().unwrap().len(), 1, "{v}");
-        assert!(v["loc_shadowed"][0].as_str().unwrap().contains("german_new"), "{v}");
+        assert!(
+            v["loc_shadowed"][0]
+                .as_str()
+                .unwrap()
+                .contains("german_new"),
+            "{v}"
+        );
 
         // Present and empty on a clean deploy, so "no warnings" is distinguishable from a build
         // that does not report them.
         let clean = super::deploy_response(gore_mod::DeployRecord::default());
         assert_eq!(clean["loc_skipped"].as_array().unwrap().len(), 0, "{clean}");
-        assert_eq!(clean["loc_shadowed"].as_array().unwrap().len(), 0, "{clean}");
+        assert_eq!(
+            clean["loc_shadowed"].as_array().unwrap().len(),
+            0,
+            "{clean}"
+        );
     }
 
     #[test]
@@ -2682,6 +2731,7 @@ mod tests {
         mgr_call(
             "mgr_set_loadout",
             json!({
+                "library_dir": lib.display().to_string(),
                 "loadout_path": lo.display().to_string(),
                 "loadout": {"format": 1, "entries": [{"id": id, "enabled": true}]}
             }),
@@ -2746,6 +2796,7 @@ mod tests {
         let set = mgr_call(
             "mgr_set_loadout",
             json!({
+                "library_dir": lib.display().to_string(),
                 "loadout_path": lo.display().to_string(),
                 "loadout": {"format": 1, "entries": [
                     {"id": second_id, "enabled": false},
@@ -2823,6 +2874,7 @@ mod tests {
         let set = mgr_call(
             "mgr_set_loadout",
             json!({
+                "library_dir": lib.display().to_string(),
                 "loadout_path": lo.display().to_string(),
                 "loadout": {"format": 1, "entries": [
                     {"id": other_id, "enabled": false},
@@ -3017,9 +3069,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let lib = tmp.path().join("library");
         let lo = tmp.path().join("loadout.json");
+        write_mgr_library_entry(&lib, "mod-a");
+        write_mgr_library_entry(&lib, "mod-b");
         let set = mgr_call(
             "mgr_set_loadout",
             json!({
+                "library_dir": lib.display().to_string(),
                 "loadout_path": lo.display().to_string(),
                 "loadout": {"format": 1, "entries": [
                     {"id": "mod-a", "enabled": true},
@@ -3042,6 +3097,103 @@ mod tests {
         assert_eq!(entries[1]["enabled"], false);
     }
 
+    #[test]
+    fn mgr_set_loadout_raw_rejects_duplicate_fields_and_oversize_before_store_access() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = serde_json::to_string(&tmp.path().join("library").display().to_string()).unwrap();
+        let lo =
+            serde_json::to_string(&tmp.path().join("loadout.json").display().to_string()).unwrap();
+        let duplicate = format!(
+            r#"{{"command":"mgr_set_loadout","payload":{{"library_dir":{lib},"loadout_path":{lo},"loadout":{{"format":1,"format":1,"entries":[]}}}}}}"#
+        );
+        let response: Value = serde_json::from_str(&execute_json(&duplicate)).unwrap();
+        assert_eq!(response["error"]["code"], "BAD_REQUEST", "{response}");
+        assert!(!tmp.path().join("library").exists());
+        assert!(!tmp.path().join("loadout.json").exists());
+
+        let oversized = format!(
+            r#"{{"command":"mgr_set_loadout","payload":{{"library_dir":"{}","loadout":{{"format":1,"entries":[]}}}}}}"#,
+            "x".repeat(MAX_MGR_SET_LOADOUT_REQUEST_BYTES)
+        );
+        let response: Value = serde_json::from_str(&execute_json(&oversized)).unwrap();
+        assert_eq!(response["error"]["code"], "BAD_REQUEST", "{response}");
+        assert!(response["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("bounded size"));
+    }
+
+    #[test]
+    fn mgr_set_loadout_command_first_routes_before_scanning_a_transport_sized_tail() {
+        let mut request = String::from(r#"{"command":"mgr_set_loadout","payload":"#);
+        request.push_str(&"x".repeat(crate::transport::MAX_TRANSPORT_REQUEST_BYTES));
+        // Deliberately leave the oversized tail syntactically incomplete. Once the bounded
+        // command is first, dispatch must hand the untouched wire to the command-local cap rather
+        // than scanning/parsing the remaining 64 MiB generic JSON value.
+        let response: Value = serde_json::from_str(&execute_json(&request)).unwrap();
+        assert_eq!(response["error"]["code"], "BAD_REQUEST", "{response}");
+        assert!(response["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("bounded size"));
+    }
+
+    #[test]
+    fn mgr_set_loadout_rejects_non_current_format_without_touching_current_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("library");
+        let lo = tmp.path().join("loadout.json");
+        write_mgr_library_entry(&lib, "mod-a");
+        gore_mod::mgr::loadout::save(
+            &lo,
+            &gore_mod::mgr::Loadout {
+                format: 1,
+                entries: vec![gore_mod::mgr::LoadoutEntry {
+                    id: "mod-a".into(),
+                    enabled: false,
+                }],
+            },
+        )
+        .unwrap();
+        let before = std::fs::read(&lo).unwrap();
+        for format in [0, 2] {
+            let response = mgr_call(
+                "mgr_set_loadout",
+                json!({
+                    "library_dir": lib.display().to_string(),
+                    "loadout_path": lo.display().to_string(),
+                    "loadout": {"format": format, "entries": []}
+                }),
+            );
+            assert_eq!(response["error"]["code"], "BAD_REQUEST", "{response}");
+            assert_eq!(std::fs::read(&lo).unwrap(), before);
+            assert!(!tmp.path().join(".gore-manager-library.lock").exists());
+        }
+    }
+
+    #[test]
+    fn mgr_set_loadout_duplicate_ids_keep_only_the_first_occurrence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("library");
+        let lo = tmp.path().join("loadout.json");
+        write_mgr_library_entry(&lib, "mod-a");
+        let response = mgr_call(
+            "mgr_set_loadout",
+            json!({
+                "library_dir": lib.display().to_string(),
+                "loadout_path": lo.display().to_string(),
+                "loadout": {"format": 1, "entries": [
+                    {"id": "mod-a", "enabled": true},
+                    {"id": "mod-a", "enabled": false}
+                ]}
+            }),
+        );
+        assert_eq!(response["ok"], true, "{response}");
+        let stored = gore_mod::mgr::loadout::load(&lo).unwrap();
+        assert_eq!(stored.entries.len(), 1);
+        assert!(stored.entries[0].enabled);
+    }
+
     // Removing a mod must also drop it from the persisted loadout (mirror `gore mgr remove`), so a
     // later mgr_apply reading the on-disk loadout does not fail on the deleted mod's metadata.
     #[test]
@@ -3049,10 +3201,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let lib = tmp.path().join("library");
         let lo = tmp.path().join("loadout.json");
-        std::fs::create_dir_all(&lib).unwrap();
+        write_mgr_library_entry(&lib, "mod-a");
+        write_mgr_library_entry(&lib, "mod-b");
         mgr_call(
             "mgr_set_loadout",
             json!({
+                "library_dir": lib.display().to_string(),
                 "loadout_path": lo.display().to_string(),
                 "loadout": {"format": 1, "entries": [
                     {"id": "mod-a", "enabled": true},
@@ -3142,6 +3296,7 @@ mod tests {
         let set = mgr_call(
             "mgr_set_loadout",
             json!({
+                "library_dir": lib.display().to_string(),
                 "loadout_path": lo.display().to_string(),
                 "loadout": {"format": 1, "entries": [
                     {"id": opaque_id, "enabled": true},
@@ -3175,10 +3330,15 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let game = tmp.path().join("game");
         std::fs::create_dir_all(&game).unwrap();
+        let lib = tmp.path().join("library");
         let lo = tmp.path().join("loadout.json");
         let v = mgr_call(
             "mgr_status",
-            json!({"game_root": game.display().to_string(), "loadout_path": lo.display().to_string()}),
+            json!({
+                "game_root": game.display().to_string(),
+                "library_dir": lib.display().to_string(),
+                "loadout_path": lo.display().to_string()
+            }),
         );
         assert_eq!(v["ok"], true, "resp: {v}");
         assert_eq!(v["status"]["state"], "nothing_deployed");
@@ -3214,6 +3374,7 @@ mod tests {
         let set = mgr_call(
             "mgr_set_loadout",
             json!({
+                "library_dir": lib.display().to_string(),
                 "loadout": {"format": 1, "entries": [{"id": id, "enabled": true}]},
                 "loadout_path": lo.display().to_string()
             }),

--- a/crates/gore-ffi/src/mgr_preflight.rs
+++ b/crates/gore-ffi/src/mgr_preflight.rs
@@ -1,6 +1,6 @@
 //! Strict raw FFI adapter for Mod Manager V1's read-only first-run evidence.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use gore_mod::mgr::preflight::ManagerPreflightV1;
 use serde::Deserialize;
@@ -38,14 +38,13 @@ pub(super) fn mgr_preflight_v1_raw(input: &str) -> Value {
         Ok(payload) => payload,
         Err(message) => return err("MGR_PREFLIGHT_BAD_REQUEST", message),
     };
-    let library_dir = payload
-        .library_dir
-        .map(PathBuf::from)
-        .unwrap_or_else(gore_mod::mgr::paths::library_dir);
-    let loadout_path = payload
-        .loadout_path
-        .map(PathBuf::from)
-        .unwrap_or_else(gore_mod::mgr::paths::loadout_path);
+    let (library_dir, loadout_path) = match crate::mgr_store_paths_from_options(
+        payload.library_dir.as_deref(),
+        payload.loadout_path.as_deref(),
+    ) {
+        Ok(paths) => paths,
+        Err(message) => return err("MGR_PREFLIGHT_BAD_REQUEST", message),
+    };
     let preflight = run_preflight(Path::new(&payload.game_root), &library_dir, &loadout_path);
     bounded_response(preflight)
 }
@@ -188,6 +187,41 @@ mod tests {
         let missing = mgr_preflight_v1_raw(&format!(r#"{{"command":"{COMMAND}","payload":{{}}}}"#));
         assert_eq!(missing["ok"], false);
         assert_eq!(missing["error"]["code"], "MGR_PREFLIGHT_BAD_REQUEST");
+    }
+
+    #[test]
+    fn manager_store_path_overrides_must_be_paired() {
+        for payload in [
+            json!({"game_root":"C:/game", "library_dir":"C:/library"}),
+            json!({"game_root":"C:/game", "loadout_path":"C:/loadout.json"}),
+        ] {
+            let parsed =
+                parse_request(&json!({"command":COMMAND, "payload":payload}).to_string()).unwrap();
+            let error = crate::mgr_store_paths_from_options(
+                parsed.library_dir.as_deref(),
+                parsed.loadout_path.as_deref(),
+            )
+            .unwrap_err();
+            assert!(error.contains("must be supplied together"), "{error}");
+        }
+
+        let parsed = parse_request(
+            &json!({
+                "command":COMMAND,
+                "payload":{
+                    "game_root":"C:/game",
+                    "library_dir":"C:/library",
+                    "loadout_path":"C:/loadout.json"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(crate::mgr_store_paths_from_options(
+            parsed.library_dir.as_deref(),
+            parsed.loadout_path.as_deref(),
+        )
+        .is_ok());
     }
 
     #[test]

--- a/crates/gore-ffi/src/transport.rs
+++ b/crates/gore-ffi/src/transport.rs
@@ -239,7 +239,7 @@ mod tests {
         assert_eq!(out.len, bytes.len());
         let response = value(&bytes);
         assert_eq!(response["ok"], true);
-        assert_eq!(response["abi"], 1);
+        assert_eq!(response["abi"], crate::CORE_PROTOCOL_ABI);
         unsafe { free(out) };
     }
 

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -9136,7 +9136,7 @@ pub(crate) fn fail_next_atomic_write(path: &Path) {
 }
 
 #[cfg(test)]
-fn take_injected_atomic_write_failure(path: &Path) -> bool {
+pub(crate) fn take_injected_atomic_write_failure(path: &Path) -> bool {
     FAIL_ATOMIC_WRITE.with(|slot| {
         let matches = slot
             .borrow()

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -508,7 +508,18 @@ pub fn apply_loadout(
     library_dir: &Path,
     loadout: &Loadout,
 ) -> crate::Result<ApplyReport> {
-    apply_loadout_with_limits(game_root, library_dir, loadout, DEFAULT_APPLY_LIMITS)
+    apply_loadout_with_limits(game_root, library_dir, loadout, DEFAULT_APPLY_LIMITS, false)
+}
+
+/// Store routes have already completed replacement recovery while holding the library mutation
+/// lock, which they retain through this call. Keeping this entry point crate-private prevents an
+/// unlocked caller from accidentally bypassing recovery.
+pub(crate) fn apply_loadout_after_store_snapshot(
+    game_root: &Path,
+    library_dir: &Path,
+    loadout: &Loadout,
+) -> crate::Result<ApplyReport> {
+    apply_loadout_with_limits(game_root, library_dir, loadout, DEFAULT_APPLY_LIMITS, true)
 }
 
 fn apply_loadout_with_limits(
@@ -516,6 +527,7 @@ fn apply_loadout_with_limits(
     library_dir: &Path,
     loadout: &Loadout,
     limits: ApplyLimits,
+    library_recovery_is_held: bool,
 ) -> crate::Result<ApplyReport> {
     // Absolutize like deploy()/undeploy() so every derived + persisted path is absolute. This MUST
     // happen before reading the record: deploy/undeploy/status all key the record off `abs_root`, so
@@ -547,7 +559,7 @@ fn apply_loadout_with_limits(
     // Loadouts are persisted input. Validate ALL slots (including disabled ones) before the empty
     // branch can undeploy an active manager deployment.
     loadout.validate()?;
-    if loadout.entries.iter().any(|entry| entry.enabled) {
+    if loadout.entries.iter().any(|entry| entry.enabled) && !library_recovery_is_held {
         super::import::recover_library_for_read(library_dir)?;
     }
 
@@ -2156,6 +2168,7 @@ mod tests {
                 max_manifest_bytes: 4,
                 ..DEFAULT_APPLY_LIMITS
             },
+            false,
         )
         .unwrap_err()
         .to_string();
@@ -2183,6 +2196,7 @@ mod tests {
                 max_wav_bytes: 4,
                 ..DEFAULT_APPLY_LIMITS
             },
+            false,
         )
         .unwrap_err()
         .to_string();
@@ -2211,6 +2225,7 @@ mod tests {
                 max_mini_bytes: 4,
                 ..DEFAULT_APPLY_LIMITS
             },
+            false,
         )
         .unwrap_err()
         .to_string();
@@ -2239,6 +2254,7 @@ mod tests {
                 max_raw_file_bytes: 4,
                 ..DEFAULT_APPLY_LIMITS
             },
+            false,
         )
         .unwrap_err()
         .to_string();
@@ -2268,6 +2284,7 @@ mod tests {
                 max_raw_total_bytes: 7,
                 ..DEFAULT_APPLY_LIMITS
             },
+            false,
         )
         .unwrap_err()
         .to_string();
@@ -2296,6 +2313,7 @@ mod tests {
                 max_additive_file_bytes: 4,
                 ..DEFAULT_APPLY_LIMITS
             },
+            false,
         )
         .unwrap_err()
         .to_string();
@@ -2318,6 +2336,7 @@ mod tests {
                 max_additive_total_bytes: 7,
                 ..DEFAULT_APPLY_LIMITS
             },
+            false,
         )
         .unwrap_err()
         .to_string();
@@ -3373,6 +3392,7 @@ mod tests {
                 max_loose_file_bytes: 4,
                 ..DEFAULT_APPLY_LIMITS
             },
+            false,
         )
         .unwrap_err()
         .to_string();

--- a/crates/gore-mod/src/mgr/import.rs
+++ b/crates/gore-mod/src/mgr/import.rs
@@ -14,10 +14,11 @@ use sha2::{Digest as _, Sha256};
 #[cfg(not(unix))]
 use super::model::metadata_is_link;
 use super::model::{
-    open_directory_nofollow, open_file_nofollow, ComponentInfo, FileIdentity, FileRevision,
-    ImportIdentityMeta, LibraryEntry, LibraryMutationFileGuard, LibraryRoot, LibrarySidecar,
-    ManagerPrivateMeta, MetaReadFailure, ModEntryMeta, ModKind, RawTarget, SecureDirectory,
-    SecureFile, SecureNode, META_FILE,
+    manager_process_lock, open_directory_nofollow, open_file_nofollow, ComponentInfo, FileIdentity,
+    FileRevision, ImportIdentityMeta, LibraryEntry, LibraryRoot, LibrarySidecar,
+    ManagerPrivateMeta, ManagerProcessGuard, ManagerRootLock, MetaReadFailure, ModEntryMeta,
+    ModKind, PreparedManagerRootLock, RawTarget, SecureDirectory, SecureFile, SecureNode,
+    META_FILE,
 };
 use crate::{Component, ModError, ModManifest, ScriptEntry, VoicePatchManifest};
 
@@ -169,13 +170,6 @@ const MAX_IDENTITY_REFUSAL_IDS: usize = 2;
 const LIBRARY_LOCK_MARKER_ENV: &str = "GORE_TEST_LIBRARY_LOCK_MARKER";
 #[cfg(test)]
 const LIBRARY_LOCK_HOLD_MS_ENV: &str = "GORE_TEST_LIBRARY_LOCK_HOLD_MS";
-
-/// The local mutex establishes one acquisition order inside this process. Windows then owns a
-/// persistent lock-file byte range; Unix flocks the retained canonical library-directory inode.
-/// Together they protect cooperative GORE recovery, identity decisions, sidecar writes,
-/// publication, list recovery, and removal. Untrusted source materialization stays outside the
-/// lane.
-static LIBRARY_MUTATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Import `source` (a folder, `.zip` archive, or single recognized game file) into the library
 /// at `library_dir`, returning the entry metadata that was also written as its sidecar.
@@ -332,6 +326,10 @@ fn import_detailed_with_limits(
         guard.0 = None;
         bound?
     };
+    // Testable post-acquire namespace race: cleanup authority is already rebound to the retained
+    // Library inode before the named path is allowed to fail closed.
+    run_library_root_swap_hook(library_lock.path());
+    library_lock.os.revalidate_named()?;
     let canonical_library_dir = library_lock.path().to_path_buf();
     recover_interrupted_replacements_locked(&library_lock)?;
     let mut staged_hashes = hash_secure_import_tree_hashes_inner(
@@ -2458,8 +2456,8 @@ fn remove_replacement_file_if_present(path: &Path, label: &str) -> crate::Result
 }
 
 struct LibraryMutationGuard {
-    os: LibraryMutationFileGuard,
-    _process: std::sync::MutexGuard<'static, ()>,
+    os: ManagerRootLock,
+    _process: ManagerProcessGuard,
 }
 
 impl LibraryMutationGuard {
@@ -2488,13 +2486,33 @@ impl LibraryMutationGuard {
 }
 
 fn library_mutation_lock(library_dir: &Path) -> crate::Result<LibraryMutationGuard> {
-    let process = LIBRARY_MUTATION_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    library_mutation_lock_excluding(library_dir, None)
+}
+
+fn library_mutation_lock_excluding(
+    library_dir: &Path,
+    forbidden_identity: Option<super::model::FileIdentity>,
+) -> crate::Result<LibraryMutationGuard> {
+    let process = manager_process_lock();
     let library = LibraryRoot::open(library_dir)?;
+    if forbidden_identity.is_some_and(|identity| library.identity() == identity) {
+        return Err(ModError::Other(format!(
+            "manager library must not be the manager loadout parent directory: {}",
+            library_dir.display()
+        )));
+    }
     let os = library.acquire_mutation_lock()?;
-    run_library_root_swap_hook(os.path());
     run_library_lock_acquired_hook()?;
+    Ok(LibraryMutationGuard {
+        os,
+        _process: process,
+    })
+}
+
+fn existing_library_read_lock(library_dir: &Path) -> crate::Result<LibraryMutationGuard> {
+    let process = manager_process_lock();
+    let library = LibraryRoot::open(library_dir)?;
+    let os = library.acquire_existing_mutation_lock()?;
     Ok(LibraryMutationGuard {
         os,
         _process: process,
@@ -4010,8 +4028,123 @@ pub(crate) fn recover_library_for_read(library_dir: &Path) -> crate::Result<()> 
     recover_interrupted_replacements_locked(&library_lock)
 }
 
+/// A recovery-complete, strict library read held under the library mutation lock. Store consumers
+/// keep this guard alive until analyze/apply/status has finished consuming the corresponding
+/// loadout, so a cooperative import cannot replace payload bytes between reconciliation and use.
+pub(crate) struct StrictLibrarySnapshot {
+    _lock: Option<LibraryMutationGuard>,
+    _process_only: Option<ManagerProcessGuard>,
+    present: bool,
+    path: PathBuf,
+    mods: Vec<ModEntryMeta>,
+}
+
+impl StrictLibrarySnapshot {
+    pub(crate) fn prepare(library_dir: &Path) -> crate::Result<PreparedManagerRootLock> {
+        std::fs::create_dir_all(library_dir).map_err(crate::io("creating library dir"))?;
+        let root = LibraryRoot::open(library_dir)?;
+        root.prepare_mutation_lock(true)
+    }
+
+    pub(crate) fn from_prelocked(
+        process: ManagerProcessGuard,
+        lock: ManagerRootLock,
+    ) -> crate::Result<Self> {
+        let lock = LibraryMutationGuard {
+            os: lock,
+            _process: process,
+        };
+        recover_interrupted_replacements_locked(&lock)?;
+        Self::from_locked(lock, false)
+    }
+
+    /// Strict advisory snapshot for Doctor. It takes only the Library lane, performs no recovery,
+    /// and never creates a missing library. Store writers cannot save while this guard is held
+    /// because their canonical composite transaction includes this same Library-root lock.
+    pub(crate) fn inspect_read_only(library_dir: &Path) -> crate::Result<Self> {
+        if metadata_if_present(library_dir)?.is_some() {
+            return Self::from_locked(existing_library_read_lock(library_dir)?, true);
+        }
+        let process = manager_process_lock();
+        if metadata_if_present(library_dir)?.is_some() {
+            drop(process);
+            return Self::from_locked(existing_library_read_lock(library_dir)?, true);
+        }
+        Ok(Self {
+            _lock: None,
+            _process_only: Some(process),
+            present: false,
+            path: library_dir.to_path_buf(),
+            mods: Vec::new(),
+        })
+    }
+
+    fn from_locked(lock: LibraryMutationGuard, read_only: bool) -> crate::Result<Self> {
+        let path = lock.path().to_path_buf();
+        let library = lock.open_library()?;
+        let mut mods = Vec::new();
+        for result in library.read_dir()? {
+            let entry = result.map_err(crate::io("enumerating manager library"))?;
+            let file_name = entry.file_name();
+            if read_only && file_name.to_string_lossy().starts_with(REPLACEMENT_PREFIX) {
+                return Err(ModError::Other(format!(
+                    "manager replacement transaction requires recovery; read-only inspection left it untouched: {}",
+                    entry.path().display()
+                )));
+            }
+            // Dot children are Manager-owned locks, staging and recovery artifacts. Recovery above
+            // has already rejected any uncertain replacement transaction.
+            if file_name.to_string_lossy().starts_with('.') {
+                continue;
+            }
+            let id = file_name.to_str().ok_or_else(|| {
+                ModError::Other(format!(
+                    "library entry id is not valid Unicode: {}",
+                    entry.path().display()
+                ))
+            })?;
+            mods.push(library.entry(id)?.read_meta()?);
+        }
+        mods.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+        drop(library);
+        Ok(Self {
+            _lock: Some(lock),
+            _process_only: None,
+            present: true,
+            path,
+            mods,
+        })
+    }
+
+    pub(crate) fn mods(&self) -> &[ModEntryMeta] {
+        &self.mods
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Whether this read-only snapshot observed no Library root. Keep this explicit rather than
+    /// inferring presence from guard layout: an absent root deliberately retains only the global
+    /// process guard and has no cross-process kernel object it could acquire without creating one.
+    pub(crate) fn is_missing(&self) -> bool {
+        !self.present
+    }
+
+    pub(crate) fn verify_read_only_stable(&self) -> crate::Result<()> {
+        if self._lock.is_none() && metadata_if_present(&self.path)?.is_some() {
+            return Err(ModError::Other(format!(
+                "manager library appeared during read-only inspection: {}",
+                self.path.display()
+            )));
+        }
+        Ok(())
+    }
+}
+
 /// All library entries, sorted by name. Entries with an unreadable/corrupt sidecar are skipped
-/// (with a note on stderr), a missing library dir is an empty library.
+/// (with a note on stderr), a missing library dir is an empty library. This legacy lenient view is
+/// retained for non-store callers; authoritative Manager store routes use [`StrictLibrarySnapshot`].
 pub fn list(library_dir: &Path) -> crate::Result<Vec<ModEntryMeta>> {
     if metadata_if_present(library_dir)?.is_none() {
         return Ok(Vec::new());
@@ -9202,28 +9335,38 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn unix_root_swap_never_redirects_import_into_the_unlocked_replacement_path() {
+    fn unix_root_swap_is_refused_without_redirecting_or_changing_evidence() {
         let tmp = tempfile::tempdir().unwrap();
         let configured = tmp.path().join("library");
         let retained = tmp.path().join("retained-library");
         let source = tmp.path().join("root-swap_P.pak");
+        fs::create_dir(&configured).unwrap();
+        fs::write(configured.join(".evidence"), b"retained").unwrap();
         fs::write(&source, b"root swap bytes").unwrap();
         let configured_for_hook = configured.clone();
         let retained_for_hook = retained.clone();
         inject_library_root_swap(move |_locked_path| {
             fs::rename(&configured_for_hook, &retained_for_hook).unwrap();
             fs::create_dir(&configured_for_hook).unwrap();
+            fs::write(configured_for_hook.join(".evidence"), b"decoy").unwrap();
         });
 
-        let outcome = import_detailed(&configured, &source).unwrap();
-        assert!(retained.join(&outcome.entry.id).is_dir());
-        assert_eq!(fs::read_dir(&configured).unwrap().count(), 0);
-        assert!(!configured.join(&outcome.entry.id).exists());
+        let error = import_detailed(&configured, &source)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("named filesystem identity"), "{error}");
+        assert_eq!(fs::read(retained.join(".evidence")).unwrap(), b"retained");
+        assert_eq!(fs::read(configured.join(".evidence")).unwrap(), b"decoy");
+        assert!(fs::read_dir(&retained)
+            .unwrap()
+            .filter_map(Result::ok)
+            .all(|entry| { !entry.file_name().to_string_lossy().starts_with(".staging-") }));
+        assert_eq!(fs::read_dir(&configured).unwrap().count(), 1);
     }
 
     #[cfg(unix)]
     #[test]
-    fn unix_root_swap_failure_cleans_staging_through_the_retained_inode() {
+    fn unix_root_swap_refusal_cleans_staging_through_the_retained_inode() {
         let tmp = tempfile::tempdir().unwrap();
         let configured = tmp.path().join("library");
         let retained = tmp.path().join("retained-library");
@@ -9235,14 +9378,10 @@ mod tests {
             fs::rename(&configured_for_hook, &retained_for_hook).unwrap();
             fs::create_dir(&configured_for_hook).unwrap();
         });
-        inject_prepublish_failure(ModError::Other(
-            "injected failure after retained-root binding".into(),
-        ));
-
         let error = import_detailed(&configured, &source)
             .unwrap_err()
             .to_string();
-        assert!(error.contains("injected failure"), "{error}");
+        assert!(error.contains("named filesystem identity"), "{error}");
         assert_eq!(fs::read_dir(&configured).unwrap().count(), 0);
         assert!(
             fs::read_dir(&retained)

--- a/crates/gore-mod/src/mgr/loadout.rs
+++ b/crates/gore-mod/src/mgr/loadout.rs
@@ -35,7 +35,13 @@ impl Default for Loadout {
 impl Loadout {
     /// Validate every persisted id, including disabled slots. Disabled entries are still saved and
     /// may later be enabled, so they must never carry an absolute/traversing library path.
-    pub(crate) fn validate(&self) -> crate::Result<()> {
+    pub fn validate(&self) -> crate::Result<()> {
+        if self.format != 1 {
+            return Err(crate::ModError::Other(format!(
+                "loadout format {} is not supported by this tool (expected format 1)",
+                self.format
+            )));
+        }
         let mut enabled_entries = 0usize;
         for (index, entry) in self.entries.iter().enumerate() {
             super::model::validate_library_id(&entry.id).map_err(|error| {
@@ -68,20 +74,7 @@ pub struct LoadoutEntry {
 /// manager works before anything was ever saved.
 pub fn load(path: &Path) -> crate::Result<Loadout> {
     match std::fs::read(path) {
-        Ok(bytes) => {
-            let parsed: Loadout = serde_json::from_slice(&bytes)?;
-            // A newer tool may have written a schema this build can't interpret; refuse rather
-            // than silently mis-reading (serde tolerates unknown fields, so a bumped format is
-            // the only signal that fields we can't see were dropped).
-            if parsed.format > 1 {
-                return Err(crate::ModError::Other(format!(
-                    "loadout format {} is newer than this tool supports",
-                    parsed.format
-                )));
-            }
-            parsed.validate()?;
-            Ok(parsed)
-        }
+        Ok(bytes) => parse_bytes(&bytes),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Loadout::default()),
         Err(e) => Err(crate::io(&format!("reading loadout {}", path.display()))(e)),
     }
@@ -90,12 +83,24 @@ pub fn load(path: &Path) -> crate::Result<Loadout> {
 /// Persist `loadout` at `path`, creating parent dirs; atomic so a crash mid-save can't
 /// truncate the previous loadout.
 pub fn save(path: &Path, loadout: &Loadout) -> crate::Result<()> {
-    loadout.validate()?;
+    let bytes = serialized_bytes(loadout)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(crate::io("creating loadout dir"))?;
     }
-    let bytes = serde_json::to_vec_pretty(loadout)?;
     crate::atomic_write(path, &bytes)
+}
+
+pub(crate) fn parse_bytes(bytes: &[u8]) -> crate::Result<Loadout> {
+    let parsed: Loadout = serde_json::from_slice(bytes)?;
+    // Only the current wire format is authoritative. Refuse both older and newer explicit
+    // versions rather than interpreting a shape whose semantics this build does not own.
+    parsed.validate()?;
+    Ok(parsed)
+}
+
+pub(crate) fn serialized_bytes(loadout: &Loadout) -> crate::Result<Vec<u8>> {
+    loadout.validate()?;
+    serde_json::to_vec_pretty(loadout).map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -167,15 +172,18 @@ mod tests {
     }
 
     #[test]
-    fn loadout_load_rejects_newer_format() {
+    fn loadout_load_rejects_every_explicit_non_current_format() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("loadout.json");
-        std::fs::write(&path, br#"{"format": 2, "entries": []}"#).unwrap();
-        let err = load(&path).unwrap_err();
-        assert!(
-            err.to_string().contains("newer than this tool supports"),
-            "got: {err}"
-        );
+        for format in [0, 2] {
+            std::fs::write(
+                &path,
+                serde_json::json!({"format": format, "entries": []}).to_string(),
+            )
+            .unwrap();
+            let err = load(&path).unwrap_err();
+            assert!(err.to_string().contains("expected format 1"), "got: {err}");
+        }
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/mod.rs
+++ b/crates/gore-mod/src/mgr/mod.rs
@@ -14,6 +14,7 @@ pub mod model;
 pub mod paths;
 pub mod preflight;
 pub mod status;
+pub mod store;
 
 pub use loadout::{Loadout, LoadoutEntry};
 pub use model::*;

--- a/crates/gore-mod/src/mgr/model.rs
+++ b/crates/gore-mod/src/mgr/model.rs
@@ -54,14 +54,14 @@ pub(crate) struct LibrarySidecar {
 }
 
 #[cfg(windows)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub(crate) struct FileIdentity {
     volume: u64,
     id: [u8; 16],
 }
 
 #[cfg(unix)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub(crate) struct FileIdentity {
     device: u64,
     inode: u64,
@@ -157,26 +157,60 @@ pub(crate) struct LibraryIdentityInspection {
     pub(crate) sidecar_sha256: String,
 }
 
-/// Crash-released operating-system lock for one canonical manager-library inode. Windows locks a
-/// persistent direct-child file; Unix locks the already-opened directory descriptor itself, whose
-/// inode cannot be substituted by unlinking a lock-file name. The retained root is the sole Unix
-/// namespace authority for the mutation lane.
+/// The one non-reentrant in-process Manager lane. Every Store and standalone Library/Identity
+/// transaction takes this guard before preparing or waiting on any kernel root lock.
+static MANAGER_PROCESS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+pub(crate) type ManagerProcessGuard = std::sync::MutexGuard<'static, ()>;
+
+pub(crate) fn manager_process_lock() -> ManagerProcessGuard {
+    MANAGER_PROCESS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// One prepared canonical Manager root, opened and identity-bound but not yet kernel-locked.
+/// Composite Store transactions sort these by physical identity before acquiring either lock.
 #[derive(Debug)]
-pub(crate) struct LibraryMutationFileGuard {
+pub(crate) struct PreparedManagerRootLock {
     #[cfg(windows)]
-    _file: std::fs::File,
+    root: SecureDirectory,
+    #[cfg(unix)]
+    root: SecureDirectory,
+    #[cfg(windows)]
+    create_lock_file: bool,
+}
+
+impl PreparedManagerRootLock {
+    pub(crate) fn identity(&self) -> FileIdentity {
+        self.root.identity()
+    }
+
+}
+
+/// Crash-released operating-system lock for one canonical Manager root. Windows locks the
+/// persistent `.gore-manager-library.lock` direct child for both Store and Library roots. Unix
+/// flocks the already-opened directory descriptor itself. Retained handles plus named-path
+/// revalidation prevent a prepared alias from being redirected while a waiter blocks.
+#[derive(Debug)]
+pub(crate) struct ManagerRootLock {
+    #[cfg(windows)]
+    sentinel: std::fs::File,
+    #[cfg(windows)]
+    sentinel_identity: FileIdentity,
+    #[cfg(windows)]
+    sentinel_path: PathBuf,
     #[cfg(windows)]
     root: RenameDirectoryGuard,
     #[cfg(unix)]
     root: SecureDirectory,
 }
 
-impl LibraryMutationFileGuard {
+impl ManagerRootLock {
     pub(crate) fn path(&self) -> &Path {
         self.root.path()
     }
 
-    #[cfg(any(not(unix), test))]
     pub(crate) fn identity(&self) -> FileIdentity {
         self.root.identity()
     }
@@ -186,6 +220,11 @@ impl LibraryMutationFileGuard {
         LibraryRoot {
             directory: self.root.clone(),
         }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn directory_file(&self) -> &std::fs::File {
+        &self.root.anchor.file
     }
 }
 
@@ -288,10 +327,58 @@ impl SecureFile {
         }
         Ok(())
     }
+
+    /// Read this already-opened, no-follow file under a hard ceiling and prove that its opened
+    /// identity, revision and length stayed stable for the complete read.
+    pub(crate) fn read_all_bounded(
+        &mut self,
+        label: &str,
+        limit: u64,
+    ) -> crate::Result<Vec<u8>> {
+        let expected = self.len;
+        if expected > limit {
+            return Err(crate::ModError::Other(format!(
+                "{label} exceeds the {limit}-byte limit: {}",
+                self.final_path.display()
+            )));
+        }
+        let capacity = usize::try_from(expected).map_err(|_| {
+            crate::ModError::Other(format!(
+                "{label} is too large for this process address space: {}",
+                self.final_path.display()
+            ))
+        })?;
+        let mut bytes = Vec::new();
+        bytes.try_reserve_exact(capacity).map_err(|_| {
+            crate::ModError::Other(format!(
+                "could not reserve {expected} bytes for {label}: {}",
+                self.final_path.display()
+            ))
+        })?;
+        self.file
+            .by_ref()
+            .take(limit.saturating_add(1))
+            .read_to_end(&mut bytes)
+            .map_err(crate::io(&format!(
+                "reading {label} {}",
+                self.final_path.display()
+            )))?;
+        if bytes.len() as u64 > limit || bytes.len() as u64 != expected {
+            return Err(crate::ModError::Other(format!(
+                "{label} changed or exceeded its bound while being read: {}",
+                self.final_path.display()
+            )));
+        }
+        self.verify_len(expected, label)?;
+        Ok(bytes)
+    }
 }
 
 #[cfg(windows)]
-fn identity_from_open_file(file: &std::fs::File, label: &str) -> crate::Result<FileIdentity> {
+pub(crate) fn identity_from_open_file(
+    file: &std::fs::File,
+    label: &str,
+) -> crate::Result<FileIdentity> {
     use std::os::windows::io::AsRawHandle as _;
     use windows_sys::Win32::Storage::FileSystem::{
         FileIdInfo, GetFileInformationByHandleEx, FILE_ID_INFO,
@@ -344,7 +431,10 @@ fn revision_from_open_file(file: &std::fs::File, label: &str) -> crate::Result<F
 }
 
 #[cfg(unix)]
-fn identity_from_open_file(file: &std::fs::File, label: &str) -> crate::Result<FileIdentity> {
+pub(crate) fn identity_from_open_file(
+    file: &std::fs::File,
+    label: &str,
+) -> crate::Result<FileIdentity> {
     use std::os::unix::fs::MetadataExt as _;
     let metadata = file
         .metadata()
@@ -925,26 +1015,6 @@ fn fstat_retry(fd: libc::c_int) -> std::io::Result<libc::stat> {
     }
 }
 
-#[cfg(unix)]
-fn fstatat_retry(
-    directory_fd: libc::c_int,
-    name: &std::ffi::CStr,
-    flags: libc::c_int,
-) -> std::io::Result<libc::stat> {
-    loop {
-        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-        // SAFETY: both the retained descriptor/name and writable result pointer are valid.
-        if unsafe { libc::fstatat(directory_fd, name.as_ptr(), stat.as_mut_ptr(), flags) } == 0 {
-            // SAFETY: successful `fstatat` initialized the structure.
-            return Ok(unsafe { stat.assume_init() });
-        }
-        let error = std::io::Error::last_os_error();
-        if error.kind() != std::io::ErrorKind::Interrupted {
-            return Err(error);
-        }
-    }
-}
-
 #[cfg(windows)]
 fn create_child_directory_new(
     parent: &DirectoryAnchor,
@@ -1173,7 +1243,7 @@ fn open_directory_rename_compatible(
 }
 
 pub(crate) fn open_directory_nofollow(path: &Path, label: &str) -> crate::Result<SecureDirectory> {
-    let opened = open_absolute_node(path, label)?;
+    let opened = open_absolute_directory(path, label)?;
     if !opened.metadata.is_dir() {
         return Err(crate::ModError::Other(format!(
             "{label} is not a real directory: {}",
@@ -1187,6 +1257,43 @@ pub(crate) fn open_directory_nofollow(path: &Path, label: &str) -> crate::Result
             identity: opened.identity,
         }),
         parents: Vec::new(),
+    })
+}
+
+#[cfg(not(unix))]
+fn open_absolute_directory(path: &Path, label: &str) -> crate::Result<OpenedNode> {
+    open_absolute_node(path, label)
+}
+
+#[cfg(unix)]
+fn open_absolute_directory(path: &Path, label: &str) -> crate::Result<OpenedNode> {
+    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
+    use std::os::unix::io::AsRawFd as _;
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(crate::io(&format!(
+            "opening {label} with O_DIRECTORY|O_NOFOLLOW {}",
+            path.display()
+        )))?;
+    let metadata = file
+        .metadata()
+        .map_err(crate::io(&format!("reading opened {label} metadata")))?;
+    let identity = FileIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    };
+    let fd_path = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
+    let final_path = std::fs::read_link(&fd_path)
+        .or_else(|_| std::fs::canonicalize(path))
+        .map_err(crate::io(&format!("resolving opened {label} handle path")))?;
+    Ok(OpenedNode {
+        file,
+        final_path,
+        identity,
+        metadata,
     })
 }
 
@@ -1600,26 +1707,50 @@ fn secure_directory_enumeration_path(anchor: &DirectoryAnchor) -> crate::Result<
     ))
 }
 
-#[cfg(windows)]
-const LIBRARY_MUTATION_LOCK_FILE: &str = ".gore-manager-library.lock";
+pub(crate) const MANAGER_ROOT_LOCK_FILE: &str = ".gore-manager-library.lock";
+
+#[cfg(test)]
+const MANAGER_FIRST_ROOT_MARKER_ENV: &str = "GORE_TEST_MANAGER_FIRST_ROOT_MARKER";
+#[cfg(test)]
+const MANAGER_FIRST_ROOT_HOLD_MS_ENV: &str = "GORE_TEST_MANAGER_FIRST_ROOT_HOLD_MS";
+
+#[cfg(test)]
+fn run_manager_first_root_lock_hook() -> crate::Result<()> {
+    if let Some(marker) = std::env::var_os(MANAGER_FIRST_ROOT_MARKER_ENV) {
+        std::fs::write(marker, b"locked")
+            .map_err(crate::io("writing first Manager-root lock marker"))?;
+    }
+    if let Ok(raw) = std::env::var(MANAGER_FIRST_ROOT_HOLD_MS_ENV) {
+        let milliseconds = raw.parse::<u64>().map_err(|error| {
+            crate::ModError::Other(format!(
+                "invalid {MANAGER_FIRST_ROOT_HOLD_MS_ENV} value {raw:?}: {error}"
+            ))
+        })?;
+        std::thread::sleep(std::time::Duration::from_millis(milliseconds));
+    }
+    Ok(())
+}
+
+#[cfg(not(test))]
+fn run_manager_first_root_lock_hook() -> crate::Result<()> {
+    Ok(())
+}
 
 #[cfg(windows)]
-fn acquire_library_mutation_file_lock(
-    library: SecureDirectory,
-) -> crate::Result<LibraryMutationFileGuard> {
+fn open_manager_root_sentinel(
+    root: &SecureDirectory,
+    create: bool,
+) -> crate::Result<OpenedNode> {
     use std::os::windows::fs::OpenOptionsExt as _;
-    use std::os::windows::io::AsRawHandle as _;
     use windows_sys::Win32::Storage::FileSystem::{
-        LockFileEx, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, FILE_SHARE_WRITE,
-        LOCKFILE_EXCLUSIVE_LOCK,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, FILE_SHARE_WRITE,
     };
-    use windows_sys::Win32::System::IO::OVERLAPPED;
 
-    let path = library.path().join(LIBRARY_MUTATION_LOCK_FILE);
+    let path = root.path().join(MANAGER_ROOT_LOCK_FILE);
     let file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
-        .create(true)
+        .create(create)
         // Cooperative processes must be able to open the same persistent file while another owns
         // its kernel byte lock. DELETE sharing is intentionally excluded for ordinary Win32
         // namespace operations. This is coordination, not a security boundary against a same-user
@@ -1627,30 +1758,80 @@ fn acquire_library_mutation_file_lock(
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
         .open(&path)
-        .map_err(crate::io(
-            "opening persistent manager-library mutation lock",
-        ))?;
-    let opened = finish_opened_windows_node(&path, "manager-library mutation lock", file)?;
-    if !opened.metadata.is_file()
-        || !handle_path_is_direct_child(library.path(), &opened.final_path)
-    {
+        .map_err(crate::io("opening persistent Manager-root lock"))?;
+    let opened = finish_opened_windows_node(&path, "Manager-root lock", file)?;
+    if !opened.metadata.is_file() || !handle_path_is_direct_child(root.path(), &opened.final_path) {
         return Err(crate::ModError::Other(format!(
-            "manager-library mutation lock is not a regular direct child: {}",
+            "Manager-root lock is not a regular direct child: {}",
             opened.final_path.display()
         )));
     }
+    Ok(opened)
+}
 
-    // A waiter must not retain the no-DELETE traversal handle while blocking: on Windows that
-    // would prevent the current lock owner from renaming library children. Preserve the exact root
-    // identity with a rename-compatible handle before entering LockFileEx instead.
-    let root = library.into_rename_guard("manager library mutation root")?;
+#[cfg(windows)]
+fn prepare_manager_root_lock(
+    root: SecureDirectory,
+    create_lock_file: bool,
+) -> crate::Result<PreparedManagerRootLock> {
+    // Keep preparation read-only. Composite callers compare every opened root identity before
+    // creating either persistent sentinel, so an invalid same-root configuration leaves no lock
+    // artifact behind.
+    Ok(PreparedManagerRootLock {
+        root,
+        create_lock_file,
+    })
+}
 
+#[cfg(unix)]
+fn prepare_manager_root_lock(
+    root: SecureDirectory,
+    _create_lock_file: bool,
+) -> crate::Result<PreparedManagerRootLock> {
+    Ok(PreparedManagerRootLock { root })
+}
+
+#[cfg(not(any(windows, unix)))]
+fn prepare_manager_root_lock(
+    _root: SecureDirectory,
+    _create_lock_file: bool,
+) -> crate::Result<PreparedManagerRootLock> {
+    Err(crate::ModError::Other(
+        "Manager-root locking is unsupported on this platform".into(),
+    ))
+}
+
+pub(crate) fn prepare_existing_manager_root_lock(
+    path: &Path,
+    label: &str,
+    create_lock_file: bool,
+) -> crate::Result<PreparedManagerRootLock> {
+    prepare_manager_root_lock(
+        open_directory_nofollow(path, label)?,
+        create_lock_file,
+    )
+}
+
+#[cfg(windows)]
+fn acquire_prepared_manager_root(
+    prepared: PreparedManagerRootLock,
+) -> crate::Result<ManagerRootLock> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{LockFileEx, LOCKFILE_EXCLUSIVE_LOCK};
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let sentinel = open_manager_root_sentinel(&prepared.root, prepared.create_lock_file)?;
+    // A waiter must not retain the no-DELETE traversal handle while blocking: that would prevent
+    // the current owner from renaming root children. The sentinel remains identity-bound.
+    let root = prepared
+        .root
+        .into_rename_guard("Manager mutation root")?;
     let mut overlapped = OVERLAPPED::default();
-    // SAFETY: `opened.file` remains alive in the returned guard. This is a synchronous blocking
+    // SAFETY: `sentinel.file` remains alive in the returned guard. This is synchronous
     // one-byte lock at offset zero, and `overlapped` is valid for the duration of the call.
     let locked = unsafe {
         LockFileEx(
-            opened.file.as_raw_handle(),
+            sentinel.file.as_raw_handle(),
             LOCKFILE_EXCLUSIVE_LOCK,
             0,
             1,
@@ -1659,35 +1840,34 @@ fn acquire_library_mutation_file_lock(
         )
     };
     if locked == 0 {
-        return Err(crate::io(
-            "locking persistent manager-library mutation lock",
-        )(std::io::Error::last_os_error()));
-    }
-    if identity_from_open_file(&opened.file, "manager-library mutation lock")? != opened.identity {
-        return Err(crate::ModError::Other(
-            "manager-library mutation lock changed filesystem identity while locking".into(),
+        return Err(crate::io("locking persistent Manager-root lock")(
+            std::io::Error::last_os_error(),
         ));
     }
-    Ok(LibraryMutationFileGuard {
-        _file: opened.file,
+    let lock = ManagerRootLock {
+        sentinel: sentinel.file,
+        sentinel_identity: sentinel.identity,
+        sentinel_path: sentinel.final_path,
         root,
-    })
+    };
+    lock.revalidate_named()?;
+    Ok(lock)
 }
 
 #[cfg(unix)]
-fn acquire_library_mutation_file_lock(
-    library: SecureDirectory,
-) -> crate::Result<LibraryMutationFileGuard> {
+fn acquire_prepared_manager_root(
+    prepared: PreparedManagerRootLock,
+) -> crate::Result<ManagerRootLock> {
     use std::os::unix::io::AsRawFd as _;
 
-    let fd = library.anchor.file.as_raw_fd();
+    let fd = prepared.root.anchor.file.as_raw_fd();
     let before = fstat_retry(fd).map_err(crate::io(
-        "reading manager-library directory identity before locking",
+        "reading Manager-root directory identity before locking",
     ))?;
     if before.st_mode & libc::S_IFMT != libc::S_IFDIR {
         return Err(crate::ModError::Other(format!(
-            "manager-library mutation authority is not a directory: {}",
-            library.path().display()
+            "Manager-root mutation authority is not a directory: {}",
+            prepared.root.path().display()
         )));
     }
 
@@ -1701,41 +1881,120 @@ fn acquire_library_mutation_file_lock(
         let error = std::io::Error::last_os_error();
         if error.kind() != std::io::ErrorKind::Interrupted {
             return Err(crate::io(
-                "locking manager-library directory mutation authority",
+                "locking Manager-root directory mutation authority",
             )(error));
         }
     }
-
-    let after = fstat_retry(fd).map_err(crate::io(
-        "revalidating locked manager-library directory identity",
-    ))?;
-    let dot = std::ffi::CString::new(".").expect("literal contains no NUL");
-    let named = fstatat_retry(fd, &dot, libc::AT_SYMLINK_NOFOLLOW).map_err(crate::io(
-        "revalidating locked manager-library directory through fstatat",
-    ))?;
-    if before.st_dev != after.st_dev
-        || before.st_ino != after.st_ino
-        || after.st_dev != named.st_dev
-        || after.st_ino != named.st_ino
-        || after.st_mode & libc::S_IFMT != libc::S_IFDIR
-        || named.st_mode & libc::S_IFMT != libc::S_IFDIR
-    {
-        return Err(crate::ModError::Other(format!(
-            "manager-library directory identity changed or became unsafe while waiting for its inode lock: {}",
-            library.path().display()
-        )));
-    }
-
-    Ok(LibraryMutationFileGuard { root: library })
+    let lock = ManagerRootLock {
+        root: prepared.root,
+    };
+    lock.revalidate_named()?;
+    Ok(lock)
 }
 
 #[cfg(not(any(windows, unix)))]
-fn acquire_library_mutation_file_lock(
-    _library: SecureDirectory,
-) -> crate::Result<LibraryMutationFileGuard> {
+fn acquire_prepared_manager_root(
+    _prepared: PreparedManagerRootLock,
+) -> crate::Result<ManagerRootLock> {
     Err(crate::ModError::Other(
-        "manager-library cross-process locking is unsupported on this platform".into(),
+        "Manager-root cross-process locking is unsupported on this platform".into(),
     ))
+}
+
+impl ManagerRootLock {
+    /// Reopen the canonical named root (and Windows sentinel) and require that both still identify
+    /// the retained objects. This is called after every blocking acquire and again after the full
+    /// composite set is owned.
+    pub(crate) fn revalidate_named(&self) -> crate::Result<()> {
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt as _;
+            use windows_sys::Win32::Storage::FileSystem::{
+                FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, FILE_SHARE_WRITE,
+            };
+
+            if identity_from_open_file(&self.sentinel, "retained Manager-root lock")?
+                != self.sentinel_identity
+            {
+                return Err(crate::ModError::Other(
+                    "retained Manager-root sentinel changed filesystem identity".into(),
+                ));
+            }
+            let named_root = open_directory_rename_compatible(
+                self.root.path(),
+                "named Manager mutation root",
+            )?;
+            if named_root.identity() != self.root.identity() {
+                return Err(crate::ModError::Other(format!(
+                    "Manager root changed named filesystem identity while locking: {}",
+                    self.root.path().display()
+                )));
+            }
+            let named_file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+                .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+                .open(&self.sentinel_path)
+                .map_err(crate::io("reopening named Manager-root lock"))?;
+            let named = finish_opened_windows_node(
+                &self.sentinel_path,
+                "named Manager-root lock",
+                named_file,
+            )?;
+            if named.identity != self.sentinel_identity
+                || !handle_path_is_direct_child(self.root.path(), &named.final_path)
+            {
+                return Err(crate::ModError::Other(format!(
+                    "Manager-root sentinel changed named filesystem identity: {}",
+                    self.sentinel_path.display()
+                )));
+            }
+        }
+
+        #[cfg(unix)]
+        {
+            let retained = identity_from_open_file(
+                &self.root.anchor.file,
+                "retained Manager mutation root",
+            )?;
+            let named = open_directory_nofollow(self.root.path(), "named Manager mutation root")?;
+            if retained != self.root.identity() || named.identity() != self.root.identity() {
+                return Err(crate::ModError::Other(format!(
+                    "Manager root changed named filesystem identity while locking: {}",
+                    self.root.path().display()
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Acquire a complete root set in one global physical order. Equal roots are an invalid Manager
+/// configuration, not a deduplication opportunity: a loadout file is not a Library entry.
+pub(crate) fn acquire_manager_root_locks(
+    mut prepared: Vec<PreparedManagerRootLock>,
+) -> crate::Result<Vec<ManagerRootLock>> {
+    prepared.sort_by_key(PreparedManagerRootLock::identity);
+    if prepared
+        .windows(2)
+        .any(|pair| pair[0].identity() == pair[1].identity())
+    {
+        return Err(crate::ModError::Other(
+            "manager loadout parent and library root must be different directories".into(),
+        ));
+    }
+    let mut locked = Vec::with_capacity(prepared.len());
+    for root in prepared {
+        locked.push(acquire_prepared_manager_root(root)?);
+        if locked.len() == 1 {
+            run_manager_first_root_lock_hook()?;
+        }
+    }
+    for root in &locked {
+        root.revalidate_named()?;
+    }
+    Ok(locked)
 }
 
 /// Canonical manager-library root used to prove that entry and payload paths stay inside the
@@ -1766,7 +2025,6 @@ impl LibraryRoot {
         Ok(Self { directory })
     }
 
-    #[cfg(any(not(unix), test))]
     pub(crate) fn identity(&self) -> FileIdentity {
         self.directory.identity()
     }
@@ -1776,12 +2034,27 @@ impl LibraryRoot {
         &self.directory
     }
 
-    /// Acquire the per-library kernel lock. Canonical aliases converge on the same Windows lock
-    /// file or Unix directory inode. Windows additionally retains FileIdInfo for immediate
-    /// pathname revalidation; this is cooperative-process coordination, not hostile same-user
-    /// access control.
-    pub(crate) fn acquire_mutation_lock(self) -> crate::Result<LibraryMutationFileGuard> {
-        acquire_library_mutation_file_lock(self.directory)
+    /// Prepare this root for canonical-order acquisition. This does not wait on a kernel lock.
+    pub(crate) fn prepare_mutation_lock(
+        self,
+        create_lock_file: bool,
+    ) -> crate::Result<PreparedManagerRootLock> {
+        prepare_manager_root_lock(self.directory, create_lock_file)
+    }
+
+    /// Standalone Library/Identity transaction using the same universal root protocol as Store.
+    pub(crate) fn acquire_mutation_lock(self) -> crate::Result<ManagerRootLock> {
+        let prepared = self.prepare_mutation_lock(true)?;
+        acquire_manager_root_locks(vec![prepared]).map(|mut roots| roots.remove(0))
+    }
+
+    /// Read-only callers may join an already-established Windows mutation lane but must not
+    /// create its persistent sentinel. Unix uses the same retained directory-inode flock.
+    pub(crate) fn acquire_existing_mutation_lock(
+        self,
+    ) -> crate::Result<ManagerRootLock> {
+        let prepared = self.prepare_mutation_lock(false)?;
+        acquire_manager_root_locks(vec![prepared]).map(|mut roots| roots.remove(0))
     }
 
     /// Resolve `id` as one real, direct library child. A safe lexical component is necessary but
@@ -2674,6 +2947,21 @@ pub enum RawTarget {
 mod tests {
     use super::*;
     use std::io::Write as _;
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_nofollow_uses_directory_only_open_semantics() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("not-a-directory");
+        std::fs::write(&file, b"bytes").unwrap();
+        let error = open_directory_nofollow(&file, "test Manager root")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("O_DIRECTORY") || error.contains("Not a directory"),
+            "{error}"
+        );
+    }
 
     #[test]
     fn footprint_coverage_matrix_is_conservative_and_derived() {

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -3094,6 +3094,9 @@ mod tests {
     fn preflight_never_reconciles_replacing_artifacts() {
         let install = install_fixture();
         let library = install.path().join("library");
+        let loadout = install.path().join("loadout.json");
+        let store_lock = install.path().join(".gore-manager-library.lock");
+        let library_lock = library.join(".gore-manager-library.lock");
         let replacing = library.join(".replacing-preserve-me");
         fs::create_dir_all(&replacing).unwrap();
         let evidence = replacing.join("bytes.bin");
@@ -3103,7 +3106,7 @@ mod tests {
         let _ = run_with(
             install.path(),
             &library,
-            &install.path().join("loadout.json"),
+            &loadout,
             |_, _, _| Ok(ManagerStatus::NothingDeployed),
             |_| safe_probe(),
             |_| Ok(false),
@@ -3111,5 +3114,14 @@ mod tests {
 
         assert!(replacing.is_dir());
         assert_eq!(fs::read(&evidence).unwrap(), before);
+        assert!(!loadout.exists(), "preflight must not create a loadout");
+        assert!(
+            !store_lock.exists(),
+            "preflight must not acquire or create the Windows Store lock artifact"
+        );
+        assert!(
+            !library_lock.exists(),
+            "preflight must not acquire or create the Windows Library lock artifact"
+        );
     }
 }

--- a/crates/gore-mod/src/mgr/store.rs
+++ b/crates/gore-mod/src/mgr/store.rs
@@ -1,0 +1,1954 @@
+//! Serialized Manager store snapshots.
+//!
+//! The loadout and library remain two explicit filesystem commits.  This module coordinates
+//! every loadout read/modify/write with a crash-released operating-system lock and reconciles a
+//! valid loadout against one strict, recovery-complete library snapshot.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use super::loadout::{self, Loadout, LoadoutEntry};
+use super::model::{
+    acquire_manager_root_locks, manager_process_lock, prepare_existing_manager_root_lock,
+    validate_library_id, ManagerRootLock, ModEntryMeta,
+};
+
+const MAX_LOADOUT_BYTES: u64 = 1024 * 1024;
+#[cfg(test)]
+const STORE_LOCK_FILE: &str = super::model::MANAGER_ROOT_LOCK_FILE;
+#[cfg(test)]
+const STORE_LOCK_MARKER_ENV: &str = "GORE_TEST_STORE_LOCK_MARKER";
+#[cfg(test)]
+const STORE_LOCK_HOLD_MS_ENV: &str = "GORE_TEST_STORE_LOCK_HOLD_MS";
+
+#[cfg(test)]
+thread_local! {
+    static LOAD_RACE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+    #[cfg(unix)]
+    static LOAD_OPEN_RACE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+    static BOOTSTRAP_RACE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+    #[cfg(unix)]
+    static PARENT_LOCK_RACE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn inject_load_race(hook: impl FnOnce() + 'static) {
+    LOAD_RACE_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+fn inject_load_open_race(hook: impl FnOnce() + 'static) {
+    LOAD_OPEN_RACE_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+fn run_load_open_race_hook() {
+    LOAD_OPEN_RACE_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(test)]
+fn run_load_race_hook() {
+    LOAD_RACE_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(test)]
+fn inject_bootstrap_race(hook: impl FnOnce() + 'static) {
+    BOOTSTRAP_RACE_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(test)]
+fn run_bootstrap_race_hook() {
+    BOOTSTRAP_RACE_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_bootstrap_race_hook() {}
+
+#[cfg(all(test, unix))]
+fn inject_parent_lock_race(hook: impl FnOnce() + 'static) {
+    PARENT_LOCK_RACE_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+fn run_parent_lock_race_hook() {
+    PARENT_LOCK_RACE_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(any(not(test), not(unix)))]
+fn run_parent_lock_race_hook() {}
+
+#[cfg(not(test))]
+fn run_load_race_hook() {}
+
+#[cfg(not(all(test, unix)))]
+fn run_load_open_race_hook() {}
+
+pub struct StoreSnapshot {
+    _kernel: KernelStoreLock,
+    loadout_path: PathBuf,
+    library: super::import::StrictLibrarySnapshot,
+    loadout: Loadout,
+}
+
+/// Doctor's advisory projection. It holds only the Library lane, never creates/acquires the Store
+/// sentinel, reconciles in memory, and exposes the same target semantics as Manager status.
+pub struct ReadOnlyStoreInspection {
+    library: super::import::StrictLibrarySnapshot,
+    loadout: Loadout,
+}
+
+/// Which input prevented Doctor from constructing an authoritative, read-only target.
+///
+/// Keeping the stages distinct matters because a strict Library refusal is not evidence that the
+/// user's loadout is corrupt and must never produce advice to delete or repair that loadout.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreInspectionError {
+    #[error("manager library could not be inspected safely: {0}")]
+    Library(#[source] crate::ModError),
+    #[error("manager loadout could not be read: {0}")]
+    Loadout(#[source] crate::ModError),
+}
+
+/// Failure after a read-only projection was built. Library stability is kept separate from the
+/// ordinary deployment-status result so Doctor never blames the deploy record for a Library race.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreInspectionStatusError {
+    #[error("manager library changed during status inspection: {0}")]
+    Library(#[source] crate::ModError),
+    #[error("manager deployment status could not be inspected: {0}")]
+    Status(#[source] crate::ModError),
+}
+
+impl StoreSnapshot {
+    /// Lock the canonical loadout target, take one strict library snapshot, and repair only a
+    /// valid loadout.  Corrupt/future loadouts are returned as errors without rewriting bytes.
+    pub fn open(library_dir: &Path, loadout_path: &Path) -> crate::Result<Self> {
+        let process = manager_process_lock();
+        let (parent_path, canonical_loadout) = canonical_parent(loadout_path)?;
+        let mut store_prepared =
+            prepare_existing_manager_root_lock(&parent_path, "manager store parent", true)?;
+
+        // A missing Library cannot be prepared for composite locking. Serialize bootstrap on the
+        // Store root first, read the authoritative loadout there, and refuse any persisted intent
+        // before creating an empty Library that reconciliation would otherwise erase.
+        let mut bootstrapped_library = false;
+        if !path_exists_no_follow(library_dir)? {
+            let mut initial = acquire_manager_root_locks(vec![store_prepared])?;
+            let initial_store = KernelStoreLock::new(initial.remove(0));
+            let loadout = initial_store.load(&canonical_loadout)?;
+            if !loadout.entries.is_empty() {
+                return Err(crate::ModError::Other(format!(
+                    "manager library is missing while the persisted loadout still contains {} entry or entries: {}",
+                    loadout.entries.len(),
+                    library_dir.display()
+                )));
+            }
+            drop(initial_store);
+            run_bootstrap_race_hook();
+            if !path_exists_no_follow(library_dir)? {
+                std::fs::create_dir_all(library_dir).map_err(crate::io(
+                    "creating manager library during empty-store bootstrap",
+                ))?;
+                bootstrapped_library = true;
+            }
+            store_prepared =
+                prepare_existing_manager_root_lock(&parent_path, "manager store parent", true)?;
+        }
+
+        let store_identity = store_prepared.identity();
+        let library_prepared = super::import::StrictLibrarySnapshot::prepare(library_dir)?;
+        let library_identity = library_prepared.identity();
+        let mut roots = acquire_manager_root_locks(vec![store_prepared, library_prepared])?;
+        let store_index = roots
+            .iter()
+            .position(|root| root.identity() == store_identity)
+            .expect("acquired root set retains Store identity");
+        let kernel = KernelStoreLock::new(roots.remove(store_index));
+        let library_index = roots
+            .iter()
+            .position(|root| root.identity() == library_identity)
+            .expect("acquired root set retains Library identity");
+        let library_root = roots.remove(library_index);
+        debug_assert!(roots.is_empty());
+        run_parent_lock_race_hook();
+        run_store_lock_acquired_hook()?;
+        let library = super::import::StrictLibrarySnapshot::from_prelocked(process, library_root)?;
+        let loadout = kernel.load(&canonical_loadout)?;
+        if bootstrapped_library && !loadout.entries.is_empty() {
+            return Err(crate::ModError::Other(
+                "manager loadout gained persisted entries during missing-library bootstrap; the loadout was left untouched"
+                    .into(),
+            ));
+        }
+        let reconciled = reconcile(library.mods(), &loadout)?;
+        if reconciled != loadout {
+            kernel.save(&canonical_loadout, &reconciled)?;
+        }
+        Ok(Self {
+            _kernel: kernel,
+            loadout_path: canonical_loadout,
+            library,
+            loadout: reconciled,
+        })
+    }
+
+    pub fn inspect_read_only(
+        library_dir: &Path,
+        loadout_path: &Path,
+    ) -> Result<ReadOnlyStoreInspection, StoreInspectionError> {
+        // Library is deliberately the only root here. Cooperative Store writers hold the same
+        // universal Library-root lock through save, irrespective of composite physical order.
+        let library = super::import::StrictLibrarySnapshot::inspect_read_only(library_dir)
+            .map_err(StoreInspectionError::Library)?;
+        let loadout =
+            load_loadout_read_only(loadout_path).map_err(StoreInspectionError::Loadout)?;
+        if library.is_missing() && !loadout.entries.is_empty() {
+            // An absent Library has no existing kernel object Doctor can lock without creating an
+            // artifact. The retained process guard excludes local writers; this stability check
+            // catches a cooperative external writer that published the root while the bounded
+            // loadout was read. Persisted intent is never reconciled to an empty target.
+            library
+                .verify_read_only_stable()
+                .map_err(StoreInspectionError::Library)?;
+            return Err(StoreInspectionError::Library(crate::ModError::Other(
+                format!(
+                    "manager library is missing while the persisted loadout still contains {} entry or entries: {}",
+                    loadout.entries.len(),
+                    library_dir.display()
+                ),
+            )));
+        }
+        let reconciled =
+            reconcile(library.mods(), &loadout).map_err(StoreInspectionError::Library)?;
+        library
+            .verify_read_only_stable()
+            .map_err(StoreInspectionError::Library)?;
+        Ok(ReadOnlyStoreInspection {
+            library,
+            loadout: reconciled,
+        })
+    }
+
+    pub fn mods(&self) -> &[ModEntryMeta] {
+        self.library.mods()
+    }
+
+    pub fn loadout(&self) -> &Loadout {
+        &self.loadout
+    }
+
+    pub fn analyze(&self) -> Vec<super::analyze::Conflict> {
+        let refs = self.library.mods().iter().collect::<Vec<_>>();
+        super::analyze::analyze(&refs, &self.loadout)
+    }
+
+    pub fn apply(&self, game_root: &Path) -> crate::Result<super::apply::ApplyReport> {
+        super::apply::apply_loadout_after_store_snapshot(
+            game_root,
+            self.library.path(),
+            &self.loadout,
+        )
+    }
+
+    pub fn status(&self, game_root: &Path) -> crate::Result<super::status::ManagerStatus> {
+        super::status::status(game_root, self.library.path(), &self.loadout)
+    }
+
+    /// Persist an explicit whole-loadout edit while the store is locked. Existing entry edits are
+    /// last-writer-wins; concurrently published library ids are still appended disabled.
+    pub fn replace_loadout(&mut self, replacement: Loadout) -> crate::Result<()> {
+        replacement.validate()?;
+        let reconciled = reconcile(self.library.mods(), &replacement)?;
+        if reconciled != self.loadout {
+            self._kernel.save(&self.loadout_path, &reconciled)?;
+            self.loadout = reconciled;
+        }
+        Ok(())
+    }
+
+    pub fn update_loadout(
+        &mut self,
+        update: impl FnOnce(&mut Loadout) -> crate::Result<()>,
+    ) -> crate::Result<()> {
+        let mut next = self.loadout.clone();
+        update(&mut next)?;
+        self.replace_loadout(next)
+    }
+}
+
+impl ReadOnlyStoreInspection {
+    pub fn loadout(&self) -> &Loadout {
+        &self.loadout
+    }
+
+    pub fn status(
+        &self,
+        game_root: &Path,
+    ) -> Result<super::status::ManagerStatus, StoreInspectionStatusError> {
+        let result = super::status::status(game_root, self.library.path(), &self.loadout)
+            .map_err(StoreInspectionStatusError::Status);
+        self.library
+            .verify_read_only_stable()
+            .map_err(StoreInspectionStatusError::Library)?;
+        result
+    }
+}
+
+fn id_key(id: &str) -> String {
+    #[cfg(windows)]
+    {
+        // Mirror the conservative portable Windows name identity used by import. Windows maps
+        // names through an uppercase table; lowercase misses aliases such as Greek final sigma.
+        id.to_uppercase()
+    }
+    #[cfg(not(windows))]
+    {
+        id.to_owned()
+    }
+}
+
+fn reconcile(mods: &[ModEntryMeta], loadout: &Loadout) -> crate::Result<Loadout> {
+    let mut canonical = BTreeMap::<String, String>::new();
+    for meta in mods {
+        validate_library_id(&meta.id)?;
+        let key = id_key(&meta.id);
+        if canonical.insert(key, meta.id.clone()).is_some() {
+            return Err(crate::ModError::Other(format!(
+                "manager library contains ambiguous ids for {:?}",
+                meta.id
+            )));
+        }
+    }
+
+    let mut seen = HashSet::<String>::new();
+    let mut entries = Vec::with_capacity(canonical.len());
+    for entry in &loadout.entries {
+        let key = id_key(&entry.id);
+        let Some(id) = canonical.get(&key) else {
+            continue;
+        };
+        if seen.insert(key) {
+            entries.push(LoadoutEntry {
+                id: id.clone(),
+                enabled: entry.enabled,
+            });
+        }
+    }
+    let mut missing = canonical
+        .into_iter()
+        .filter(|(key, _)| !seen.contains(key))
+        .map(|(_, id)| id)
+        .collect::<Vec<_>>();
+    missing.sort();
+    entries.extend(
+        missing
+            .into_iter()
+            .map(|id| LoadoutEntry { id, enabled: false }),
+    );
+    let reconciled = Loadout {
+        format: loadout.format,
+        entries,
+    };
+    reconciled.validate()?;
+    Ok(reconciled)
+}
+
+fn path_exists_no_follow(path: &Path) -> crate::Result<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(crate::io(&format!(
+            "inspecting manager path {}",
+            path.display()
+        ))(error)),
+    }
+}
+
+fn canonical_parent(path: &Path) -> crate::Result<(PathBuf, PathBuf)> {
+    let file_name = path.file_name().ok_or_else(|| {
+        crate::ModError::Other(format!("loadout path has no file name: {}", path.display()))
+    })?;
+    let parent = path.parent().ok_or_else(|| {
+        crate::ModError::Other(format!("loadout path has no parent: {}", path.display()))
+    })?;
+    // A child path such as `loadout.json` has an empty parent component. Filesystem APIs do not
+    // consistently treat that spelling as the current directory, so normalize it explicitly.
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    std::fs::create_dir_all(parent).map_err(crate::io("creating manager store directory"))?;
+    let parent = std::fs::canonicalize(parent).map_err(crate::io(&format!(
+        "resolving manager store directory {}",
+        parent.display()
+    )))?;
+    // The configured parent may be an intentional alias, but the loadout itself is always opened
+    // no-follow. Canonicalizing an existing final component here would silently bless a symlink.
+    let canonical = parent.join(file_name);
+    if canonical.file_name().is_some_and(|name| {
+        #[cfg(windows)]
+        {
+            name.to_string_lossy()
+                .eq_ignore_ascii_case(super::model::MANAGER_ROOT_LOCK_FILE)
+        }
+        #[cfg(not(windows))]
+        {
+            name == super::model::MANAGER_ROOT_LOCK_FILE
+        }
+    }) {
+        return Err(crate::ModError::Other(format!(
+            "loadout path collides with reserved manager store lock: {}",
+            canonical.display()
+        )));
+    }
+    let canonical_parent = canonical.parent().ok_or_else(|| {
+        crate::ModError::Other(format!(
+            "canonical loadout target has no parent: {}",
+            canonical.display()
+        ))
+    })?;
+    Ok((canonical_parent.to_path_buf(), canonical))
+}
+
+fn canonical_loadout_for_read(path: &Path) -> crate::Result<Option<PathBuf>> {
+    let file_name = path.file_name().ok_or_else(|| {
+        crate::ModError::Other(format!("loadout path has no file name: {}", path.display()))
+    })?;
+    let parent = path.parent().ok_or_else(|| {
+        crate::ModError::Other(format!("loadout path has no parent: {}", path.display()))
+    })?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    let parent = match std::fs::canonicalize(parent) {
+        Ok(parent) => parent,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(crate::io(&format!(
+                "resolving manager store directory {}",
+                parent.display()
+            ))(error))
+        }
+    };
+    Ok(Some(parent.join(file_name)))
+}
+
+fn load_loadout_read_only(path: &Path) -> crate::Result<Loadout> {
+    let Some(path) = canonical_loadout_for_read(path)? else {
+        return Ok(Loadout::default());
+    };
+    match std::fs::symlink_metadata(&path) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Loadout::default()),
+        Err(error) => return Err(crate::io("inspecting manager loadout")(error)),
+    }
+    let mut file = super::model::open_file_nofollow(&path, "manager loadout")?;
+    run_load_race_hook();
+    let bytes = file.read_all_bounded("manager loadout", MAX_LOADOUT_BYTES)?;
+    loadout::parse_bytes(&bytes)
+}
+
+#[cfg(test)]
+fn run_store_lock_acquired_hook() -> crate::Result<()> {
+    if let Some(marker) = std::env::var_os(STORE_LOCK_MARKER_ENV) {
+        std::fs::write(marker, b"locked").map_err(crate::io("writing store-lock marker"))?;
+    }
+    if let Ok(raw) = std::env::var(STORE_LOCK_HOLD_MS_ENV) {
+        let milliseconds = raw.parse::<u64>().map_err(|error| {
+            crate::ModError::Other(format!("invalid store-lock hold duration {raw:?}: {error}"))
+        })?;
+        std::thread::sleep(std::time::Duration::from_millis(milliseconds));
+    }
+    Ok(())
+}
+
+#[cfg(not(test))]
+fn run_store_lock_acquired_hook() -> crate::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+#[derive(Debug)]
+struct KernelStoreLock {
+    root: ManagerRootLock,
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WindowsFileIdentity {
+    volume: u64,
+    id: [u8; 16],
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WindowsFileRevision {
+    last_write_time: i64,
+    change_time: i64,
+}
+
+#[cfg(windows)]
+fn windows_file_identity(file: &std::fs::File, label: &str) -> crate::Result<WindowsFileIdentity> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileIdInfo, GetFileInformationByHandleEx, FILE_ID_INFO,
+    };
+    let mut info = FILE_ID_INFO::default();
+    let ok = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileIdInfo,
+            (&mut info as *mut FILE_ID_INFO).cast(),
+            std::mem::size_of::<FILE_ID_INFO>() as u32,
+        )
+    };
+    if ok == 0 {
+        return Err(crate::io(&format!("querying {label} identity"))(
+            std::io::Error::last_os_error(),
+        ));
+    }
+    Ok(WindowsFileIdentity {
+        volume: info.VolumeSerialNumber,
+        id: info.FileId.Identifier,
+    })
+}
+
+#[cfg(windows)]
+fn windows_file_revision(file: &std::fs::File, label: &str) -> crate::Result<WindowsFileRevision> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileBasicInfo, GetFileInformationByHandleEx, FILE_BASIC_INFO,
+    };
+    let mut info = FILE_BASIC_INFO::default();
+    let ok = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileBasicInfo,
+            (&mut info as *mut FILE_BASIC_INFO).cast(),
+            std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    };
+    if ok == 0 {
+        return Err(crate::io(&format!("querying {label} revision"))(
+            std::io::Error::last_os_error(),
+        ));
+    }
+    Ok(WindowsFileRevision {
+        last_write_time: info.LastWriteTime,
+        change_time: info.ChangeTime,
+    })
+}
+
+#[cfg(windows)]
+fn windows_metadata_is_reparse(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+    metadata.file_attributes() & 0x400 != 0
+}
+
+#[cfg(windows)]
+impl KernelStoreLock {
+    fn new(root: ManagerRootLock) -> Self {
+        Self { root }
+    }
+
+    fn revalidate(&self) -> crate::Result<()> {
+        self.root.revalidate_named()
+    }
+
+    fn load(&self, path: &Path) -> crate::Result<Loadout> {
+        use std::io::Read as _;
+        use std::os::windows::fs::OpenOptionsExt as _;
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
+        };
+        self.revalidate()?;
+        let result = (|| -> crate::Result<Loadout> {
+            run_load_open_race_hook();
+            let mut file = match std::fs::OpenOptions::new()
+                .read(true)
+                .share_mode(FILE_SHARE_READ)
+                .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+                .open(path)
+            {
+                Ok(file) => file,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(Loadout::default())
+                }
+                Err(error) => return Err(crate::io("opening locked manager loadout")(error)),
+            };
+            let metadata = file
+                .metadata()
+                .map_err(crate::io("reading locked manager loadout metadata"))?;
+            if !metadata.is_file() || windows_metadata_is_reparse(&metadata) {
+                return Err(crate::ModError::Other(format!(
+                    "manager loadout is not a real regular file: {}",
+                    path.display()
+                )));
+            }
+            if metadata.len() > MAX_LOADOUT_BYTES {
+                return Err(crate::ModError::Other(format!(
+                    "loadout exceeds the {MAX_LOADOUT_BYTES}-byte limit: {}",
+                    path.display()
+                )));
+            }
+            let identity = windows_file_identity(&file, "manager loadout")?;
+            let revision = windows_file_revision(&file, "manager loadout")?;
+            run_load_race_hook();
+            let mut bytes = Vec::new();
+            bytes
+                .try_reserve_exact(metadata.len() as usize)
+                .map_err(|_| {
+                    crate::ModError::Other("could not reserve bounded loadout bytes".into())
+                })?;
+            file.by_ref()
+                .take(MAX_LOADOUT_BYTES + 1)
+                .read_to_end(&mut bytes)
+                .map_err(crate::io("reading locked manager loadout"))?;
+            let after = file
+                .metadata()
+                .map_err(crate::io("rechecking locked manager loadout metadata"))?;
+            if bytes.len() as u64 > MAX_LOADOUT_BYTES
+                || bytes.len() as u64 != after.len()
+                || metadata.len() != after.len()
+                || windows_file_identity(&file, "manager loadout")? != identity
+                || windows_file_revision(&file, "manager loadout")? != revision
+            {
+                return Err(crate::ModError::Other(format!(
+                    "manager loadout changed or exceeded its bound while being read: {}",
+                    path.display()
+                )));
+            }
+            loadout::parse_bytes(&bytes)
+        })();
+        self.revalidate()?;
+        result
+    }
+
+    fn save(&self, path: &Path, value: &Loadout) -> crate::Result<()> {
+        self.revalidate()?;
+        let bytes = loadout::serialized_bytes(value)?;
+        if bytes.len() as u64 > MAX_LOADOUT_BYTES {
+            return Err(crate::ModError::Other(format!(
+                "loadout serialization exceeds the {MAX_LOADOUT_BYTES}-byte limit"
+            )));
+        }
+        let result = crate::atomic_write(path, &bytes);
+        self.revalidate()?;
+        result
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct KernelStoreLock {
+    root: ManagerRootLock,
+}
+
+#[cfg(unix)]
+fn unix_child_name(path: &Path, label: &str) -> crate::Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt as _;
+    let name = path.file_name().ok_or_else(|| {
+        crate::ModError::Other(format!("{label} has no file name: {}", path.display()))
+    })?;
+    std::ffi::CString::new(name.as_bytes()).map_err(|_| {
+        crate::ModError::Other(format!(
+            "{label} file name contains NUL: {}",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(unix)]
+fn openat_retry(
+    directory: std::os::unix::io::RawFd,
+    name: &std::ffi::CStr,
+    flags: i32,
+    mode: libc::mode_t,
+) -> std::io::Result<std::os::unix::io::RawFd> {
+    loop {
+        let fd = unsafe { libc::openat(directory, name.as_ptr(), flags, mode) };
+        if fd >= 0 {
+            return Ok(fd);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn renameat_retry(
+    directory: std::os::unix::io::RawFd,
+    from: &std::ffi::CStr,
+    to: &std::ffi::CStr,
+) -> std::io::Result<()> {
+    loop {
+        if unsafe { libc::renameat(directory, from.as_ptr(), directory, to.as_ptr()) } == 0 {
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn unlinkat_file(directory: std::os::unix::io::RawFd, name: &std::ffi::CStr) {
+    loop {
+        if unsafe { libc::unlinkat(directory, name.as_ptr(), 0) } == 0 {
+            return;
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return;
+        }
+    }
+}
+
+#[cfg(unix)]
+impl KernelStoreLock {
+    fn new(root: ManagerRootLock) -> Self {
+        Self { root }
+    }
+
+    fn parent(&self) -> &std::fs::File {
+        self.root.directory_file()
+    }
+
+    fn revalidate(&self) -> crate::Result<()> {
+        self.root.revalidate_named()
+    }
+
+    fn load(&self, path: &Path) -> crate::Result<Loadout> {
+        use std::io::Read as _;
+        use std::os::unix::fs::MetadataExt as _;
+        use std::os::unix::io::{AsRawFd as _, FromRawFd as _};
+
+        self.revalidate()?;
+        let result = (|| -> crate::Result<Loadout> {
+            run_load_open_race_hook();
+            let name = unix_child_name(path, "manager loadout")?;
+            let fd = match openat_retry(
+                self.parent().as_raw_fd(),
+                &name,
+                libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+                0,
+            ) {
+                Ok(fd) => fd,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(Loadout::default())
+                }
+                Err(error) => return Err(crate::io("opening locked manager loadout")(error)),
+            };
+            let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+            let before = file
+                .metadata()
+                .map_err(crate::io("reading locked manager loadout metadata"))?;
+            if !before.is_file() {
+                return Err(crate::ModError::Other(format!(
+                    "manager loadout is not a regular file: {}",
+                    path.display()
+                )));
+            }
+            if before.len() > MAX_LOADOUT_BYTES {
+                return Err(crate::ModError::Other(format!(
+                    "loadout exceeds the {MAX_LOADOUT_BYTES}-byte limit: {}",
+                    path.display()
+                )));
+            }
+            run_load_race_hook();
+            let mut bytes = Vec::new();
+            bytes
+                .try_reserve_exact(before.len() as usize)
+                .map_err(|_| {
+                    crate::ModError::Other("could not reserve bounded loadout bytes".into())
+                })?;
+            file.by_ref()
+                .take(MAX_LOADOUT_BYTES + 1)
+                .read_to_end(&mut bytes)
+                .map_err(crate::io("reading locked manager loadout"))?;
+            let after = file
+                .metadata()
+                .map_err(crate::io("rechecking locked manager loadout metadata"))?;
+            if bytes.len() as u64 > MAX_LOADOUT_BYTES
+                || before.dev() != after.dev()
+                || before.ino() != after.ino()
+                || before.len() != after.len()
+                || before.mtime() != after.mtime()
+                || before.mtime_nsec() != after.mtime_nsec()
+                || before.ctime() != after.ctime()
+                || before.ctime_nsec() != after.ctime_nsec()
+                || bytes.len() as u64 != after.len()
+            {
+                return Err(crate::ModError::Other(format!(
+                    "manager loadout changed or exceeded its bound while being read: {}",
+                    path.display()
+                )));
+            }
+            loadout::parse_bytes(&bytes)
+        })();
+        self.revalidate()?;
+        result
+    }
+
+    fn save(&self, path: &Path, value: &Loadout) -> crate::Result<()> {
+        use std::io::Write as _;
+        use std::os::unix::io::{AsRawFd as _, FromRawFd as _};
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        self.revalidate()?;
+        let result = (|| -> crate::Result<()> {
+            let bytes = loadout::serialized_bytes(value)?;
+            if bytes.len() as u64 > MAX_LOADOUT_BYTES {
+                return Err(crate::ModError::Other(format!(
+                    "loadout serialization exceeds the {MAX_LOADOUT_BYTES}-byte limit"
+                )));
+            }
+            #[cfg(test)]
+            if crate::take_injected_atomic_write_failure(path) {
+                return Err(crate::ModError::Other(format!(
+                    "injected atomic-write failure for {}",
+                    path.display()
+                )));
+            }
+            static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+            let destination = unix_child_name(path, "manager loadout")?;
+            let directory = self.parent().as_raw_fd();
+            let (temp_name, mut temp) = loop {
+                let suffix = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+                let raw = format!(".gore-loadout-{}-{suffix}.pending", std::process::id());
+                let name = std::ffi::CString::new(raw).expect("generated name contains no NUL");
+                match openat_retry(
+                    directory,
+                    &name,
+                    libc::O_WRONLY
+                        | libc::O_CREAT
+                        | libc::O_EXCL
+                        | libc::O_NOFOLLOW
+                        | libc::O_CLOEXEC,
+                    0o600,
+                ) {
+                    Ok(fd) => break (name, unsafe { std::fs::File::from_raw_fd(fd) }),
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => {
+                        return Err(crate::io("creating locked loadout staging file")(error))
+                    }
+                }
+            };
+            let publish = (|| -> crate::Result<()> {
+                temp.write_all(&bytes)
+                    .map_err(crate::io("writing locked loadout staging file"))?;
+                temp.sync_all()
+                    .map_err(crate::io("syncing locked loadout staging file"))?;
+                drop(temp);
+                renameat_retry(directory, &temp_name, &destination)
+                    .map_err(crate::io("publishing locked manager loadout"))?;
+                self.parent()
+                    .sync_all()
+                    .map_err(crate::io("syncing manager store directory"))?;
+                Ok(())
+            })();
+            if publish.is_err() {
+                unlinkat_file(directory, &temp_name);
+            }
+            publish
+        })();
+        self.revalidate()?;
+        result
+    }
+}
+
+#[cfg(not(any(windows, unix)))]
+#[derive(Debug)]
+struct KernelStoreLock;
+
+#[cfg(not(any(windows, unix)))]
+impl KernelStoreLock {
+    fn new(_root: ManagerRootLock) -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn meta(id: &str) -> ModEntryMeta {
+        ModEntryMeta {
+            id: id.into(),
+            kind: super::super::model::ModKind::ForeignPak,
+            name: id.into(),
+            version: String::new(),
+            author: String::new(),
+            imported_at: "2026-01-01T00:00:00Z".into(),
+            source: String::new(),
+            components: Vec::new(),
+        }
+    }
+
+    fn write_entry(library: &Path, id: &str) {
+        let entry = library.join(id);
+        fs::create_dir_all(&entry).unwrap();
+        fs::write(
+            entry.join(super::super::model::META_FILE),
+            serde_json::to_vec(&meta(id)).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn write_loadout(path: &Path, entries: &[(&str, bool)]) {
+        loadout::save(
+            path,
+            &Loadout {
+                format: 1,
+                entries: entries
+                    .iter()
+                    .map(|(id, enabled)| LoadoutEntry {
+                        id: (*id).into(),
+                        enabled: *enabled,
+                    })
+                    .collect(),
+            },
+        )
+        .unwrap();
+    }
+
+    fn prepare_read_only_library_lock(library: &Path) {
+        #[cfg(windows)]
+        fs::write(library.join(".gore-manager-library.lock"), b"").unwrap();
+        #[cfg(not(windows))]
+        let _ = library;
+    }
+
+    #[test]
+    fn reconcile_keeps_first_known_slot_and_appends_missing_sorted_disabled() {
+        let loadout = Loadout {
+            format: 1,
+            entries: vec![
+                LoadoutEntry {
+                    id: "b".into(),
+                    enabled: true,
+                },
+                LoadoutEntry {
+                    id: "stale".into(),
+                    enabled: true,
+                },
+                LoadoutEntry {
+                    id: "b".into(),
+                    enabled: false,
+                },
+            ],
+        };
+        assert_eq!(
+            reconcile(&[meta("c"), meta("b"), meta("a")], &loadout)
+                .unwrap()
+                .entries,
+            vec![
+                LoadoutEntry {
+                    id: "b".into(),
+                    enabled: true
+                },
+                LoadoutEntry {
+                    id: "a".into(),
+                    enabled: false
+                },
+                LoadoutEntry {
+                    id: "c".into(),
+                    enabled: false
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn open_repairs_valid_drift_but_never_rewrites_an_equal_loadout() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "a");
+        write_entry(&library, "b");
+        write_loadout(&path, &[("a", true), ("stale", true), ("a", false)]);
+
+        let first = StoreSnapshot::open(&library, &path).unwrap();
+        assert_eq!(
+            first.loadout().entries,
+            vec![
+                LoadoutEntry {
+                    id: "a".into(),
+                    enabled: true
+                },
+                LoadoutEntry {
+                    id: "b".into(),
+                    enabled: false
+                },
+            ]
+        );
+        drop(first);
+
+        // A save would trip this injection. An already-reconciled authoritative read must not
+        // rewrite merely to refresh its timestamp or inode.
+        crate::fail_next_atomic_write(&path);
+        let second = StoreSnapshot::open(&library, &path).unwrap();
+        assert_eq!(second.loadout().entries.len(), 2);
+    }
+
+    #[test]
+    fn read_only_inspection_reconciles_only_in_memory_and_creates_no_store_artifact() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "a");
+        write_entry(&library, "b");
+        prepare_read_only_library_lock(&library);
+        write_loadout(&path, &[("a", true), ("stale", true), ("a", false)]);
+        let before = fs::read(&path).unwrap();
+        crate::fail_next_atomic_write(&path);
+
+        let inspection = StoreSnapshot::inspect_read_only(&library, &path).unwrap();
+        assert_eq!(
+            inspection.loadout().entries,
+            vec![
+                LoadoutEntry {
+                    id: "a".into(),
+                    enabled: true,
+                },
+                LoadoutEntry {
+                    id: "b".into(),
+                    enabled: false,
+                },
+            ]
+        );
+        drop(inspection);
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert!(!temp.path().join(STORE_LOCK_FILE).exists());
+        assert!(!fs::read_dir(temp.path()).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("pending")));
+
+        // The read-only path did not even attempt a save: the injected failure is still armed for
+        // the next writable reconciliation.
+        assert!(StoreSnapshot::open(&library, &path).is_err());
+        assert_eq!(fs::read(&path).unwrap(), before);
+    }
+
+    #[test]
+    fn read_only_inspection_of_missing_store_creates_nothing() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("missing-library");
+        let path = temp.path().join("missing-store").join("loadout.json");
+        let inspection = StoreSnapshot::inspect_read_only(&library, &path).unwrap();
+        assert!(inspection.loadout().entries.is_empty());
+        drop(inspection);
+        assert!(!library.exists());
+        assert!(!path.parent().unwrap().exists());
+        assert!(!temp.path().join(STORE_LOCK_FILE).exists());
+    }
+
+    #[test]
+    fn read_only_inspection_refuses_missing_library_with_persisted_intent_without_artifacts() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("missing-library");
+        let store = temp.path().join("store");
+        let path = store.join("loadout.json");
+        fs::create_dir(&store).unwrap();
+        write_loadout(&path, &[("still-wanted", true)]);
+        let before = fs::read(&path).unwrap();
+
+        let error = match StoreSnapshot::inspect_read_only(&library, &path) {
+            Err(StoreInspectionError::Library(error)) => error.to_string(),
+            Err(error) => panic!("missing Library was classified as {error}"),
+            Ok(_) => panic!("missing Library erased persisted intent in memory"),
+        };
+        assert!(error.contains("library is missing"), "{error}");
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert!(!library.exists());
+        assert!(!store.join(STORE_LOCK_FILE).exists());
+        assert!(!library.join(STORE_LOCK_FILE).exists());
+        assert!(!fs::read_dir(&store).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("pending")));
+    }
+
+    #[test]
+    fn read_only_missing_library_intent_detects_library_appearance_during_load() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("missing-library");
+        let path = temp.path().join("loadout.json");
+        write_loadout(&path, &[("still-wanted", true)]);
+        let before = fs::read(&path).unwrap();
+        let raced_library = library.clone();
+        inject_load_race(move || fs::create_dir(&raced_library).unwrap());
+
+        let error = match StoreSnapshot::inspect_read_only(&library, &path) {
+            Err(StoreInspectionError::Library(error)) => error.to_string(),
+            Err(error) => panic!("Library appearance was classified as {error}"),
+            Ok(_) => panic!("Library appearance was accepted as a stable absent snapshot"),
+        };
+        assert!(error.contains("appeared during"), "{error}");
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert!(!temp.path().join(STORE_LOCK_FILE).exists());
+        assert!(!library.join(STORE_LOCK_FILE).exists());
+    }
+
+    #[test]
+    fn read_only_status_classifies_a_library_that_appears_after_projection() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("missing-library");
+        let path = temp.path().join("loadout.json");
+        let inspection = StoreSnapshot::inspect_read_only(&library, &path).unwrap();
+        fs::create_dir(&library).unwrap();
+
+        let error = inspection.status(temp.path()).unwrap_err();
+        assert!(
+            matches!(error, StoreInspectionStatusError::Library(_)),
+            "{error}"
+        );
+        assert!(!temp.path().join(STORE_LOCK_FILE).exists());
+        assert!(!library.join(".gore-manager-library.lock").exists());
+    }
+
+    #[test]
+    fn read_only_inspection_refuses_replacement_evidence_without_recovery() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "a");
+        prepare_read_only_library_lock(&library);
+        write_loadout(&path, &[("a", true)]);
+        let transaction = library.join(".replacing-read-only-test");
+        fs::create_dir(&transaction).unwrap();
+        let evidence = transaction.join("evidence");
+        fs::write(&evidence, b"keep").unwrap();
+        let before = fs::read(&path).unwrap();
+
+        let error = match StoreSnapshot::inspect_read_only(&library, &path) {
+            Ok(_) => panic!("read-only inspection consumed uncertain replacement state"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("requires recovery"), "{error}");
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert_eq!(fs::read(&evidence).unwrap(), b"keep");
+        assert!(!temp.path().join(STORE_LOCK_FILE).exists());
+    }
+
+    #[test]
+    fn corrupt_or_unsupported_loadout_is_left_byte_exact() {
+        for bytes in [
+            b"{not json".as_slice(),
+            br#"{"format":0,"entries":[]}"#.as_slice(),
+            br#"{"format":2,"entries":[]}"#.as_slice(),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let library = temp.path().join("library");
+            let path = temp.path().join("loadout.json");
+            write_entry(&library, "a");
+            fs::write(&path, bytes).unwrap();
+            assert!(StoreSnapshot::open(&library, &path).is_err());
+            assert_eq!(fs::read(&path).unwrap(), bytes);
+        }
+    }
+
+    #[test]
+    fn loadout_over_one_mib_is_refused_without_rewrite() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        fs::create_dir_all(&library).unwrap();
+        let file = fs::File::create(&path).unwrap();
+        file.set_len(MAX_LOADOUT_BYTES + 1).unwrap();
+        drop(file);
+        let before = fs::metadata(&path).unwrap().len();
+        let error = match StoreSnapshot::open(&library, &path) {
+            Ok(_) => panic!("oversized loadout was accepted"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("1048576-byte limit"), "{error}");
+        assert_eq!(fs::metadata(&path).unwrap().len(), before);
+    }
+
+    #[test]
+    fn same_size_loadout_mutation_is_detected_or_denied_by_the_open_handle() {
+        use std::io::{Seek as _, SeekFrom, Write as _};
+        use std::sync::{Arc, Mutex};
+
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "aaaa");
+        write_loadout(&path, &[("aaaa", true)]);
+        let before = fs::read(&path).unwrap();
+        let replacement = String::from_utf8(before.clone())
+            .unwrap()
+            .replace("aaaa", "bbbb")
+            .into_bytes();
+        assert_eq!(replacement.len(), before.len());
+        let result = Arc::new(Mutex::new(None));
+        let observed = result.clone();
+        let target = path.clone();
+        inject_load_race(move || {
+            let wrote = match fs::OpenOptions::new().write(true).open(&target) {
+                Ok(mut file) => {
+                    file.seek(SeekFrom::Start(0)).unwrap();
+                    file.write_all(&replacement).unwrap();
+                    file.sync_all().unwrap();
+                    true
+                }
+                Err(_) => false,
+            };
+            *observed.lock().unwrap() = Some(wrote);
+        });
+        let opened = StoreSnapshot::open(&library, &path);
+        let writer_succeeded = *result.lock().unwrap();
+        match writer_succeeded {
+            Some(true) => {
+                let error = match opened {
+                    Ok(_) => panic!("same-size mutation escaped revision validation"),
+                    Err(error) => error.to_string(),
+                };
+                assert!(
+                    error.contains("changed") || error.contains("revision"),
+                    "{error}"
+                );
+            }
+            Some(false) => assert!(opened.is_ok(), "denied writer should preserve valid bytes"),
+            None => panic!("load race hook did not run"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn missing_loadout_open_race_revalidates_named_store_root_before_success() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        write_entry(&library, "a");
+        let parent = temp.path().join("store");
+        let retained = temp.path().join("retained-store");
+        let decoy = temp.path().join("decoy-store");
+        fs::create_dir(&parent).unwrap();
+        fs::create_dir(&decoy).unwrap();
+        let requested = parent.join("missing-loadout.json");
+        let hook_parent = parent.clone();
+        let hook_retained = retained.clone();
+        let hook_decoy = decoy.clone();
+        inject_load_open_race(move || {
+            fs::rename(&hook_parent, &hook_retained).unwrap();
+            std::os::unix::fs::symlink(&hook_decoy, &hook_parent).unwrap();
+        });
+
+        let error = match StoreSnapshot::open(&library, &requested) {
+            Ok(_) => panic!("missing-loadout race bypassed named-root post-validation"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("named Manager mutation root")
+                || error.contains("named filesystem identity"),
+            "{error}"
+        );
+        assert!(!retained.join("missing-loadout.json").exists());
+        assert!(!decoy.join("missing-loadout.json").exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[cfg_attr(
+        windows,
+        ignore = "requires Windows symbolic-link privilege; run explicitly on a privileged worker"
+    )]
+    #[test]
+    fn final_loadout_symlink_is_refused_without_following_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let outside = temp.path().join("outside.json");
+        let path = temp.path().join("loadout.json");
+        fs::create_dir_all(&library).unwrap();
+        write_loadout(&outside, &[]);
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, &path).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&outside, &path).unwrap();
+        let before = fs::read(&outside).unwrap();
+        assert!(StoreSnapshot::open(&library, &path).is_err());
+        assert_eq!(fs::read(&outside).unwrap(), before);
+    }
+
+    #[test]
+    fn strict_library_uncertainty_refuses_without_repairing_loadout() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "a");
+        fs::create_dir_all(library.join("broken")).unwrap();
+        fs::write(
+            library.join("broken").join(super::super::model::META_FILE),
+            b"not json",
+        )
+        .unwrap();
+        write_loadout(&path, &[("stale", true)]);
+        let before = fs::read(&path).unwrap();
+
+        let error = match StoreSnapshot::open(&library, &path) {
+            Ok(_) => panic!("strict library accepted a corrupt public entry"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("corrupt") || error.contains("expected"),
+            "{error}"
+        );
+        assert_eq!(fs::read(&path).unwrap(), before);
+    }
+
+    #[test]
+    fn failed_reconciliation_save_preserves_the_previous_loadout() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "a");
+        write_loadout(&path, &[("stale", true)]);
+        let before = fs::read(&path).unwrap();
+        crate::fail_next_atomic_write(&path);
+
+        assert!(StoreSnapshot::open(&library, &path).is_err());
+        assert_eq!(fs::read(&path).unwrap(), before);
+    }
+
+    #[test]
+    fn explicit_replacement_cannot_drop_a_concurrently_published_library_slot() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "a");
+        write_entry(&library, "new");
+        write_loadout(&path, &[("a", false)]);
+
+        let mut store = StoreSnapshot::open(&library, &path).unwrap();
+        store
+            .replace_loadout(Loadout {
+                format: 1,
+                entries: vec![LoadoutEntry {
+                    id: "a".into(),
+                    enabled: true,
+                }],
+            })
+            .unwrap();
+        assert_eq!(
+            store.loadout().entries,
+            vec![
+                LoadoutEntry {
+                    id: "a".into(),
+                    enabled: true
+                },
+                LoadoutEntry {
+                    id: "new".into(),
+                    enabled: false
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn serialized_rmw_preserves_independent_parallel_edits() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "a");
+        write_entry(&library, "b");
+        write_loadout(&path, &[("a", false), ("b", false)]);
+        std::thread::scope(|scope| {
+            for id in ["a", "b"] {
+                let library = library.clone();
+                let path = path.clone();
+                scope.spawn(move || {
+                    let mut store = StoreSnapshot::open(&library, &path).unwrap();
+                    store
+                        .update_loadout(|loadout| {
+                            loadout
+                                .entries
+                                .iter_mut()
+                                .find(|entry| entry.id == id)
+                                .unwrap()
+                                .enabled = true;
+                            Ok(())
+                        })
+                        .unwrap();
+                });
+            }
+        });
+        let final_loadout = loadout::load(&path).unwrap();
+        assert!(final_loadout.entries.iter().all(|entry| entry.enabled));
+    }
+
+    #[test]
+    fn parallel_library_publications_reconcile_without_losing_either_slot() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        let first = temp.path().join("first_P.pak");
+        let second = temp.path().join("second_P.pak");
+        fs::write(&first, b"first").unwrap();
+        fs::write(&second, b"second").unwrap();
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        std::thread::scope(|scope| {
+            for source in [&first, &second] {
+                let barrier = barrier.clone();
+                let library = library.clone();
+                let path = path.clone();
+                scope.spawn(move || {
+                    super::super::import::import(&library, source).unwrap();
+                    barrier.wait();
+                    drop(StoreSnapshot::open(&library, &path).unwrap());
+                });
+            }
+        });
+        let final_loadout = loadout::load(&path).unwrap();
+        assert_eq!(final_loadout.entries.len(), 2);
+        assert!(final_loadout.entries.iter().all(|entry| !entry.enabled));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_loadout_alias_is_rewritten_to_the_library_spelling() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "CaseID");
+        write_loadout(&path, &[("caseid", true)]);
+        let store = StoreSnapshot::open(&library, &path).unwrap();
+        assert_eq!(store.loadout().entries[0].id, "CaseID");
+        assert!(store.loadout().entries[0].enabled);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_final_sigma_alias_preserves_enabled_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let path = temp.path().join("loadout.json");
+        write_entry(&library, "Σ");
+        write_loadout(&path, &[("ς", true)]);
+        let store = StoreSnapshot::open(&library, &path).unwrap();
+        assert_eq!(store.loadout().entries[0].id, "Σ");
+        assert!(store.loadout().entries[0].enabled);
+    }
+
+    #[test]
+    #[ignore = "child-process worker; invoked explicitly by store lock tests"]
+    fn store_lock_child_worker() {
+        let library = PathBuf::from(std::env::var_os("GORE_TEST_CHILD_LIBRARY").unwrap());
+        let loadout = PathBuf::from(std::env::var_os("GORE_TEST_CHILD_LOADOUT").unwrap());
+        match std::env::var("GORE_TEST_CHILD_STORE_MODE")
+            .unwrap_or_else(|_| "lock".into())
+            .as_str()
+        {
+            "lock" => drop(StoreSnapshot::open(&library, &loadout).unwrap()),
+            "enable" => {
+                let id = std::env::var("GORE_TEST_CHILD_STORE_ID").unwrap();
+                let mut store = StoreSnapshot::open(&library, &loadout).unwrap();
+                store
+                    .update_loadout(|loadout| {
+                        loadout
+                            .entries
+                            .iter_mut()
+                            .find(|entry| entry.id == id)
+                            .unwrap()
+                            .enabled = true;
+                        Ok(())
+                    })
+                    .unwrap();
+            }
+            mode => panic!("unknown child store mode {mode:?}"),
+        }
+    }
+
+    fn spawn_store_child(
+        library: &Path,
+        loadout: &Path,
+        marker: &Path,
+        hold_ms: u64,
+        mode: &str,
+        id: Option<&str>,
+    ) -> std::process::Child {
+        let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+        command
+            .arg("store_lock_child_worker")
+            .arg("--ignored")
+            .arg("--nocapture")
+            .env("GORE_TEST_CHILD_LIBRARY", library)
+            .env("GORE_TEST_CHILD_LOADOUT", loadout)
+            .env(STORE_LOCK_MARKER_ENV, marker)
+            .env(STORE_LOCK_HOLD_MS_ENV, hold_ms.to_string())
+            .env("GORE_TEST_CHILD_STORE_MODE", mode)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped());
+        if let Some(id) = id {
+            command.env("GORE_TEST_CHILD_STORE_ID", id);
+        }
+        command.spawn().unwrap()
+    }
+
+    fn spawn_crossed_store_child(
+        library: &Path,
+        loadout: &Path,
+        first_marker: &Path,
+        first_hold_ms: u64,
+    ) -> std::process::Child {
+        std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("store_lock_child_worker")
+            .arg("--ignored")
+            .arg("--nocapture")
+            .env("GORE_TEST_CHILD_LIBRARY", library)
+            .env("GORE_TEST_CHILD_LOADOUT", loadout)
+            .env("GORE_TEST_CHILD_STORE_MODE", "lock")
+            .env("GORE_TEST_MANAGER_FIRST_ROOT_MARKER", first_marker)
+            .env(
+                "GORE_TEST_MANAGER_FIRST_ROOT_HOLD_MS",
+                first_hold_ms.to_string(),
+            )
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap()
+    }
+
+    fn spawn_identity_lock_child(
+        library: &Path,
+        marker: &Path,
+        hold_ms: u64,
+    ) -> std::process::Child {
+        std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("library_lock_child_worker")
+            .arg("--ignored")
+            .arg("--nocapture")
+            .env("GORE_TEST_CHILD_LIBRARY", library)
+            .env("GORE_TEST_CHILD_MODE", "lock")
+            .env("GORE_TEST_LIBRARY_LOCK_MARKER", marker)
+            .env("GORE_TEST_LIBRARY_LOCK_HOLD_MS", hold_ms.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap()
+    }
+
+    fn child_output_bounded(
+        mut child: std::process::Child,
+        timeout: std::time::Duration,
+    ) -> std::process::Output {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if child.try_wait().unwrap().is_some() {
+                return child.wait_with_output().unwrap();
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = child.kill();
+                let output = child.wait_with_output().unwrap();
+                panic!(
+                    "child timed out; stderr: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    fn assert_child_output_success(output: std::process::Output) {
+        assert!(
+            output.status.success(),
+            "child failed with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn wait_for_path(path: &Path) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !path.exists() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for {}",
+                path.display()
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn kernel_store_lock_blocks_another_process_and_crash_releases_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let loadout = temp.path().join("loadout.json");
+        let marker_a = temp.path().join("locked-a");
+        let marker_b = temp.path().join("locked-b");
+        let mut first = spawn_store_child(&library, &loadout, &marker_a, 60_000, "lock", None);
+        wait_for_path(&marker_a);
+        let mut second = spawn_store_child(&library, &loadout, &marker_b, 0, "lock", None);
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(
+            !marker_b.exists(),
+            "second process acquired held store lock"
+        );
+        assert!(
+            second.try_wait().unwrap().is_none(),
+            "second process did not block"
+        );
+        first.kill().unwrap();
+        first.wait().unwrap();
+        let output = second.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(marker_b.exists());
+    }
+
+    #[test]
+    fn cross_process_rmw_preserves_independent_existing_slot_edits() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        let loadout = temp.path().join("loadout.json");
+        write_entry(&library, "a");
+        write_entry(&library, "b");
+        write_loadout(&loadout, &[("a", false), ("b", false)]);
+        let marker_a = temp.path().join("rmw-a");
+        let marker_b = temp.path().join("rmw-b");
+        let first = spawn_store_child(&library, &loadout, &marker_a, 200, "enable", Some("a"));
+        let second = spawn_store_child(&library, &loadout, &marker_b, 0, "enable", Some("b"));
+        for child in [first, second] {
+            let output = child.wait_with_output().unwrap();
+            assert!(
+                output.status.success(),
+                "child failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let stored = loadout::load(&loadout).unwrap();
+        assert!(stored.entries.iter().all(|entry| entry.enabled));
+    }
+
+    #[test]
+    fn crossed_store_library_pairs_finish_in_canonical_physical_order() {
+        let temp = tempfile::tempdir().unwrap();
+        let root_a = temp.path().join("root-a");
+        let root_b = temp.path().join("root-b");
+        fs::create_dir(&root_a).unwrap();
+        fs::create_dir(&root_b).unwrap();
+        let loadout_a = root_a.join(".loadout-a.json");
+        let loadout_b = root_b.join(".loadout-b.json");
+        write_loadout(&loadout_a, &[]);
+        write_loadout(&loadout_b, &[]);
+        let marker_a = temp.path().join("first-a");
+        let marker_b = temp.path().join("first-b");
+
+        let first = spawn_crossed_store_child(&root_b, &loadout_a, &marker_a, 250);
+        let second = spawn_crossed_store_child(&root_a, &loadout_b, &marker_b, 250);
+        assert_child_output_success(child_output_bounded(
+            first,
+            std::time::Duration::from_secs(10),
+        ));
+        assert_child_output_success(child_output_bounded(
+            second,
+            std::time::Duration::from_secs(10),
+        ));
+        assert_eq!(loadout::load(&loadout_a).unwrap(), Loadout::default());
+        assert_eq!(loadout::load(&loadout_b).unwrap(), Loadout::default());
+    }
+
+    #[test]
+    fn crash_while_holding_first_canonical_root_releases_the_waiter() {
+        let temp = tempfile::tempdir().unwrap();
+        let root_a = temp.path().join("root-a");
+        let root_b = temp.path().join("root-b");
+        fs::create_dir(&root_a).unwrap();
+        fs::create_dir(&root_b).unwrap();
+        let loadout_a = root_a.join(".loadout-a.json");
+        let loadout_b = root_b.join(".loadout-b.json");
+        write_loadout(&loadout_a, &[]);
+        write_loadout(&loadout_b, &[]);
+        let marker_a = temp.path().join("first-a");
+        let marker_b = temp.path().join("first-b");
+
+        let mut killed = spawn_crossed_store_child(&root_b, &loadout_a, &marker_a, 60_000);
+        wait_for_path(&marker_a);
+        let waiter = spawn_crossed_store_child(&root_a, &loadout_b, &marker_b, 0);
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(!marker_b.exists(), "waiter bypassed the held first root");
+        killed.kill().unwrap();
+        killed.wait().unwrap();
+        assert_child_output_success(child_output_bounded(
+            waiter,
+            std::time::Duration::from_secs(10),
+        ));
+        assert!(marker_b.exists());
+    }
+
+    #[test]
+    fn store_and_standalone_identity_contend_on_the_same_universal_root_both_directions() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_root = temp.path().join("store");
+        let library = temp.path().join("library");
+        fs::create_dir(&store_root).unwrap();
+        fs::create_dir(&library).unwrap();
+        let loadout = store_root.join("loadout.json");
+        write_loadout(&loadout, &[]);
+
+        let store_marker = temp.path().join("store-first");
+        let identity_marker = temp.path().join("identity-waiting");
+        let mut store = spawn_store_child(&library, &loadout, &store_marker, 60_000, "lock", None);
+        wait_for_path(&store_marker);
+        let identity = spawn_identity_lock_child(&library, &identity_marker, 0);
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(
+            !identity_marker.exists(),
+            "standalone Identity bypassed Store's Library-root lock"
+        );
+        store.kill().unwrap();
+        store.wait().unwrap();
+        assert_child_output_success(child_output_bounded(
+            identity,
+            std::time::Duration::from_secs(10),
+        ));
+
+        fs::remove_file(&store_marker).unwrap();
+        fs::remove_file(&identity_marker).unwrap();
+        let mut identity = spawn_identity_lock_child(&library, &identity_marker, 60_000);
+        wait_for_path(&identity_marker);
+        let store = spawn_store_child(&library, &loadout, &store_marker, 0, "lock", None);
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(
+            !store_marker.exists(),
+            "Store bypassed standalone Identity's universal root lock"
+        );
+        identity.kill().unwrap();
+        identity.wait().unwrap();
+        assert_child_output_success(child_output_bounded(
+            store,
+            std::time::Duration::from_secs(10),
+        ));
+        assert!(store_marker.exists());
+    }
+
+    #[test]
+    fn same_root_alias_is_rejected_without_rewriting_loadout() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("one-root");
+        fs::create_dir(&root).unwrap();
+        let loadout = root.join("loadout.json");
+        write_loadout(&loadout, &[]);
+        let before = fs::read(&loadout).unwrap();
+
+        let error = match StoreSnapshot::open(&root.join("."), &loadout) {
+            Ok(_) => panic!("same physical root was accepted for Store and Library"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("must be different directories"), "{error}");
+        assert_eq!(fs::read(&loadout).unwrap(), before);
+        assert!(
+            !root.join(STORE_LOCK_FILE).exists(),
+            "same-root rejection created a persistent Manager lock artifact"
+        );
+        assert!(!fs::read_dir(&root).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("pending")));
+    }
+
+    #[test]
+    fn in_process_crossed_pairs_serialize_without_deadlock() {
+        let temp = tempfile::tempdir().unwrap();
+        let root_a = temp.path().join("root-a");
+        let root_b = temp.path().join("root-b");
+        fs::create_dir(&root_a).unwrap();
+        fs::create_dir(&root_b).unwrap();
+        let loadout_a = root_a.join(".loadout-a.json");
+        let loadout_b = root_b.join(".loadout-b.json");
+        write_loadout(&loadout_a, &[]);
+        write_loadout(&loadout_b, &[]);
+        let (send, receive) = std::sync::mpsc::channel();
+        let mut workers = Vec::new();
+        for (library, loadout) in [(root_b.clone(), loadout_a), (root_a.clone(), loadout_b)] {
+            let send = send.clone();
+            workers.push(std::thread::spawn(move || {
+                let result = StoreSnapshot::open(&library, &loadout).map(drop);
+                send.send(result.map_err(|error| error.to_string()))
+                    .unwrap();
+            }));
+        }
+        drop(send);
+        for _ in 0..2 {
+            receive
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .expect("crossed in-process Store pair deadlocked")
+                .unwrap();
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn missing_library_with_persisted_intent_is_left_absent_and_byte_exact() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("missing-library");
+        let loadout = temp.path().join("loadout.json");
+        write_loadout(&loadout, &[("keep-intent", true)]);
+        let before = fs::read(&loadout).unwrap();
+
+        let error = match StoreSnapshot::open(&library, &loadout) {
+            Ok(_) => panic!("missing Library erased persisted loadout intent"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("library is missing"), "{error}");
+        assert!(!library.exists());
+        assert_eq!(fs::read(&loadout).unwrap(), before);
+    }
+
+    #[test]
+    fn library_published_during_empty_bootstrap_is_snapshotted_not_overwritten() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("raced-library");
+        let loadout = temp.path().join("loadout.json");
+        write_loadout(&loadout, &[]);
+        let raced_library = library.clone();
+        inject_bootstrap_race(move || write_entry(&raced_library, "raced-mod"));
+
+        let store = StoreSnapshot::open(&library, &loadout).unwrap();
+        assert_eq!(
+            store.loadout().entries,
+            vec![LoadoutEntry {
+                id: "raced-mod".into(),
+                enabled: false,
+            }]
+        );
+        drop(store);
+        assert_eq!(
+            loadout::load(&loadout).unwrap().entries,
+            vec![LoadoutEntry {
+                id: "raced-mod".into(),
+                enabled: false,
+            }]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_parent_alias_swap_during_lock_is_refused_without_touching_decoy() {
+        let temp = tempfile::tempdir().unwrap();
+        let library = temp.path().join("library");
+        write_entry(&library, "a");
+        let parent = temp.path().join("store");
+        let retained = temp.path().join("retained");
+        let decoy = temp.path().join("decoy");
+        fs::create_dir(&parent).unwrap();
+        fs::create_dir(&decoy).unwrap();
+        let requested = parent.join("loadout.json");
+        let decoy_loadout = decoy.join("loadout.json");
+        write_loadout(&requested, &[("a", false)]);
+        write_loadout(&decoy_loadout, &[("decoy", true)]);
+        let retained_before = fs::read(&requested).unwrap();
+        let decoy_before = fs::read(&decoy_loadout).unwrap();
+
+        let hook_parent = parent.clone();
+        let hook_retained = retained.clone();
+        let hook_decoy = decoy.clone();
+        inject_parent_lock_race(move || {
+            fs::rename(&hook_parent, &hook_retained).unwrap();
+            std::os::unix::fs::symlink(&hook_decoy, &hook_parent).unwrap();
+        });
+
+        let error = match StoreSnapshot::open(&library, &requested) {
+            Ok(_) => panic!("store accepted a parent alias swapped while locking"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("opening manager store directory")
+                || error.contains("opening named Manager mutation root")
+                || error.contains("changed filesystem identity"),
+            "{error}"
+        );
+        assert_eq!(
+            fs::read(retained.join("loadout.json")).unwrap(),
+            retained_before
+        );
+        assert_eq!(fs::read(&decoy_loadout).unwrap(), decoy_before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_store_io_refuses_after_parent_path_replacement_and_preserves_both_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("store");
+        fs::create_dir(&parent).unwrap();
+        let requested = parent.join("loadout.json");
+        write_loadout(&requested, &[("old", false)]);
+        let _process = manager_process_lock();
+        let (parent_path, canonical) = canonical_parent(&requested).unwrap();
+        let prepared =
+            prepare_existing_manager_root_lock(&parent_path, "test manager Store parent", true)
+                .unwrap();
+        let kernel = KernelStoreLock::new(
+            acquire_manager_root_locks(vec![prepared])
+                .unwrap()
+                .remove(0),
+        );
+        assert!(!parent.join(STORE_LOCK_FILE).exists());
+
+        let retained = temp.path().join("retained");
+        fs::rename(&parent, &retained).unwrap();
+        fs::create_dir(&parent).unwrap();
+        write_loadout(&requested, &[("decoy", true)]);
+        let retained_bytes = fs::read(retained.join("loadout.json")).unwrap();
+        let replacement_bytes = fs::read(&requested).unwrap();
+
+        let error = kernel
+            .save(
+                &canonical,
+                &Loadout {
+                    format: 1,
+                    entries: vec![LoadoutEntry {
+                        id: "new".into(),
+                        enabled: true,
+                    }],
+                },
+            )
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("identity") || error.contains("named"),
+            "{error}"
+        );
+        assert_eq!(
+            fs::read(retained.join("loadout.json")).unwrap(),
+            retained_bytes
+        );
+        assert_eq!(fs::read(&requested).unwrap(), replacement_bytes);
+    }
+}

--- a/crates/gore/src/cmd/doctor.rs
+++ b/crates/gore/src/cmd/doctor.rs
@@ -23,7 +23,9 @@
 //! [`gore_loc::loc_store::status`] (what `gore loc status` prints). A doctor that disagreed with
 //! the commands it diagnoses would be worse than no doctor at all.
 //!
-//! Nothing in this module writes, creates, or removes anything.
+//! Nothing in this module writes, creates, or removes anything. Deployment inspection joins an
+//! already-established Windows Library lock (or the Unix directory-inode lock), but deliberately
+//! never creates/acquires the Store sentinel and never repairs the loadout.
 
 use anyhow::Result;
 use serde::Serialize;
@@ -106,9 +108,17 @@ struct Check {
 }
 
 impl Check {
-    fn new(id: &'static str, title: &'static str, verdict: Verdict, detail: impl Into<String>) -> Self {
+    fn new(
+        id: &'static str,
+        title: &'static str,
+        verdict: Verdict,
+        detail: impl Into<String>,
+    ) -> Self {
         let detail = detail.into();
-        debug_assert!(is_prose(&detail), "detail must be one unpadded line: {detail:?}");
+        debug_assert!(
+            is_prose(&detail),
+            "detail must be one unpadded line: {detail:?}"
+        );
         Self {
             id,
             title,
@@ -172,8 +182,7 @@ impl Report {
         // Notes as well as problems, which the first version of this missed — and a Note is where
         // the next one turned up, one round later. `Skipped` is exempt: it says a check could not
         // run, and the reason it could not is reported by whichever check established that.
-        let owes_a_fix =
-            |check: &Check| matches!(check.verdict, Verdict::Problem | Verdict::Note);
+        let owes_a_fix = |check: &Check| matches!(check.verdict, Verdict::Problem | Verdict::Note);
         debug_assert!(
             checks
                 .iter()
@@ -225,7 +234,11 @@ fn collect(explicit: Option<&Path>) -> Report {
     let source = game_path_source(explicit.is_some(), cfg.game_path.as_deref());
     let resolved = gore_loc::config::game_root(explicit.map(Path::to_path_buf)).ok();
 
-    let mut checks = vec![check_game_path(explicit, cfg.game_path.as_deref(), resolved.as_deref())];
+    let mut checks = vec![check_game_path(
+        explicit,
+        cfg.game_path.as_deref(),
+        resolved.as_deref(),
+    )];
 
     // A root that resolved to nothing on disk is no more inspectable than one that did not
     // resolve, and running the rest against it would restate the same single cause as four more
@@ -246,10 +259,13 @@ fn collect(explicit: Option<&Path>) -> Report {
             // that was right all along.
             for (id, title) in SKIPPED_WITHOUT_INSTALL {
                 checks.push(
-                    Check::new(id, title, Verdict::Skipped, format!("could not be read: {error}"))
-                        .with_fix(
-                            "run the same command from a shell that can read the install",
-                        ),
+                    Check::new(
+                        id,
+                        title,
+                        Verdict::Skipped,
+                        format!("could not be read: {error}"),
+                    )
+                    .with_fix("run the same command from a shell that can read the install"),
                 );
             }
             return Report::new(resolved.as_deref(), source, checks);
@@ -279,7 +295,8 @@ fn collect(explicit: Option<&Path>) -> Report {
     // game files are still modified.
     // The backups the deployment claims, so a leftover from an unrelated in-place edit stays
     // visible instead of being absorbed into "this is what a deployment looks like".
-    let owned_backups = gore_mod::deployed_backup_paths(&gp.root).map_err(|error| error.to_string());
+    let owned_backups =
+        gore_mod::deployed_backup_paths(&gp.root).map_err(|error| error.to_string());
 
     checks.push(check_install(&gp));
     checks.push(check_ue4ss(&gp));
@@ -446,12 +463,16 @@ fn check_game_path(
                 // Nothing about this reads like a moved install, and the two usual causes below
                 // would send somebody looking for a drive that is mounted and a game that never
                 // moved.
-                Occupant::Obstruction => "the configured path resolves to something that is not a \
+                Occupant::Obstruction => {
+                    "the configured path resolves to something that is not a \
                                           directory, so no part of the install can be under it. \
                                           Point the config at the install with 'gore config set \
-                                          game-path <path>'",
-                _ => "the path resolved but there is no directory there — the game moved, or the \
-                      drive is not mounted. Set it again with 'gore config set game-path <path>'",
+                                          game-path <path>'"
+                }
+                _ => {
+                    "the path resolved but there is no directory there — the game moved, or the \
+                      drive is not mounted. Set it again with 'gore config set game-path <path>'"
+                }
             });
         }
         // The configured path is right and something is stopping this process from reading it.
@@ -462,7 +483,10 @@ fn check_game_path(
                 "game_path",
                 "game path",
                 Verdict::Problem,
-                format!("{} (source: {source}) could not be read: {error}", root.display()),
+                format!(
+                    "{} (source: {source}) could not be read: {error}",
+                    root.display()
+                ),
             )
             .with_items(items)
             .with_fix(
@@ -645,18 +669,17 @@ fn check_ue4ss(gp: &GamePaths) -> Check {
         }
         Err(error) => return unreadable(error),
     };
-    let mods_present = match occupant(mods, Wanted::Folder) {
-        Ok(Occupant::Wanted) => true,
-        Ok(Occupant::Absent) => false,
-        Ok(Occupant::Obstruction) => {
-            return obstructed(
+    let mods_present =
+        match occupant(mods, Wanted::Folder) {
+            Ok(Occupant::Wanted) => true,
+            Ok(Occupant::Absent) => false,
+            Ok(Occupant::Obstruction) => return obstructed(
                 mods,
                 Wanted::Folder,
                 "'gore mod deploy' and 'gore gen -o <mods dir>' both create that folder, and they",
-            )
-        }
-        Err(error) => return unreadable(error),
-    };
+            ),
+            Err(error) => return unreadable(error),
+        };
     // UE4SS.dll is the payload; something has to load it. The game imports a proxy DLL, and the one
     // this toolkit knows is `dwmapi.dll` beside the executable — `gore-as` moves that exact file
     // aside for a regen, so its name is not a guess. Without it the payload sits there unloaded and
@@ -1121,6 +1144,40 @@ fn deployment_without_a_loadout(
          command reads it first",
         loadout_path.display()
     );
+    deployment_without_authoritative_target(
+        gp,
+        library,
+        items,
+        "the manager loadout could not be read",
+        "the manager loadout is unreadable",
+        broken,
+    )
+}
+
+/// Preserve the record-only status ladder when strict Library state prevents an authoritative
+/// target projection, without misdiagnosing a valid loadout or recommending destructive repair.
+fn deployment_without_a_library_projection(
+    gp: &GamePaths,
+    library: &Path,
+    items: Vec<String>,
+    error: impl std::fmt::Display,
+) -> Check {
+    let unavailable = format!("the manager library could not be inspected safely: {error}");
+    let fix = format!(
+        "{unavailable}. Resolve the reported library uncertainty, then rerun 'gore doctor'; do \
+         not delete or repair the loadout based on this result"
+    );
+    deployment_without_authoritative_target(gp, library, items, &unavailable, &unavailable, fix)
+}
+
+fn deployment_without_authoritative_target(
+    gp: &GamePaths,
+    library: &Path,
+    items: Vec<String>,
+    unavailable: &str,
+    deployed_unavailable: &str,
+    fix: String,
+) -> Check {
     // An empty target is safe for exactly the record-only rungs, and its answer is ignored for
     // every other one.
     let record_only = gore_mod::mgr::status::status(&gp.root, library, &Default::default());
@@ -1134,16 +1191,16 @@ fn deployment_without_a_loadout(
         .with_items(items)
         .with_fix(format!(
             "run 'gore mgr reset' (or 'gore mod undeploy') to restore the game before deploying \
-             anything else. Separately: {broken}"
+             anything else. Separately: {fix}"
         )),
         Ok(ManagerStatus::StudioDeployActive { mod_name }) => Check::new(
             "deployment",
             "deployment",
             Verdict::Problem,
-            format!("one bundle is deployed: {mod_name}; the manager loadout is unreadable"),
+            format!("one bundle is deployed: {mod_name}; {deployed_unavailable}"),
         )
         .with_items(items)
-        .with_fix(broken),
+        .with_fix(fix),
         // Rung 4, and the ladder's own words for it are "stale regardless of the loadout" — it is
         // decided by verifying the recorded files, not by any diff against a target. It is also
         // literally the case this whole report exists for: deploy said yes and the game shows
@@ -1162,7 +1219,7 @@ fn deployment_without_a_loadout(
         .with_fix(format!(
             "this is the case where the tool reported success and the game shows nothing. Run \
              'gore mgr apply' (or re-deploy the bundle) to rebuild against the refreshed files. \
-             Separately: {broken}"
+             Separately: {fix}"
         )),
         // Two failures, and the deploy record is the one that stops things working. Reporting only
         // the loadout named the lesser of them and left the other out of the report entirely.
@@ -1173,17 +1230,14 @@ fn deployment_without_a_loadout(
             format!("the deploy record could not be read: {error}"),
         )
         .with_items(items)
-        .with_fix(format!("{broken}. The deploy record is the more urgent of the two")),
+        .with_fix(format!(
+            "{fix}. The deploy record is the more urgent of the two"
+        )),
         // What is left is `NothingDeployed`, `InSync` and `ChangesPending`. The last two ARE the
         // diff against the loadout that could not be read, so there is nothing to say about them.
-        Ok(_) => Check::new(
-            "deployment",
-            "deployment",
-            Verdict::Problem,
-            "the manager loadout could not be read",
-        )
-        .with_items(items)
-        .with_fix(broken),
+        Ok(_) => Check::new("deployment", "deployment", Verdict::Problem, unavailable)
+            .with_items(items)
+            .with_fix(fix),
     }
 }
 
@@ -1202,12 +1256,18 @@ fn check_deployment(gp: &GamePaths, library: &Path, loadout_path: &Path) -> Chec
         format!("loadout: {}", loadout_path.display()),
     ];
 
-    let target = match gore_mod::mgr::loadout::load(loadout_path) {
-        Ok(loadout) => loadout,
-        Err(error) => return deployment_without_a_loadout(gp, library, items, loadout_path, error),
+    let target = match gore_mod::mgr::store::StoreSnapshot::inspect_read_only(library, loadout_path)
+    {
+        Ok(target) => target,
+        Err(gore_mod::mgr::store::StoreInspectionError::Loadout(error)) => {
+            return deployment_without_a_loadout(gp, library, items, loadout_path, error);
+        }
+        Err(gore_mod::mgr::store::StoreInspectionError::Library(error)) => {
+            return deployment_without_a_library_projection(gp, library, items, error);
+        }
     };
 
-    match gore_mod::mgr::status::status(&gp.root, library, &target) {
+    match target.status(&gp.root) {
         Ok(ManagerStatus::NothingDeployed) => Check::new(
             "deployment",
             "deployment",
@@ -1273,7 +1333,10 @@ fn check_deployment(gp: &GamePaths, library: &Path, loadout_path: &Path) -> Chec
         ),
         // A Problem with no fix is half a report, and this type's own contract says so: what was
         // looked at, what was found, and what to do about it.
-        Err(error) => Check::new(
+        Err(gore_mod::mgr::store::StoreInspectionStatusError::Library(error)) => {
+            deployment_without_a_library_projection(gp, library, items, error)
+        }
+        Err(gore_mod::mgr::store::StoreInspectionStatusError::Status(error)) => Check::new(
             "deployment",
             "deployment",
             Verdict::Problem,
@@ -1548,7 +1611,11 @@ fn check_leftovers(
     let (scan, scan_error) = match find_backups(gp) {
         Ok(scan) => (scan, None),
         Err(error) => (
-            BackupScan { found: Vec::new(), occupied: Vec::new(), complete: false },
+            BackupScan {
+                found: Vec::new(),
+                occupied: Vec::new(),
+                complete: false,
+            },
             Some(error),
         ),
     };
@@ -1999,7 +2066,10 @@ fn check_loc_catalog(
     );
     let items = vec![
         format!("catalog: {}", meta.catalog_path),
-        format!("source:  {} ({} bytes)", meta.source_path, meta.source_bytes),
+        format!(
+            "source:  {} ({} bytes)",
+            meta.source_path, meta.source_bytes
+        ),
     ];
 
     let Some(installed) = installed else {
@@ -2195,9 +2265,7 @@ fn check_loc_catalog(
                  unchanged. Run 'gore loc extract' so the shared catalog describes the text that \
                  is installed",
             ),
-            Written::NoTimestamp => {
-                inconclusive("this filesystem reported no modification time")
-            }
+            Written::NoTimestamp => inconclusive("this filesystem reported no modification time"),
             Written::SameSecond => inconclusive(
                 "it was last written in the same second the extraction recorded, and the record \
                  keeps whole seconds only",
@@ -2303,7 +2371,11 @@ fn find_backups(gp: &GamePaths) -> Result<BackupScan, String> {
     found.dedup();
     occupied.sort();
     occupied.dedup();
-    Ok(BackupScan { found, occupied, complete })
+    Ok(BackupScan {
+        found,
+        occupied,
+        complete,
+    })
 }
 
 /// Sort one entry by the rule `gore_mod`'s backup step applies, and say whether it took it.
@@ -2381,7 +2453,8 @@ fn find_backups_under(
             return Ok(false);
         }
         *budget -= 1;
-        let entry = entry.map_err(|error| format!("{} could not be read: {error}", dir.display()))?;
+        let entry =
+            entry.map_err(|error| format!("{} could not be read: {error}", dir.display()))?;
         let path = entry.path();
         // `symlink_metadata`, not `metadata`: a junction pointing back up its own tree would
         // otherwise be followed until the budget ran out, and the honest answer for a link is that
@@ -2438,8 +2511,8 @@ fn mods_entries(dir: &Path) -> Result<Vec<ModsEntry>, String> {
     };
     let mut found = Vec::new();
     for entry in entries {
-        let entry = entry
-            .map_err(|error| format!("{} could not be read: {error}", dir.display()))?;
+        let entry =
+            entry.map_err(|error| format!("{} could not be read: {error}", dir.display()))?;
         found.push(ModsEntry {
             name: entry.file_name().to_string_lossy().into_owned(),
             is_file: present(&entry.path())?.is_some_and(|metadata| metadata.is_file()),
@@ -2456,15 +2529,14 @@ fn file_names(dir: &Path) -> Result<Vec<String>, String> {
     };
     let mut names = Vec::new();
     for entry in entries {
-        let entry = entry
-            .map_err(|error| format!("{} could not be read: {error}", dir.display()))?;
+        let entry =
+            entry.map_err(|error| format!("{} could not be read: {error}", dir.display()))?;
         if present(&entry.path())?.is_some_and(|metadata| metadata.is_file()) {
             names.push(entry.file_name().to_string_lossy().into_owned());
         }
     }
     Ok(names)
 }
-
 
 /// Windows path identity is case-insensitive, which is the same reason `semantic_install_root`
 /// compares its `G1R` component with `eq_ignore_ascii_case`. Not canonicalized: that would
@@ -2552,7 +2624,7 @@ fn print_report(report: &Report) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gore_modgen::gen::{gen_lua, MetaConfig, OverridesConfig, OverrideValue, SingleOverride};
+    use gore_modgen::gen::{gen_lua, MetaConfig, OverrideValue, OverridesConfig, SingleOverride};
 
     /// A GamePaths for a fixture tree, built the way every command builds it.
     fn paths(root: &Path) -> GamePaths {
@@ -2578,6 +2650,44 @@ mod tests {
         .unwrap();
     }
 
+    fn manager_meta(id: &str) -> gore_mod::mgr::ModEntryMeta {
+        gore_mod::mgr::ModEntryMeta {
+            id: id.into(),
+            kind: gore_mod::mgr::ModKind::ForeignPak,
+            name: id.into(),
+            version: String::new(),
+            author: String::new(),
+            imported_at: "2026-01-01T00:00:00Z".into(),
+            source: String::new(),
+            components: Vec::new(),
+        }
+    }
+
+    fn write_manager_entry(library: &Path, id: &str) -> gore_mod::mgr::ModEntryMeta {
+        let meta = manager_meta(id);
+        let entry = library.join(id);
+        std::fs::create_dir_all(&entry).unwrap();
+        std::fs::write(
+            entry.join(gore_mod::mgr::model::META_FILE),
+            serde_json::to_vec(&meta).unwrap(),
+        )
+        .unwrap();
+        meta
+    }
+
+    fn prepare_existing_read_only_library_lock(library: &Path) {
+        #[cfg(windows)]
+        std::fs::write(library.join(".gore-manager-library.lock"), b"").unwrap();
+        #[cfg(not(windows))]
+        let _ = library;
+    }
+
+    fn write_deploy_record(root: &Path, record: &gore_mod::DeployRecord) {
+        let path = gore_mod::deploy_record_path(root);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, serde_json::to_vec(record).unwrap()).unwrap();
+    }
+
     #[test]
     fn a_broken_config_is_told_apart_from_an_absent_one() {
         // `config::load` returns the default for all three, so a corrupt file reads as "nothing
@@ -2585,7 +2695,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         let absent = read_config_file(&dir.path().join("config.json"));
-        assert!(matches!(absent, ConfigFile::Absent), "a missing file is not a fault");
+        assert!(
+            matches!(absent, ConfigFile::Absent),
+            "a missing file is not a fault"
+        );
 
         let good = dir.path().join("good.json");
         // Forward slashes: a Windows path in JSON needs its backslashes escaped, and a fixture
@@ -2770,7 +2883,11 @@ mod tests {
 
         let listing = check_ue4ss_mods(&gp);
         assert_eq!(listing.verdict, Verdict::Problem, "{}", listing.detail);
-        assert!(listing.detail.contains("is not a folder"), "{}", listing.detail);
+        assert!(
+            listing.detail.contains("is not a folder"),
+            "{}",
+            listing.detail
+        );
 
         // The control. With every path the right kind, none of the above fires.
         std::fs::remove_file(&gp.ue4ss_mods).unwrap();
@@ -2843,7 +2960,10 @@ mod tests {
         let check = check_ue4ss_mods(&gp);
         assert_eq!(check.verdict, Verdict::Problem);
         let fix = check.fix.unwrap();
-        assert!(fix.contains("OldBalance") && fix.contains("NewBalance"), "{fix}");
+        assert!(
+            fix.contains("OldBalance") && fix.contains("NewBalance"),
+            "{fix}"
+        );
     }
 
     #[test]
@@ -2981,7 +3101,11 @@ mod tests {
             },
             overrides: Vec::new(),
         });
-        assert!(lua.starts_with(GENERATED_MARKER), "{}", &lua[..40.min(lua.len())]);
+        assert!(
+            lua.starts_with(GENERATED_MARKER),
+            "{}",
+            &lua[..40.min(lua.len())]
+        );
     }
 
     #[test]
@@ -3013,7 +3137,11 @@ mod tests {
         std::fs::remove_dir_all(root.join("G1R").join("Script")).unwrap();
         let check = check_install(&paths(root));
         assert_eq!(check.verdict, Verdict::Problem);
-        assert!(check.detail.starts_with("install is incomplete"), "{}", check.detail);
+        assert!(
+            check.detail.starts_with("install is incomplete"),
+            "{}",
+            check.detail
+        );
     }
 
     /// No deploy record at all: every backup found is a leftover.
@@ -3068,7 +3196,11 @@ mod tests {
         let check = check_leftovers(&paths(root), &probe(root, false), &nothing_deployed());
         assert_eq!(check.verdict, Verdict::Problem);
         assert!(check.detail.contains("refuse to start"), "{}", check.detail);
-        assert!(check.detail.contains("could not be read"), "{}", check.detail);
+        assert!(
+            check.detail.contains("could not be read"),
+            "{}",
+            check.detail
+        );
         assert!(check.fix.unwrap().contains("gore mod undeploy"));
         assert!(check
             .items
@@ -3089,10 +3221,10 @@ mod tests {
         make_install(root);
         std::fs::write(root.join(".gore-install-mutation.lock"), b"{}").unwrap();
 
-        let probe = gore_as::compile::probe_install_compile_state_with_stated_game_process(
-            root,
-            || Err("the process list could not be read".into()),
-        );
+        let probe =
+            gore_as::compile::probe_install_compile_state_with_stated_game_process(root, || {
+                Err("the process list could not be read".into())
+            });
         assert_eq!(
             probe.disposition,
             InstallCompileStateDisposition::InspectionFailed
@@ -3123,18 +3255,28 @@ mod tests {
         assert_eq!(orphaned.verdict, Verdict::Note);
         assert!(orphaned.fix.unwrap().contains("gore audio restore"));
 
-        let claimed =
-            check_leftovers(&paths(root), &probe(root, false), &deployment_owns(&[&backup]));
+        let claimed = check_leftovers(
+            &paths(root),
+            &probe(root, false),
+            &deployment_owns(&[&backup]),
+        );
         assert_eq!(claimed.verdict, Verdict::Ok);
         assert!(claimed.fix.is_none());
 
         // And the case the old `bool` could not see: a deployment IS active, but this backup is
         // not one of its own — an in-place `gore audio replace` beside a UE4SS-only bundle.
         let elsewhere = root.join("G1R").join("Script").join("other.gore-bak");
-        let unrelated =
-            check_leftovers(&paths(root), &probe(root, false), &deployment_owns(&[&elsewhere]));
+        let unrelated = check_leftovers(
+            &paths(root),
+            &probe(root, false),
+            &deployment_owns(&[&elsewhere]),
+        );
         assert_eq!(unrelated.verdict, Verdict::Note, "{}", unrelated.detail);
-        assert!(unrelated.detail.contains("no deployment claims"), "{}", unrelated.detail);
+        assert!(
+            unrelated.detail.contains("no deployment claims"),
+            "{}",
+            unrelated.detail
+        );
     }
 
     #[test]
@@ -3158,7 +3300,10 @@ mod tests {
         let check = check_leftovers(&paths(root), &probe(root, false), &nothing_deployed());
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
         assert!(
-            check.items.iter().any(|item| item.contains("Normal.PNG.gore-bak")),
+            check
+                .items
+                .iter()
+                .any(|item| item.contains("Normal.PNG.gore-bak")),
             "{:?}",
             check.items
         );
@@ -3180,13 +3325,19 @@ mod tests {
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
         assert!(check.detail.contains("not a file"), "{}", check.detail);
         assert!(
-            check.items.iter().any(|item| item.contains("SFX.bank.gore-bak")),
+            check
+                .items
+                .iter()
+                .any(|item| item.contains("SFX.bank.gore-bak")),
             "{:?}",
             check.items
         );
         let fix = check.fix.unwrap();
         assert!(fix.contains("Remove or rename"), "{fix}");
-        assert!(!fix.contains("gore audio restore"), "nothing restores from a directory: {fix}");
+        assert!(
+            !fix.contains("gore audio restore"),
+            "nothing restores from a directory: {fix}"
+        );
 
         // Windows folds case, so `SFX.bank.GORE-BAK` IS the file the backup step writes as
         // `SFX.bank.gore-bak` — the next operation consumes or collides with it, and a
@@ -3195,7 +3346,10 @@ mod tests {
         std::fs::write(banks.join("Music.bank.GORE-BAK"), b"pristine").unwrap();
         let check = check_leftovers(&paths(root), &probe(root, false), &nothing_deployed());
         assert!(
-            check.items.iter().any(|item| item.contains("Music.bank.GORE-BAK")),
+            check
+                .items
+                .iter()
+                .any(|item| item.contains("Music.bank.GORE-BAK")),
             "{:?}",
             check.items
         );
@@ -3214,7 +3368,10 @@ mod tests {
             let check = check_leftovers(&paths(root), &probe(root, false), &nothing_deployed());
             assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
             assert!(
-                check.items.iter().any(|item| item.contains("SFX.bank.gore-bak")),
+                check
+                    .items
+                    .iter()
+                    .any(|item| item.contains("SFX.bank.gore-bak")),
                 "{:?}",
                 check.items
             );
@@ -3230,7 +3387,10 @@ mod tests {
             let check = check_leftovers(&paths(root), &probe(root, false), &nothing_deployed());
             assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
             assert!(
-                check.items.iter().any(|item| item.contains("Normal.PNG.gore-bak")),
+                check
+                    .items
+                    .iter()
+                    .any(|item| item.contains("Normal.PNG.gore-bak")),
                 "{:?}",
                 check.items
             );
@@ -3345,7 +3505,10 @@ mod tests {
         let digest = std::fs::read(source)
             .ok()
             .map(|bytes| gore_loc::loc_store::sha256_hex(&bytes));
-        LocMeta { source_sha256: digest, ..meta(source, bytes) }
+        LocMeta {
+            source_sha256: digest,
+            ..meta(source, bytes)
+        }
     }
 
     #[test]
@@ -3387,7 +3550,10 @@ mod tests {
         std::fs::write(&cache, vec![0u8; 2048]).unwrap();
 
         let recorded = meta_with_identity(&cache, 2048);
-        assert!(recorded.source_sha256.is_some(), "the fixture must record one");
+        assert!(
+            recorded.source_sha256.is_some(),
+            "the fixture must record one"
+        );
 
         let unchanged = loc_check(
             Some(recorded.clone()),
@@ -3414,7 +3580,11 @@ mod tests {
             cache.parent().unwrap(),
         );
         assert_eq!(rewritten.verdict, Verdict::Problem, "{}", rewritten.detail);
-        assert!(rewritten.detail.contains("same length"), "{}", rewritten.detail);
+        assert!(
+            rewritten.detail.contains("same length"),
+            "{}",
+            rewritten.detail
+        );
     }
 
     #[test]
@@ -3585,18 +3755,33 @@ mod tests {
         let root = dir.path();
         make_install(root);
         let gp = paths(root);
-        assert_eq!(check_install(&gp).verdict, Verdict::Ok, "the fixture starts healthy");
+        assert_eq!(
+            check_install(&gp).verdict,
+            Verdict::Ok,
+            "the fixture starts healthy"
+        );
 
         // A directory where the executable belongs: the arm that reads "this is not the game".
         std::fs::remove_file(&gp.executable).unwrap();
         std::fs::create_dir_all(&gp.executable).unwrap();
         let check = check_install(&gp);
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
-        assert!(check.detail.contains("occupied by something else"), "{}", check.detail);
-        assert!(check.items.iter().any(|item| item.contains("not a file")), "{:?}", check.items);
+        assert!(
+            check.detail.contains("occupied by something else"),
+            "{}",
+            check.detail
+        );
+        assert!(
+            check.items.iter().any(|item| item.contains("not a file")),
+            "{:?}",
+            check.items
+        );
         let fix = check.fix.unwrap();
         assert!(fix.contains("Remove or rename"), "{fix}");
-        assert!(!fix.contains("gore config set game-path"), "the path is right: {fix}");
+        assert!(
+            !fix.contains("gore config set game-path"),
+            "the path is right: {fix}"
+        );
         std::fs::remove_dir(&gp.executable).unwrap();
         std::fs::write(&gp.executable, b"exe").unwrap();
 
@@ -3606,7 +3791,11 @@ mod tests {
         std::fs::write(&cache, b"not a folder").unwrap();
         let check = check_install(&gp);
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
-        assert!(check.items.iter().any(|item| item.contains("not a folder")), "{:?}", check.items);
+        assert!(
+            check.items.iter().any(|item| item.contains("not a folder")),
+            "{:?}",
+            check.items
+        );
         assert!(!check.fix.unwrap().contains("verify the game files"));
 
         // The control: genuinely absent keeps the sentence and the remedy it had.
@@ -3637,11 +3826,17 @@ mod tests {
             "and while creating the folder over it really does fail"
         );
 
-        assert!(matches!(occupant(&dangling, Wanted::Folder), Ok(Occupant::Obstruction)));
+        assert!(matches!(
+            occupant(&dangling, Wanted::Folder),
+            Ok(Occupant::Obstruction)
+        ));
 
         // The control: a name nothing holds is still absent.
         let free = dir.path().join("nothing-here");
-        assert!(matches!(occupant(&free, Wanted::Folder), Ok(Occupant::Absent)));
+        assert!(matches!(
+            occupant(&free, Wanted::Folder),
+            Ok(Occupant::Absent)
+        ));
     }
 
     /// A symlink at `link` pointing at a FILE. Separate from the directory helper because
@@ -3694,7 +3889,9 @@ mod tests {
         std::fs::write(&file, b"x").unwrap();
 
         assert!(present(&file).unwrap().is_some_and(|m| m.is_file()));
-        assert!(present(&dir.path().join("not-there.txt")).unwrap().is_none());
+        assert!(present(&dir.path().join("not-there.txt"))
+            .unwrap()
+            .is_none());
         assert!(present(dir.path()).unwrap().is_some_and(|m| m.is_dir()));
     }
 
@@ -3714,7 +3911,11 @@ mod tests {
             cache.parent().unwrap(),
         );
         assert_eq!(check.verdict, Verdict::Problem);
-        assert!(check.detail.contains("the catalog itself is gone"), "{}", check.detail);
+        assert!(
+            check.detail.contains("the catalog itself is gone"),
+            "{}",
+            check.detail
+        );
         assert!(check.fix.unwrap().contains("gore loc extract"));
     }
 
@@ -3730,9 +3931,18 @@ mod tests {
         let broken = dir.path().join("loc_catalog.json");
         std::fs::write(&broken, br#"{"itfo_apple":{"german":"Apf"#).unwrap();
 
-        let check = loc_check(Some(meta_with_identity(&cache, 2048)), &broken, Some(&cache), cache.parent().unwrap());
+        let check = loc_check(
+            Some(meta_with_identity(&cache, 2048)),
+            &broken,
+            Some(&cache),
+            cache.parent().unwrap(),
+        );
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
-        assert!(check.detail.contains("cannot be loaded"), "{}", check.detail);
+        assert!(
+            check.detail.contains("cannot be loaded"),
+            "{}",
+            check.detail
+        );
         assert!(check.fix.unwrap().contains("gore loc extract"));
     }
 
@@ -3748,10 +3958,18 @@ mod tests {
         let catalog = dir.path().join("loc_catalog.json");
         std::fs::write(&catalog, br#"{"itfo_apple":{"german":42}}"#).unwrap();
 
-        let check =
-            loc_check(Some(meta_with_identity(&cache, 2048)), &catalog, Some(&cache), cache.parent().unwrap());
+        let check = loc_check(
+            Some(meta_with_identity(&cache, 2048)),
+            &catalog,
+            Some(&cache),
+            cache.parent().unwrap(),
+        );
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
-        assert!(check.detail.contains("cannot be loaded"), "{}", check.detail);
+        assert!(
+            check.detail.contains("cannot be loaded"),
+            "{}",
+            check.detail
+        );
     }
 
     #[test]
@@ -3764,8 +3982,12 @@ mod tests {
         let catalog = dir.path().join("loc_catalog.json");
         std::fs::write(&catalog, br#"{"a":{"german":"x"},"b":{"german":"y"}}"#).unwrap();
 
-        let check =
-            loc_check(Some(meta_with_identity(&cache, 2048)), &catalog, Some(&cache), cache.parent().unwrap());
+        let check = loc_check(
+            Some(meta_with_identity(&cache, 2048)),
+            &catalog,
+            Some(&cache),
+            cache.parent().unwrap(),
+        );
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
         assert!(check.detail.contains("holds 2 ids"), "{}", check.detail);
     }
@@ -3799,7 +4021,13 @@ mod tests {
         let sidecar = dir.path().join("loc_meta.json");
         std::fs::create_dir_all(&sidecar).unwrap();
 
-        let check = check_loc_catalog(None, &catalog, &sidecar, Some(&cache), cache.parent().unwrap());
+        let check = check_loc_catalog(
+            None,
+            &catalog,
+            &sidecar,
+            Some(&cache),
+            cache.parent().unwrap(),
+        );
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
         assert!(check.detail.contains("loc_meta.json"), "{}", check.detail);
         assert!(check.detail.contains("is not a file"), "{}", check.detail);
@@ -3810,7 +4038,13 @@ mod tests {
         // The control: with nothing at that path the catalog is still reported as usable, so the
         // branch is answering the obstruction and not every absent sidecar.
         std::fs::remove_dir(&sidecar).unwrap();
-        let check = check_loc_catalog(None, &catalog, &sidecar, Some(&cache), cache.parent().unwrap());
+        let check = check_loc_catalog(
+            None,
+            &catalog,
+            &sidecar,
+            Some(&cache),
+            cache.parent().unwrap(),
+        );
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
         assert!(check.fix.unwrap().contains("usable as it is"));
     }
@@ -3830,13 +4064,21 @@ mod tests {
         for meta in [None, Some(meta_with_identity(&cache, 2048))] {
             let described = meta.is_some();
             let check = loc_check(meta, &catalog, Some(&cache), cache.parent().unwrap());
-            assert_eq!(check.verdict, Verdict::Problem, "sidecar={described}: {}", check.detail);
+            assert_eq!(
+                check.verdict,
+                Verdict::Problem,
+                "sidecar={described}: {}",
+                check.detail
+            );
             assert!(
                 check.detail.contains("is not a file"),
                 "sidecar={described}: {}",
                 check.detail
             );
-            assert!(check.fix.unwrap().contains("Remove or rename"), "sidecar={described}");
+            assert!(
+                check.fix.unwrap().contains("Remove or rename"),
+                "sidecar={described}"
+            );
         }
     }
 
@@ -3850,7 +4092,11 @@ mod tests {
 
         let check = loc_check(None, &catalog, None, dir.path());
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
-        assert!(check.detail.contains("cannot be loaded"), "{}", check.detail);
+        assert!(
+            check.detail.contains("cannot be loaded"),
+            "{}",
+            check.detail
+        );
     }
 
     #[test]
@@ -3906,7 +4152,11 @@ mod tests {
             &occupied,
         );
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
-        assert!(check.detail.contains("could not be listed"), "{}", check.detail);
+        assert!(
+            check.detail.contains("could not be listed"),
+            "{}",
+            check.detail
+        );
         assert!(check.fix.unwrap().contains("shell that can read"));
 
         // The control: a folder that genuinely is not there stays the note it was, so the branch
@@ -3919,7 +4169,11 @@ mod tests {
             &absent,
         );
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
-        assert!(check.detail.contains("no AlkimiaLocalization"), "{}", check.detail);
+        assert!(
+            check.detail.contains("no AlkimiaLocalization"),
+            "{}",
+            check.detail
+        );
     }
 
     #[test]
@@ -4011,7 +4265,10 @@ mod tests {
         let check = check_mods_folder(&gp);
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
         assert!(
-            check.items.iter().any(|i| i.contains("zzz_Half_P.utoc") && i.contains("not mounted")),
+            check
+                .items
+                .iter()
+                .any(|i| i.contains("zzz_Half_P.utoc") && i.contains("not mounted")),
             "{:?}",
             check.items
         );
@@ -4069,7 +4326,13 @@ mod tests {
         let gp = paths(root);
         let mods = gore_tex::container::mods_dir(&gp.root);
         std::fs::create_dir_all(&mods).unwrap();
-        for name in ["zzz_A_P.utoc", "zzz_A_P.ucas", "zzz_B_P.utoc", "zzz_B_P.ucas", "zzz_C_P.pak"] {
+        for name in [
+            "zzz_A_P.utoc",
+            "zzz_A_P.ucas",
+            "zzz_B_P.utoc",
+            "zzz_B_P.ucas",
+            "zzz_C_P.pak",
+        ] {
             std::fs::write(mods.join(name), b"x").unwrap();
         }
 
@@ -4090,7 +4353,10 @@ mod tests {
         let check = check_mods_folder(&gp);
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
         assert!(
-            check.items.iter().any(|item| item.contains("not the same container")),
+            check
+                .items
+                .iter()
+                .any(|item| item.contains("not the same container")),
             "{:?}",
             check.items
         );
@@ -4124,7 +4390,10 @@ mod tests {
         let check = check_mods_folder(&gp);
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
         assert!(
-            check.items.iter().any(|item| item.contains("triplet of three")),
+            check
+                .items
+                .iter()
+                .any(|item| item.contains("triplet of three")),
             "{:?}",
             check.items
         );
@@ -4154,7 +4423,10 @@ mod tests {
         let check = check_mods_folder(&gp);
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
         assert!(
-            check.items.iter().any(|item| item.contains("not a usable deploy record")),
+            check
+                .items
+                .iter()
+                .any(|item| item.contains("not a usable deploy record")),
             "{:?}",
             check.items
         );
@@ -4203,7 +4475,10 @@ mod tests {
         let check = check_mods_folder(&gp);
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
         assert!(
-            check.items.iter().any(|item| item.contains("not this folder's")),
+            check
+                .items
+                .iter()
+                .any(|item| item.contains("not this folder's")),
             "{:?}",
             check.items
         );
@@ -4285,7 +4560,10 @@ mod tests {
         let check = check_mods_folder(&gp);
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
         assert!(
-            check.items.iter().any(|item| item.contains("which is not here")),
+            check
+                .items
+                .iter()
+                .any(|item| item.contains("which is not here")),
             "{:?}",
             check.items
         );
@@ -4338,7 +4616,12 @@ mod tests {
         Report::new(
             None,
             "config",
-            vec![Check::new("ue4ss", "UE4SS", Verdict::Problem, "not installed")],
+            vec![Check::new(
+                "ue4ss",
+                "UE4SS",
+                Verdict::Problem,
+                "not installed",
+            )],
         );
     }
 
@@ -4350,7 +4633,12 @@ mod tests {
         Report::new(
             None,
             "config",
-            vec![Check::new("loc_catalog", "loc catalog", Verdict::Note, "could not be read")],
+            vec![Check::new(
+                "loc_catalog",
+                "loc catalog",
+                Verdict::Note,
+                "could not be read",
+            )],
         );
     }
 
@@ -4372,7 +4660,9 @@ mod tests {
         );
         assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
         assert!(
-            check.fix.is_some_and(|fix| fix.contains("gore mod undeploy")),
+            check
+                .fix
+                .is_some_and(|fix| fix.contains("gore mod undeploy")),
             "a Problem must say what to do next"
         );
     }
@@ -4393,7 +4683,10 @@ mod tests {
         let check = check_mods_folder(&gp);
         assert_eq!(check.verdict, Verdict::Note, "{}", check.detail);
         assert!(
-            check.items.iter().any(|item| item.contains(".tmp") && item.contains("not mounted")),
+            check
+                .items
+                .iter()
+                .any(|item| item.contains(".tmp") && item.contains("not mounted")),
             "{:?}",
             check.items
         );
@@ -4416,7 +4709,10 @@ mod tests {
         assert!(check.detail.contains("dwmapi.dll"), "{}", check.detail);
         let fix = check.fix.unwrap();
         assert!(fix.contains("dwmapi.dll"), "{fix}");
-        assert!(fix.contains("gore mod deploy"), "both findings are named: {fix}");
+        assert!(
+            fix.contains("gore mod deploy"),
+            "both findings are named: {fix}"
+        );
     }
 
     #[test]
@@ -4429,9 +4725,217 @@ mod tests {
 
         let check = check_deployment(&paths(root), &library, &loadout);
         assert_eq!(check.verdict, Verdict::Ok);
-        assert!(check.detail.contains("nothing is deployed"), "{}", check.detail);
+        assert!(
+            check.detail.contains("nothing is deployed"),
+            "{}",
+            check.detail
+        );
         // A reader who wants to look for themselves gets the three paths involved.
         assert_eq!(check.items.len(), 3);
+        assert!(!library.exists());
+        assert!(!loadout.exists());
+        assert!(!dir.path().join(".gore-manager-library.lock").exists());
+        assert!(!library.join(".gore-manager-library.lock").exists());
+    }
+
+    #[test]
+    fn deployment_uses_strict_reconciled_projection_without_repairing_or_creating_store_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("game");
+        make_install(&root);
+        let library = dir.path().join("library");
+        let loadout = dir.path().join("loadout.json");
+        let canonical_id = "CaseID";
+        let meta = write_manager_entry(&library, canonical_id);
+        write_manager_entry(&library, "disabled-b");
+        prepare_existing_read_only_library_lock(&library);
+        let configured_id = if cfg!(windows) {
+            "caseid"
+        } else {
+            canonical_id
+        };
+        std::fs::write(
+            &loadout,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "format": 1,
+                "entries": [
+                    {"id": configured_id, "enabled": true},
+                    {"id": "stale", "enabled": true},
+                    {"id": configured_id, "enabled": false}
+                ]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let before = std::fs::read(&loadout).unwrap();
+        let mut record = gore_mod::DeployRecord {
+            owner: "manager".into(),
+            mod_name: "manager".into(),
+            loadout: vec![gore_mod::mgr::LoadoutEntry {
+                id: canonical_id.into(),
+                enabled: true,
+            }],
+            ..Default::default()
+        };
+        record
+            .deployed_fingerprints
+            .insert(canonical_id.into(), meta.fingerprint());
+        write_deploy_record(&root, &record);
+
+        let check = check_deployment(&paths(&root), &library, &loadout);
+        assert_eq!(check.verdict, Verdict::Ok, "{}", check.detail);
+        assert!(check.detail.contains("in sync"), "{}", check.detail);
+        assert_eq!(std::fs::read(&loadout).unwrap(), before);
+        assert!(!dir.path().join(".gore-manager-library.lock").exists());
+        assert!(!std::fs::read_dir(dir.path()).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("pending")));
+    }
+
+    #[test]
+    fn corrupt_loadout_keeps_record_only_recovery_priority_and_creates_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("game");
+        make_install(&root);
+        let library = dir.path().join("library");
+        let loadout = dir.path().join("loadout.json");
+        let bytes = br#"{"format":0,"entries":[]}"#;
+        std::fs::write(&loadout, bytes).unwrap();
+        let record = gore_mod::DeployRecord {
+            owner: "manager".into(),
+            mod_name: "manager".into(),
+            phase: gore_mod::DeployPhase::RecoveryRequired,
+            ..Default::default()
+        };
+        write_deploy_record(&root, &record);
+
+        let check = check_deployment(&paths(&root), &library, &loadout);
+        assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
+        assert!(check.detail.contains("interrupted"), "{}", check.detail);
+        assert!(check
+            .fix
+            .as_deref()
+            .is_some_and(|fix| fix.contains("loadout") && fix.contains("format 0")));
+        assert_eq!(std::fs::read(&loadout).unwrap(), bytes);
+        assert!(!library.exists());
+        assert!(!dir.path().join(".gore-manager-library.lock").exists());
+    }
+
+    #[test]
+    fn missing_library_with_persisted_intent_is_library_uncertainty_without_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("game");
+        make_install(&root);
+        let library = dir.path().join("missing-library");
+        let store = dir.path().join("store");
+        let loadout = store.join("loadout.json");
+        std::fs::create_dir(&store).unwrap();
+        let bytes = br#"{"format":1,"entries":[{"id":"still-wanted","enabled":true}]}"#;
+        std::fs::write(&loadout, bytes).unwrap();
+
+        let check = check_deployment(&paths(&root), &library, &loadout);
+        assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
+        assert!(check.detail.contains("library"), "{}", check.detail);
+        assert!(
+            !check.detail.contains("loadout could not be read"),
+            "{}",
+            check.detail
+        );
+        let fix = check.fix.expect("missing Library must be actionable");
+        assert!(fix.contains("library uncertainty"), "{fix}");
+        assert!(fix.contains("do not delete or repair the loadout"), "{fix}");
+        assert!(!fix.contains("Delete or repair"), "{fix}");
+        assert_eq!(std::fs::read(&loadout).unwrap(), bytes);
+        assert!(!library.exists());
+        assert!(!store.join(".gore-manager-library.lock").exists());
+        assert!(!library.join(".gore-manager-library.lock").exists());
+        assert!(!std::fs::read_dir(&store).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("pending")));
+    }
+
+    #[test]
+    fn recovery_priority_names_missing_library_uncertainty_without_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("game");
+        make_install(&root);
+        let library = dir.path().join("missing-library");
+        let store = dir.path().join("store");
+        let loadout = store.join("loadout.json");
+        std::fs::create_dir(&store).unwrap();
+        let bytes = br#"{"format":1,"entries":[{"id":"still-wanted","enabled":true}]}"#;
+        std::fs::write(&loadout, bytes).unwrap();
+        write_deploy_record(
+            &root,
+            &gore_mod::DeployRecord {
+                owner: "manager".into(),
+                mod_name: "manager".into(),
+                phase: gore_mod::DeployPhase::RecoveryRequired,
+                ..Default::default()
+            },
+        );
+
+        let check = check_deployment(&paths(&root), &library, &loadout);
+        assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
+        assert!(check.detail.contains("interrupted"), "{}", check.detail);
+        let fix = check
+            .fix
+            .expect("recovery plus Library uncertainty must be actionable");
+        assert!(fix.contains("gore mgr reset"), "{fix}");
+        assert!(fix.contains("library uncertainty"), "{fix}");
+        assert!(fix.contains("do not delete or repair the loadout"), "{fix}");
+        assert!(!fix.contains("Delete or repair"), "{fix}");
+        assert_eq!(std::fs::read(&loadout).unwrap(), bytes);
+        assert!(!library.exists());
+        assert!(!store.join(".gore-manager-library.lock").exists());
+        assert!(!library.join(".gore-manager-library.lock").exists());
+        assert!(!std::fs::read_dir(&store).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("pending")));
+    }
+
+    #[test]
+    fn uncertain_library_is_not_misreported_as_a_corrupt_loadout_or_repaired() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("game");
+        make_install(&root);
+        let library = dir.path().join("library");
+        let loadout = dir.path().join("loadout.json");
+        write_manager_entry(&library, "a");
+        prepare_existing_read_only_library_lock(&library);
+        let loadout_bytes = br#"{"format":1,"entries":[{"id":"a","enabled":true}]}"#;
+        std::fs::write(&loadout, loadout_bytes).unwrap();
+        let transaction = library.join(".replacing-doctor-test");
+        std::fs::create_dir(&transaction).unwrap();
+        let evidence = transaction.join("evidence");
+        std::fs::write(&evidence, b"keep").unwrap();
+
+        let check = check_deployment(&paths(&root), &library, &loadout);
+        assert_eq!(check.verdict, Verdict::Problem, "{}", check.detail);
+        assert!(check.detail.contains("library"), "{}", check.detail);
+        let fix = check
+            .fix
+            .expect("strict Library refusal must be actionable");
+        assert!(fix.contains("library uncertainty"), "{fix}");
+        assert!(fix.contains("do not delete or repair the loadout"), "{fix}");
+        assert!(!fix.contains("Delete or repair"), "{fix}");
+        assert_eq!(std::fs::read(&loadout).unwrap(), loadout_bytes);
+        assert_eq!(std::fs::read(&evidence).unwrap(), b"keep");
+        assert!(transaction.is_dir());
+        assert!(!dir.path().join(".gore-manager-library.lock").exists());
+        assert!(!std::fs::read_dir(dir.path()).unwrap().any(|entry| {
+            entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("pending")
+        }));
     }
 
     #[test]

--- a/crates/gore/src/cmd/mgr.rs
+++ b/crates/gore/src/cmd/mgr.rs
@@ -3,10 +3,10 @@
 //! a **loadout** (which mods are enabled, in mount order), conflict analysis, and
 //! composing the enabled set into ONE deployment against the game.
 //!
-//! Every subcommand resolves its `--library` / `--loadout` overrides against the
-//! shared per-user defaults (`gore_mod::mgr::paths`), so with no flags every tool
-//! sees the same state. Engine errors (`gore_mod::ModError`) are wrapped into
-//! `anyhow` here.
+//! Every subcommand uses either the shared per-user Store or one explicit
+//! `--library` / `--loadout` pair. Requiring both overrides prevents a custom
+//! loadout from being reconciled against an unrelated library. Engine errors
+//! (`gore_mod::ModError`) are wrapped into `anyhow` here.
 
 use anyhow::{Context, Result};
 use clap::Subcommand;
@@ -114,14 +114,16 @@ pub enum MgrAction {
     },
 }
 
-/// Resolve the library dir: the `--library` override or the shared default.
-fn library_of(arg: Option<PathBuf>) -> PathBuf {
-    arg.unwrap_or_else(mgr::paths::library_dir)
-}
-
-/// Resolve the loadout path: the `--loadout` override or the shared default.
-fn loadout_of(arg: Option<PathBuf>) -> PathBuf {
-    arg.unwrap_or_else(mgr::paths::loadout_path)
+/// Resolve one complete Store identity. A lone override cannot identify which Library and Loadout
+/// belong together, and opening that mixed pair could destructively reconcile the wrong file.
+fn store_paths(library: Option<PathBuf>, loadout: Option<PathBuf>) -> Result<(PathBuf, PathBuf)> {
+    match (library, loadout) {
+        (None, None) => Ok((mgr::paths::library_dir(), mgr::paths::loadout_path())),
+        (Some(library), Some(loadout)) => Ok((library, loadout)),
+        _ => anyhow::bail!(
+            "--library and --loadout overrides must be supplied together so they identify one manager store"
+        ),
+    }
 }
 
 pub fn run(action: MgrAction) -> Result<()> {
@@ -131,8 +133,7 @@ pub fn run(action: MgrAction) -> Result<()> {
             library,
             loadout,
         } => {
-            let lib = library_of(library);
-            let ld_path = loadout_of(loadout);
+            let (lib, ld_path) = store_paths(library, loadout)?;
 
             let outcome = import::import_detailed(&lib, &path)
                 .map_err(|e| anyhow::anyhow!("{e}"))
@@ -162,8 +163,7 @@ pub fn run(action: MgrAction) -> Result<()> {
         }
 
         MgrAction::List { library, loadout } => {
-            let lib = library_of(library);
-            let ld_path = loadout_of(loadout);
+            let (lib, ld_path) = store_paths(library, loadout)?;
 
             let store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
             let ld = store.loadout();
@@ -212,8 +212,7 @@ pub fn run(action: MgrAction) -> Result<()> {
             library,
             loadout,
         } => {
-            let lib = library_of(library);
-            let ld_path = loadout_of(loadout);
+            let (lib, ld_path) = store_paths(library, loadout)?;
 
             let removed = import::remove(&lib, &id).map_err(|e| anyhow::anyhow!("{e}"))?;
             StoreSnapshot::open(&lib, &ld_path)
@@ -243,8 +242,7 @@ pub fn run(action: MgrAction) -> Result<()> {
             library,
             loadout,
         } => {
-            let lib = library_of(library);
-            let ld_path = loadout_of(loadout);
+            let (lib, ld_path) = store_paths(library, loadout)?;
             let mut store =
                 StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
             let mut to = 0;
@@ -275,8 +273,7 @@ pub fn run(action: MgrAction) -> Result<()> {
         }
 
         MgrAction::Analyze { library, loadout } => {
-            let lib = library_of(library);
-            let ld_path = loadout_of(loadout);
+            let (lib, ld_path) = store_paths(library, loadout)?;
 
             let store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
             let conflicts = store.analyze();
@@ -297,8 +294,7 @@ pub fn run(action: MgrAction) -> Result<()> {
             loadout,
         } => {
             let game = gore_loc::config::game_root(game)?;
-            let lib = library_of(library);
-            let ld_path = loadout_of(loadout);
+            let (lib, ld_path) = store_paths(library, loadout)?;
 
             let store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
             let report = match store.apply(&game) {
@@ -339,8 +335,7 @@ pub fn run(action: MgrAction) -> Result<()> {
             loadout,
         } => {
             let game = gore_loc::config::game_root(game)?;
-            let lib = library_of(library);
-            let ld_path = loadout_of(loadout);
+            let (lib, ld_path) = store_paths(library, loadout)?;
             let store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
             let st = store.status(&game).map_err(|e| anyhow::anyhow!("{e}"))?;
             println!("{}", describe_status(&st));
@@ -384,8 +379,7 @@ fn set_enabled(
     library: Option<PathBuf>,
     loadout: Option<PathBuf>,
 ) -> Result<()> {
-    let lib = library_of(library);
-    let ld_path = loadout_of(loadout);
+    let (lib, ld_path) = store_paths(library, loadout)?;
     let mut store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
     store
         .update_loadout(|loadout| {
@@ -439,6 +433,20 @@ fn describe_status(st: &ManagerStatus) -> String {
 mod tests {
     use super::*;
     use gore_mod::mgr::analyze::ConflictKind;
+
+    #[test]
+    fn custom_store_overrides_must_be_paired() {
+        assert!(store_paths(Some(PathBuf::from("library")), None).is_err());
+        assert!(store_paths(None, Some(PathBuf::from("loadout.json"))).is_err());
+        assert_eq!(
+            store_paths(
+                Some(PathBuf::from("library")),
+                Some(PathBuf::from("loadout.json")),
+            )
+            .unwrap(),
+            (PathBuf::from("library"), PathBuf::from("loadout.json")),
+        );
+    }
 
     fn conflict(severity: Severity) -> Conflict {
         Conflict {

--- a/crates/gore/src/cmd/mgr.rs
+++ b/crates/gore/src/cmd/mgr.rs
@@ -14,11 +14,11 @@ use std::path::PathBuf;
 
 use gore_mod::mgr::{
     self,
-    analyze::{analyze, Conflict, Severity},
-    apply::{apply_loadout, undeploy_all},
+    analyze::{Conflict, Severity},
+    apply::undeploy_all,
     import,
-    loadout::{self, Loadout, LoadoutEntry},
-    status::{status, ManagerStatus},
+    status::ManagerStatus,
+    store::StoreSnapshot,
 };
 
 #[derive(Subcommand)]
@@ -138,18 +138,17 @@ pub fn run(action: MgrAction) -> Result<()> {
                 .map_err(|e| anyhow::anyhow!("{e}"))
                 .with_context(|| format!("importing {}", path.display()))?;
             let entry = &outcome.entry;
-
-            // Also register the new mod in the loadout (disabled) so `enable`
-            // can find it. Skip if an entry with this id already exists (re-import
-            // / update): keep its current enabled state and position.
-            let mut ld = loadout::load(&ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-            if !ld.entries.iter().any(|e| e.id == entry.id) {
-                ld.entries.push(LoadoutEntry {
-                    id: entry.id.clone(),
-                    enabled: false,
-                });
-                loadout::save(&ld_path, &ld).map_err(|e| anyhow::anyhow!("{e}"))?;
-            }
+            // Library publication and loadout registration are deliberately two commits. Import
+            // has released its Library lock before Store acquires its canonical root set and repairs any
+            // valid partial publication. A loadout error leaves the imported library entry intact.
+            StoreSnapshot::open(&lib, &ld_path)
+                .map_err(|e| anyhow::anyhow!("{e}"))
+                .with_context(|| {
+                    format!(
+                        "imported {:?} into the library but failed to reconcile the loadout",
+                        entry.id
+                    )
+                })?;
 
             println!(
                 "imported {} ({}) [{:?}] disposition={} matched_by={}",
@@ -166,8 +165,9 @@ pub fn run(action: MgrAction) -> Result<()> {
             let lib = library_of(library);
             let ld_path = loadout_of(loadout);
 
-            let ld = loadout::load(&ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-            let mods = import::list(&lib).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let ld = store.loadout();
+            let mods = store.mods();
 
             // One row per loadout entry (in loadout order), joined to its metadata
             // by id; library mods not in the loadout are appended after.
@@ -192,7 +192,7 @@ pub fn run(action: MgrAction) -> Result<()> {
                 );
                 shown.push(&e.id);
             }
-            for m in &mods {
+            for m in mods {
                 if shown.iter().any(|id| *id == m.id) {
                     continue;
                 }
@@ -216,40 +216,60 @@ pub fn run(action: MgrAction) -> Result<()> {
             let ld_path = loadout_of(loadout);
 
             let removed = import::remove(&lib, &id).map_err(|e| anyhow::anyhow!("{e}"))?;
-
-            // Drop it from the loadout too so a stale entry doesn't linger.
-            let mut ld = loadout::load(&ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-            let before = ld.entries.len();
-            ld.entries.retain(|e| e.id != id);
-            if ld.entries.len() != before {
-                loadout::save(&ld_path, &ld).map_err(|e| anyhow::anyhow!("{e}"))?;
-            }
+            StoreSnapshot::open(&lib, &ld_path)
+                .map_err(|e| anyhow::anyhow!("{e}"))
+                .with_context(|| {
+                    format!("removed {id:?} from the library but failed to reconcile the loadout")
+                })?;
 
             println!("removed {id}: {removed}");
             Ok(())
         }
 
-        MgrAction::Enable { id, loadout, .. } => set_enabled(&id, true, loadout),
-        MgrAction::Disable { id, loadout, .. } => set_enabled(&id, false, loadout),
+        MgrAction::Enable {
+            id,
+            library,
+            loadout,
+        } => set_enabled(&id, true, library, loadout),
+        MgrAction::Disable {
+            id,
+            library,
+            loadout,
+        } => set_enabled(&id, false, library, loadout),
 
         MgrAction::Order {
-            id, pos, loadout, ..
+            id,
+            pos,
+            library,
+            loadout,
         } => {
+            let lib = library_of(library);
             let ld_path = loadout_of(loadout);
-            let mut ld = loadout::load(&ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let mut store =
+                StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let mut to = 0;
+            store
+                .update_loadout(|ld| {
+                    let from = ld
+                        .entries
+                        .iter()
+                        .position(|entry| entry.id == id)
+                        .ok_or_else(|| {
+                            gore_mod::ModError::Other(format!("no loadout entry with id {id:?}"))
+                        })?;
+                    to = pos.min(ld.entries.len() - 1);
+                    let entry = ld.entries.remove(from);
+                    ld.entries.insert(to, entry);
+                    Ok(())
+                })
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-            let from = ld
+            let order: Vec<&str> = store
+                .loadout()
                 .entries
                 .iter()
-                .position(|e| e.id == id)
-                .ok_or_else(|| anyhow::anyhow!("no loadout entry with id {id:?}"))?;
-            // Clamp to the last slot (len-1); entries is non-empty since `from` exists.
-            let to = pos.min(ld.entries.len() - 1);
-            let entry = ld.entries.remove(from);
-            ld.entries.insert(to, entry);
-            loadout::save(&ld_path, &ld).map_err(|e| anyhow::anyhow!("{e}"))?;
-
-            let order: Vec<&str> = ld.entries.iter().map(|e| e.id.as_str()).collect();
+                .map(|e| e.id.as_str())
+                .collect();
             println!("moved {id} to position {to}; order: {}", order.join(" -> "));
             Ok(())
         }
@@ -258,10 +278,8 @@ pub fn run(action: MgrAction) -> Result<()> {
             let lib = library_of(library);
             let ld_path = loadout_of(loadout);
 
-            let mods = import::list(&lib).map_err(|e| anyhow::anyhow!("{e}"))?;
-            let ld = loadout::load(&ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-            let refs: Vec<&_> = mods.iter().collect();
-            let conflicts = analyze(&refs, &ld);
+            let store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let conflicts = store.analyze();
 
             if conflicts.is_empty() {
                 println!("no conflicts");
@@ -282,8 +300,8 @@ pub fn run(action: MgrAction) -> Result<()> {
             let lib = library_of(library);
             let ld_path = loadout_of(loadout);
 
-            let ld = loadout::load(&ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-            let report = match apply_loadout(&game, &lib, &ld) {
+            let store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let report = match store.apply(&game) {
                 Ok(r) => r,
                 Err(e) => {
                     let msg = e.to_string();
@@ -323,8 +341,8 @@ pub fn run(action: MgrAction) -> Result<()> {
             let game = gore_loc::config::game_root(game)?;
             let lib = library_of(library);
             let ld_path = loadout_of(loadout);
-            let ld = loadout::load(&ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-            let st = status(&game, &lib, &ld).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let st = store.status(&game).map_err(|e| anyhow::anyhow!("{e}"))?;
             println!("{}", describe_status(&st));
             Ok(())
         }
@@ -359,17 +377,31 @@ fn format_conflict(conflict: &Conflict) -> String {
 }
 
 /// Set the `enabled` flag of loadout entry `id`; error if it isn't in the loadout.
-/// (`--library` is accepted for a uniform CLI surface but isn't needed here.)
-fn set_enabled(id: &str, enabled: bool, loadout: Option<PathBuf>) -> Result<()> {
+/// The selected library is part of the same strict Store snapshot and must be forwarded.
+fn set_enabled(
+    id: &str,
+    enabled: bool,
+    library: Option<PathBuf>,
+    loadout: Option<PathBuf>,
+) -> Result<()> {
+    let lib = library_of(library);
     let ld_path = loadout_of(loadout);
-    let mut ld: Loadout = loadout::load(&ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-    let entry = ld
-        .entries
-        .iter_mut()
-        .find(|e| e.id == id)
-        .ok_or_else(|| anyhow::anyhow!("no loadout entry with id {id:?} (import it first)"))?;
-    entry.enabled = enabled;
-    loadout::save(&ld_path, &ld).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let mut store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+    store
+        .update_loadout(|loadout| {
+            let entry = loadout
+                .entries
+                .iter_mut()
+                .find(|entry| entry.id == id)
+                .ok_or_else(|| {
+                    gore_mod::ModError::Other(format!(
+                        "no loadout entry with id {id:?} (import it first)"
+                    ))
+                })?;
+            entry.enabled = enabled;
+            Ok(())
+        })
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     println!("{id}: {}", if enabled { "enabled" } else { "disabled" });
     Ok(())
 }

--- a/crates/gore/tests/integration/mgr.rs
+++ b/crates/gore/tests/integration/mgr.rs
@@ -149,6 +149,25 @@ fn mgr_import_keeps_prefix_and_reports_structured_success_outcome() {
     assert!(moved.contains("matched_by=content"), "{moved}");
 }
 
+#[test]
+fn mgr_accepts_child_loadout_path_relative_to_the_process_cwd() {
+    let tmp = TempDir::new().unwrap();
+    Command::cargo_bin("gore")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args([
+            "mgr",
+            "list",
+            "--library",
+            "library",
+            "--loadout",
+            "loadout.json",
+        ])
+        .assert()
+        .success();
+    assert!(tmp.path().join("library").is_dir());
+}
+
 /// The whole loadout lifecycle with NO real game deploy. This is the always-run gate.
 #[test]
 fn mgr_import_list_enable_disable_order_analyze_status_reset() {
@@ -189,7 +208,15 @@ fn mgr_import_list_enable_disable_order_analyze_status_reset() {
     for id in [&id_a, &id_b] {
         Command::cargo_bin("gore")
             .unwrap()
-            .args(["mgr", "enable", id, "--loadout", loadout.to_str().unwrap()])
+            .args([
+                "mgr",
+                "enable",
+                id,
+                "--library",
+                lib.to_str().unwrap(),
+                "--loadout",
+                loadout.to_str().unwrap(),
+            ])
             .assert()
             .success()
             .stdout(predicates::str::contains("enabled"));
@@ -235,6 +262,8 @@ fn mgr_import_list_enable_disable_order_analyze_status_reset() {
             "mgr",
             "disable",
             &id_b,
+            "--library",
+            lib.to_str().unwrap(),
             "--loadout",
             loadout.to_str().unwrap(),
         ])
@@ -264,6 +293,8 @@ fn mgr_import_list_enable_disable_order_analyze_status_reset() {
             "order",
             &id_b,
             "0",
+            "--library",
+            lib.to_str().unwrap(),
             "--loadout",
             loadout.to_str().unwrap(),
         ])
@@ -282,6 +313,8 @@ fn mgr_import_list_enable_disable_order_analyze_status_reset() {
             "status",
             "--game",
             game.to_str().unwrap(),
+            "--library",
+            lib.to_str().unwrap(),
             "--loadout",
             loadout.to_str().unwrap(),
         ])
@@ -334,6 +367,7 @@ fn mgr_import_list_enable_disable_order_analyze_status_reset() {
 #[test]
 fn mgr_enable_unknown_id_errors() {
     let tmp = TempDir::new().unwrap();
+    let library = tmp.path().join("library");
     let loadout = tmp.path().join("loadout.json");
     Command::cargo_bin("gore")
         .unwrap()
@@ -341,6 +375,8 @@ fn mgr_enable_unknown_id_errors() {
             "mgr",
             "enable",
             "does-not-exist",
+            "--library",
+            library.to_str().unwrap(),
             "--loadout",
             loadout.to_str().unwrap(),
         ])
@@ -376,7 +412,15 @@ fn mgr_pak_file_patch_reorders_and_resets_in_a_temp_game() {
     for id in [&alpha, &bravo] {
         Command::cargo_bin("gore")
             .unwrap()
-            .args(["mgr", "enable", id, "--loadout", loadout.to_str().unwrap()])
+            .args([
+                "mgr",
+                "enable",
+                id,
+                "--library",
+                lib.to_str().unwrap(),
+                "--loadout",
+                loadout.to_str().unwrap(),
+            ])
             .assert()
             .success();
     }
@@ -464,6 +508,8 @@ fn mgr_pak_file_patch_reorders_and_resets_in_a_temp_game() {
             "order",
             &bravo,
             "0",
+            "--library",
+            lib.to_str().unwrap(),
             "--loadout",
             loadout.to_str().unwrap(),
         ])
@@ -566,7 +612,15 @@ fn mgr_apply_on_temp_game() {
     let id = import(&lib, &loadout, &bundle);
     Command::cargo_bin("gore")
         .unwrap()
-        .args(["mgr", "enable", &id, "--loadout", loadout.to_str().unwrap()])
+        .args([
+            "mgr",
+            "enable",
+            &id,
+            "--library",
+            lib.to_str().unwrap(),
+            "--loadout",
+            loadout.to_str().unwrap(),
+        ])
         .assert()
         .success();
 

--- a/crates/gore/tests/integration/mgr.rs
+++ b/crates/gore/tests/integration/mgr.rs
@@ -168,6 +168,38 @@ fn mgr_accepts_child_loadout_path_relative_to_the_process_cwd() {
     assert!(tmp.path().join("library").is_dir());
 }
 
+#[test]
+fn mgr_rejects_unpaired_loadout_override_before_reconciliation() {
+    let tmp = TempDir::new().unwrap();
+    let data = tmp.path().join("data");
+    let default_library = data.join("gore/mod-manager/library");
+    std::fs::create_dir_all(&default_library).unwrap();
+    let loadout = tmp.path().join("custom-loadout.json");
+    let bytes = br#"{"format":1,"entries":[{"id":"custom","enabled":true}]}"#;
+    std::fs::write(&loadout, bytes).unwrap();
+
+    for args in [
+        vec!["mgr", "enable", "custom", "--loadout"],
+        vec!["mgr", "disable", "custom", "--loadout"],
+        vec!["mgr", "order", "custom", "0", "--loadout"],
+    ] {
+        Command::cargo_bin("gore")
+            .unwrap()
+            .env("LOCALAPPDATA", &data)
+            .env("APPDATA", &data)
+            .env("XDG_DATA_HOME", &data)
+            .args(args)
+            .arg(&loadout)
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains(
+                "--library and --loadout overrides must be supplied together",
+            ));
+        assert_eq!(std::fs::read(&loadout).unwrap(), bytes);
+        assert_eq!(std::fs::read_dir(&default_library).unwrap().count(), 0);
+    }
+}
+
 /// The whole loadout lifecycle with NO real game deploy. This is the always-run gate.
 #[test]
 fn mgr_import_list_enable_disable_order_analyze_status_reset() {

--- a/docs/guide/mod-manager.md
+++ b/docs/guide/mod-manager.md
@@ -100,6 +100,45 @@ error; callers must refresh the authoritative library/loadout state. The
 library lock does not claim a joint transaction or cross-process atomicity for
 the loadout. Identity refusals happen before publication and loadout activation.
 
+All authoritative Manager reads and loadout edits use one native Store
+snapshot. It locks the loadout store before the library, validates every
+non-dot library entry, and refuses uncertainty instead of silently presenting a
+partial library. A valid loadout is reconciled to that snapshot: the first
+known occurrence keeps its order and enabled state, duplicates and stale ids
+are removed, and newly published ids are appended disabled in stable id order.
+Corrupt, oversized, symlinked, or future-format loadouts are refused and left
+untouched. Reconciliation writes only when those canonical bytes actually
+change.
+
+`gore doctor` remains advisory and read-only. Its deployment check takes only
+the existing Library coordination lane, reads the loadout through the same
+bounded no-follow stability checks, and applies the same strict reconciliation
+in memory. It never creates the Store lock, repairs the loadout, or recovers a
+library transaction. On Windows it joins an existing persistent Library lock
+file but does not create one; missing coordination or recovery evidence is
+reported without changing it. Cooperative Store writers include that same
+Library root in their canonical physical lock set before they read or save, so
+the Library guard keeps Doctor's projection stable while status consumes it.
+
+Manager root locks coordinate GORE processes and are released by the kernel
+after a crash. Store opens both the canonical loadout parent and Library root,
+rejects one directory serving both roles, sorts their physical identities, and
+locks in that global order. Unix locks each retained directory inode and
+performs load/save relative to the Store handle; Windows uses the persistent
+`.gore-manager-library.lock` direct child for every Manager root. Both platforms
+revalidate retained and named root identities after acquisition. This is
+cooperative serialization on a local filesystem, not an access-control boundary
+against unrelated processes. Import and remove first
+finish their separately locked library publication, release that lock, and then
+take the Store snapshot for reconciliation; they intentionally remain two
+explicit commits.
+
+The app consumes this native snapshot directly and does not write it back while
+refreshing. An explicit full-loadout replacement is serialized, but concurrent
+full replacements of existing slots remain last-writer-wins. Reconciliation
+still preserves every id currently present in the library; this compatibility
+API does not claim CAS semantics or zero lost UI intent.
+
 ### GORE bundle format gate
 
 Recognizing a root `gore-mod.json` commits import to the closed


### PR DESCRIPTION
## Summary
- serialize Manager loadout/library mutations across GUI and CLI processes
- reconcile one strict native Store snapshot and remove Flutter writeback races
- share universal Manager root locks across Store and import identity operations
- keep Doctor and preflight read-only, bounded, fail-closed, and artifact-free

## Validation
- Windows: gore-mod 428 passed; gore 261 plus integrations; gore-ffi 498 plus Dart parity
- Linux/WSL: gore-mod 441 passed; Store 29 passed
- Flutter: 209 passed; analyze clean
- Clippy and diff checks clean
- three independent final reviews clean

No real game install, save, launch, or deployment mutation was performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches cross-process locking, loadout persistence, and the FFI protocol ABI for Manager store mutations—failure modes can corrupt or desync shared library/loadout state.
> 
> **Overview**
> Moves library/loadout authority into a locked native **`StoreSnapshot`**, so GUI and CLI share one reconciled Manager store instead of racing on separate reads and writes.
> 
> **Flutter no longer reconciles or writebacks loadouts.** `LibraryNotifier` treats `mgr_library_list` as an authoritative snapshot, and `MgrFfi` fail-closes on malformed or inconsistent native responses. Protocol ABI bumps to **2**.
> 
> On the Rust side, all `mgr_*` store routes require **paired** `library_dir`/`loadout_path` overrides, route `mgr_set_loadout` through a bounded raw parser into `StoreSnapshot::replace_loadout`, and share universal Manager root locks with import/identity work. Doctor and preflight stay read-only and artifact-free.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8296f290d73a5424b7d62c16a87fb9a3d5bb8ce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->