### PR TITLE
fix(release): accept canonical Inno metadata

### DIFF
--- a/scripts/test_verify_mod_manager_release.py
+++ b/scripts/test_verify_mod_manager_release.py
@@ -47,6 +47,11 @@ def _installer_metadata(name: str) -> dict[str, str]:
     }
 
 
+def _inno_installer_metadata(name: str) -> dict[str, str]:
+    info = _installer_metadata(name)
+    return {field: value + " " * 7 for field, value in info.items()}
+
+
 class _ReleaseFixture:
     def __init__(self) -> None:
         self.temp = tempfile.TemporaryDirectory()
@@ -408,6 +413,56 @@ class ModManagerReleaseContractTest(unittest.TestCase):
             fixture.root, VERSION, version_info_reader=fixture.metadata
         )
         self.assert_problem(problems, "unexpected package artifact")
+
+    def test_inno_installer_metadata_accepts_only_canonical_padding(self) -> None:
+        fixture = self.fixture()
+
+        def padded_metadata(path: Path) -> dict[str, str]:
+            if path.name == fixture.installer.name:
+                return _inno_installer_metadata(path.name)
+            return _app_metadata()
+
+        self.assertEqual(
+            verifier.verify_release(
+                fixture.root, VERSION, version_info_reader=padded_metadata
+            ),
+            [],
+        )
+
+        for label, field, value in (
+            ("non-space suffix", "CompanyName", "dh0er X"),
+            ("internal mismatch", "ProductName", "GORE  Mod Manager   "),
+            (
+                "unconverted copyright",
+                "LegalCopyright",
+                "Copyright (C) 2026 dh0er. All rights reserved.   ",
+            ),
+        ):
+            with self.subTest(label=label):
+                def invalid_metadata(path: Path) -> dict[str, str]:
+                    if path.name == fixture.installer.name:
+                        info = _inno_installer_metadata(path.name)
+                        info[field] = value
+                        return info
+                    return _app_metadata()
+
+                problems = verifier.verify_release(
+                    fixture.root, VERSION, version_info_reader=invalid_metadata
+                )
+                self.assert_problem(problems, field)
+
+        def padded_app_metadata(path: Path) -> dict[str, str]:
+            if path.name == fixture.installer.name:
+                return _inno_installer_metadata(path.name)
+            info = _app_metadata()
+            info["CompanyName"] += " "
+            return info
+
+        problems = verifier.verify_release(
+            fixture.root, VERSION, version_info_reader=padded_app_metadata
+        )
+        self.assert_problem(problems, "portable zip app: CompanyName='dh0er '")
+        self.assert_problem(problems, "installer source app: CompanyName='dh0er '")
 
     def test_repository_metadata_and_installer_recipe_are_not_templates(self) -> None:
         runner = (

--- a/scripts/test_verify_mod_manager_release.py
+++ b/scripts/test_verify_mod_manager_release.py
@@ -49,7 +49,10 @@ def _installer_metadata(name: str) -> dict[str, str]:
 
 def _inno_installer_metadata(name: str) -> dict[str, str]:
     info = _installer_metadata(name)
-    return {field: value + " " * 7 for field, value in info.items()}
+    return {
+        field: value.ljust(verifier.INNO_INSTALLER_METADATA_WIDTHS[field], " ")
+        for field, value in info.items()
+    }
 
 
 class _ReleaseFixture:
@@ -429,10 +432,46 @@ class ModManagerReleaseContractTest(unittest.TestCase):
             [],
         )
 
+        canonical = _inno_installer_metadata(fixture.installer.name)
+        self.assertEqual(
+            {field: len(value) for field, value in canonical.items()},
+            verifier.INNO_INSTALLER_METADATA_WIDTHS,
+        )
+        self.assertEqual(
+            {
+                field: len(value) - len(value.rstrip(" "))
+                for field, value in canonical.items()
+            },
+            {
+                "CompanyName": 55,
+                "FileDescription": 38,
+                "FileVersion": 15,
+                "LegalCopyright": 56,
+                "OriginalFilename": 18,
+                "ProductName": 44,
+                "ProductVersion": 45,
+            },
+        )
+
+        for field, value in canonical.items():
+            for suffix, invalid_value in (
+                ("missing space", value[:-1]),
+                ("extra space", value + " "),
+            ):
+                with self.subTest(field=field, suffix=suffix):
+                    def invalid_padding(path: Path) -> dict[str, str]:
+                        if path.name == fixture.installer.name:
+                            info = canonical.copy()
+                            info[field] = invalid_value
+                            return info
+                        return _app_metadata()
+
+                    problems = verifier.verify_release(
+                        fixture.root, VERSION, version_info_reader=invalid_padding
+                    )
+                    self.assert_problem(problems, field)
+
         for label, field, value in (
-            ("missing padding", "CompanyName", "dh0er"),
-            ("short padding", "CompanyName", "dh0er "),
-            ("long padding", "ProductName", "GORE Mod Manager        "),
             ("non-space suffix", "CompanyName", "dh0er X"),
             ("internal mismatch", "ProductName", "GORE  Mod Manager   "),
             (

--- a/scripts/test_verify_mod_manager_release.py
+++ b/scripts/test_verify_mod_manager_release.py
@@ -123,7 +123,7 @@ Source: "..\\..\\..\\THIRD_PARTY_LICENSES.md"; DestDir: "{app}"; Flags: ignoreve
 
     def metadata(self, path: Path) -> dict[str, str]:
         if path.name == self.installer.name:
-            return _installer_metadata(path.name)
+            return _inno_installer_metadata(path.name)
         return _app_metadata()
 
     def _portable_entries(self) -> list[tuple[str, bytes | None]]:
@@ -430,6 +430,9 @@ class ModManagerReleaseContractTest(unittest.TestCase):
         )
 
         for label, field, value in (
+            ("missing padding", "CompanyName", "dh0er"),
+            ("short padding", "CompanyName", "dh0er "),
+            ("long padding", "ProductName", "GORE Mod Manager        "),
             ("non-space suffix", "CompanyName", "dh0er X"),
             ("internal mismatch", "ProductName", "GORE  Mod Manager   "),
             (

--- a/scripts/verify_mod_manager_release.py
+++ b/scripts/verify_mod_manager_release.py
@@ -72,6 +72,15 @@ INSTALLER_METADATA = {
     "LegalCopyright": "Copyright © 2026 dh0er. All rights reserved.",
     "ProductName": "GORE Mod Manager",
 }
+INNO_INSTALLER_METADATA_WIDTHS = {
+    "CompanyName": 60,
+    "FileDescription": 60,
+    "FileVersion": 20,
+    "LegalCopyright": 100,
+    "OriginalFilename": 50,
+    "ProductName": 60,
+    "ProductVersion": 50,
+}
 VERSION_FIELDS = (
     "CompanyName",
     "FileDescription",
@@ -413,9 +422,23 @@ def _check_inno_metadata(
     # Inno Setup updates fixed-size version-resource placeholders in place. It
     # leaves the unused suffix as ASCII spaces and canonicalizes every `(C)`
     # sequence to the real copyright symbol. Accept only that documented
-    # representation; application metadata remains exact.
-    padded = {field: value + " " * 7 for field, value in expected.items()}
-    return _check_metadata(info, padded, label)
+    # representation at each field's fixed Inno placeholder width;
+    # application metadata remains exact.
+    padded: dict[str, str] = {}
+    problems: list[str] = []
+    for field, value in expected.items():
+        width = INNO_INSTALLER_METADATA_WIDTHS.get(field)
+        if width is None:
+            problems.append(f"{label}: no Inno metadata width declared for {field}")
+            continue
+        if len(value) > width:
+            problems.append(
+                f"{label}: expected {field} exceeds Inno metadata width {width}"
+            )
+            continue
+        padded[field] = value.ljust(width, " ")
+    problems.extend(_check_metadata(info, padded, label))
+    return problems
 
 
 def _zip_contract(

--- a/scripts/verify_mod_manager_release.py
+++ b/scripts/verify_mod_manager_release.py
@@ -414,8 +414,8 @@ def _check_inno_metadata(
     # leaves the unused suffix as ASCII spaces and canonicalizes every `(C)`
     # sequence to the real copyright symbol. Accept only that documented
     # representation; application metadata remains exact.
-    normalized = {field: value.rstrip(" ") for field, value in info.items()}
-    return _check_metadata(normalized, expected, label)
+    padded = {field: value + " " * 7 for field, value in expected.items()}
+    return _check_metadata(info, padded, label)
 
 
 def _zip_contract(

--- a/scripts/verify_mod_manager_release.py
+++ b/scripts/verify_mod_manager_release.py
@@ -69,7 +69,7 @@ APP_METADATA = {
 INSTALLER_METADATA = {
     "CompanyName": "dh0er",
     "FileDescription": "GORE Mod Manager Setup",
-    "LegalCopyright": "Copyright (C) 2026 dh0er. All rights reserved.",
+    "LegalCopyright": "Copyright © 2026 dh0er. All rights reserved.",
     "ProductName": "GORE Mod Manager",
 }
 VERSION_FIELDS = (
@@ -407,6 +407,17 @@ def _check_metadata(
     ]
 
 
+def _check_inno_metadata(
+    info: Mapping[str, str], expected: Mapping[str, str], label: str
+) -> list[str]:
+    # Inno Setup updates fixed-size version-resource placeholders in place. It
+    # leaves the unused suffix as ASCII spaces and canonicalizes every `(C)`
+    # sequence to the real copyright symbol. Accept only that documented
+    # representation; application metadata remains exact.
+    normalized = {field: value.rstrip(" ") for field, value in info.items()}
+    return _check_metadata(normalized, expected, label)
+
+
 def _zip_contract(
     root: Path,
     archive: Path,
@@ -693,7 +704,7 @@ def _installer_contract(
                 "OriginalFilename": installer.name,
                 "ProductVersion": version,
             }
-            problems.extend(_check_metadata(info, expected, "installer"))
+            problems.extend(_check_inno_metadata(info, expected, "installer"))
 
     for license_name in ("LICENSE", "THIRD_PARTY_LICENSES.md"):
         license_path = root / license_name


### PR DESCRIPTION
## Summary
- accept Inno Setup's canonical fixed-field ASCII space padding only for final installer metadata
- expect Inno's deliberate `(C)` to `©` conversion in the generated setup executable
- keep portable and application metadata strict, with explicit negative regressions

## Verification
- `python -m unittest scripts.test_verify_mod_manager_release -v` (12/12)
- `python -m unittest discover -s scripts -p test_*.py` (51/51)
- `python scripts/check_release_workflow.py`
- `git diff --check`

Fixes the release-validator failure in non-publishing smoke run 31640828242. The installer build and signing succeeded; upload, release, and appcast feed steps were skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the mod-manager release verification script and its unit tests; no runtime, auth, or packaging behavior.
> 
> **Overview**
> Fixes release validation failing on real Inno-built setup executables even when the build succeeded.
> 
> **Installer `.exe` metadata** is now checked with `_check_inno_metadata` instead of byte-for-byte `_check_metadata`: each field is compared after left-justifying the expected value to Inno’s fixed placeholder widths (`INNO_INSTALLER_METADATA_WIDTHS`). Expected installer `LegalCopyright` uses `©` because Inno rewrites `(C)` that way.
> 
> **Portable zip and installer source app** metadata stay strict exact match; tests add `_inno_installer_metadata` for fixtures and `test_inno_installer_metadata_accepts_only_canonical_padding` to lock in canonical padding, reject wrong padding or unconverted copyright, and ensure app metadata still fails on trailing spaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe15b3c6f9410fc0c1235f75fe4da3bb70839e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->