### PR TITLE
Sign Mod Manager uninstaller

### DIFF
--- a/apps/mod-manager/installer/setup.iss
+++ b/apps/mod-manager/installer/setup.iss
@@ -54,6 +54,16 @@ UninstallDisplayIcon={app}\gore_manager.exe
 WizardStyle=modern
 SetupIconFile=..\windows\runner\resources\app_icon.ico
 LicenseFile=..\..\..\LICENSE
+#ifdef GORE_SIGNED_INSTALLER
+; build.py defines this uniquely named /S tool only when GORE_SIGN=1.
+; Inno signs both Setup and the embedded uninstaller with the same command.
+#ifndef GORE_SIGNED_UNINSTALLER_DIR
+  #error "Pass /DGORE_SIGNED_UNINSTALLER_DIR=<temporary path>"
+#endif
+SignTool=gore_mod_manager_ats_b7e4d2c95a184f6b
+SignedUninstaller=yes
+SignedUninstallerDir={#GORE_SIGNED_UNINSTALLER_DIR}
+#endif
 
 [UninstallDelete]
 ; Active settings live under the shared gore umbrella

--- a/build.py
+++ b/build.py
@@ -43,9 +43,9 @@ Code signing (Azure Trusted / Artifact Signing):
         TRUSTED_SIGNING_ENDPOINT  TRUSTED_SIGNING_ACCOUNT  TRUSTED_SIGNING_PROFILE
         AZURE_TENANT_ID  AZURE_CLIENT_ID  AZURE_CLIENT_SECRET   (service principal)
     With GORE_SIGN=1 a missing var hard-fails rather than silently shipping
-    unsigned. GORE_SIGN_NO_PROXY=1 makes the signtool call alone bypass the
-    system proxy, for machines whose PAC routes AAD login through a tunnel that
-    may be down (the rest of the build keeps the system proxy).
+    unsigned. GORE_SIGN_NO_PROXY=1 makes only the signing subprocess tree
+    (direct signtool, or ISCC and its signtool child) bypass the system proxy,
+    for machines whose PAC routes AAD login through a tunnel that may be down.
 """
 
 from __future__ import annotations
@@ -139,6 +139,11 @@ PROJECTS: dict[str, dict] = {
         "tag_prefix": "gore-mod-manager",
         "changelog": "CHANGELOG.md",
         "installer": "installer/setup.iss",
+        # Let Inno sign both Setup and its embedded uninstaller in signed builds.
+        # This globally unique name is deliberately not a generic `byparam`
+        # alias: Inno's /S command can otherwise be reused by injected script
+        # content with attacker-controlled parameters.
+        "inno_sign_tool": "gore_mod_manager_ats_b7e4d2c95a184f6b",
         "exe": "gore_manager.exe",  # CMake BINARY_NAME
         "core_crate": "gore-ffi",  # shares the mod-studio FFI crate
         "core_dll": "gore_ffi",  # dll gore_ffi.dll (cargo underscores it)
@@ -274,9 +279,9 @@ def _signing_config() -> dict[str, str] | None:
 # A corporate PAC may route login.microsoftonline.com through a local tunnel; when
 # that tunnel is down, token acquisition dies with "No connection could be made
 # because the target machine actively refused it (localhost:9000)" and signing
-# fails even though the network is fine. These overrides are handed to the signtool
-# child process alone, so the rest of the build (Flutter, cargo, pub) keeps using
-# the system proxy untouched.
+# fails even though the network is fine. These overrides are handed only to the
+# process that owns signing (direct signtool, or ISCC and its signtool child), so
+# the rest of the build (Flutter, cargo, pub) keeps the system proxy untouched.
 #
 # .NET only builds its proxy from the environment when a proxy is actually set
 # there, and only then honours NO_PROXY -- hence the deliberately dead dummy
@@ -292,7 +297,7 @@ _SIGN_NO_PROXY = (
 def _sign_proxy_overrides() -> dict[str, str]:
     if os.environ.get("GORE_SIGN_NO_PROXY") != "1":
         return {}
-    print("signing: bypassing the system proxy for signtool (GORE_SIGN_NO_PROXY=1)")
+    print("signing: bypassing the system proxy (GORE_SIGN_NO_PROXY=1)")
     return {
         "HTTP_PROXY": "http://127.0.0.1:9",
         "HTTPS_PROXY": "http://127.0.0.1:9",
@@ -378,16 +383,52 @@ def sign_paths(paths: list[Path], dry: bool) -> None:
     try:
         run(
             f"code-sign {len(pe)} file(s)",
-            [
-                signtool, "sign", "/v", "/fd", "SHA256",
-                "/tr", TS_TIMESTAMP, "/td", "SHA256",
-                "/dlib", dlib, "/dmdf", meta,
-                *pe,
-            ],
+            _trusted_signing_args(signtool, dlib, meta, pe),
             extra_env=_sign_proxy_overrides(),
         )
     finally:
         meta.unlink(missing_ok=True)
+
+
+def _trusted_signing_args(
+    signtool: Path, dlib: Path, metadata: Path, paths: list[Path | str]
+) -> list[Path | str]:
+    """Build the one Azure Trusted Signing command used by direct and Inno signing."""
+    return [
+        signtool,
+        "sign",
+        "/v",
+        "/fd",
+        "SHA256",
+        "/tr",
+        TS_TIMESTAMP,
+        "/td",
+        "SHA256",
+        "/dlib",
+        dlib,
+        "/dmdf",
+        metadata,
+        *paths,
+    ]
+
+
+def _inno_quote_sign_arg(value: Path | str) -> str:
+    """Quote a fixed SignTool argument using Inno's command-line placeholders."""
+    raw = str(value)
+    if '"' in raw or "\r" in raw or "\n" in raw:
+        raise SystemExit(f"invalid character in Inno SignTool argument: {raw!r}")
+    return f"$q{raw.replace('$', '$$')}$q"
+
+
+def _inno_trusted_signing_command(
+    signtool: Path, dlib: Path, metadata: Path
+) -> str:
+    """Render Trusted Signing for ISCC /S; Inno replaces $f with its target."""
+    args = _trusted_signing_args(signtool, dlib, metadata, ["$f"])
+    return " ".join(
+        _inno_quote_sign_arg(arg) if isinstance(arg, Path) else str(arg)
+        for arg in args
+    )
 
 
 def sign_dir(
@@ -1237,25 +1278,53 @@ def installer_project(project: str, dry: bool) -> Path | None:
     # dist_project signed the staging copy for the zip; the installer packages
     # from the Release dir, so sign those PE files too before Inno bundles them.
     _sign_and_stage_app_local_runtime(project, rel, dry=dry)
-    run(
-        f"installer {project}",
-        [
-            ISCC,
-            "/Qp",
-            f"/DAppVersion={version}",
-            f"/DSourceDir={rel}",
-            f"/DOutputDir={dist}",
-            # Passed in rather than hardcoded per .iss, so the produced file name
-            # and the path this function returns cannot drift apart.
-            f"/DOutputBaseName={installer_basename(project, version)}",
-            iss,
-        ],
-        dry=dry,
-    )
+    base_args: list[Path | str] = [
+        ISCC,
+        "/Qp",
+        f"/DAppVersion={version}",
+        f"/DSourceDir={rel}",
+        f"/DOutputDir={dist}",
+        # Passed in rather than hardcoded per .iss, so the produced file name
+        # and the path this function returns cannot drift apart.
+        f"/DOutputBaseName={installer_basename(project, version)}",
+    ]
+
+    inno_tool = cfg.get("inno_sign_tool")
+    signing_cfg = _signing_config() if inno_tool is not None else None
+    inno_signs_installer = inno_tool is not None and signing_cfg is not None
+    if inno_signs_installer and dry:
+        print("[dry-run] would configure Inno to sign Setup and Uninstall")
+        run(f"installer {project}", [*base_args, iss], dry=True)
+    elif inno_signs_installer:
+        assert signing_cfg is not None
+        dlib = _ensure_dlib()
+        signtool = _find_signtool()
+        meta = _write_metadata(signing_cfg)
+        try:
+            with tempfile.TemporaryDirectory(prefix="gore-inno-uninstaller-") as cache:
+                sign_command = _inno_trusted_signing_command(signtool, dlib, meta)
+                run(
+                    f"installer {project}",
+                    [
+                        *base_args,
+                        f"/S{inno_tool}={sign_command}",
+                        "/DGORE_SIGNED_INSTALLER=1",
+                        f"/DGORE_SIGNED_UNINSTALLER_DIR={cache}",
+                        iss,
+                    ],
+                    dry=False,
+                    extra_env=_sign_proxy_overrides(),
+                )
+        finally:
+            meta.unlink(missing_ok=True)
+    else:
+        run(f"installer {project}", [*base_args, iss], dry=dry)
     out = dist / f"{installer_basename(project, version)}.exe"
-    # Sign the installer itself. Must happen before the CI appcast step computes
-    # its DSA signature over the final shipped bytes.
-    sign_paths([out], dry=dry)
+    if inno_tool is None:
+        # Products without integrated Inno signing retain the existing outer
+        # Setup signing path. Manager's signed path was already signed by Inno;
+        # signing it again here would append a redundant Authenticode signature.
+        sign_paths([out], dry=dry)
     print(f"installer: {out}")
     return out
 

--- a/scripts/test_build_signing.py
+++ b/scripts/test_build_signing.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+import re
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+import build as gore_build  # noqa: E402
+
+
+SIGNING_CONFIG = {
+    "TRUSTED_SIGNING_ENDPOINT": "https://example.codesigning.azure.net/",
+    "TRUSTED_SIGNING_ACCOUNT": "account",
+    "TRUSTED_SIGNING_PROFILE": "profile",
+    "AZURE_TENANT_ID": "tenant",
+    "AZURE_CLIENT_ID": "client",
+    "AZURE_CLIENT_SECRET": "secret",
+}
+
+
+class InstallerSigningTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name) / "repo"
+        self.release = self.root / "release"
+        self.dist = self.root / "dist"
+        self.release.mkdir(parents=True)
+        self.dist.mkdir(parents=True)
+        for project in ("mod-manager", "save-editor"):
+            setup = self.root / "apps" / project / "installer" / "setup.iss"
+            setup.parent.mkdir(parents=True)
+            setup.write_text("[Setup]\n", encoding="utf-8")
+        self.signtool = Path(r"C:\Signing Tools$\signtool.exe")
+        self.iscc = Path(r"C:\Inno Setup\ISCC.exe")
+        self.dlib = self.root / "Trusted Signing$" / "Azure.CodeSigning.Dlib.dll"
+        self.metadata = self.root / "temp signing$" / "metadata.json"
+        self.proxy = {"HTTPS_PROXY": "http://127.0.0.1:9"}
+
+    @contextmanager
+    def patched(self, signing_config: dict[str, str] | None):
+        self.metadata.parent.mkdir(parents=True, exist_ok=True)
+        self.metadata.write_text("{}", encoding="utf-8")
+        with (
+            mock.patch.object(gore_build, "ROOT", self.root),
+            mock.patch.object(gore_build, "ISCC", self.iscc),
+            mock.patch.object(gore_build, "dist_project"),
+            mock.patch.object(gore_build, "read_version", return_value="0.1.0"),
+            mock.patch.object(
+                gore_build, "flutter_release_dir", return_value=self.release
+            ),
+            mock.patch.object(gore_build, "dist_dir", return_value=self.dist),
+            mock.patch.object(gore_build, "_sign_and_stage_app_local_runtime"),
+            mock.patch.object(
+                gore_build, "_signing_config", return_value=signing_config
+            ) as signing_config_reader,
+            mock.patch.object(gore_build, "_find_signtool", return_value=self.signtool) as finder,
+            mock.patch.object(gore_build, "_ensure_dlib", return_value=self.dlib) as dlib_loader,
+            mock.patch.object(
+                gore_build, "_write_metadata", return_value=self.metadata
+            ) as metadata_writer,
+            mock.patch.object(
+                gore_build, "_sign_proxy_overrides", return_value=self.proxy
+            ) as proxy_reader,
+            mock.patch.object(gore_build, "sign_paths") as direct_signer,
+            mock.patch.object(gore_build, "run") as runner,
+        ):
+            yield {
+                "signing_config_reader": signing_config_reader,
+                "finder": finder,
+                "dlib_loader": dlib_loader,
+                "metadata_writer": metadata_writer,
+                "proxy_reader": proxy_reader,
+                "direct_signer": direct_signer,
+                "runner": runner,
+            }
+
+    def test_signed_manager_routes_setup_and_uninstaller_through_inno(self) -> None:
+        with self.patched(SIGNING_CONFIG) as calls:
+            output = gore_build.installer_project("gore-mod-manager", dry=False)
+
+        self.assertEqual(output, self.dist / "gore-mod-manager-0.1.0-setup.exe")
+        calls["runner"].assert_called_once()
+        command = calls["runner"].call_args.args[1]
+        tool_name = gore_build.PROJECTS["gore-mod-manager"]["inno_sign_tool"]
+        sign_options = [str(arg) for arg in command if str(arg).startswith("/S")]
+        self.assertEqual(len(sign_options), 1)
+        self.assertTrue(sign_options[0].startswith(f"/S{tool_name}="))
+        self.assertIn("/DGORE_SIGNED_INSTALLER=1", command)
+        cache_defines = [
+            str(arg)
+            for arg in command
+            if str(arg).startswith("/DGORE_SIGNED_UNINSTALLER_DIR=")
+        ]
+        self.assertEqual(len(cache_defines), 1)
+        cache = Path(cache_defines[0].split("=", 1)[1])
+        self.assertEqual(cache.name.split("-")[:3], ["gore", "inno", "uninstaller"])
+        self.assertFalse(cache.exists())
+        self.assertEqual(
+            command,
+            [
+                self.iscc,
+                "/Qp",
+                "/DAppVersion=0.1.0",
+                f"/DSourceDir={self.release}",
+                f"/DOutputDir={self.dist}",
+                "/DOutputBaseName=gore-mod-manager-0.1.0-setup",
+                sign_options[0],
+                "/DGORE_SIGNED_INSTALLER=1",
+                cache_defines[0],
+                self.root / "apps" / "mod-manager" / "installer" / "setup.iss",
+            ],
+        )
+        self.assertIn(
+            "$qC:\\Signing Tools$$\\signtool.exe$q sign /v /fd SHA256",
+            sign_options[0],
+        )
+        self.assertIn(
+            "/dlib $q" + str(self.dlib).replace("$", "$$") + "$q",
+            sign_options[0],
+        )
+        self.assertIn(
+            "/dmdf $q" + str(self.metadata).replace("$", "$$") + "$q",
+            sign_options[0],
+        )
+        self.assertTrue(sign_options[0].endswith(" $f"))
+        self.assertEqual(sign_options[0].count("$f"), 1)
+        self.assertEqual(calls["runner"].call_args.kwargs["extra_env"], self.proxy)
+        calls["direct_signer"].assert_not_called()
+        calls["metadata_writer"].assert_called_once_with(SIGNING_CONFIG)
+        self.assertFalse(self.metadata.exists())
+
+    def test_manager_recipe_and_build_share_one_unique_sign_tool_name(self) -> None:
+        tool_name = gore_build.PROJECTS["gore-mod-manager"]["inno_sign_tool"]
+        self.assertRegex(tool_name, re.compile(r"^gore_mod_manager_ats_[a-f0-9]{16}$"))
+        setup = (
+            ROOT / "apps" / "mod-manager" / "installer" / "setup.iss"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(setup.count(f"SignTool={tool_name}"), 1)
+        self.assertIn("#ifdef GORE_SIGNED_INSTALLER", setup)
+        self.assertIn("SignedUninstaller=yes", setup)
+        self.assertIn(
+            "SignedUninstallerDir={#GORE_SIGNED_UNINSTALLER_DIR}", setup
+        )
+        self.assertNotIn("inno_sign_tool", gore_build.PROJECTS["gore-save-editor"])
+        self.assertNotIn("inno_sign_tool", gore_build.PROJECTS["gore-mod-studio"])
+
+    def test_inno_failure_still_removes_signing_metadata(self) -> None:
+        with self.patched(SIGNING_CONFIG) as calls:
+            calls["runner"].side_effect = SystemExit("ISCC failed")
+            with self.assertRaisesRegex(SystemExit, "ISCC failed"):
+                gore_build.installer_project("gore-mod-manager", dry=False)
+
+        self.assertFalse(self.metadata.exists())
+        command = calls["runner"].call_args.args[1]
+        cache_define = next(
+            str(arg)
+            for arg in command
+            if str(arg).startswith("/DGORE_SIGNED_UNINSTALLER_DIR=")
+        )
+        self.assertFalse(Path(cache_define.split("=", 1)[1]).exists())
+        calls["direct_signer"].assert_not_called()
+
+    def test_unsigned_manager_has_no_sign_tool_or_uninstaller_prompt_path(self) -> None:
+        with self.patched(None) as calls:
+            gore_build.installer_project("gore-mod-manager", dry=False)
+
+        command = calls["runner"].call_args.args[1]
+        self.assertEqual(
+            command,
+            [
+                self.iscc,
+                "/Qp",
+                "/DAppVersion=0.1.0",
+                f"/DSourceDir={self.release}",
+                f"/DOutputDir={self.dist}",
+                "/DOutputBaseName=gore-mod-manager-0.1.0-setup",
+                self.root / "apps" / "mod-manager" / "installer" / "setup.iss",
+            ],
+        )
+        self.assertNotIn("extra_env", calls["runner"].call_args.kwargs)
+        calls["finder"].assert_not_called()
+        calls["dlib_loader"].assert_not_called()
+        calls["metadata_writer"].assert_not_called()
+        calls["proxy_reader"].assert_not_called()
+        calls["direct_signer"].assert_not_called()
+        self.assertTrue(self.metadata.exists())
+
+    def test_other_installers_keep_outer_setup_signing(self) -> None:
+        with self.patched(SIGNING_CONFIG) as calls:
+            output = gore_build.installer_project("gore-save-editor", dry=False)
+
+        self.assertEqual(output, self.dist / "gore-save-editor-0.1.0-setup.exe")
+        command = calls["runner"].call_args.args[1]
+        self.assertFalse(any(str(arg).startswith("/S") for arg in command))
+        calls["signing_config_reader"].assert_not_called()
+        calls["direct_signer"].assert_called_once_with([output], dry=False)
+        self.assertTrue(self.metadata.exists())
+
+    def test_inno_sign_arguments_reject_command_injection(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "invalid character"):
+            gore_build._inno_quote_sign_arg("safe\nmalicious")
+        self.assertEqual(gore_build._inno_quote_sign_arg("C:\\cash$dir"), "$qC:\\cash$$dir$q")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verify_mod_manager_release.py
+++ b/scripts/test_verify_mod_manager_release.py
@@ -90,7 +90,20 @@ class _ReleaseFixture:
         self.setup = self.root / "apps" / "mod-manager" / "installer" / "setup.iss"
         self.setup.parent.mkdir(parents=True)
         self.setup.write_text(
-            """[Setup]
+            """#ifndef AppVersion
+#error "Pass /DAppVersion=x.y.z"
+#endif
+#ifndef SourceDir
+#error "Pass /DSourceDir=<path to flutter Release dir>"
+#endif
+#ifndef OutputDir
+#error "Pass /DOutputDir=<path for installer exe>"
+#endif
+#ifndef OutputBaseName
+#error "Pass /DOutputBaseName=<installer file stem>"
+#endif
+
+[Setup]
 AppVersion={#AppVersion}
 OutputBaseFilename={#OutputBaseName}
 ArchitecturesAllowed=x64compatible
@@ -105,6 +118,14 @@ VersionInfoProductTextVersion={#AppVersion}
 VersionInfoProductVersion={#AppVersion}.0
 VersionInfoTextVersion={#AppVersion}
 VersionInfoVersion={#AppVersion}.0
+#ifdef GORE_SIGNED_INSTALLER
+#ifndef GORE_SIGNED_UNINSTALLER_DIR
+#error "Pass /DGORE_SIGNED_UNINSTALLER_DIR=<temporary path>"
+#endif
+SignTool=gore_mod_manager_ats_b7e4d2c95a184f6b
+SignedUninstaller=yes
+SignedUninstallerDir={#GORE_SIGNED_UNINSTALLER_DIR}
+#endif
 
 [Files]
 Source: "{#SourceDir}\\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -393,6 +414,54 @@ class ModManagerReleaseContractTest(unittest.TestCase):
             fixture.root, VERSION, version_info_reader=fixture.metadata
         )
         self.assert_problem(problems, "[Files] contract changed")
+
+        for old, new, expected in (
+            ("SignedUninstaller=yes", "SignedUninstaller=no", "SignedUninstaller"),
+            (
+                "SignedUninstallerDir={#GORE_SIGNED_UNINSTALLER_DIR}",
+                "SignedUninstallerDir={#OutputDir}",
+                "SignedUninstallerDir",
+            ),
+            (
+                "SignTool=gore_mod_manager_ats_b7e4d2c95a184f6b",
+                "SignTool=byparam",
+                "SignTool",
+            ),
+            (
+                "#ifdef GORE_SIGNED_INSTALLER",
+                "; signing condition removed",
+                "conditional Inno signing block",
+            ),
+            (
+                "#ifdef GORE_SIGNED_INSTALLER",
+                "#include attacker.iss\n#ifdef GORE_SIGNED_INSTALLER",
+                "preprocessor contract changed",
+            ),
+            (
+                "[Setup]",
+                "#undef GORE_SIGNED_INSTALLER\n[Setup]",
+                "preprocessor contract changed",
+            ),
+            (
+                "SignedUninstaller=yes",
+                "SignedUninstaller=yes\nsigneduninstaller=yes",
+                "duplicate [Setup] directive",
+            ),
+            (
+                "SignTool=gore_mod_manager_ats_b7e4d2c95a184f6b",
+                "SignTool=gore_mod_manager_ats_b7e4d2c95a184f6b\n"
+                "signtool = gore_mod_manager_ats_b7e4d2c95a184f6b",
+                "duplicate [Setup] directive",
+            ),
+        ):
+            with self.subTest(signing_recipe=old):
+                fixture = self.fixture()
+                text = fixture.setup.read_text(encoding="utf-8")
+                fixture.setup.write_text(text.replace(old, new, 1), encoding="utf-8")
+                problems = verifier.verify_release(
+                    fixture.root, VERSION, version_info_reader=fixture.metadata
+                )
+                self.assert_problem(problems, expected)
 
     def test_version_product_metadata_and_exact_artifact_names_are_required(self) -> None:
         fixture = self.fixture()

--- a/scripts/verify_mod_manager_release.py
+++ b/scripts/verify_mod_manager_release.py
@@ -97,6 +97,31 @@ EXPECTED_INSTALLER_FILES = (
     'Source: "..\\..\\..\\LICENSE"; DestDir: "{app}"; Flags: ignoreversion',
     'Source: "..\\..\\..\\THIRD_PARTY_LICENSES.md"; DestDir: "{app}"; Flags: ignoreversion',
 )
+EXPECTED_INNO_SIGNING_BLOCK = (
+    "#ifdef GORE_SIGNED_INSTALLER",
+    "#ifndef GORE_SIGNED_UNINSTALLER_DIR",
+    '#error "Pass /DGORE_SIGNED_UNINSTALLER_DIR=<temporary path>"',
+    "#endif",
+    "SignTool=gore_mod_manager_ats_b7e4d2c95a184f6b",
+    "SignedUninstaller=yes",
+    "SignedUninstallerDir={#GORE_SIGNED_UNINSTALLER_DIR}",
+    "#endif",
+)
+EXPECTED_INSTALLER_PREPROCESSOR = (
+    "#ifndef AppVersion",
+    '#error "Pass /DAppVersion=x.y.z"',
+    "#endif",
+    "#ifndef SourceDir",
+    '#error "Pass /DSourceDir=<path to flutter Release dir>"',
+    "#endif",
+    "#ifndef OutputDir",
+    '#error "Pass /DOutputDir=<path for installer exe>"',
+    "#endif",
+    "#ifndef OutputBaseName",
+    '#error "Pass /DOutputBaseName=<installer file stem>"',
+    "#endif",
+    *(line for line in EXPECTED_INNO_SIGNING_BLOCK if line.startswith("#")),
+)
 
 THIRD_PARTY_NOTICE_FILES = ("about.hbs", "THIRD_PARTY_LICENSES.md")
 WINSPARKLE_NOTICE_START = "### WinSparkle 0.8.1 updater"
@@ -603,19 +628,55 @@ def _installer_recipe_contract(setup: Path, version: str, installer_name: str) -
         return [f"{label}: cannot read {setup}: {error}"]
 
     problems: list[str] = []
+    semantic_lines = tuple(
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.strip().startswith(";")
+    )
+    signing_blocks = sum(
+        semantic_lines[index : index + len(EXPECTED_INNO_SIGNING_BLOCK)]
+        == EXPECTED_INNO_SIGNING_BLOCK
+        for index in range(len(semantic_lines) - len(EXPECTED_INNO_SIGNING_BLOCK) + 1)
+    )
+    if signing_blocks != 1:
+        problems.append(
+            f"{label}: conditional Inno signing block count is {signing_blocks}; expected 1"
+        )
+    preprocessor_lines = tuple(
+        line.strip() for line in text.splitlines() if line.strip().startswith("#")
+    )
+    if preprocessor_lines != EXPECTED_INSTALLER_PREPROCESSOR:
+        problems.append(
+            f"{label}: preprocessor contract changed: {preprocessor_lines!r}"
+        )
     files = tuple(_section_lines(text, "Files"))
     if files != EXPECTED_INSTALLER_FILES:
         problems.append(f"{label}: [Files] contract changed: {files!r}")
 
-    settings: dict[str, str] = {}
-    for line in _section_lines(text, "Setup"):
+    setup_lines = tuple(_section_lines(text, "Setup"))
+    preprocessor_lines = tuple(line for line in setup_lines if line.startswith("#"))
+    expected_preprocessor_lines = tuple(
+        line for line in EXPECTED_INNO_SIGNING_BLOCK if line.startswith("#")
+    )
+    if preprocessor_lines != expected_preprocessor_lines:
+        problems.append(
+            f"{label}: [Setup] preprocessor contract changed: {preprocessor_lines!r}"
+        )
+
+    settings: dict[str, tuple[str, str]] = {}
+    for line in setup_lines:
+        if line.startswith("#"):
+            continue
         if "=" not in line:
             problems.append(f"{label}: malformed [Setup] directive: {line}")
             continue
-        key, value = line.split("=", 1)
-        if key in settings:
+        raw_key, raw_value = line.split("=", 1)
+        key = raw_key.strip()
+        canonical = key.casefold()
+        if canonical in settings:
             problems.append(f"{label}: duplicate [Setup] directive: {key}")
-        settings[key] = value
+            continue
+        settings[canonical] = (raw_key, raw_value)
     expected_settings = {
         "AppVersion": "{#AppVersion}",
         "OutputBaseFilename": "{#OutputBaseName}",
@@ -631,10 +692,14 @@ def _installer_recipe_contract(setup: Path, version: str, installer_name: str) -
         "VersionInfoProductVersion": "{#AppVersion}.0",
         "VersionInfoTextVersion": "{#AppVersion}",
         "VersionInfoVersion": "{#AppVersion}.0",
+        "SignTool": "gore_mod_manager_ats_b7e4d2c95a184f6b",
+        "SignedUninstaller": "yes",
+        "SignedUninstallerDir": "{#GORE_SIGNED_UNINSTALLER_DIR}",
     }
     for key, value in expected_settings.items():
-        if settings.get(key) != value:
-            problems.append(f"{label}: {key}={settings.get(key)!r}; expected {value!r}")
+        actual = settings.get(key.casefold())
+        if actual != (key, value):
+            problems.append(f"{label}: {key}={actual!r}; expected {(key, value)!r}")
 
     expected_installer = f"gore-mod-manager-{version}-setup.exe"
     if installer_name != expected_installer:


### PR DESCRIPTION
## Summary
- route signed Mod Manager installer builds through Inno's uniquely named Azure Trusted Signing tool
- sign both Setup and embedded uninstaller without double-signing Setup
- keep unsigned local builds free of SignTool activation and clean temporary signing state
- pin the conditional Inno recipe against preprocessor and case-insensitive directive drift

## Validation
- `python -m unittest discover -s scripts -p test_*.py -v` (57 passed)
- `python scripts/check_release_workflow.py`
- `python -m py_compile build.py scripts/test_build_signing.py scripts/verify_mod_manager_release.py scripts/test_verify_mod_manager_release.py`
- `python -m ruff check build.py scripts/test_build_signing.py scripts/verify_mod_manager_release.py scripts/test_verify_mod_manager_release.py`
- `git diff --check`

No release workflow, tag, GitHub Release, installation, game launch, or save access is part of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release signing and installer packaging for Mod Manager only; mistakes could ship unsigned or mis-signed installers, but scope is build/CI with strong contract tests and other products unchanged.
> 
> **Overview**
> **Signed Mod Manager releases** now pass Azure Trusted Signing into Inno via a project-specific `inno_sign_tool` name and ISCC `/S…` command built from the same `signtool` args as direct signing. When `GORE_SIGN=1`, `build.py` defines `GORE_SIGNED_INSTALLER`, supplies a temp `GORE_SIGNED_UNINSTALLER_DIR`, applies proxy bypass to the ISCC/signing subprocess tree, and **skips** the post-Inno `sign_paths` on the setup exe so Setup is not signed twice. Unsigned local builds omit those defines and behave as before.
> 
> **`setup.iss`** gains a guarded `[Setup]` block (`SignTool`, `SignedUninstaller`, `SignedUninstallerDir`) that only activates in signed builds. **Release verification** and new **`test_build_signing.py`** tests lock the preprocessor/signing recipe (unique tool name vs generic `byparam`, duplicate directives, drift). Other products still sign the installer after ISCC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28be31c2d8182fc73b0dd2b465d4dc23839d7baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->