### PR TITLE
Mod Manager: compose external script mods safely

### DIFF
--- a/apps/mod-manager/lib/library/domain/conflicts_provider.dart
+++ b/apps/mod-manager/lib/library/domain/conflicts_provider.dart
@@ -123,7 +123,7 @@ List<ConflictView> conflictsForMod(List<ConflictView> conflicts, String modId) {
 
 /// A conflict's mod ids arranged in loadout order (lowest priority first),
 /// with the winner flagged for proven soft/hard conflicts. Informational
-/// unknown-footprint advisories have no winner. Load order list order is
+/// advisories (including compatible raw-base + patch composition) have no winner. Load order is
 /// priority-ascending on the Rust side, so the highest-priority (last)
 /// participant wins otherwise. Ids not present in [order] keep their original
 /// relative position at the front. When the conflict names fewer than two mods,

--- a/apps/mod-manager/test/conflicts_provider_recompute_test.dart
+++ b/apps/mod-manager/test/conflicts_provider_recompute_test.dart
@@ -371,6 +371,23 @@ void main() {
     expect(chain.winnerId, isNull);
   });
 
+  test('raw-base patch info advisory is ordered but has no winner', () {
+    const conflict = ConflictView(
+      kind: 'raw_file',
+      target: 'script_cache',
+      modIds: ['patch', 'raw'],
+      severity: 'info',
+    );
+    for (final order in [
+      const ['raw', 'patch'],
+      const ['patch', 'raw'],
+    ]) {
+      final chain = orderConflictChain(conflict, order);
+      expect(chain.modIds, order);
+      expect(chain.winnerId, isNull);
+    }
+  });
+
   test('proven soft conflict keeps later-wins winner', () {
     const conflict = ConflictView(
       kind: 'cdo',

--- a/apps/mod-manager/test/core/mgr_ffi_test.dart
+++ b/apps/mod-manager/test/core/mgr_ffi_test.dart
@@ -54,6 +54,24 @@ Map<String, Object?> _libraryListResponse() => {
           'targets': ['Game/Items/ItLsTorch'],
           'coverage': 'exact',
         },
+        {
+          'type': 'file_patch',
+          'rel': 'files',
+          'targets': ['G1R/Content/Movies/Intro.bk2'],
+          'coverage': 'exact',
+        },
+        {
+          'type': 'pak_file_patch',
+          'rel': 'pak_files',
+          'targets': ['G1R/Content/Slate/Cursors/Normal/Normal.PNG'],
+          'coverage': 'exact',
+        },
+        {
+          'type': 'voice_archive_patch',
+          'rel': 'voice',
+          'targets': ['German.zip|NPC/Hero/hello.ogg'],
+          'coverage': 'exact',
+        },
       ],
     },
     {
@@ -186,6 +204,9 @@ void main() {
         'audio_patch',
         'texture_patch',
         'angel_script_patch',
+        'file_patch',
+        'pak_file_patch',
+        'voice_archive_patch',
       ]);
       final lua = a.components[0];
       expect(lua.name, 'torches');
@@ -200,6 +221,23 @@ void main() {
       expect(loc.opaque, isFalse);
       expect(loc.coverage, FootprintCoverage.exact);
       expect(loc.displayLabel, 'loc/patch.json');
+      final filePatch = a.components[5];
+      expect(filePatch.rel, 'files');
+      expect(filePatch.targets, ['G1R/Content/Movies/Intro.bk2']);
+      expect(filePatch.coverage, FootprintCoverage.exact);
+      expect(filePatch.displayLabel, 'files');
+      final pakFilePatch = a.components[6];
+      expect(pakFilePatch.rel, 'pak_files');
+      expect(pakFilePatch.targets, [
+        'G1R/Content/Slate/Cursors/Normal/Normal.PNG',
+      ]);
+      expect(pakFilePatch.coverage, FootprintCoverage.exact);
+      expect(pakFilePatch.displayLabel, 'pak_files');
+      final voiceArchivePatch = a.components[7];
+      expect(voiceArchivePatch.rel, 'voice');
+      expect(voiceArchivePatch.targets, ['German.zip|NPC/Hero/hello.ogg']);
+      expect(voiceArchivePatch.coverage, FootprintCoverage.exact);
+      expect(voiceArchivePatch.displayLabel, 'voice');
 
       final b = mods[1];
       expect(b.kind, 'foreign_mixed');

--- a/apps/mod-manager/test/library/widgets_test.dart
+++ b/apps/mod-manager/test/library/widgets_test.dart
@@ -193,6 +193,24 @@ Map<String, Object?> _oneHardConflict() => {
   ],
 };
 
+Map<String, Object?> _hardAndInfoSameRawTarget() => {
+  'ok': true,
+  'conflicts': [
+    {
+      'kind': 'raw_file',
+      'target': 'bank:Voice.bank',
+      'mods': ['mod-a', 'mod-b'],
+      'severity': 'hard',
+    },
+    {
+      'kind': 'raw_file',
+      'target': 'bank:Voice.bank',
+      'mods': ['mod-a', 'mod-b'],
+      'severity': 'info',
+    },
+  ],
+};
+
 /// A shared config, backed by its own temp file, seeded with a fixed exe path
 /// so the game root resolves. Isolated per call so tests don't share state.
 SharedConfig _fixedSharedConfig(String exePath) {
@@ -1027,6 +1045,60 @@ void main() {
     expect(winnerFinder, findsWidgets);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'same raw target keeps hard winner and no-winner info as separate rows',
+    (tester) async {
+      final fake = FakeGoreCoreFfiService(
+        responses: {
+          'mgr_library_list': _libraryList(),
+          'mgr_analyze': _hardAndInfoSameRawTarget(),
+          'mgr_status': {
+            'ok': true,
+            'status': {'state': 'nothing_deployed'},
+          },
+        },
+      );
+      await tester.pumpWidget(_appWith(fake));
+      await tester.pumpAndSettle();
+
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      await tester.tap(find.text(l10n.conflictsTitle(2)).first);
+      await tester.pumpAndSettle();
+
+      final hardRow = find.byWidgetPredicate(
+        (widget) =>
+            widget is ConflictRow &&
+            widget.conflict.kind == 'raw_file' &&
+            widget.conflict.target == 'bank:Voice.bank' &&
+            widget.conflict.severity == 'hard',
+        description: 'hard raw-file conflict row',
+      );
+      final infoRow = find.byWidgetPredicate(
+        (widget) =>
+            widget is ConflictRow &&
+            widget.conflict.kind == 'raw_file' &&
+            widget.conflict.target == 'bank:Voice.bank' &&
+            widget.conflict.severity == 'info',
+        description: 'info raw-file advisory row',
+      );
+      expect(hardRow, findsOneWidget);
+      expect(infoRow, findsOneWidget);
+
+      Finder winnerTextUnder(Finder row) => find.descendant(
+        of: row,
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is RichText &&
+              widget.text.toPlainText().contains(l10n.conflictWinner),
+          description: 'winner-tagged mod chip',
+        ),
+      );
+      expect(winnerTextUnder(hardRow), findsOneWidget);
+      expect(winnerTextUnder(infoRow), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('studio status details open the take-over dialog', (
     tester,

--- a/crates/gore-as/src/cache/default_fingerprint.rs
+++ b/crates/gore-as/src/cache/default_fingerprint.rs
@@ -23,6 +23,7 @@ use super::default_tag_map::normalize_reference_proven_tag_map_operands;
 use super::disasm::disassemble;
 use super::header::CacheHeader;
 use super::model::parse_modules;
+use super::remap::{preflight_cache_module_work, preflight_tail_tables};
 use super::tables::parse_tail_tables;
 use super::walk_modules::{collect_function_bytecode_spans, module_region_end};
 
@@ -78,6 +79,9 @@ struct NormalizedRange {
 pub fn combined_default_cache_fingerprint(
     cache: &[u8],
 ) -> Result<DefaultCacheFingerprint, DefaultFingerprintError> {
+    // Keep resource-limit failures on the cache-structure error path rather than wrapping them as
+    // tag-map findings, and reject them before the tag normalizer clones the complete cache.
+    preflight_default_cache(cache)?;
     let (mut normalized, tag_report) = normalize_reference_proven_tag_map_operands(cache)
         .map_err(|error| DefaultFingerprintError::TagMap(error.to_string()))?;
     let scalar_ranges = scalar_default_operand_ranges(&normalized)?;
@@ -122,9 +126,11 @@ pub fn combined_default_cache_fingerprint(
 pub(crate) fn scalar_default_cache_sha256(
     cache: &[u8],
 ) -> Result<[u8; 32], DefaultFingerprintError> {
-    let mut normalized = cache.to_vec();
     let mut ranges = scalar_default_operand_ranges(cache)?;
     validate_non_overlapping(&mut ranges)?;
+    // The structural/resource checks and bytecode-span walk above must finish before duplicating a
+    // potentially large external cache.
+    let mut normalized = cache.to_vec();
     for operand in ranges {
         normalized
             .get_mut(operand.range)
@@ -221,8 +227,7 @@ fn validate_non_overlapping(ranges: &mut [NormalizedRange]) -> Result<(), Defaul
 }
 
 fn validate_cache(cache: &[u8]) -> Result<(), DefaultFingerprintError> {
-    CacheHeader::parse(cache)
-        .map_err(|error| DefaultFingerprintError::Header(error.to_string()))?;
+    preflight_default_cache(cache)?;
     let tail = module_region_end(cache)
         .map_err(|error| DefaultFingerprintError::Wire(error.to_string()))?;
     let tables = parse_tail_tables(cache, tail)
@@ -257,9 +262,75 @@ fn validate_cache(cache: &[u8]) -> Result<(), DefaultFingerprintError> {
     Ok(())
 }
 
+fn preflight_default_cache(cache: &[u8]) -> Result<(), DefaultFingerprintError> {
+    CacheHeader::parse(cache)
+        .map_err(|error| DefaultFingerprintError::Header(error.to_string()))?;
+    preflight_cache_module_work(cache)
+        .map_err(|error| DefaultFingerprintError::Wire(error.to_string()))?;
+    preflight_tail_tables(cache)
+        .map_err(|error| DefaultFingerprintError::Wire(error.to_string()))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use super::super::header::CACHE_MAGIC;
     use super::*;
+
+    fn cache_header(module_count: u32) -> Vec<u8> {
+        let mut cache = vec![0; CacheHeader::SIZE];
+        cache[0x10..0x14].copy_from_slice(&CACHE_MAGIC.to_le_bytes());
+        cache[0x14..0x18].copy_from_slice(&module_count.to_le_bytes());
+        cache
+    }
+
+    fn cache_with_excessive_tail_rows() -> Vec<u8> {
+        let mut cache = cache_header(0);
+        cache.extend_from_slice(&0i32.to_le_bytes()); // TypeReferences
+        cache.extend_from_slice(&1_000_001i32.to_le_bytes()); // TypeIdReferenceToPointer
+        cache
+    }
+
+    fn cache_with_excessive_modules() -> Vec<u8> {
+        const MODULE_COUNT: u32 = 1_000_001;
+        const MIN_MODULE_BYTES: usize = 60;
+        let mut cache = cache_header(MODULE_COUNT);
+        cache.resize(
+            CacheHeader::SIZE + MODULE_COUNT as usize * MIN_MODULE_BYTES,
+            0,
+        );
+        cache
+    }
+
+    #[test]
+    fn default_fingerprint_paths_map_tail_resource_limit_consistently() {
+        let cache = cache_with_excessive_tail_rows();
+        assert!(matches!(
+            combined_default_cache_fingerprint(&cache),
+            Err(DefaultFingerprintError::Wire(message))
+                if message.contains("tail keyed rows")
+        ));
+        assert!(matches!(
+            scalar_default_cache_sha256(&cache),
+            Err(DefaultFingerprintError::Wire(message))
+                if message.contains("tail keyed rows")
+        ));
+    }
+
+    #[test]
+    fn default_fingerprint_paths_preflight_module_work_before_cache_copies() {
+        let cache = cache_with_excessive_modules();
+        assert!(matches!(
+            combined_default_cache_fingerprint(&cache),
+            Err(DefaultFingerprintError::Wire(message))
+                if message.contains("module authority Modules")
+        ));
+        assert!(matches!(
+            scalar_default_cache_sha256(&cache),
+            Err(DefaultFingerprintError::Wire(message))
+                if message.contains("module authority Modules")
+        ));
+    }
 
     #[test]
     fn configured_combined_fingerprint_is_stable_under_tag_edits() {

--- a/crates/gore-as/src/cache/default_tag_map.rs
+++ b/crates/gore-as/src/cache/default_tag_map.rs
@@ -15,8 +15,9 @@ use super::default_patterns::{
     is_reachable_linear_initializer,
 };
 use super::disasm::{disassemble, Instr};
+use super::remap::{preflight_cache_module_work, preflight_tail_tables};
 use super::walk_modules::{collect_function_bytecode_spans, module_region_end, FuncCodeSpan};
-use super::wire::{Cursor, WireError};
+use super::wire::{Cursor, SiaBytes, WireError};
 
 #[cfg(test)]
 use super::disasm::DisasmError;
@@ -138,6 +139,11 @@ pub(crate) struct ExactReferenceIndex {
 
 impl ExactReferenceIndex {
     pub fn build(cache: &[u8]) -> Result<Self, ExactReferenceError> {
+        // Bound every module-backed allocation before the tail preflight has to walk the module
+        // region, then bound tail rows/strings before the exact index creates owned identities and
+        // lookup maps. Public tag-map scans all enter through this constructor.
+        preflight_cache_module_work(cache)?;
+        preflight_tail_tables(cache)?;
         let tail = module_region_end(cache)?;
         Self::parse_tail(cache, tail)
     }
@@ -234,11 +240,20 @@ impl ExactReferenceIndex {
         c.ensure_minimum_remaining(global_count, 24, "GlobalReferences")?;
         for _ in 0..global_count {
             let key = c.read_i64()?;
+            let (name, name_offset) = read_exact_sia_bytes(&mut c, cache, "GlobalReference.Name")?;
+            let module = read_exact_sia(&mut c, cache, "GlobalReference.Module")?;
+            let namespace = read_exact_sia(&mut c, cache, "GlobalReference.Namespace")?;
+            let is_string = read_canonical_bool(&mut c, "GlobalReference.bIsString")?;
+            let name = if is_string {
+                decode_exact_utf8(&name, name_offset, "GlobalReference.Name")?
+            } else {
+                name.decode_ansi()
+            };
             let global = ExactGlobalReference {
-                name: read_exact_sia(&mut c, cache, "GlobalReference.Name")?,
-                module: read_exact_sia(&mut c, cache, "GlobalReference.Module")?,
-                namespace: read_exact_sia(&mut c, cache, "GlobalReference.Namespace")?,
-                is_string: read_canonical_bool(&mut c, "GlobalReference.bIsString")?,
+                name,
+                module,
+                namespace,
+                is_string,
             };
             insert_unique(&mut globals, key, global, "GlobalReferences")?;
         }
@@ -313,16 +328,15 @@ fn read_canonical_bool(
     }
 }
 
-/// Validate the raw SIA encoding after the shared cursor advances. The general decoder is
-/// intentionally tolerant and lossy for decompilation; mutation evidence must reject malformed
-/// UTF-8/UTF-16, embedded terminators, and nonzero terminators instead of normalizing them.
-fn read_exact_sia(
-    c: &mut Cursor<'_>,
+/// Validate the raw SIA framing without choosing its contextual character encoding. This is
+/// needed for GlobalReference.Name because bIsString is serialized after all three strings.
+fn read_exact_sia_bytes<'a>(
+    c: &mut Cursor<'a>,
     source: &[u8],
     field: &'static str,
-) -> Result<String, ExactReferenceError> {
+) -> Result<(SiaBytes<'a>, usize), ExactReferenceError> {
     let start = c.pos();
-    let decoded = c.read_sia()?;
+    let encoded = c.read_sia_bytes()?;
     let end = c.pos();
     let raw = source.get(start..end).ok_or(WireError::Eof {
         pos: start,
@@ -340,12 +354,11 @@ fn read_exact_sia(
         offset: start,
         reason: reason.to_owned(),
     };
-    let exact = match length.cmp(&0) {
+    match length.cmp(&0) {
         std::cmp::Ordering::Equal => {
             if raw.len() != 4 {
                 return Err(invalid("zero-length encoding has trailing bytes"));
             }
-            String::new()
         }
         std::cmp::Ordering::Greater => {
             let payload = raw
@@ -357,31 +370,34 @@ fn read_exact_sia(
             if payload.contains(&0) {
                 return Err(invalid("positive encoding contains an embedded zero"));
             }
-            std::str::from_utf8(payload)
-                .map_err(|_| invalid("positive encoding is not valid UTF-8"))?
-                .to_owned()
         }
-        std::cmp::Ordering::Less => {
-            let payload = raw
-                .get(4..raw.len().saturating_sub(2))
-                .ok_or_else(|| invalid("wide encoding is truncated"))?;
-            if raw.get(raw.len().saturating_sub(2)..) != Some(&[0, 0][..]) {
-                return Err(invalid("wide encoding has no zero terminator"));
-            }
-            let units: Vec<_> = payload
-                .chunks_exact(2)
-                .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
-                .collect();
-            if units.contains(&0) {
-                return Err(invalid("wide encoding contains an embedded zero"));
-            }
-            String::from_utf16(&units).map_err(|_| invalid("wide encoding is not valid UTF-16"))?
-        }
-    };
-    if exact != decoded {
-        return Err(invalid("tolerant decoder did not preserve the exact text"));
+        std::cmp::Ordering::Less => return Err(invalid("negative ANSI length")),
     }
-    Ok(exact)
+    Ok((encoded, start))
+}
+
+fn read_exact_sia<'a>(
+    c: &mut Cursor<'a>,
+    source: &[u8],
+    field: &'static str,
+) -> Result<String, ExactReferenceError> {
+    let (encoded, _) = read_exact_sia_bytes(c, source, field)?;
+    Ok(encoded.decode_ansi())
+}
+
+fn decode_exact_utf8(
+    encoded: &SiaBytes<'_>,
+    offset: usize,
+    field: &'static str,
+) -> Result<String, ExactReferenceError> {
+    encoded.decode_utf8(offset).map_err(|error| match error {
+        WireError::InvalidSia { pos, detail } => ExactReferenceError::NonCanonicalString {
+            field,
+            offset: pos,
+            reason: detail.to_owned(),
+        },
+        other => ExactReferenceError::Wire(other),
+    })
 }
 
 fn insert_unique<K, V>(
@@ -895,6 +911,7 @@ fn encode_hex(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::super::header::{CacheHeader, CACHE_MAGIC};
     use super::super::types::DataType;
     use super::super::walk_modules::FuncCode;
     use super::*;
@@ -902,6 +919,14 @@ mod tests {
     const TAG_PTR: u64 = 0x024b_dd09_8bc8;
     const CALLEE_PTR: u64 = 0x024b_ef73_8200;
     const OWNER_TYPE_ID: u32 = 0x0400_1269;
+
+    fn cache_with_excessive_tail_rows() -> Vec<u8> {
+        let mut cache = vec![0; CacheHeader::SIZE];
+        cache[0x10..0x14].copy_from_slice(&CACHE_MAGIC.to_le_bytes());
+        cache.extend_from_slice(&0i32.to_le_bytes()); // TypeReferences
+        cache.extend_from_slice(&1_000_001i32.to_le_bytes()); // TypeIdReferenceToPointer
+        cache
+    }
 
     fn op(opcode: u8, word: u16) -> i32 {
         (u32::from(opcode) | (u32::from(word) << 16)) as i32
@@ -1048,11 +1073,15 @@ mod tests {
     }
 
     fn push_sia(out: &mut Vec<u8>, value: &str) {
+        push_sia_bytes(out, value.as_bytes());
+    }
+
+    fn push_sia_bytes(out: &mut Vec<u8>, value: &[u8]) {
         if value.is_empty() {
             out.extend_from_slice(&0i32.to_le_bytes());
         } else {
             out.extend_from_slice(&(value.len() as i32).to_le_bytes());
-            out.extend_from_slice(value.as_bytes());
+            out.extend_from_slice(value);
             out.push(0);
         }
     }
@@ -1073,12 +1102,25 @@ mod tests {
     }
 
     fn exact_tail_fixture(function_const: i32) -> Vec<u8> {
-        exact_tail_fixture_with_duplicate_type(function_const, false)
+        exact_tail_fixture_with_options(function_const, false, b"Tag", 0)
     }
 
     fn exact_tail_fixture_with_duplicate_type(
         function_const: i32,
         duplicate_type: bool,
+    ) -> Vec<u8> {
+        exact_tail_fixture_with_options(function_const, duplicate_type, b"Tag", 0)
+    }
+
+    fn exact_tail_fixture_with_global_name(name: &[u8], is_string: i32) -> Vec<u8> {
+        exact_tail_fixture_with_options(0, false, name, is_string)
+    }
+
+    fn exact_tail_fixture_with_options(
+        function_const: i32,
+        duplicate_type: bool,
+        global_name: &[u8],
+        global_is_string: i32,
     ) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(&(if duplicate_type { 2i32 } else { 1i32 }).to_le_bytes());
@@ -1113,10 +1155,10 @@ mod tests {
 
         out.extend_from_slice(&1i32.to_le_bytes()); // GlobalReferences
         out.extend_from_slice(&0x3000i64.to_le_bytes());
-        push_sia(&mut out, "Tag");
+        push_sia_bytes(&mut out, global_name);
         push_sia(&mut out, "GlobalModule");
         push_sia(&mut out, "GlobalNamespace");
-        out.extend_from_slice(&0i32.to_le_bytes()); // non-string
+        out.extend_from_slice(&global_is_string.to_le_bytes());
 
         out.extend_from_slice(&0i32.to_le_bytes()); // StaticNames
 
@@ -1217,16 +1259,40 @@ mod tests {
     }
 
     #[test]
-    fn exact_tail_parser_rejects_lossy_string_identity() {
+    fn exact_tail_parser_preserves_ansi_string_identity_without_lossy_decoding() {
         let mut tail = exact_tail_fixture(0);
         // count(4) + key(8) + SIA length(4) => first TypeReference.Name payload byte.
         tail[16] = 0xff;
+        let refs = ExactReferenceIndex::parse_tail(&tail, 0).unwrap();
+        assert_eq!(refs.type_by_id(7).unwrap().identity.name, "ÿOwner");
+    }
+
+    #[test]
+    fn exact_tail_parser_decodes_only_string_global_names_as_utf8() {
+        let text = "Grüße 世界";
+        let tail = exact_tail_fixture_with_global_name(text.as_bytes(), 1);
+        let refs = ExactReferenceIndex::parse_tail(&tail, 0).unwrap();
+        let global = refs.global_by_ptr(0x3000).unwrap();
+        assert!(global.is_string);
+        assert_eq!(global.name, text);
+
+        let ansi = exact_tail_fixture_with_global_name(&[0xff], 0);
+        let refs = ExactReferenceIndex::parse_tail(&ansi, 0).unwrap();
+        assert_eq!(refs.global_by_ptr(0x3000).unwrap().name, "\u{00ff}");
+    }
+
+    #[test]
+    fn exact_tail_parser_rejects_invalid_utf8_string_global_with_field_diagnostic() {
         assert!(matches!(
-            ExactReferenceIndex::parse_tail(&tail, 0),
+            ExactReferenceIndex::parse_tail(
+                &exact_tail_fixture_with_global_name(&[0xff], 1),
+                0,
+            ),
             Err(ExactReferenceError::NonCanonicalString {
-                field: "TypeReference.Name",
+                field: "GlobalReference.Name",
+                reason,
                 ..
-            })
+            }) if reason == "script string literal is not valid UTF-8"
         ));
     }
 
@@ -1244,6 +1310,19 @@ mod tests {
         assert!(matches!(
             ExactReferenceIndex::parse_tail(&trailing, 0),
             Err(ExactReferenceError::TailNotAtEof { .. })
+        ));
+    }
+
+    #[test]
+    fn tag_map_normalization_rejects_tail_row_bomb_in_central_preflight() {
+        assert!(matches!(
+            normalize_reference_proven_tag_map_operands(&cache_with_excessive_tail_rows()),
+            Err(TagMapReferenceScanError::ExactReferences(
+                ExactReferenceError::Wire(WireError::BadLen {
+                    field: "tail keyed rows",
+                    ..
+                })
+            ))
         ));
     }
 

--- a/crates/gore-as/src/cache/disasm.rs
+++ b/crates/gore-as/src/cache/disasm.rs
@@ -7,6 +7,44 @@
 
 use super::isa::{BcType, OpInfo, OPCODES};
 
+/// Maximum number of decoded instructions in one function.
+///
+/// The 2026-08-14 Shipping-cache census found a real maximum of 389,358
+/// instructions (852,642 dwords) in
+/// `Map.MainMap.WorldPointManagerConfig_MainMap.UWorldpointManagerConfig_MainMap::__InitDefaults`.
+/// This limit therefore retains about 2.69x instruction-count headroom.
+pub const MAX_DISASSEMBLED_INSTRUCTIONS: usize = 1_048_576;
+
+/// Maximum conservatively projected heap use for one decoded function.
+///
+/// On the Win64 target each [`Instr`] occupies 88 bytes. The projection also
+/// charges 64 bytes for every non-empty operand `Vec`, covering its small
+/// payload and allocator overhead. The largest function in the audited
+/// Shipping cache projects to 58,114,576 bytes (55.42 MiB), leaving about
+/// 2.31x headroom below this limit.
+pub const MAX_DISASSEMBLY_PROJECTED_HEAP_BYTES: usize = 128 * 1024 * 1024;
+
+const PROJECTED_NONEMPTY_OPERAND_VEC_BYTES: usize = 64;
+const INSTRUCTION_RESOURCE: &str = "instructions";
+const PROJECTED_HEAP_RESOURCE: &str = "projected heap bytes";
+
+#[derive(Debug, Clone, Copy)]
+struct DisasmLimits {
+    max_instructions: usize,
+    max_projected_heap_bytes: usize,
+}
+
+const PRODUCTION_LIMITS: DisasmLimits = DisasmLimits {
+    max_instructions: MAX_DISASSEMBLED_INSTRUCTIONS,
+    max_projected_heap_bytes: MAX_DISASSEMBLY_PROJECTED_HEAP_BYTES,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DisasmPreflight {
+    instruction_count: usize,
+    projected_heap_bytes: usize,
+}
+
 /// One decoded instruction. Operand values are collected positionally into
 /// `words` (16-bit), `dwords` (32-bit), `qwords` (64-bit) in source order.
 #[derive(Debug, Clone)]
@@ -30,6 +68,15 @@ pub enum DisasmError {
         need: usize,
         have: usize,
     },
+    ResourceLimit {
+        resource: &'static str,
+        offset_dw: usize,
+        actual: usize,
+        limit: usize,
+    },
+    AllocationFailed {
+        requested_instructions: usize,
+    },
 }
 
 impl std::fmt::Display for DisasmError {
@@ -48,14 +95,112 @@ impl std::fmt::Display for DisasmError {
                     "truncated instruction at dword {offset_dw}: need {need} dwords, have {have}"
                 )
             }
+            DisasmError::ResourceLimit {
+                resource,
+                offset_dw,
+                actual,
+                limit,
+            } => write!(
+                f,
+                "disassembly resource limit exceeded for {resource} at dword {offset_dw}: {actual} > {limit}"
+            ),
+            DisasmError::AllocationFailed {
+                requested_instructions,
+            } => write!(
+                f,
+                "failed to allocate disassembly output for {requested_instructions} instructions"
+            ),
         }
     }
+}
+
+impl std::error::Error for DisasmError {}
+
+const fn nonempty_operand_vec_count(fmt: BcType) -> usize {
+    use BcType::*;
+    match fmt {
+        INFO | NO_ARG => 0,
+        rW_DW_ARG | wW_DW_ARG | wW_QW_ARG | wW_rW_DW_ARG | QW_DW_ARG | rW_QW_ARG | W_DW_ARG
+        | rW_W_DW_ARG | rW_DW_DW_ARG => 2,
+        W_ARG | wW_ARG | DW_ARG | QW_ARG | DW_DW_ARG | wW_rW_rW_ARG | wW_rW_ARG | rW_ARG
+        | rW_rW_ARG | wW_W_ARG | W_rW_ARG => 1,
+    }
+}
+
+const fn projected_instruction_heap_bytes(fmt: BcType) -> usize {
+    std::mem::size_of::<Instr>()
+        + nonempty_operand_vec_count(fmt) * PROJECTED_NONEMPTY_OPERAND_VEC_BYTES
+}
+
+/// Validate and size a disassembly without allocating instruction or operand
+/// storage. Malformed-bytecode errors deliberately win over a resource error
+/// for the same instruction, preserving the decoder's diagnostic order.
+fn preflight_disassembly(
+    bytecode: &[i32],
+    limits: DisasmLimits,
+) -> Result<DisasmPreflight, DisasmError> {
+    let mut instruction_count = 0usize;
+    let mut projected_heap_bytes = 0usize;
+    let mut i = 0usize;
+    while i < bytecode.len() {
+        let opcode = (bytecode[i] as u32 & 0xFF) as u8;
+        let op = OPCODES
+            .get(opcode as usize)
+            .ok_or(DisasmError::UnknownOpcode {
+                offset_dw: i,
+                opcode,
+            })?;
+        let size = op.size_dwords as usize;
+        let have = bytecode.len() - i;
+        if size == 0 || size > have {
+            return Err(DisasmError::Truncated {
+                offset_dw: i,
+                need: size.max(1),
+                have,
+            });
+        }
+
+        let next_instruction_count = instruction_count.saturating_add(1);
+        if next_instruction_count > limits.max_instructions {
+            return Err(DisasmError::ResourceLimit {
+                resource: INSTRUCTION_RESOURCE,
+                offset_dw: i,
+                actual: next_instruction_count,
+                limit: limits.max_instructions,
+            });
+        }
+
+        let next_projected_heap_bytes =
+            projected_heap_bytes.saturating_add(projected_instruction_heap_bytes(op.fmt));
+        if next_projected_heap_bytes > limits.max_projected_heap_bytes {
+            return Err(DisasmError::ResourceLimit {
+                resource: PROJECTED_HEAP_RESOURCE,
+                offset_dw: i,
+                actual: next_projected_heap_bytes,
+                limit: limits.max_projected_heap_bytes,
+            });
+        }
+
+        instruction_count = next_instruction_count;
+        projected_heap_bytes = next_projected_heap_bytes;
+        i += size;
+    }
+
+    Ok(DisasmPreflight {
+        instruction_count,
+        projected_heap_bytes,
+    })
 }
 
 /// Decode a function's bytecode into a flat instruction list.
 pub fn disassemble(bytecode: &[i32]) -> Result<Vec<Instr>, DisasmError> {
     use BcType::*;
+    let preflight = preflight_disassembly(bytecode, PRODUCTION_LIMITS)?;
     let mut out = Vec::new();
+    out.try_reserve_exact(preflight.instruction_count)
+        .map_err(|_| DisasmError::AllocationFailed {
+            requested_instructions: preflight.instruction_count,
+        })?;
     let mut i = 0usize;
     while i < bytecode.len() {
         let opcode = (bytecode[i] as u32 & 0xFF) as u8;
@@ -156,4 +301,124 @@ pub fn listing(instrs: &[Instr]) -> String {
         ));
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limits(max_instructions: usize, max_projected_heap_bytes: usize) -> DisasmLimits {
+        DisasmLimits {
+            max_instructions,
+            max_projected_heap_bytes,
+        }
+    }
+
+    #[test]
+    fn preflight_counts_zero_one_and_two_operand_vecs_at_exact_boundaries() {
+        let zero_vec_bytes = std::mem::size_of::<Instr>();
+        let one_vec_bytes = zero_vec_bytes + PROJECTED_NONEMPTY_OPERAND_VEC_BYTES;
+        let two_vec_bytes = zero_vec_bytes + 2 * PROJECTED_NONEMPTY_OPERAND_VEC_BYTES;
+
+        let assert_projection = |bytecode: &[i32], projected_heap_bytes: usize| {
+            assert_eq!(
+                preflight_disassembly(bytecode, limits(1, projected_heap_bytes)),
+                Ok(DisasmPreflight {
+                    instruction_count: 1,
+                    projected_heap_bytes,
+                })
+            );
+
+            let error =
+                preflight_disassembly(bytecode, limits(1, projected_heap_bytes - 1)).unwrap_err();
+            assert_eq!(
+                error,
+                DisasmError::ResourceLimit {
+                    resource: PROJECTED_HEAP_RESOURCE,
+                    offset_dw: 0,
+                    actual: projected_heap_bytes,
+                    limit: projected_heap_bytes - 1,
+                }
+            );
+            assert_eq!(
+                error.to_string(),
+                format!(
+                    "disassembly resource limit exceeded for projected heap bytes at dword 0: {projected_heap_bytes} > {}",
+                    projected_heap_bytes - 1
+                )
+            );
+        };
+
+        // PopPtr has no operands, PSF one non-empty operand Vec, and LdGRdR4 two.
+        assert_projection(&[0], zero_vec_bytes);
+        assert_projection(&[4], one_vec_bytes);
+        assert_projection(&[8, 0, 0], two_vec_bytes);
+
+        let bytecode = [0, 4, 8, 0, 0];
+        assert_eq!(
+            preflight_disassembly(&bytecode, limits(2, usize::MAX)),
+            Err(DisasmError::ResourceLimit {
+                resource: INSTRUCTION_RESOURCE,
+                offset_dw: 2,
+                actual: 3,
+                limit: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn malformed_instruction_diagnostics_precede_resource_limits() {
+        let no_resources = limits(0, 0);
+        assert_eq!(
+            preflight_disassembly(&[255], no_resources),
+            Err(DisasmError::UnknownOpcode {
+                offset_dw: 0,
+                opcode: 255,
+            })
+        );
+        assert_eq!(
+            preflight_disassembly(&[1], no_resources),
+            Err(DisasmError::Truncated {
+                offset_dw: 0,
+                need: 3,
+                have: 1,
+            })
+        );
+
+        let one_instruction = limits(1, usize::MAX);
+        assert_eq!(
+            preflight_disassembly(&[0, 255], one_instruction),
+            Err(DisasmError::UnknownOpcode {
+                offset_dw: 1,
+                opcode: 255,
+            })
+        );
+        assert_eq!(
+            preflight_disassembly(&[0, 1], one_instruction),
+            Err(DisasmError::Truncated {
+                offset_dw: 1,
+                need: 3,
+                have: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn public_disassemble_refuses_max_plus_one_compact_instructions() {
+        let bytecode = vec![0; MAX_DISASSEMBLED_INSTRUCTIONS + 1];
+        let error = disassemble(&bytecode).unwrap_err();
+        assert_eq!(
+            error,
+            DisasmError::ResourceLimit {
+                resource: INSTRUCTION_RESOURCE,
+                offset_dw: MAX_DISASSEMBLED_INSTRUCTIONS,
+                actual: MAX_DISASSEMBLED_INSTRUCTIONS + 1,
+                limit: MAX_DISASSEMBLED_INSTRUCTIONS,
+            }
+        );
+        assert_eq!(
+            error.to_string(),
+            "disassembly resource limit exceeded for instructions at dword 1048576: 1048577 > 1048576"
+        );
+    }
 }

--- a/crates/gore-as/src/cache/npc_archetypes.rs
+++ b/crates/gore-as/src/cache/npc_archetypes.rs
@@ -16,7 +16,7 @@ use super::model::{self, Class, Func, Module};
 use super::refs::RefResolver;
 use super::tables::parse_tail_tables;
 use super::walk_modules::module_names;
-use super::wire::WireError;
+use super::wire::{Cursor, SiaBytes, WireError};
 
 pub const MAX_NPC_CACHE_BYTES: usize = 256 * 1024 * 1024;
 pub const MAX_NPC_BINDS_BYTES: usize = 32 * 1024 * 1024;
@@ -462,6 +462,19 @@ impl<'a> PreflightCursor<'a> {
     fn read_bool(&mut self) -> Result<bool, NpcArchetypeError> {
         Ok(self.read_i32()? != 0)
     }
+
+    fn read_canonical_bool(&mut self) -> Result<bool, NpcArchetypeError> {
+        let position = self.position;
+        match self.read_i32()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            value => Err(invalid_wire(WireError::BadLen {
+                pos: position,
+                len: i64::from(value),
+                field: "bool",
+            })),
+        }
+    }
 }
 
 struct PreflightBudget {
@@ -571,6 +584,32 @@ impl PreflightBudget {
                 )
             }
         };
+        self.charge_serialized_string(content_bytes)?;
+        cursor.skip(payload_bytes).map_err(|error| match error {
+            NpcArchetypeError::InvalidShippingCache(_) => invalid_wire(WireError::Eof {
+                pos: position,
+                need: payload_bytes.saturating_add(4),
+                have: cursor.remaining().saturating_add(4),
+            }),
+            other => other,
+        })
+    }
+
+    /// Parse one allocation-free SIA payload while retaining its raw bytes for a later contextual
+    /// encoding decision. GlobalReference.bIsString follows Name/Module/Namespace on the wire.
+    fn sia_bytes<'a>(
+        &mut self,
+        cursor: &mut PreflightCursor<'a>,
+    ) -> Result<(SiaBytes<'a>, usize), NpcArchetypeError> {
+        let position = cursor.position;
+        let mut wire = Cursor::at(cursor.bytes, position);
+        let encoded = wire.read_sia_bytes().map_err(invalid_wire)?;
+        self.charge_serialized_string(encoded.len())?;
+        cursor.position = wire.pos();
+        Ok((encoded, position))
+    }
+
+    fn charge_serialized_string(&mut self, content_bytes: usize) -> Result<(), NpcArchetypeError> {
         if content_bytes > self.limits.serialized_string_bytes {
             return Err(NpcArchetypeError::StringTooLong {
                 kind: "serialized cache string",
@@ -587,14 +626,7 @@ impl PreflightBudget {
             });
         }
         self.string_payload_bytes = next;
-        cursor.skip(payload_bytes).map_err(|error| match error {
-            NpcArchetypeError::InvalidShippingCache(_) => invalid_wire(WireError::Eof {
-                pos: position,
-                need: payload_bytes.saturating_add(4),
-                have: cursor.remaining().saturating_add(4),
-            }),
-            other => other,
-        })
+        Ok(())
     }
 
     fn fixed_array(
@@ -916,10 +948,12 @@ fn preflight_tail(
     budget.fixed_array(cursor, 12, "FunctionIdReferenceToPointer")?;
     preflight_tail_map(cursor, budget, "GlobalReferences", |cursor, budget| {
         cursor.skip(8)?;
+        let (name, name_position) = budget.sia_bytes(cursor)?;
         budget.string(cursor, false)?;
         budget.string(cursor, false)?;
-        budget.string(cursor, false)?;
-        cursor.skip(4)?;
+        if cursor.read_canonical_bool()? {
+            name.decode_utf8(name_position).map_err(invalid_wire)?;
+        }
         Ok(())
     })?;
     budget.string_array(cursor, "StaticNames")?;
@@ -2162,6 +2196,41 @@ mod tests {
             .unwrap()
     }
 
+    fn push_preflight_sia(out: &mut Vec<u8>, value: &[u8]) {
+        if value.is_empty() {
+            out.extend_from_slice(&0i32.to_le_bytes());
+        } else {
+            out.extend_from_slice(&(value.len() as i32).to_le_bytes());
+            out.extend_from_slice(value);
+            out.push(0);
+        }
+    }
+
+    fn preflight_tail_with_global_name(
+        name: &[u8],
+        is_string: i32,
+    ) -> Result<(), NpcArchetypeError> {
+        let mut tail = Vec::new();
+        tail.extend_from_slice(&0i32.to_le_bytes()); // TypeReferences
+        tail.extend_from_slice(&0i32.to_le_bytes()); // TypeIdReferenceToPointer
+        tail.extend_from_slice(&0i32.to_le_bytes()); // FunctionReferences
+        tail.extend_from_slice(&0i32.to_le_bytes()); // FunctionIdReferenceToPointer
+        tail.extend_from_slice(&1i32.to_le_bytes()); // GlobalReferences
+        tail.extend_from_slice(&0x3000i64.to_le_bytes());
+        push_preflight_sia(&mut tail, name);
+        push_preflight_sia(&mut tail, b""); // Module
+        push_preflight_sia(&mut tail, b""); // Namespace
+        tail.extend_from_slice(&is_string.to_le_bytes());
+        tail.extend_from_slice(&0i32.to_le_bytes()); // StaticNames
+        tail.extend_from_slice(&0i32.to_le_bytes()); // PropertyReferences
+
+        let mut cursor = PreflightCursor::at(&tail, 0);
+        let mut budget = PreflightBudget::new(NpcLimits::default());
+        preflight_tail(&mut cursor, &mut budget)?;
+        assert_eq!(cursor.position, tail.len());
+        Ok(())
+    }
+
     #[test]
     fn exact_bytecode_edges_accept_non_suffix_triple_deterministically() {
         let fixture = fixture();
@@ -2360,6 +2429,23 @@ mod tests {
                 actual: 9,
                 max: 8,
             })
+        ));
+    }
+
+    #[test]
+    fn structural_preflight_validates_global_name_with_contextual_encoding() {
+        preflight_tail_with_global_name("Grüße 世界".as_bytes(), 1).unwrap();
+        preflight_tail_with_global_name(&[0xff], 0).unwrap();
+
+        assert!(matches!(
+            preflight_tail_with_global_name(&[0xff], 1),
+            Err(NpcArchetypeError::InvalidShippingCache(message))
+                if message.contains("script string literal is not valid UTF-8")
+        ));
+        assert!(matches!(
+            preflight_tail_with_global_name(b"literal", 2),
+            Err(NpcArchetypeError::InvalidShippingCache(message))
+                if message.contains("field bool")
         ));
     }
 

--- a/crates/gore-as/src/cache/refs.rs
+++ b/crates/gore-as/src/cache/refs.rs
@@ -91,6 +91,10 @@ pub struct RefResolver {
 impl RefResolver {
     /// Parse a cache's 7 tail tables into name lookups.
     pub fn build(bytes: &[u8]) -> Result<Self, WireError> {
+        // Bound all serialized row counts/bytes before the resolver materializes its lookup maps.
+        // Bytediff and other public readers accept external caches without going through the
+        // sequential composition guard, so they need the same allocation-light gate here.
+        super::remap::preflight_tail_tables(bytes)?;
         let tail = module_region_end(bytes)?;
         let mut c = Cursor::at(bytes, tail);
         let mut r = RefResolver::default();
@@ -186,10 +190,16 @@ impl RefResolver {
         c.ensure_minimum_remaining(global_reference_count, 24, "GlobalReferences")?;
         for _ in 0..global_reference_count {
             let key = c.read_i64()?;
-            let name = c.read_sia()?;
+            let name_pos = c.pos();
+            let name = c.read_sia_bytes()?;
             c.read_sia()?; // Module
             let ns = c.read_sia()?; // Namespace
             let is_string = c.read_bool4()?;
+            let name = if is_string {
+                name.decode_utf8(name_pos)?
+            } else {
+                name.decode_ansi()
+            };
             if is_string {
                 r.global_is_string.insert(key);
             }
@@ -995,8 +1005,14 @@ mod tests {
         bytes.extend_from_slice(&50_000_000i32.to_le_bytes());
         let error = RefResolver::build(&bytes).unwrap_err();
         assert!(
-            error.to_string().contains("unexpected end of data"),
-            "{error}"
+            matches!(
+                error,
+                WireError::BadLen {
+                    field: "tail keyed rows",
+                    ..
+                }
+            ),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/gore-as/src/cache/remap.rs
+++ b/crates/gore-as/src/cache/remap.rs
@@ -16,7 +16,11 @@
 //! `OP_REFS` below. Remap is SIZE-PRESERVING (i64 key->i64 key, i32 id->i32 id) so operand
 //! dwords are patched in place; no resize.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
 
 use super::disasm::disassemble;
 use super::header::CacheHeader;
@@ -78,6 +82,80 @@ pub enum RemapError {
     MissingStaticName(i64),
     #[error("StaticNames index {0} does not fit the bytecode operand that references it")]
     StaticNameIndexOverflow(i64),
+    #[error(
+        "mini-cache contains an unresolved {kind} reference in {op} ({key:#x}); the key/id is absent from both the target base and the mini's retained tail tables"
+    )]
+    UnresolvedEffectiveReference {
+        kind: &'static str,
+        op: &'static str,
+        key: i64,
+    },
+    #[error(
+        "mini-cache tail table {table} row {row_key:#x} has an unresolved {kind} dependency {dependency:#x}; the dependency is absent from both the target base and the mini's retained tail tables"
+    )]
+    UnresolvedTailDependency {
+        table: usize,
+        row_key: i64,
+        kind: &'static str,
+        dependency: i64,
+    },
+    #[error(
+        "mini-cache tail table {table} row {row_key:#x} violates the {kind} invariant ({detail})"
+    )]
+    InvalidTailRow {
+        table: usize,
+        row_key: i64,
+        kind: &'static str,
+        detail: String,
+    },
+    #[error("module {module:?} violates the {field} cache invariant ({detail})")]
+    InvalidModuleStructure {
+        module: String,
+        field: &'static str,
+        detail: String,
+    },
+    #[error(
+        "cache-wide function Id collision {id:#x}: module {first_module:?} and module {second_module:?}"
+    )]
+    FunctionIdCollision {
+        id: i32,
+        first_module: String,
+        second_module: String,
+    },
+    #[error("inner module identity {name:?} is registered more than once")]
+    ModuleNameCollision { name: String },
+    #[error("loadout Script-ID plan was built for a different pristine base cache")]
+    LoadoutPlanBaseMismatch,
+    #[error("loadout Script-ID plan did not inspect this mini-cache")]
+    LoadoutPlanMiniNotInspected,
+    #[error("loadout Script-ID plan's bound novel-identity set does not match this mini-cache")]
+    LoadoutPlanIdentityMismatch,
+    #[error("loadout Script-ID plan has no {kind} assignment for identity {identity:?}")]
+    LoadoutPlanMissingAssignment {
+        kind: &'static str,
+        identity: String,
+    },
+    #[error("loadout Script-ID plan exceeds {resource}: {actual} > {limit}")]
+    LoadoutPlanResourceLimit {
+        resource: &'static str,
+        actual: usize,
+        limit: usize,
+    },
+    #[error("loadout Script-ID {artifact} header is invalid: {detail}")]
+    LoadoutPlanInvalidHeader {
+        artifact: &'static str,
+        detail: String,
+    },
+    #[error("loadout Script-ID mini GUID {mini:?} does not match pristine GUID {pristine:?}")]
+    LoadoutPlanGuidMismatch { pristine: [u8; 16], mini: [u8; 16] },
+    #[error(
+        "portable type identity {identity:?} has conflicting T2 object kinds {first:#x} and {second:#x}"
+    )]
+    LoadoutPlanTypeKindConflict {
+        identity: String,
+        first: u32,
+        second: u32,
+    },
 }
 
 /// Opt-in behavior for [`remap_module_to_base_with_options`]. The default is intentionally
@@ -91,12 +169,259 @@ pub struct RemapOptions {
     pub allow_new_symbols: bool,
 }
 
-/// Field separator for composing a stable symbol identity string (unlikely in any name).
+/// Legacy separator used only by the compact bytediff unit-test identity fixtures. Production
+/// identities are length-framed because serialized names may contain any delimiter byte.
 const SEP: char = '\u{1f}';
 
 /// Field separator INSIDE a namespace field's `::`-qualified segments (regen drops leading
 /// `Ns::` segments — see [`ns_drift_ok`]).
 const NS_SEP: &str = "::";
+
+/// Shipped caches currently nest T1 template dependencies at most three rows deep. Keep a
+/// generous semantic ceiling so an externally supplied acyclic chain cannot overflow the stack.
+const MAX_TYPE_IDENTITY_DEPTH: usize = 64;
+
+/// Recursive portable identities are derived from cache rows not yet semantically admitted. The
+/// largest identity is below 1.3 KiB; these generous limits prevent DAG/string amplification
+/// without constraining real symbols.
+const MAX_IDENTITY_BYTES: usize = 64 * 1024;
+const MAX_IDENTITY_NAMESPACES: usize = 4096;
+const MIN_IDENTITY_BUDGET: usize = 64 * 1024;
+// The current 124 MiB Shipping cache's framed T1/T3/T5 footprint is above 128 MiB once owned-map
+// and diagnostic strings are counted. Keep a hard ceiling, but leave broad headroom above that
+// real generation while the 4x-input rule remains the tighter bound for normal/minimal caches.
+const MAX_IDENTITY_BUDGET: usize = 256 * 1024 * 1024;
+
+/// Namespace-tolerant identity equality is deliberately pairwise and non-transitive. Bound the
+/// worst-case bytes each comparison may inspect to a small multiple of the effective plus incoming
+/// identity footprint, with an absolute ceiling, so one huge same-skeleton bucket cannot force
+/// quadratic preflight time even when its strings differ only near the end.
+const IDENTITY_COMPARISON_WORK_MULTIPLIER: usize = 4;
+const MIN_IDENTITY_COMPARISON_WORK: usize = 64 * 1024;
+const MAX_IDENTITY_COMPARISON_WORK: usize = 256 * 1024 * 1024;
+
+// Declaration authority is queried only for keyed T1/T5/T7 rows. Keep the transient query set at
+// the same production envelope as sequential keyed-row composition, while allowing the compact
+// pristine declaration index broad headroom for the complete Shipping cache.
+// Final composed validation scans T1+T5+T7. The measured Shipping fixture already has 184,315
+// such rows, so this must use the complete-cache envelope rather than the much smaller one-mini
+// contribution envelope.
+const MAX_DECLARATION_QUERY_ROWS: usize = 1_000_000;
+const MAX_DECLARATION_QUERY_BYTES: usize = 64 * 1024 * 1024;
+const MAX_DECLARATION_AUTHORITY_ROWS: usize = 1_000_000;
+// Function declarations retain full runtime-effective DataType identities plus compact lookup
+// indexes. The real Shipping declaration inventory exceeds 128 MiB under that conservative heap
+// accounting, so share the established complete-cache 256-MiB identity envelope.
+const MAX_DECLARATION_AUTHORITY_BYTES: usize = 256 * 1024 * 1024;
+const MAX_TAIL_PREFLIGHT_ROWS: usize = 1_000_000;
+const MAX_TAIL_PREFLIGHT_BYTES: usize = 256 * 1024 * 1024;
+const MAX_TAIL_PREFLIGHT_STATIC_NAMES: usize = 1_000_000;
+const MAX_TAIL_PREFLIGHT_STATIC_NAME_BYTES: usize = 128 * 1024 * 1024;
+// Windows-1252 input bytes may expand to three UTF-8 bytes when decoded into Rust Strings. Bound
+// that projected owned payload before SymTables/TailMetadata perform their first allocation-heavy
+// pass; the raw serialized-byte cap alone is not enough to prevent several copies from nearing a
+// gigabyte on worst-case high-bit FString payloads.
+const MAX_TAIL_PREFLIGHT_DECODED_STRING_BYTES: usize = 256 * 1024 * 1024;
+
+// Before any detailed module walker materializes CodeSpan/embed/record vectors, a streaming pass
+// bounds both the number of function-like records and every variable-width record array it sees.
+// The caller supplies the stricter per-function and aggregate ByteCode limits.
+const MAX_MINI_STREAMED_FUNCTIONS: usize = 131_072;
+// ByteCode dwords themselves are charged as work, but splice owns the stable 16M aggregate
+// ByteCode error. Leave another 16M for record/metadata arrays so the bytecode-specific limit
+// wins at its exact boundary while total materialized work remains firmly bounded.
+const MAX_MINI_MODULE_WORK_ITEMS: usize = 32 * 1024 * 1024;
+const MAX_CACHE_MODULE_WORK_ITEMS: usize = 50_000_000;
+
+#[derive(Debug)]
+struct IdentityBudget {
+    remaining: usize,
+    max: usize,
+    charged: usize,
+}
+
+impl IdentityBudget {
+    fn for_composed_input(
+        total_input_len: usize,
+        already_charged: usize,
+    ) -> Result<Self, WireError> {
+        let max = total_input_len
+            .checked_mul(4)
+            .unwrap_or(usize::MAX)
+            .clamp(MIN_IDENTITY_BUDGET, MAX_IDENTITY_BUDGET);
+        let remaining = max
+            .checked_sub(already_charged)
+            .ok_or(WireError::IdentityBudgetExceeded { max })?;
+        Ok(Self {
+            remaining,
+            max,
+            charged: 0,
+        })
+    }
+
+    fn charge(&mut self, key: i64, identity: &Ident) -> Result<(), WireError> {
+        let logical = identity_footprint(key, identity)?;
+        self.remaining = self
+            .remaining
+            .checked_sub(logical)
+            .ok_or(WireError::IdentityBudgetExceeded { max: self.max })?;
+        self.charged = self
+            .charged
+            .checked_add(logical)
+            .ok_or(WireError::IdentityBudgetExceeded { max: self.max })?;
+        Ok(())
+    }
+}
+
+fn identity_footprint(key: i64, identity: &Ident) -> Result<usize, WireError> {
+    let logical = std::mem::size_of::<Ident>()
+        .checked_add(identity.full.len())
+        .and_then(|n| n.checked_add(identity.ns_stripped.len()))
+        .and_then(|n| n.checked_add(identity.display.len()))
+        .and_then(|n| {
+            identity.namespaces.iter().try_fold(n, |sum, namespace| {
+                sum.checked_add(std::mem::size_of::<String>())?
+                    .checked_add(namespace.len())
+            })
+        })
+        .and_then(|n| n.checked_add(identity.function_owner.as_ref().map_or(0, String::len)))
+        .and_then(|n| n.checked_add(identity.function_name.as_ref().map_or(0, String::len)))
+        .ok_or(WireError::IdentityTooLarge {
+            key,
+            max: MAX_IDENTITY_BYTES,
+        })?;
+    if logical > MAX_IDENTITY_BYTES || identity.namespaces.len() > MAX_IDENTITY_NAMESPACES {
+        return Err(WireError::IdentityTooLarge {
+            key,
+            max: MAX_IDENTITY_BYTES,
+        });
+    }
+    Ok(logical)
+}
+
+fn checked_identity_append(key: i64, target: &mut String, value: &str) -> Result<(), WireError> {
+    if target
+        .len()
+        .checked_add(value.len())
+        .is_none_or(|len| len > MAX_IDENTITY_BYTES)
+    {
+        return Err(WireError::IdentityTooLarge {
+            key,
+            max: MAX_IDENTITY_BYTES,
+        });
+    }
+    target.push_str(value);
+    Ok(())
+}
+
+/// Length-prefix every field. Cache strings may contain any byte accepted by FString, including
+/// our display separator, so delimiter-only concatenation is not an injective symbol identity.
+struct IdentityEncoder {
+    key: i64,
+    out: String,
+}
+
+impl IdentityEncoder {
+    fn new(key: i64) -> Self {
+        Self {
+            key,
+            out: String::new(),
+        }
+    }
+
+    fn field(&mut self, value: &str) -> Result<(), WireError> {
+        let len = value.len().to_string();
+        checked_identity_append(self.key, &mut self.out, &len)?;
+        checked_identity_append(self.key, &mut self.out, ":")?;
+        checked_identity_append(self.key, &mut self.out, value)
+    }
+
+    fn number(&mut self, value: impl std::fmt::Display) -> Result<(), WireError> {
+        self.field(&value.to_string())
+    }
+
+    fn finish(self) -> String {
+        self.out
+    }
+}
+
+/// Incremental namespace collector. Re-summing the accumulated vector on every append turns one
+/// wide template/function signature into quadratic work; this tracks the exact owned footprint
+/// once and inspects only newly appended namespace fields.
+struct NamespaceAccumulator {
+    values: Vec<String>,
+    bytes: usize,
+}
+
+impl NamespaceAccumulator {
+    fn new() -> Self {
+        Self {
+            values: Vec::new(),
+            bytes: 0,
+        }
+    }
+
+    fn push(&mut self, key: i64, value: &str) -> Result<(), WireError> {
+        let count = self
+            .values
+            .len()
+            .checked_add(1)
+            .ok_or(WireError::IdentityTooLarge {
+                key,
+                max: MAX_IDENTITY_BYTES,
+            })?;
+        let bytes = self
+            .bytes
+            .checked_add(std::mem::size_of::<String>())
+            .and_then(|bytes| bytes.checked_add(value.len()));
+        if count > MAX_IDENTITY_NAMESPACES || bytes.is_none_or(|bytes| bytes > MAX_IDENTITY_BYTES) {
+            return Err(WireError::IdentityTooLarge {
+                key,
+                max: MAX_IDENTITY_BYTES,
+            });
+        }
+        self.bytes = bytes.expect("checked above");
+        self.values.push(value.to_owned());
+        Ok(())
+    }
+
+    fn extend(&mut self, key: i64, value: &[String]) -> Result<(), WireError> {
+        let count =
+            self.values
+                .len()
+                .checked_add(value.len())
+                .ok_or(WireError::IdentityTooLarge {
+                    key,
+                    max: MAX_IDENTITY_BYTES,
+                })?;
+        let added = value.iter().try_fold(0usize, |sum, namespace| {
+            sum.checked_add(std::mem::size_of::<String>())?
+                .checked_add(namespace.len())
+        });
+        let bytes = added.and_then(|added| self.bytes.checked_add(added));
+        if count > MAX_IDENTITY_NAMESPACES || bytes.is_none_or(|bytes| bytes > MAX_IDENTITY_BYTES) {
+            return Err(WireError::IdentityTooLarge {
+                key,
+                max: MAX_IDENTITY_BYTES,
+            });
+        }
+        self.bytes = bytes.expect("checked above");
+        self.values.extend(value.iter().cloned());
+        Ok(())
+    }
+
+    fn finish(self) -> Vec<String> {
+        self.values
+    }
+}
+
+fn checked_display(key: i64, parts: &[&str]) -> Result<String, WireError> {
+    let mut display = String::new();
+    for part in parts {
+        checked_identity_append(key, &mut display, part)?;
+    }
+    Ok(display)
+}
 
 /// A symbol identity in three parallel forms. `full` is the display/exact-match string
 /// (namespaces embedded); `ns_stripped` is the same string with every namespace field replaced
@@ -113,6 +438,11 @@ pub struct Ident {
     full: String,
     ns_stripped: String,
     namespaces: Vec<String>,
+    display: String,
+    /// Present only for T3 identities. Avoid reparsing the recursively framed owner identity to
+    /// recover the stable owner/method key used by the bytediff scope normalizer.
+    function_owner: Option<String>,
+    function_name: Option<String>,
 }
 
 impl Ident {
@@ -157,6 +487,7 @@ fn is_ns_suffix(long: &str, short: &str) -> bool {
 
 /// Symbol identity → key inverse maps for one cache's tail tables, plus the forward key→name
 /// maps needed to compose function/global identities and to report unresolved refs.
+#[derive(Clone, Debug)]
 struct SymTables {
     /// T1: type ptr key -> identity ; identity -> ptr key.
     type_id_of_ptr: HashMap<i64, String>,
@@ -166,8 +497,8 @@ struct SymTables {
     type_ident_of_ptr: HashMap<i64, Ident>,
     /// T2: type-id (i32, raw operand) -> type ptr.
     typeid_to_ptr: HashMap<i32, i64>,
-    /// inverse of T2: type ptr -> type-id (raw i32 operand).
-    ptr_to_typeid: HashMap<i64, i32>,
+    /// Alias-aware inverse of T2: (type ptr, object-kind bits) -> canonical raw type-id.
+    ptr_kind_to_typeid: HashMap<(i64, u32), i32>,
     /// T3: func ptr key -> identity ; identity -> ptr key.
     func_id_of_ptr: HashMap<i64, String>,
     func_ptr_of_id: HashMap<String, Vec<i64>>,
@@ -185,12 +516,434 @@ struct SymTables {
     global_ptr_of_id: HashMap<String, Vec<i64>>,
     /// T5: global ptr key -> the oracle [`Ident`] (parallel to `global_id_of_ptr`).
     global_ident_of_ptr: HashMap<i64, Ident>,
+    /// T5 string literals are runtime-created values, so equal literal identities may legally
+    /// appear under many raw keys. Non-string globals remain unique declarations.
+    global_is_string_of_ptr: HashMap<i64, bool>,
     /// EVERY int64 ptr-key that appears as a key in this cache's tail tables: T1 type ptrs,
     /// T3 func ptrs, T5 global ptrs, and the ptr values in T2/T4 (id->ptr). Used by the
     /// post-condition scan to assert no regen ptr-key survives in a remapped module's bytes.
     /// (T7 PropertyReferences keys are DERIVED `(tid<<1)|(off<<33)|1` — not raw ptrs — and are
     /// never an operand/embedded field, so they are excluded here; the type-id remap handles them.)
     all_ptr_keys: HashSet<i64>,
+    /// Logical heap footprint charged while constructing portable T1/T3/T5 identities.
+    identity_bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct TailPreflightSummary {
+    tail: usize,
+}
+
+fn charge_projected_tail_string(
+    projected: &mut usize,
+    raw_len: usize,
+    pos: usize,
+) -> Result<(), WireError> {
+    let decoded = raw_len.checked_mul(3).ok_or(WireError::BadLen {
+        pos,
+        len: i64::MAX,
+        field: "tail projected decoded string bytes",
+    })?;
+    *projected = projected.checked_add(decoded).ok_or(WireError::BadLen {
+        pos,
+        len: i64::MAX,
+        field: "tail projected decoded string bytes",
+    })?;
+    if *projected > MAX_TAIL_PREFLIGHT_DECODED_STRING_BYTES {
+        return Err(WireError::BadLen {
+            pos,
+            len: (*projected).min(i64::MAX as usize) as i64,
+            field: "tail projected decoded string bytes",
+        });
+    }
+    Ok(())
+}
+
+fn preflight_keyed_tail_table(
+    c: &mut Cursor<'_>,
+    field: &'static str,
+    key_bytes: usize,
+    keyed_rows: &mut usize,
+    keyed_bytes: &mut usize,
+    projected_string_bytes: &mut usize,
+    read_value: fn(&mut Cursor<'_>, &mut usize) -> Result<(), WireError>,
+) -> Result<(), WireError> {
+    let count_pos = c.pos();
+    let count = c.read_count(field)?;
+    *keyed_rows = keyed_rows.checked_add(count).ok_or(WireError::BadLen {
+        pos: count_pos,
+        len: i64::MAX,
+        field: "tail keyed rows",
+    })?;
+    if *keyed_rows > MAX_TAIL_PREFLIGHT_ROWS {
+        return Err(WireError::BadLen {
+            pos: count_pos,
+            len: *keyed_rows as i64,
+            field: "tail keyed rows",
+        });
+    }
+    let entries_start = c.pos();
+    for _ in 0..count {
+        c.skip(key_bytes)?;
+        read_value(c, projected_string_bytes)?;
+    }
+    *keyed_bytes = keyed_bytes
+        .checked_add(c.pos().saturating_sub(entries_start))
+        .ok_or(WireError::BadLen {
+            pos: entries_start,
+            len: i64::MAX,
+            field: "tail keyed bytes",
+        })?;
+    if *keyed_bytes > MAX_TAIL_PREFLIGHT_BYTES {
+        return Err(WireError::BadLen {
+            pos: entries_start,
+            len: *keyed_bytes as i64,
+            field: "tail keyed bytes",
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn preflight_tail_tables(bytes: &[u8]) -> Result<TailPreflightSummary, WireError> {
+    let tail = module_region_end(bytes)?;
+    let mut c = Cursor::at(bytes, tail);
+    let mut keyed_rows = 0usize;
+    let mut keyed_bytes = 0usize;
+    let mut projected_string_bytes = 0usize;
+    preflight_keyed_tail_table(
+        &mut c,
+        "TypeReferences",
+        8,
+        &mut keyed_rows,
+        &mut keyed_bytes,
+        &mut projected_string_bytes,
+        |c, projected| {
+            for _ in 0..3 {
+                let pos = c.pos();
+                let raw = c.read_sia_bytes()?;
+                charge_projected_tail_string(projected, raw.len(), pos)?;
+            }
+            c.skip_tarray_fixed(DATA_TYPE_SIZE, "TypeRef.SubTypes")
+        },
+    )?;
+    preflight_keyed_tail_table(
+        &mut c,
+        "TypeIdReferenceToPointer",
+        4,
+        &mut keyed_rows,
+        &mut keyed_bytes,
+        &mut projected_string_bytes,
+        |c, _| c.skip(8),
+    )?;
+    preflight_keyed_tail_table(
+        &mut c,
+        "FunctionReferences",
+        8,
+        &mut keyed_rows,
+        &mut keyed_bytes,
+        &mut projected_string_bytes,
+        |c, projected| {
+            for _ in 0..3 {
+                let pos = c.pos();
+                let raw = c.read_sia_bytes()?;
+                charge_projected_tail_string(projected, raw.len(), pos)?;
+            }
+            c.skip(20)?;
+            c.skip_tarray_fixed(DATA_TYPE_SIZE, "FuncRef.ParameterTypes")?;
+            c.skip(DATA_TYPE_SIZE)
+        },
+    )?;
+    preflight_keyed_tail_table(
+        &mut c,
+        "FunctionIdReferenceToPointer",
+        4,
+        &mut keyed_rows,
+        &mut keyed_bytes,
+        &mut projected_string_bytes,
+        |c, _| c.skip(8),
+    )?;
+    preflight_keyed_tail_table(
+        &mut c,
+        "GlobalReferences",
+        8,
+        &mut keyed_rows,
+        &mut keyed_bytes,
+        &mut projected_string_bytes,
+        |c, projected| {
+            let name_pos = c.pos();
+            let name = c.read_sia_bytes()?;
+            charge_projected_tail_string(projected, name.len(), name_pos)?;
+            for _ in 0..2 {
+                let pos = c.pos();
+                let raw = c.read_sia_bytes()?;
+                charge_projected_tail_string(projected, raw.len(), pos)?;
+            }
+            if c.read_bool4()? {
+                name.decode_utf8(name_pos)?;
+            }
+            Ok(())
+        },
+    )?;
+
+    let static_pos = c.pos();
+    let static_count = c.read_count("StaticNames")?;
+    if static_count > MAX_TAIL_PREFLIGHT_STATIC_NAMES {
+        return Err(WireError::BadLen {
+            pos: static_pos,
+            len: static_count as i64,
+            field: "StaticNames count",
+        });
+    }
+    let mut static_bytes = 0usize;
+    for _ in 0..static_count {
+        let name_pos = c.pos();
+        let raw = c.read_sia_bytes()?;
+        charge_projected_tail_string(&mut projected_string_bytes, raw.len(), name_pos)?;
+        static_bytes = static_bytes
+            .checked_add(raw.len())
+            .ok_or(WireError::BadLen {
+                pos: static_pos,
+                len: i64::MAX,
+                field: "StaticNames bytes",
+            })?;
+        if static_bytes > MAX_TAIL_PREFLIGHT_STATIC_NAME_BYTES {
+            return Err(WireError::BadLen {
+                pos: static_pos,
+                len: static_bytes as i64,
+                field: "StaticNames bytes",
+            });
+        }
+    }
+    preflight_keyed_tail_table(
+        &mut c,
+        "PropertyReferences",
+        8,
+        &mut keyed_rows,
+        &mut keyed_bytes,
+        &mut projected_string_bytes,
+        |c, projected| {
+            let pos = c.pos();
+            let raw = c.read_sia_bytes()?;
+            charge_projected_tail_string(projected, raw.len(), pos)?;
+            c.skip(4)
+        },
+    )?;
+    if c.pos() != bytes.len() {
+        return Err(WireError::BadLen {
+            pos: c.pos(),
+            len: bytes.len().saturating_sub(c.pos()) as i64,
+            field: "tail trailing bytes",
+        });
+    }
+    Ok(TailPreflightSummary { tail })
+}
+
+#[derive(Clone, Debug)]
+struct RawTypeIdentityDataType {
+    flags: [bool; 6],
+    type_info: i64,
+    token: i32,
+}
+
+#[derive(Clone, Debug)]
+struct RawTypeIdentityRow {
+    key: i64,
+    name: String,
+    module: String,
+    namespace: String,
+    subs: Vec<RawTypeIdentityDataType>,
+}
+
+fn datatype_identity(
+    key: i64,
+    flags: [bool; 6],
+    token: i32,
+    type_info: i64,
+    nested: &Ident,
+) -> Result<Ident, WireError> {
+    let [is_ref, is_object_const, is_object_handle, is_const_handle, is_auto, _if_handle_const] =
+        flags;
+    let (tag, effective_flags, nested_identity) = if is_auto {
+        if token != 5 || type_info != 0 {
+            return Err(WireError::InvalidDataType {
+                key,
+                detail: "auto requires token 5 and a null TypeInfo",
+            });
+        }
+        (
+            "auto",
+            [
+                is_ref,
+                is_object_const,
+                is_object_handle,
+                is_object_handle && is_const_handle,
+            ],
+            None,
+        )
+    } else if token == 5 {
+        if type_info == 0 || nested.full.is_empty() {
+            return Err(WireError::InvalidDataType {
+                key,
+                detail: "identifier requires a concrete TypeReference",
+            });
+        }
+        (
+            "object",
+            [
+                is_ref,
+                is_object_const,
+                is_object_handle,
+                is_object_handle && is_const_handle,
+            ],
+            Some(nested),
+        )
+    } else if matches!(
+        token,
+        0x3b | 0x41 | 0x44 | 0x45 | 0x46 | 0x47 | 0x4b | 0x4c | 0x4d | 0x4e | 0x50 | 0x51 | 0x52
+    ) && type_info == 0
+    {
+        ("primitive", [is_ref, is_object_const, false, false], None)
+    } else {
+        return Err(WireError::InvalidDataType {
+            key,
+            detail: "unsupported token/pointer shape",
+        });
+    };
+
+    let mut full = IdentityEncoder::new(key);
+    full.field(tag)?;
+    full.number(token)?;
+    for flag in effective_flags {
+        full.number(flag as u8)?;
+    }
+    if let Some(nested) = nested_identity {
+        full.field(&nested.full)?;
+    }
+    let mut stripped = IdentityEncoder::new(key);
+    stripped.field(tag)?;
+    stripped.number(token)?;
+    for flag in effective_flags {
+        stripped.number(flag as u8)?;
+    }
+    if let Some(nested) = nested_identity {
+        stripped.field(&nested.ns_stripped)?;
+    }
+    Ok(Ident {
+        full: full.finish(),
+        ns_stripped: stripped.finish(),
+        namespaces: nested_identity
+            .map(|identity| identity.namespaces.clone())
+            .unwrap_or_default(),
+        display: checked_display(key, &[tag, "(", &token.to_string(), ") ", &nested.display])?,
+        function_owner: None,
+        function_name: None,
+    })
+}
+
+/// Resolve a complete, build-portable T1 identity. Nested template arguments are themselves
+/// full DataTypes; flattening them to an immediate bare name conflates distinct nested types.
+fn resolve_type_identity(
+    key: i64,
+    rows: &[RawTypeIdentityRow],
+    row_by_key: &HashMap<i64, usize>,
+    fallback: Option<&SymTables>,
+    memo: &mut HashMap<i64, Ident>,
+    visiting: &mut HashSet<i64>,
+    depth: usize,
+) -> Result<Ident, WireError> {
+    if let Some(identity) = memo.get(&key) {
+        return Ok(identity.clone());
+    }
+    let Some(&index) = row_by_key.get(&key) else {
+        return Ok(fallback
+            .and_then(|prior| prior.type_ident_of_ptr.get(&key))
+            .cloned()
+            .unwrap_or_default());
+    };
+    if depth > MAX_TYPE_IDENTITY_DEPTH {
+        return Err(WireError::TypeReferenceDepth {
+            key,
+            max: MAX_TYPE_IDENTITY_DEPTH,
+        });
+    }
+    if !visiting.insert(key) {
+        // Runtime keys are generation-local, so they cannot safely anchor a portable cycle
+        // identity. Shipped caches are acyclic; reject an adversarial cycle instead.
+        return Err(WireError::CyclicTypeReference { key });
+    }
+
+    let row = &rows[index];
+    let mut subs_full = String::new();
+    let mut subs_stripped = String::new();
+    let mut namespaces = NamespaceAccumulator::new();
+    namespaces.push(key, &row.namespace)?;
+    for subtype in &row.subs {
+        let nested = if subtype.token == 5 {
+            resolve_type_identity(
+                subtype.type_info,
+                rows,
+                row_by_key,
+                fallback,
+                memo,
+                visiting,
+                depth + 1,
+            )?
+        } else {
+            Ident::default()
+        };
+        let datatype = datatype_identity(
+            key,
+            subtype.flags,
+            subtype.token,
+            subtype.type_info,
+            &nested,
+        )?;
+        let mut framed = IdentityEncoder::new(key);
+        framed.field(&datatype.full)?;
+        checked_identity_append(key, &mut subs_full, &framed.finish())?;
+        let mut framed = IdentityEncoder::new(key);
+        framed.field(&datatype.ns_stripped)?;
+        checked_identity_append(key, &mut subs_stripped, &framed.finish())?;
+        namespaces.extend(key, &datatype.namespaces)?;
+    }
+    visiting.remove(&key);
+
+    let sentinel_template_subtype = row.module == "$__T__";
+    if sentinel_template_subtype && (row.namespace.is_empty() || !row.subs.is_empty()) {
+        return Err(WireError::InvalidTypeReference {
+            key,
+            detail: "$__T__ rows require a namespace and no SubTypes",
+        });
+    }
+    // Runtime template-instance lookup ignores the declaring module. The `$__T__` subtype
+    // sentinel and ordinary non-template script types use separate branches where it matters.
+    let effective_module = if !row.subs.is_empty() && !sentinel_template_subtype {
+        ""
+    } else {
+        &row.module
+    };
+    let mut full = IdentityEncoder::new(key);
+    full.field(effective_module)?;
+    full.field(&row.namespace)?;
+    full.field(&row.name)?;
+    full.number(row.subs.len())?;
+    full.field(&subs_full)?;
+    let mut ns_stripped = IdentityEncoder::new(key);
+    ns_stripped.field(effective_module)?;
+    ns_stripped.field("")?;
+    ns_stripped.field(&row.name)?;
+    ns_stripped.number(row.subs.len())?;
+    ns_stripped.field(&subs_stripped)?;
+    let identity = Ident {
+        full: full.finish(),
+        ns_stripped: ns_stripped.finish(),
+        namespaces: namespaces.finish(),
+        display: checked_display(key, &[&row.module, "::", &row.name])?,
+        function_owner: None,
+        function_name: None,
+    };
+    memo.insert(key, identity.clone());
+    Ok(identity)
 }
 
 /// Read a DataType's stable identity contribution: token + (for object/value types) the
@@ -201,9 +954,11 @@ struct SymTables {
 /// Returns the oracle [`Ident`] triple: the nested type's namespace fields (which drift, GAP-A)
 /// are carried through into both the stripped skeleton and the namespace list, so a func/global
 /// identity that embeds this DataType composes correctly for [`Ident::oracle_eq`].
-fn datatype_identity(
+fn datatype_identity_with_fallback(
+    key: i64,
     c: &mut Cursor,
     type_ident_of_ptr: &HashMap<i64, Ident>,
+    fallback: Option<&HashMap<i64, Ident>>,
 ) -> Result<Ident, WireError> {
     // 6 bools, i64 type_info, i32 token (mirror DataType::read order).
     let b0 = c.read_bool4()?;
@@ -217,27 +972,122 @@ fn datatype_identity(
     let tident = if token == 5 {
         type_ident_of_ptr
             .get(&type_info)
+            .or_else(|| fallback.and_then(|prior| prior.get(&type_info)))
             .cloned()
             .unwrap_or_default()
     } else {
         Ident::default()
     };
-    let prefix = format!(
-        "{}{}{}{}{}{}:{token}:",
-        b0 as u8, b1 as u8, b2 as u8, b3 as u8, b4 as u8, b5 as u8
-    );
-    Ok(Ident {
-        full: format!("{prefix}{}", tident.full),
-        ns_stripped: format!("{prefix}{}", tident.ns_stripped),
-        namespaces: tident.namespaces,
+    datatype_identity(key, [b0, b1, b2, b3, b4, b5], token, type_info, &tident)
+}
+
+fn function_declaration_identity(
+    key: i64,
+    branch: &'static str,
+    module: &str,
+    namespace: &str,
+    owner: Option<&Ident>,
+    name: &str,
+    is_const: bool,
+    params: &[Ident],
+    ret: &Ident,
+) -> Result<FunctionDeclarationIdentity, WireError> {
+    let owner = owner.cloned().unwrap_or_default();
+    let mut params_full = String::new();
+    let mut params_stripped = String::new();
+    let mut param_namespaces = NamespaceAccumulator::new();
+    for param in params {
+        checked_identity_append(key, &mut params_full, &param.full)?;
+        checked_identity_append(key, &mut params_full, ",")?;
+        checked_identity_append(key, &mut params_stripped, &param.ns_stripped)?;
+        checked_identity_append(key, &mut params_stripped, ",")?;
+        param_namespaces.extend(key, &param.namespaces)?;
+    }
+    let effective_namespace = if branch == "global" { namespace } else { "" };
+    let effective_module = if branch == "method" { "" } else { module };
+    let effective_owner = if branch == "method" {
+        owner
+    } else {
+        Ident::default()
+    };
+    let mut full = IdentityEncoder::new(key);
+    full.field(branch)?;
+    full.field(effective_module)?;
+    full.field(effective_namespace)?;
+    full.field(&effective_owner.full)?;
+    full.field(name)?;
+    full.number(is_const as u8)?;
+    full.field(&params_full)?;
+    full.field(&ret.full)?;
+    let mut stripped = IdentityEncoder::new(key);
+    stripped.field(branch)?;
+    stripped.field(effective_module)?;
+    stripped.field("")?;
+    stripped.field(&effective_owner.ns_stripped)?;
+    stripped.field(name)?;
+    stripped.number(is_const as u8)?;
+    stripped.field(&params_stripped)?;
+    stripped.field(&ret.ns_stripped)?;
+    let mut namespaces = NamespaceAccumulator::new();
+    if branch == "global" {
+        namespaces.push(key, effective_namespace)?;
+    }
+    namespaces.extend(key, &effective_owner.namespaces)?;
+    namespaces.extend(key, &param_namespaces.finish())?;
+    namespaces.extend(key, &ret.namespaces)?;
+    Ok(FunctionDeclarationIdentity {
+        identity: Ident {
+            full: full.finish(),
+            ns_stripped: stripped.finish(),
+            namespaces: namespaces.finish(),
+            display: checked_display(key, &[module, "::", name])?,
+            function_owner: None,
+            function_name: Some(name.to_owned()),
+        },
+        footprint: 0,
     })
+}
+
+fn duplicate_tail_key_wire(pos: usize, table: usize) -> WireError {
+    let field = match table {
+        0 => "duplicate TypeReferences key",
+        1 => "duplicate TypeIdReferenceToPointer key",
+        2 => "duplicate FunctionReferences key",
+        3 => "duplicate FunctionIdReferenceToPointer key",
+        4 => "duplicate GlobalReferences key",
+        _ => "duplicate tail-table key",
+    };
+    WireError::BadLen { pos, len: 2, field }
 }
 
 impl SymTables {
     /// Parse the 7 tail tables of `bytes` into identity maps. Two passes over T3 are avoided
     /// by parsing T1 first (so func owner/param type ptrs resolve to names).
     fn build(bytes: &[u8]) -> Result<Self, WireError> {
-        let tail = module_region_end(bytes)?;
+        Self::build_inner(bytes, None, bytes.len(), 0)
+    }
+
+    /// Parse only `bytes`' own rows, using `fallback` solely to name T1 dependencies omitted from
+    /// a minimal independently-remapped mini. The fallback never makes a missing executable ref
+    /// valid; it only makes portable identity comparison complete. The composed source/identity
+    /// budget prevents a sequence of individually-small minis from growing retained state without
+    /// bound.
+    fn build_with_type_fallback_and_budget(
+        bytes: &[u8],
+        fallback: &SymTables,
+        total_source_bytes: usize,
+        already_charged: usize,
+    ) -> Result<Self, WireError> {
+        Self::build_inner(bytes, Some(fallback), total_source_bytes, already_charged)
+    }
+
+    fn build_inner(
+        bytes: &[u8],
+        fallback: Option<&SymTables>,
+        total_source_bytes: usize,
+        already_charged: usize,
+    ) -> Result<Self, WireError> {
+        let tail = preflight_tail_tables(bytes)?.tail;
         let mut c = Cursor::at(bytes, tail);
 
         let mut all_ptr_keys: HashSet<i64> = HashSet::new();
@@ -251,34 +1101,35 @@ impl SymTables {
         // identity must include each subtype's RESOLVED NAME (so `TSubclassOf<AFoo>` differs
         // from `TSubclassOf<ABar>` — they share Name `TSubclassOf` but distinct subtype ptrs),
         // and subtype ptrs may forward-reference other T1 rows, so build names first.
-        struct RawType {
-            key: i64,
-            name: String,
-            module: String,
-            namespace: String,
-            /// (token, subtype_type_info_ptr) per subtype.
-            subs: Vec<(i32, i64)>,
-        }
         let ntypes = c.read_count("TypeReferences")?;
+        c.ensure_minimum_remaining(ntypes, 24, "TypeReferences")?;
         let mut raw_types = Vec::with_capacity(ntypes);
+        let mut row_by_key = HashMap::with_capacity(ntypes);
         for _ in 0..ntypes {
+            let key_pos = c.pos();
             let key = c.read_i64()?;
+            if row_by_key.insert(key, raw_types.len()).is_some() {
+                return Err(duplicate_tail_key_wire(key_pos, 0));
+            }
             all_ptr_keys.insert(key);
             let name = c.read_sia()?;
             let module = c.read_sia()?;
             let namespace = c.read_sia()?;
             let nsub = c.read_count("TypeRef.SubTypes")?;
+            c.ensure_minimum_remaining(nsub, DATA_TYPE_SIZE, "TypeRef.SubTypes")?;
             let mut subs = Vec::with_capacity(nsub);
             for _ in 0..nsub {
-                // DataType (36 B): 24 bools + i64 type_info + i32 token.
-                let base = c.pos();
-                let type_info = i64::from_le_bytes(bytes[base + 24..base + 32].try_into().unwrap());
-                let token = i32::from_le_bytes(bytes[base + 32..base + 36].try_into().unwrap());
-                subs.push((token, type_info));
-                c.skip(DATA_TYPE_SIZE)?;
+                let mut flags = [false; 6];
+                for flag in &mut flags {
+                    *flag = c.read_bool4()?;
+                }
+                subs.push(RawTypeIdentityDataType {
+                    flags,
+                    type_info: c.read_i64()?,
+                    token: c.read_i32()?,
+                });
             }
-            type_name_of_ptr.insert(key, name.clone());
-            raw_types.push(RawType {
+            raw_types.push(RawTypeIdentityRow {
                 key,
                 name,
                 module,
@@ -286,55 +1137,47 @@ impl SymTables {
                 subs,
             });
         }
-        // PASS 2: compose identities using resolved subtype names. Subtype names are the bare
+        // PASS 2: recursively compose complete subtype identities. The old bare-name form
         // T1 Name (no module/namespace), so a subtype contributes NO namespace field — the only
-        // namespace in a type identity is the type's OWN (field index 1). The oracle skeleton
-        // drops it; the namespace list carries it (GAP-A).
+        // collapsed nested template arguments; nested skeletons and namespaces now travel too.
+        let mut memo = HashMap::new();
+        let mut identity_budget =
+            IdentityBudget::for_composed_input(total_source_bytes, already_charged)?;
         for rt in &raw_types {
-            let mut sub_ident = String::new();
-            for (token, sub_ptr) in &rt.subs {
-                let sub_name = if *token == 5 {
-                    type_name_of_ptr.get(sub_ptr).cloned().unwrap_or_default()
-                } else {
-                    String::new()
-                };
-                sub_ident.push_str(&format!("{token}:{sub_name},"));
-            }
-            let identity = format!(
-                "{}{SEP}{}{SEP}{}{SEP}{}:{sub_ident}",
-                rt.module,
-                rt.namespace,
-                rt.name,
-                rt.subs.len()
-            );
-            // ns-stripped skeleton: identical but with the namespace field blanked.
-            let ns_stripped = format!(
-                "{}{SEP}{SEP}{}{SEP}{}:{sub_ident}",
-                rt.module,
-                rt.name,
-                rt.subs.len()
-            );
-            type_ident_of_ptr.insert(
+            let identity = resolve_type_identity(
                 rt.key,
-                Ident {
-                    full: identity.clone(),
-                    ns_stripped,
-                    namespaces: vec![rt.namespace.clone()],
-                },
-            );
-            type_id_of_ptr.insert(rt.key, identity.clone());
-            type_ptr_of_id.entry(identity).or_default().push(rt.key);
+                &raw_types,
+                &row_by_key,
+                fallback,
+                &mut memo,
+                &mut HashSet::new(),
+                0,
+            )?;
+            identity_budget.charge(rt.key, &identity)?;
+            type_name_of_ptr.insert(rt.key, rt.name.clone());
+            type_ident_of_ptr.insert(rt.key, identity.clone());
+            type_id_of_ptr.insert(rt.key, identity.full.clone());
+            type_ptr_of_id
+                .entry(identity.full)
+                .or_default()
+                .push(rt.key);
         }
 
         // T2 TypeIdReferenceToPointer: i32 id -> i64 ptr.
         let mut typeid_to_ptr = HashMap::new();
-        let mut ptr_to_typeid = HashMap::new();
+        let mut ptr_kind_to_typeid: HashMap<(i64, u32), i32> = HashMap::new();
         for _ in 0..c.read_count("TypeIdRef")? {
+            let key_pos = c.pos();
             let id = c.read_i32()?;
             let ptr = c.read_i64()?;
             all_ptr_keys.insert(ptr);
-            typeid_to_ptr.insert(id, ptr);
-            ptr_to_typeid.insert(ptr, id);
+            if typeid_to_ptr.insert(id, ptr).is_some() {
+                return Err(duplicate_tail_key_wire(key_pos, 1));
+            }
+            ptr_kind_to_typeid
+                .entry((ptr, id as u32 & TYPE_ID_OBJECT_MASK))
+                .and_modify(|canonical| *canonical = (*canonical).min(id))
+                .or_insert(id);
         }
 
         // T3 FunctionReferences: i64 key + (Name, Module, Namespace, 3 bool, i64 ObjectType,
@@ -344,13 +1187,17 @@ impl SymTables {
         let mut func_ident_of_ptr: HashMap<i64, Ident> = HashMap::new();
         let mut func_name_of_ptr = HashMap::new();
         for _ in 0..c.read_count("FunctionReferences")? {
+            let key_pos = c.pos();
             let key = c.read_i64()?;
+            if func_id_of_ptr.contains_key(&key) {
+                return Err(duplicate_tail_key_wire(key_pos, 2));
+            }
             all_ptr_keys.insert(key);
             let name = c.read_sia()?;
             let module = c.read_sia()?;
             let namespace = c.read_sia()?;
-            let _is_const = c.read_bool4()?;
-            let _is_imported = c.read_bool4()?;
+            let is_const = c.read_bool4()?;
+            let is_imported = c.read_bool4()?;
             let is_method = c.read_bool4()?;
             let objtype = c.read_i64()?;
             // Use the owner's FULL type identity (name + template subtypes), not just its name,
@@ -359,41 +1206,100 @@ impl SymTables {
             // ret are type identities that carry their OWN (drifting) namespace fields, so compose
             // all three oracle forms in lockstep (GAP-A: a func's own ns is field index 1, then the
             // owner's ns, then each param's, then ret's — traversal order preserved in the list).
-            let owner = type_ident_of_ptr.get(&objtype).cloned().unwrap_or_default();
+            let type_identity = |ptr: &i64| {
+                type_ident_of_ptr
+                    .get(ptr)
+                    .or_else(|| fallback.and_then(|prior| prior.type_ident_of_ptr.get(ptr)))
+                    .cloned()
+            };
+            let owner = type_identity(&objtype).unwrap_or_default();
             let nparams = c.read_count("FuncRef.Params")?;
             let mut params_full = String::new();
             let mut params_stripped = String::new();
-            let mut param_ns: Vec<String> = Vec::new();
+            let mut param_ns = NamespaceAccumulator::new();
             for _ in 0..nparams {
-                let p = datatype_identity(&mut c, &type_ident_of_ptr)?;
-                params_full.push_str(&p.full);
-                params_full.push(',');
-                params_stripped.push_str(&p.ns_stripped);
-                params_stripped.push(',');
-                param_ns.extend(p.namespaces);
+                let p = datatype_identity_with_fallback(
+                    key,
+                    &mut c,
+                    &type_ident_of_ptr,
+                    fallback.map(|prior| &prior.type_ident_of_ptr),
+                )?;
+                checked_identity_append(key, &mut params_full, &p.full)?;
+                checked_identity_append(key, &mut params_full, ",")?;
+                checked_identity_append(key, &mut params_stripped, &p.ns_stripped)?;
+                checked_identity_append(key, &mut params_stripped, ",")?;
+                param_ns.extend(key, &p.namespaces)?;
             }
-            let ret = datatype_identity(&mut c, &type_ident_of_ptr)?;
-            let identity = format!(
-                "{module}{SEP}{namespace}{SEP}{}{SEP}{name}{SEP}{}{SEP}{params_full}{SEP}{}",
-                owner.full, is_method as u8, ret.full
-            );
-            let ns_stripped = format!(
-                "{module}{SEP}{SEP}{}{SEP}{name}{SEP}{}{SEP}{params_stripped}{SEP}{}",
-                owner.ns_stripped, is_method as u8, ret.ns_stripped
-            );
-            let mut namespaces = Vec::with_capacity(2 + param_ns.len() + ret.namespaces.len());
-            namespaces.push(namespace.clone()); // the func's own namespace (field index 1)
-            namespaces.extend(owner.namespaces.iter().cloned());
-            namespaces.extend(param_ns);
-            namespaces.extend(ret.namespaces.iter().cloned());
-            func_ident_of_ptr.insert(
+            let ret = datatype_identity_with_fallback(
                 key,
-                Ident {
-                    full: identity.clone(),
-                    ns_stripped,
-                    namespaces,
-                },
-            );
+                &mut c,
+                &type_ident_of_ptr,
+                fallback.map(|prior| &prior.type_ident_of_ptr),
+            )?;
+            if is_imported && (is_method || objtype != 0) {
+                return Err(WireError::InvalidFunctionReference {
+                    key,
+                    detail: "imported declarations cannot have a method owner",
+                });
+            }
+            // Project exactly the fields consumed by the runtime lookup branch. Imported
+            // declarations ignore Namespace/owner; methods ignore Module/Namespace; globals use
+            // Module+Namespace. This prevents byte-distinct rows from aliasing at runtime.
+            let (branch, effective_module, effective_namespace, effective_owner) = if is_imported {
+                ("imported", module.as_str(), "", Ident::default())
+            } else if is_method {
+                ("method", "", "", owner.clone())
+            } else {
+                (
+                    "global",
+                    module.as_str(),
+                    namespace.as_str(),
+                    Ident::default(),
+                )
+            };
+            let mut identity = IdentityEncoder::new(key);
+            identity.field(branch)?;
+            identity.field(effective_module)?;
+            identity.field(effective_namespace)?;
+            identity.field(&effective_owner.full)?;
+            identity.field(&name)?;
+            identity.number(is_const as u8)?;
+            identity.field(&params_full)?;
+            identity.field(&ret.full)?;
+            let identity = identity.finish();
+            let mut ns_stripped = IdentityEncoder::new(key);
+            ns_stripped.field(branch)?;
+            ns_stripped.field(effective_module)?;
+            ns_stripped.field("")?;
+            ns_stripped.field(&effective_owner.ns_stripped)?;
+            ns_stripped.field(&name)?;
+            ns_stripped.number(is_const as u8)?;
+            ns_stripped.field(&params_stripped)?;
+            ns_stripped.field(&ret.ns_stripped)?;
+            let ns_stripped = ns_stripped.finish();
+            let mut namespaces = NamespaceAccumulator::new();
+            if !is_imported && !is_method {
+                namespaces.push(key, effective_namespace)?;
+            }
+            namespaces.extend(key, &effective_owner.namespaces)?;
+            namespaces.extend(key, &param_ns.finish())?;
+            namespaces.extend(key, &ret.namespaces)?;
+            let function_identity = Ident {
+                full: identity.clone(),
+                ns_stripped,
+                namespaces: namespaces.finish(),
+                display: checked_display(key, &[&module, "::", &name])?,
+                function_owner: is_method.then(|| {
+                    type_name_of_ptr
+                        .get(&objtype)
+                        .or_else(|| fallback.and_then(|prior| prior.type_name_of_ptr.get(&objtype)))
+                        .cloned()
+                        .unwrap_or_default()
+                }),
+                function_name: Some(name.clone()),
+            };
+            identity_budget.charge(key, &function_identity)?;
+            func_ident_of_ptr.insert(key, function_identity);
             func_id_of_ptr.insert(key, identity.clone());
             func_ptr_of_id.entry(identity).or_default().push(key);
             func_name_of_ptr.insert(key, name);
@@ -401,54 +1307,97 @@ impl SymTables {
 
         // T4 FunctionIdReferenceToPointer: i32 id -> i64 ptr.
         let mut funcid_to_ptr = HashMap::new();
-        let mut ptr_to_funcid = HashMap::new();
+        let mut ptr_to_funcid: HashMap<i64, i32> = HashMap::new();
         for _ in 0..c.read_count("FuncIdRef")? {
+            let key_pos = c.pos();
             let id = c.read_i32()?;
             let ptr = c.read_i64()?;
             all_ptr_keys.insert(ptr);
-            funcid_to_ptr.insert(id, ptr);
-            ptr_to_funcid.insert(ptr, id);
+            if funcid_to_ptr.insert(id, ptr).is_some() {
+                return Err(duplicate_tail_key_wire(key_pos, 3));
+            }
+            ptr_to_funcid
+                .entry(ptr)
+                .and_modify(|canonical| {
+                    // Zero is the null operand sentinel. A real pointer may nevertheless have
+                    // a historical T4 alias at zero, so prefer any non-zero alias and otherwise
+                    // keep the deterministic smallest wire id.
+                    if *canonical == 0 || (id != 0 && id < *canonical) {
+                        *canonical = id;
+                    }
+                })
+                .or_insert(id);
         }
 
         // T5 GlobalReferences: i64 key + (Name, Module, Namespace, i32 bIsString).
         let mut global_id_of_ptr = HashMap::new();
         let mut global_ptr_of_id: HashMap<String, Vec<i64>> = HashMap::new();
         let mut global_ident_of_ptr: HashMap<i64, Ident> = HashMap::new();
+        let mut global_is_string_of_ptr = HashMap::new();
         let mut global_name_of_ptr = HashMap::new();
         for _ in 0..c.read_count("GlobalReferences")? {
+            let key_pos = c.pos();
             let key = c.read_i64()?;
+            if global_id_of_ptr.contains_key(&key) {
+                return Err(duplicate_tail_key_wire(key_pos, 4));
+            }
             all_ptr_keys.insert(key);
-            let name = c.read_sia()?;
+            let name_pos = c.pos();
+            let name = c.read_sia_bytes()?;
             let module = c.read_sia()?;
             let namespace = c.read_sia()?;
             let is_string = c.read_bool4()?;
-            let identity = format!(
-                "{module}{SEP}{namespace}{SEP}{name}{SEP}{}",
-                is_string as u8
-            );
-            // ns-stripped skeleton: namespace field (index 1) blanked (GAP-A).
-            let ns_stripped = format!("{module}{SEP}{SEP}{name}{SEP}{}", is_string as u8);
-            global_ident_of_ptr.insert(
-                key,
-                Ident {
-                    full: identity.clone(),
-                    ns_stripped,
-                    namespaces: vec![namespace.clone()],
-                },
-            );
+            let name = if is_string {
+                name.decode_utf8(name_pos)?
+            } else {
+                name.decode_ansi()
+            };
+            let effective_module = if is_string { "" } else { module.as_str() };
+            let effective_namespace = if is_string { "" } else { namespace.as_str() };
+            let mut identity = IdentityEncoder::new(key);
+            identity.field(effective_module)?;
+            identity.field(effective_namespace)?;
+            identity.field(&name)?;
+            identity.number(is_string as u8)?;
+            let identity = identity.finish();
+            let mut ns_stripped = IdentityEncoder::new(key);
+            ns_stripped.field(effective_module)?;
+            ns_stripped.field("")?;
+            ns_stripped.field(&name)?;
+            ns_stripped.number(is_string as u8)?;
+            let ns_stripped = ns_stripped.finish();
+            let mut global_namespaces = NamespaceAccumulator::new();
+            if !is_string {
+                global_namespaces.push(key, &namespace)?;
+            }
+            let global_identity = Ident {
+                full: identity.clone(),
+                ns_stripped,
+                namespaces: global_namespaces.finish(),
+                display: checked_display(key, &[&module, "::", &name])?,
+                function_owner: None,
+                function_name: None,
+            };
+            identity_budget.charge(key, &global_identity)?;
+            global_ident_of_ptr.insert(key, global_identity);
+            global_is_string_of_ptr.insert(key, is_string);
             global_id_of_ptr.insert(key, identity.clone());
             global_ptr_of_id.entry(identity).or_default().push(key);
             global_name_of_ptr.insert(key, name);
         }
+        for keys in global_ptr_of_id.values_mut() {
+            keys.sort_unstable();
+        }
         // T6 StaticNames + T7 PropertyReferences are not operand-referenced (member ops carry a
         // TYPE-ID, not a prop key — the prop key is derived from typeid+offset), so skip them.
 
+        let identity_bytes = identity_budget.charged;
         Ok(SymTables {
             type_id_of_ptr,
             type_ptr_of_id,
             type_ident_of_ptr,
             typeid_to_ptr,
-            ptr_to_typeid,
+            ptr_kind_to_typeid,
             func_id_of_ptr,
             func_ptr_of_id,
             func_ident_of_ptr,
@@ -460,7 +1409,9 @@ impl SymTables {
             global_id_of_ptr,
             global_ptr_of_id,
             global_ident_of_ptr,
+            global_is_string_of_ptr,
             all_ptr_keys,
+            identity_bytes,
         })
     }
 
@@ -479,6 +1430,308 @@ impl SymTables {
     }
 }
 
+#[derive(Debug)]
+struct IdentityReverseSummary {
+    by_skeleton: HashMap<String, Vec<(i64, usize)>>,
+    identity_bytes: usize,
+}
+
+#[derive(Debug)]
+struct SymbolIdentitySummaries {
+    types: IdentityReverseSummary,
+    functions: IdentityReverseSummary,
+    globals: IdentityReverseSummary,
+}
+
+impl IdentityReverseSummary {
+    fn build(rows: &HashMap<i64, Ident>) -> Result<Self, WireError> {
+        Self::build_filtered(rows, |_| true)
+    }
+
+    fn build_filtered(
+        rows: &HashMap<i64, Ident>,
+        include: impl Fn(i64) -> bool,
+    ) -> Result<Self, WireError> {
+        let mut by_skeleton: HashMap<String, Vec<(i64, usize)>> = HashMap::new();
+        let mut identity_bytes = 0usize;
+        for (&key, identity) in rows {
+            if !include(key) {
+                continue;
+            }
+            let footprint = identity_footprint(key, identity)?;
+            identity_bytes = identity_bytes.checked_add(footprint).ok_or(
+                WireError::IdentityComparisonBudgetExceeded {
+                    max: MAX_IDENTITY_COMPARISON_WORK,
+                },
+            )?;
+            by_skeleton
+                .entry(identity.ns_stripped.clone())
+                .or_default()
+                .push((key, footprint));
+        }
+        Ok(Self {
+            by_skeleton,
+            identity_bytes,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct IdPointerSummary {
+    min_id_by_ptr: HashMap<i64, i32>,
+    count_by_ptr: HashMap<i64, usize>,
+}
+
+impl IdPointerSummary {
+    fn build(rows: &HashMap<i32, i64>) -> Self {
+        let mut min_id_by_ptr = HashMap::new();
+        let mut count_by_ptr = HashMap::new();
+        for (&id, &ptr) in rows {
+            min_id_by_ptr
+                .entry(ptr)
+                .and_modify(|prior: &mut i32| *prior = (*prior).min(id))
+                .or_insert(id);
+            *count_by_ptr.entry(ptr).or_default() += 1;
+        }
+        Self {
+            min_id_by_ptr,
+            count_by_ptr,
+        }
+    }
+
+    /// Summarize only rows whose id is not already present in `base`. Exact base-row repeats in a
+    /// prepared mini are one effective TMap entry, not a second reverse mapping.
+    fn build_additional(base: &HashMap<i32, i64>, rows: &HashMap<i32, i64>) -> Self {
+        let mut min_id_by_ptr = HashMap::new();
+        let mut count_by_ptr = HashMap::new();
+        for (&id, &ptr) in rows {
+            if base.contains_key(&id) {
+                continue;
+            }
+            min_id_by_ptr
+                .entry(ptr)
+                .and_modify(|prior: &mut i32| *prior = (*prior).min(id))
+                .or_insert(id);
+            *count_by_ptr.entry(ptr).or_default() += 1;
+        }
+        Self {
+            min_id_by_ptr,
+            count_by_ptr,
+        }
+    }
+
+    fn count(&self, ptr: i64) -> usize {
+        self.count_by_ptr.get(&ptr).copied().unwrap_or_default()
+    }
+
+    fn unique_id_with(&self, additional: &Self, ptr: i64) -> Option<i32> {
+        match (self.count(ptr), additional.count(ptr)) {
+            (1, 0) => self.min_id_by_ptr.get(&ptr).copied(),
+            (0, 1) => additional.min_id_by_ptr.get(&ptr).copied(),
+            _ => None,
+        }
+    }
+}
+
+fn ensure_unique_symbol_identities(
+    table: usize,
+    base: &HashMap<i64, Ident>,
+    base_summary: &IdentityReverseSummary,
+    accepted: &HashMap<i64, Ident>,
+    mini: &HashMap<i64, Ident>,
+) -> Result<(), RemapError> {
+    ensure_unique_symbol_identities_filtered(table, base, base_summary, accepted, mini, |_| true)
+}
+
+fn ensure_unique_symbol_identities_filtered(
+    table: usize,
+    base: &HashMap<i64, Ident>,
+    base_summary: &IdentityReverseSummary,
+    accepted: &HashMap<i64, Ident>,
+    mini: &HashMap<i64, Ident>,
+    include_mini: impl Fn(i64) -> bool,
+) -> Result<(), RemapError> {
+    let mut accepted_by_skeleton: HashMap<&str, Vec<(i64, &Ident, usize)>> = HashMap::new();
+    let accepted_identity_bytes = accepted.iter().try_fold(
+        0usize,
+        |total, (&key, identity)| -> Result<usize, WireError> {
+            let footprint = identity_footprint(key, identity)?;
+            accepted_by_skeleton
+                .entry(identity.ns_stripped.as_str())
+                .or_default()
+                .push((key, identity, footprint));
+            total
+                .checked_add(footprint)
+                .ok_or(WireError::IdentityComparisonBudgetExceeded {
+                    max: MAX_IDENTITY_COMPARISON_WORK,
+                })
+        },
+    )?;
+    let mut rows: Vec<(i64, &Ident, usize)> = mini
+        .iter()
+        .filter(|(key, _)| include_mini(**key))
+        .map(|(&key, identity)| Ok((key, identity, identity_footprint(key, identity)?)))
+        .collect::<Result<_, WireError>>()?;
+    let mini_identity_bytes = rows.iter().try_fold(0usize, |total, (_, _, footprint)| {
+        total
+            .checked_add(*footprint)
+            .ok_or(WireError::IdentityComparisonBudgetExceeded {
+                max: MAX_IDENTITY_COMPARISON_WORK,
+            })
+    })?;
+    let identity_bytes = base_summary
+        .identity_bytes
+        .checked_add(accepted_identity_bytes)
+        .and_then(|bytes| bytes.checked_add(mini_identity_bytes))
+        .ok_or(WireError::IdentityComparisonBudgetExceeded {
+            max: MAX_IDENTITY_COMPARISON_WORK,
+        })?;
+    let max_comparison_work = identity_bytes
+        .checked_mul(IDENTITY_COMPARISON_WORK_MULTIPLIER)
+        .unwrap_or(MAX_IDENTITY_COMPARISON_WORK)
+        .clamp(MIN_IDENTITY_COMPARISON_WORK, MAX_IDENTITY_COMPARISON_WORK);
+    let mut remaining_comparison_work = max_comparison_work;
+    rows.sort_by_key(|(key, _, _)| *key);
+    let mut mini_by_skeleton: HashMap<&str, Vec<(i64, &Ident, usize)>> = HashMap::new();
+    for (key, identity, footprint) in rows {
+        // A base/prior key is grandfathered. The collision layer has already required its row
+        // bytes to be identical; do not reinterpret historical identity ambiguity here.
+        if base.contains_key(&key) || accepted.contains_key(&key) {
+            continue;
+        }
+        let mut matching_prior = None;
+        if let Some(candidates) = base_summary.by_skeleton.get(identity.ns_stripped.as_str()) {
+            for &(prior_key, prior_footprint) in candidates {
+                if prior_key == key {
+                    continue;
+                }
+                let comparison_work = footprint.checked_add(prior_footprint).ok_or(
+                    WireError::IdentityComparisonBudgetExceeded {
+                        max: max_comparison_work,
+                    },
+                )?;
+                remaining_comparison_work = remaining_comparison_work
+                    .checked_sub(comparison_work)
+                    .ok_or(WireError::IdentityComparisonBudgetExceeded {
+                        max: max_comparison_work,
+                    })?;
+                let prior = base
+                    .get(&prior_key)
+                    .expect("base identity summary points to its source row");
+                if identity.oracle_eq(prior) {
+                    matching_prior = Some(
+                        matching_prior.map_or(prior_key, |current: i64| current.min(prior_key)),
+                    );
+                }
+            }
+        }
+        for candidates in [
+            accepted_by_skeleton.get(identity.ns_stripped.as_str()),
+            mini_by_skeleton.get(identity.ns_stripped.as_str()),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            for &(prior_key, prior, prior_footprint) in candidates {
+                if prior_key == key {
+                    continue;
+                }
+                let comparison_work = footprint.checked_add(prior_footprint).ok_or(
+                    WireError::IdentityComparisonBudgetExceeded {
+                        max: max_comparison_work,
+                    },
+                )?;
+                remaining_comparison_work = remaining_comparison_work
+                    .checked_sub(comparison_work)
+                    .ok_or(WireError::IdentityComparisonBudgetExceeded {
+                        max: max_comparison_work,
+                    })?;
+                if identity.oracle_eq(prior) {
+                    matching_prior = Some(
+                        matching_prior.map_or(prior_key, |current: i64| current.min(prior_key)),
+                    );
+                }
+            }
+        }
+        if let Some(prior_key) = matching_prior {
+            return Err(RemapError::InvalidTailRow {
+                table,
+                row_key: key,
+                kind: "symbol identity",
+                detail: format!(
+                    "the same portable identity is already registered at key {prior_key:#x}"
+                ),
+            });
+        }
+        mini_by_skeleton
+            .entry(identity.ns_stripped.as_str())
+            .or_default()
+            .push((key, identity, footprint));
+    }
+    Ok(())
+}
+
+fn ensure_unique_id_pointers(
+    table: usize,
+    base: &HashMap<i32, i64>,
+    base_summary: &IdPointerSummary,
+    accepted: &HashMap<i32, i64>,
+    mini: &HashMap<i32, i64>,
+) -> Result<(), RemapError> {
+    let mut by_ptr: HashMap<i64, i32> = HashMap::new();
+    for (&id, &ptr) in accepted {
+        by_ptr
+            .entry(ptr)
+            .and_modify(|prior| *prior = (*prior).min(id))
+            .or_insert(id);
+    }
+    let mut rows: Vec<(i32, i64)> = mini.iter().map(|(&id, &ptr)| (id, ptr)).collect();
+    rows.sort_unstable();
+    for (id, ptr) in rows {
+        if base.contains_key(&id) || accepted.contains_key(&id) {
+            continue;
+        }
+        let prior = base_summary
+            .min_id_by_ptr
+            .get(&ptr)
+            .into_iter()
+            .chain(by_ptr.get(&ptr))
+            .copied()
+            .min();
+        if let Some(prior) = prior {
+            return Err(RemapError::InvalidTailRow {
+                table,
+                row_key: id as i64,
+                kind: "pointer-to-id mapping",
+                detail: format!("pointer {ptr:#x} is already mapped by id {prior:#x}"),
+            });
+        }
+        by_ptr.insert(ptr, id);
+    }
+    Ok(())
+}
+
+/// Count only mappings added after the pristine base. Keeping this delta separate lets callers
+/// query the precomputed base summary without cloning its full T2/T4 map for every mini.
+fn additional_pointer_id_counts(
+    base: &HashMap<i32, i64>,
+    accepted: &HashMap<i32, i64>,
+    mini: &HashMap<i32, i64>,
+) -> HashMap<i64, usize> {
+    let mut counts = HashMap::new();
+    for (&id, &ptr) in accepted {
+        if !base.contains_key(&id) {
+            *counts.entry(ptr).or_default() += 1;
+        }
+    }
+    for (&id, &ptr) in mini {
+        if !base.contains_key(&id) && !accepted.contains_key(&id) {
+            *counts.entry(ptr).or_default() += 1;
+        }
+    }
+    counts
+}
+
 // -------------------------------------------------------------------------------------------------
 // Raw tail-row metadata used only by the explicit new-symbol path. The strict/default remapper
 // above deliberately keeps its historical parsing and output behavior unchanged.
@@ -489,9 +1742,11 @@ struct TypeRowMeta {
     start: usize,
     end: usize,
     key: i64,
+    name: String,
     module: String,
-    /// Absolute byte offsets + raw values of DataType.TypeInfo.OldReference fields in SubTypes.
-    type_deps: Vec<(usize, i64)>,
+    namespace: String,
+    /// DataType fields embedded by this row.
+    type_deps: Vec<DataTypeDep>,
 }
 
 #[derive(Clone)]
@@ -501,8 +1756,12 @@ struct FuncRowMeta {
     key: i64,
     name: String,
     module: String,
-    /// ObjectType plus every parameter/return DataType.TypeInfo.OldReference.
-    type_deps: Vec<(usize, i64)>,
+    namespace: String,
+    /// The optional ObjectType plus every parameter/return DataType.
+    owner_dep: (usize, i64),
+    is_imported: bool,
+    is_method: bool,
+    type_deps: Vec<DataTypeDep>,
 }
 
 #[derive(Clone)]
@@ -510,7 +1769,10 @@ struct GlobalRowMeta {
     start: usize,
     end: usize,
     key: i64,
+    name: String,
     module: String,
+    namespace: String,
+    is_string: bool,
 }
 
 #[derive(Clone)]
@@ -541,37 +1803,87 @@ struct PropertyRowMeta {
     member_offset: i32,
 }
 
+#[derive(Clone, Copy)]
+struct DataTypeDep {
+    off: usize,
+    ptr: i64,
+    token: i32,
+    is_auto: bool,
+}
+
+#[derive(Clone, Copy)]
+enum UniqueRowIndex {
+    Unique(usize),
+    Ambiguous,
+}
+
+fn record_ptr_row(index: &mut HashMap<i64, UniqueRowIndex>, ptr: i64, row: usize) {
+    index
+        .entry(ptr)
+        .and_modify(|state| *state = UniqueRowIndex::Ambiguous)
+        .or_insert(UniqueRowIndex::Unique(row));
+}
+
+fn duplicate_tail_row(table: usize, row_key: i64, pos: usize) -> RemapError {
+    RemapError::InvalidTailRow {
+        table,
+        row_key,
+        kind: "duplicate key",
+        detail: format!("the keyed table contains another row for this key (at {pos:#x})"),
+    }
+}
+
 struct TailMetadata {
     types: Vec<TypeRowMeta>,
+    type_by_key: HashMap<i64, usize>,
     type_ids: Vec<IdPtrRowMeta>,
+    type_id_by_ptr: HashMap<i64, UniqueRowIndex>,
     funcs: Vec<FuncRowMeta>,
+    func_by_key: HashMap<i64, usize>,
     func_ids: Vec<IdPtrRowMeta>,
+    func_id_by_ptr: HashMap<i64, UniqueRowIndex>,
     globals: Vec<GlobalRowMeta>,
     static_names: Vec<StaticRowMeta>,
     properties: Vec<PropertyRowMeta>,
+    property_by_key: HashMap<i64, usize>,
 }
 
-/// Consume one inline DataType and return its TypeInfo.OldReference field location/value.
-fn read_datatype_dep(c: &mut Cursor) -> Result<(usize, i64), WireError> {
-    c.skip(24)?; // six archive bools
+/// Consume one inline DataType and retain the pointer plus the token that determines whether it
+/// must be a concrete T1 reference (`ttIdentifier == 5`) or the exact null primitive sentinel.
+fn read_datatype_dep(c: &mut Cursor) -> Result<DataTypeDep, WireError> {
+    c.skip(8)?; // reference + object-const
+    c.skip(4)?; // object-handle (identity normalization handles this in SymTables)
+    c.skip(4)?; // read-only/const-handle
+    let is_auto = c.read_bool4()?;
+    c.skip(4)?; // if-handle-then-const
     let off = c.pos();
     let ptr = c.read_i64()?;
-    c.skip(4)?; // token
-    Ok((off, ptr))
+    let token = c.read_i32()?;
+    Ok(DataTypeDep {
+        off,
+        ptr,
+        token,
+        is_auto,
+    })
 }
 
 impl TailMetadata {
     fn build(bytes: &[u8]) -> Result<Self, RemapError> {
-        let tail = module_region_end(bytes)?;
+        let tail = preflight_tail_tables(bytes)?.tail;
         let mut c = Cursor::at(bytes, tail);
 
-        let mut types = Vec::new();
-        for _ in 0..c.read_count("TypeReferences")? {
+        let type_count = c.read_count("TypeReferences")?;
+        let mut types = Vec::with_capacity(type_count);
+        let mut type_by_key = HashMap::with_capacity(type_count);
+        for _ in 0..type_count {
             let start = c.pos();
             let key = c.read_i64()?;
-            c.read_sia()?; // Name
+            if type_by_key.insert(key, types.len()).is_some() {
+                return Err(duplicate_tail_row(0, key, start));
+            }
+            let name = c.read_sia()?;
             let module = c.read_sia()?;
-            c.read_sia()?; // Namespace
+            let namespace = c.read_sia()?;
             let mut type_deps = Vec::new();
             for _ in 0..c.read_count("TypeRef.SubTypes")? {
                 type_deps.push(read_datatype_dep(&mut c)?);
@@ -580,16 +1892,25 @@ impl TailMetadata {
                 start,
                 end: c.pos(),
                 key,
+                name,
                 module,
+                namespace,
                 type_deps,
             });
         }
 
-        let mut type_ids = Vec::new();
-        for _ in 0..c.read_count("TypeIdRef")? {
+        let type_id_count = c.read_count("TypeIdRef")?;
+        let mut type_ids = Vec::with_capacity(type_id_count);
+        let mut type_id_keys = HashSet::with_capacity(type_id_count);
+        let mut type_id_by_ptr = HashMap::with_capacity(type_id_count);
+        for _ in 0..type_id_count {
             let start = c.pos();
             let id = c.read_i32()?;
+            if !type_id_keys.insert(id) {
+                return Err(duplicate_tail_row(1, id as i64, start));
+            }
             let ptr = c.read_i64()?;
+            record_ptr_row(&mut type_id_by_ptr, ptr, type_ids.len());
             type_ids.push(IdPtrRowMeta {
                 start,
                 end: c.pos(),
@@ -598,17 +1919,25 @@ impl TailMetadata {
             });
         }
 
-        let mut funcs = Vec::new();
-        for _ in 0..c.read_count("FunctionReferences")? {
+        let func_count = c.read_count("FunctionReferences")?;
+        let mut funcs = Vec::with_capacity(func_count);
+        let mut func_by_key = HashMap::with_capacity(func_count);
+        for _ in 0..func_count {
             let start = c.pos();
             let key = c.read_i64()?;
+            if func_by_key.insert(key, funcs.len()).is_some() {
+                return Err(duplicate_tail_row(2, key, start));
+            }
             let name = c.read_sia()?;
             let module = c.read_sia()?;
-            c.read_sia()?; // Namespace
-            c.skip(12)?; // const/imported/method
+            let namespace = c.read_sia()?;
+            c.read_bool4()?; // const (projected into SymTables' runtime identity)
+            let is_imported = c.read_bool4()?;
+            let is_method = c.read_bool4()?;
             let owner_off = c.pos();
             let owner = c.read_i64()?;
-            let mut type_deps = vec![(owner_off, owner)];
+            let owner_dep = (owner_off, owner);
+            let mut type_deps = Vec::new();
             for _ in 0..c.read_count("FuncRef.Params")? {
                 type_deps.push(read_datatype_dep(&mut c)?);
             }
@@ -619,15 +1948,26 @@ impl TailMetadata {
                 key,
                 name,
                 module,
+                namespace,
+                owner_dep,
+                is_imported,
+                is_method,
                 type_deps,
             });
         }
 
-        let mut func_ids = Vec::new();
-        for _ in 0..c.read_count("FuncIdRef")? {
+        let func_id_count = c.read_count("FuncIdRef")?;
+        let mut func_ids = Vec::with_capacity(func_id_count);
+        let mut func_id_keys = HashSet::with_capacity(func_id_count);
+        let mut func_id_by_ptr = HashMap::with_capacity(func_id_count);
+        for _ in 0..func_id_count {
             let start = c.pos();
             let id = c.read_i32()?;
+            if !func_id_keys.insert(id) {
+                return Err(duplicate_tail_row(3, id as i64, start));
+            }
             let ptr = c.read_i64()?;
+            record_ptr_row(&mut func_id_by_ptr, ptr, func_ids.len());
             func_ids.push(IdPtrRowMeta {
                 start,
                 end: c.pos(),
@@ -636,24 +1976,39 @@ impl TailMetadata {
             });
         }
 
-        let mut globals = Vec::new();
-        for _ in 0..c.read_count("GlobalReferences")? {
+        let global_count = c.read_count("GlobalReferences")?;
+        let mut globals = Vec::with_capacity(global_count);
+        let mut global_keys = HashSet::with_capacity(global_count);
+        for _ in 0..global_count {
             let start = c.pos();
             let key = c.read_i64()?;
-            c.read_sia()?; // Name
+            if !global_keys.insert(key) {
+                return Err(duplicate_tail_row(4, key, start));
+            }
+            let name_pos = c.pos();
+            let name = c.read_sia_bytes()?;
             let module = c.read_sia()?;
-            c.read_sia()?; // Namespace
-            c.skip(4)?; // bIsString
+            let namespace = c.read_sia()?;
+            let is_string = c.read_bool4()?;
+            let name = if is_string {
+                name.decode_utf8(name_pos)?
+            } else {
+                name.decode_ansi()
+            };
             globals.push(GlobalRowMeta {
                 start,
                 end: c.pos(),
                 key,
+                name,
                 module,
+                namespace,
+                is_string,
             });
         }
 
-        let mut static_names = Vec::new();
-        for index in 0..c.read_count("StaticNames")? {
+        let static_count = c.read_count("StaticNames")?;
+        let mut static_names = Vec::with_capacity(static_count);
+        for index in 0..static_count {
             let start = c.pos();
             let name = c.read_sia()?;
             static_names.push(StaticRowMeta {
@@ -664,10 +2019,13 @@ impl TailMetadata {
             });
         }
 
-        let mut properties = Vec::new();
-        for index in 0..c.read_count("PropertyReferences")? {
+        let property_count = c.read_count("PropertyReferences")?;
+        let mut properties = Vec::with_capacity(property_count);
+        let mut property_by_key = HashMap::with_capacity(property_count);
+        for index in 0..property_count {
             let start = c.pos();
             let key = c.read_i64()?;
+            property_by_key.entry(key).or_insert(index);
             let name = c.read_sia()?;
             let old_type_id = c.read_i32()?;
             // Exact inverse of refs.rs: (type_id << 1) | (offset << 33) | 1.
@@ -691,29 +2049,842 @@ impl TailMetadata {
         }
         Ok(TailMetadata {
             types,
+            type_by_key,
             type_ids,
+            type_id_by_ptr,
             funcs,
+            func_by_key,
             func_ids,
+            func_id_by_ptr,
             globals,
             static_names,
             properties,
+            property_by_key,
         })
     }
 
     fn type_row(&self, key: i64) -> Option<&TypeRowMeta> {
-        self.types.iter().find(|r| r.key == key)
+        self.type_by_key
+            .get(&key)
+            .and_then(|&index| self.types.get(index))
     }
 
     fn func_row(&self, key: i64) -> Option<&FuncRowMeta> {
-        self.funcs.iter().find(|r| r.key == key)
+        self.func_by_key
+            .get(&key)
+            .and_then(|&index| self.funcs.get(index))
     }
+}
+
+/// Collect the authoritative module identities used by runtime symbol lookup. `Modules` is a
+/// TMap, but its outer FString key is only a container key/alias; tail rows bind to the inner
+/// `FAngelscriptPrecompiledModule::ModuleName` instead.
+fn inner_module_names(bytes: &[u8]) -> Result<HashSet<String>, RemapError> {
+    let mut names = HashSet::new();
+    let mut outer_names = HashSet::new();
+    for (outer, start, _) in super::walk_modules::module_ranges(bytes)? {
+        if !outer_names.insert(outer.clone()) {
+            return Err(RemapError::ModuleNameCollision { name: outer });
+        }
+        let mut cursor = Cursor::at(bytes, start);
+        cursor.read_fstring()?; // outer TMap key: deliberately not authority
+        let inner = cursor.read_sia()?;
+        if !inner.is_empty() && !names.insert(inner.clone()) {
+            return Err(RemapError::ModuleNameCollision { name: inner });
+        }
+    }
+    Ok(names)
+}
+
+fn missing_module_authority(
+    table: usize,
+    row_key: i64,
+    declaration: &str,
+    module: &str,
+) -> RemapError {
+    RemapError::InvalidTailRow {
+        table,
+        row_key,
+        kind: "module authority",
+        detail: format!(
+            "{declaration} names module {module:?}, which is absent from both the pristine base and the current mini"
+        ),
+    }
+}
+
+fn missing_declaration_membership(
+    table: usize,
+    row_key: i64,
+    detail: impl Into<String>,
+) -> RemapError {
+    RemapError::InvalidTailRow {
+        table,
+        row_key,
+        kind: "declaration membership",
+        detail: detail.into(),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TypeDeclarationKind {
+    ScriptLeaf,
+    EngineLeaf,
+    Template,
+    TemplateSentinel,
+}
+
+#[derive(Clone, Debug)]
+struct TypeDeclarationDescriptor {
+    identity: DeclarationIdentity,
+    kind: TypeDeclarationKind,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct PristinePropertyIdentity {
+    owner_identity: String,
+    name: String,
+    member_offset: i32,
+}
+
+#[derive(Debug)]
+struct PristineDeclarationAuthority {
+    declarations: DeclarationInventory,
+    types_by_ptr: HashMap<i64, TypeDeclarationDescriptor>,
+    template_bases: HashMap<(String, usize), HashSet<String>>,
+    properties: HashSet<PristinePropertyIdentity>,
+    orphan_functions: HashSet<i64>,
+    script_owners: ScriptOwnerIndex,
+}
+
+#[derive(Debug, Default)]
+struct ScriptOwnerIndex {
+    buckets: HashMap<DeclarationSkeleton, HashMap<String, Ident>>,
+}
+
+impl ScriptOwnerIndex {
+    fn insert(
+        &mut self,
+        declaration: &DeclarationIdentity,
+        identity: &Ident,
+        pos: usize,
+    ) -> Result<(), WireError> {
+        let bucket = self
+            .buckets
+            .entry(DeclarationSkeleton::from(declaration))
+            .or_default();
+        if let Some(prior) = bucket.get(&declaration.namespace) {
+            if prior.full == identity.full {
+                return Ok(());
+            }
+            return Err(WireError::BadLen {
+                pos,
+                len: 2,
+                field: "ambiguous script class declaration",
+            });
+        }
+        bucket.insert(declaration.namespace.clone(), identity.clone());
+        Ok(())
+    }
+
+    fn exact(&self, declaration: &DeclarationIdentity) -> Option<&Ident> {
+        self.buckets
+            .get(&DeclarationSkeleton::from(declaration))?
+            .get(&declaration.namespace)
+    }
+}
+
+fn type_declaration_descriptor(row: &TypeRowMeta) -> TypeDeclarationDescriptor {
+    let kind = if !row.type_deps.is_empty() {
+        TypeDeclarationKind::Template
+    } else if row.module == "$__T__" {
+        TypeDeclarationKind::TemplateSentinel
+    } else if row.module.is_empty() {
+        TypeDeclarationKind::EngineLeaf
+    } else {
+        TypeDeclarationKind::ScriptLeaf
+    };
+    TypeDeclarationDescriptor {
+        identity: DeclarationIdentity {
+            module: row.module.clone(),
+            namespace: row.namespace.clone(),
+            name: row.name.clone(),
+        },
+        kind,
+    }
+}
+
+impl PristineDeclarationAuthority {
+    fn build(
+        meta: &TailMetadata,
+        syms: &SymTables,
+        declarations: DeclarationInventory,
+        comparison_budget: &mut IdentityComparisonBudget,
+    ) -> Result<Self, WireError> {
+        let mut authority_rows = declarations.rows;
+        let mut authority_bytes = declarations.bytes;
+        let mut charge = |rows: usize, bytes: usize, pos: usize| -> Result<(), WireError> {
+            authority_rows = authority_rows.checked_add(rows).ok_or(WireError::BadLen {
+                pos,
+                len: i64::MAX,
+                field: "pristine declaration authority rows",
+            })?;
+            if authority_rows > MAX_DECLARATION_AUTHORITY_ROWS {
+                return Err(WireError::BadLen {
+                    pos,
+                    len: authority_rows as i64,
+                    field: "pristine declaration authority rows",
+                });
+            }
+            authority_bytes = authority_bytes
+                .checked_add(bytes)
+                .ok_or(WireError::BadLen {
+                    pos,
+                    len: i64::MAX,
+                    field: "pristine declaration authority bytes",
+                })?;
+            if authority_bytes > MAX_DECLARATION_AUTHORITY_BYTES {
+                return Err(WireError::BadLen {
+                    pos,
+                    len: authority_bytes as i64,
+                    field: "pristine declaration authority bytes",
+                });
+            }
+            Ok(())
+        };
+        let mut types_by_ptr = HashMap::new();
+        let mut template_bases: HashMap<(String, usize), HashSet<String>> = HashMap::new();
+        let mut script_owners = ScriptOwnerIndex::default();
+        for row in &meta.types {
+            let descriptor = type_declaration_descriptor(row);
+            let mut bytes = declaration_identity_bytes(&descriptor.identity);
+            if descriptor.kind == TypeDeclarationKind::Template {
+                bytes = bytes
+                    .checked_add(row.name.len())
+                    .and_then(|value| value.checked_add(row.namespace.len()))
+                    .ok_or(WireError::BadLen {
+                        pos: row.start,
+                        len: i64::MAX,
+                        field: "pristine declaration authority bytes",
+                    })?;
+            }
+            charge(1, bytes, row.start)?;
+            if descriptor.kind == TypeDeclarationKind::Template {
+                let namespaces = template_bases
+                    .entry((row.name.clone(), row.type_deps.len()))
+                    .or_default();
+                namespaces.insert(row.namespace.clone());
+            }
+            if descriptor.kind == TypeDeclarationKind::ScriptLeaf {
+                if let Some(identity) = syms.type_ident_of_ptr.get(&row.key) {
+                    script_owners.insert(&descriptor.identity, identity, row.start)?;
+                }
+            }
+            types_by_ptr.insert(row.key, descriptor);
+        }
+
+        let mut properties = HashSet::new();
+        for row in &meta.properties {
+            let Some(owner_ptr) = syms.typeid_to_ptr.get(&row.old_type_id) else {
+                continue;
+            };
+            let Some(owner_identity) = syms.type_id_of_ptr.get(owner_ptr) else {
+                continue;
+            };
+            let bytes = owner_identity
+                .len()
+                .checked_add(row.name.len())
+                .and_then(|value| {
+                    value.checked_add(std::mem::size_of::<PristinePropertyIdentity>())
+                })
+                .ok_or(WireError::BadLen {
+                    pos: row.start,
+                    len: i64::MAX,
+                    field: "pristine declaration authority bytes",
+                })?;
+            charge(1, bytes, row.start)?;
+            properties.insert(PristinePropertyIdentity {
+                owner_identity: owner_identity.clone(),
+                name: row.name.clone(),
+                member_offset: row.member_offset,
+            });
+        }
+        let mut orphan_functions = HashSet::new();
+        for row in &meta.funcs {
+            let Some(identity) = syms.func_ident_of_ptr.get(&row.key) else {
+                continue;
+            };
+            match match_function_declarations(&[&declarations], identity, comparison_budget)? {
+                FunctionDeclarationMatch::Missing => {
+                    orphan_functions.insert(row.key);
+                }
+                FunctionDeclarationMatch::Unique => {}
+                FunctionDeclarationMatch::Ambiguous => {
+                    return Err(WireError::BadLen {
+                        pos: row.start,
+                        len: 2,
+                        field: "ambiguous function declaration membership",
+                    });
+                }
+            }
+        }
+        Ok(Self {
+            declarations,
+            types_by_ptr,
+            template_bases,
+            properties,
+            orphan_functions,
+            script_owners,
+        })
+    }
+}
+
+fn match_template_base(
+    pristine: &PristineDeclarationAuthority,
+    name: &str,
+    namespace: &str,
+    arity: usize,
+    budget: &mut IdentityComparisonBudget,
+) -> Result<FunctionDeclarationMatch, WireError> {
+    let Some(candidates) = pristine.template_bases.get(&(name.to_owned(), arity)) else {
+        return Ok(FunctionDeclarationMatch::Missing);
+    };
+    if candidates.contains(namespace) {
+        return Ok(FunctionDeclarationMatch::Unique);
+    }
+    Ok(match_unique_namespace(namespace, candidates.iter().map(String::as_str), budget)?.into())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FunctionDeclarationMatch {
+    Missing,
+    Unique,
+    Ambiguous,
+}
+
+#[derive(Debug)]
+struct IdentityComparisonBudget {
+    remaining: usize,
+    max: usize,
+}
+
+impl IdentityComparisonBudget {
+    /// Create one cumulative oracle-work budget for a complete validation/planning phase. Exact
+    /// hash-index hits are free; every namespace-tolerant candidate comparison shares this pool.
+    fn new(phase_bytes: usize) -> Self {
+        let max = phase_bytes
+            .saturating_mul(IDENTITY_COMPARISON_WORK_MULTIPLIER)
+            .clamp(MIN_IDENTITY_COMPARISON_WORK, MAX_IDENTITY_COMPARISON_WORK);
+        Self {
+            remaining: max,
+            max,
+        }
+    }
+
+    fn charge(&mut self, query: usize, candidate: usize) -> Result<(), WireError> {
+        let work = query
+            .checked_add(candidate)
+            .ok_or(WireError::IdentityComparisonBudgetExceeded { max: self.max })?;
+        self.remaining = self
+            .remaining
+            .checked_sub(work)
+            .ok_or(WireError::IdentityComparisonBudgetExceeded { max: self.max })?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NamespaceMatch<'a> {
+    Missing,
+    Unique(&'a str),
+    Ambiguous,
+}
+
+impl From<NamespaceMatch<'_>> for FunctionDeclarationMatch {
+    fn from(value: NamespaceMatch<'_>) -> Self {
+        match value {
+            NamespaceMatch::Missing => Self::Missing,
+            NamespaceMatch::Unique(_) => Self::Unique,
+            NamespaceMatch::Ambiguous => Self::Ambiguous,
+        }
+    }
+}
+
+fn match_unique_namespace<'a>(
+    query: &str,
+    candidates: impl IntoIterator<Item = &'a str>,
+    budget: &mut IdentityComparisonBudget,
+) -> Result<NamespaceMatch<'a>, WireError> {
+    let query_footprint = query.len().saturating_add(std::mem::size_of::<String>());
+    let mut matched = None;
+    for candidate in candidates {
+        let candidate_footprint = candidate
+            .len()
+            .saturating_add(std::mem::size_of::<String>());
+        budget.charge(query_footprint, candidate_footprint)?;
+        if !ns_drift_ok(query, candidate) {
+            continue;
+        }
+        match matched {
+            None => matched = Some(candidate),
+            Some(prior) if prior == candidate => {}
+            Some(_) => return Ok(NamespaceMatch::Ambiguous),
+        }
+    }
+    Ok(matched.map_or(NamespaceMatch::Missing, NamespaceMatch::Unique))
+}
+
+fn has_exact_function_declaration(declarations: &DeclarationInventory, identity: &Ident) -> bool {
+    declarations
+        .function_exact
+        .get(&function_identity_hash(&identity.full))
+        .is_some_and(|indices| {
+            indices
+                .iter()
+                .any(|&index| declarations.functions[index].identity.full == identity.full)
+        })
+}
+
+/// Exact full identity wins across the entire pristine/current union. Without an exact match,
+/// benign namespace drift is accepted only when it identifies one distinct declaration; the same
+/// exact declaration repeated in pristine/current is deduplicated, while two drift candidates are
+/// fail-closed as ambiguous.
+fn match_function_declarations(
+    inventories: &[&DeclarationInventory],
+    identity: &Ident,
+    budget: &mut IdentityComparisonBudget,
+) -> Result<FunctionDeclarationMatch, WireError> {
+    if inventories
+        .iter()
+        .any(|inventory| has_exact_function_declaration(inventory, identity))
+    {
+        return Ok(FunctionDeclarationMatch::Unique);
+    }
+    let query_footprint = identity_footprint(0, identity)?;
+    let mut matched_full: Option<&str> = None;
+    for inventory in inventories {
+        let Some(indices) = inventory.function_buckets.get(&identity.ns_stripped) else {
+            continue;
+        };
+        for &index in indices {
+            let candidate = &inventory.functions[index];
+            budget.charge(query_footprint, candidate.footprint)?;
+            if !identity.oracle_eq(&candidate.identity) {
+                continue;
+            }
+            match matched_full {
+                None => matched_full = Some(candidate.identity.full.as_str()),
+                Some(full) if full == candidate.identity.full => {}
+                Some(_) => return Ok(FunctionDeclarationMatch::Ambiguous),
+            }
+        }
+    }
+    Ok(if matched_full.is_some() {
+        FunctionDeclarationMatch::Unique
+    } else {
+        FunctionDeclarationMatch::Missing
+    })
+}
+
+#[derive(Clone, Copy)]
+enum DeclarationSetKind {
+    Type,
+    Global,
+}
+
+fn match_declaration_identities(
+    inventories: &[&DeclarationInventory],
+    identity: &DeclarationIdentity,
+    kind: DeclarationSetKind,
+    budget: &mut IdentityComparisonBudget,
+) -> Result<FunctionDeclarationMatch, WireError> {
+    let exact = |inventory: &DeclarationInventory| match kind {
+        DeclarationSetKind::Type => inventory.types.contains(identity),
+        DeclarationSetKind::Global => inventory.globals.contains(identity),
+    };
+    if inventories.iter().any(|inventory| exact(inventory)) {
+        return Ok(FunctionDeclarationMatch::Unique);
+    }
+    let skeleton = DeclarationSkeleton::from(identity);
+    let candidates = inventories.iter().flat_map(|inventory| {
+        match kind {
+            DeclarationSetKind::Type => inventory.type_buckets.get(&skeleton),
+            DeclarationSetKind::Global => inventory.global_buckets.get(&skeleton),
+        }
+        .into_iter()
+        .flat_map(HashSet::iter)
+        .map(String::as_str)
+    });
+    Ok(match_unique_namespace(&identity.namespace, candidates, budget)?.into())
+}
+
+fn match_property_declarations(
+    inventories: &[&DeclarationInventory],
+    identity: &PropertyDeclarationIdentity,
+    budget: &mut IdentityComparisonBudget,
+) -> Result<FunctionDeclarationMatch, WireError> {
+    if inventories
+        .iter()
+        .any(|inventory| inventory.properties.contains(identity))
+    {
+        return Ok(FunctionDeclarationMatch::Unique);
+    }
+    let skeleton = PropertyDeclarationSkeleton::from(identity);
+    let candidates = inventories.iter().flat_map(|inventory| {
+        inventory
+            .property_buckets
+            .get(&skeleton)
+            .into_iter()
+            .flat_map(HashSet::iter)
+            .map(String::as_str)
+    });
+    Ok(match_unique_namespace(&identity.owner.namespace, candidates, budget)?.into())
+}
+
+/// Require every genuinely new declaration to be owned by either the pristine cache or the
+/// module currently being admitted. Previously accepted minis are collision/novelty history,
+/// never a source of module authority for a later mini.
+fn validate_novel_declaration_membership(
+    meta: &TailMetadata,
+    syms: &SymTables,
+    pristine_syms: &SymTables,
+    pristine: &PristineDeclarationAuthority,
+    current: &DeclarationInventory,
+    has_authority: impl Fn(&str) -> bool,
+    is_novel_type: impl Fn(i64) -> bool,
+    is_novel_func: impl Fn(i64) -> bool,
+    is_novel_global: impl Fn(i64) -> bool,
+    comparison_budget: &mut IdentityComparisonBudget,
+) -> Result<(), RemapError> {
+    let inventories = [&pristine.declarations, current];
+    for row in &meta.types {
+        if !is_novel_type(row.key) {
+            continue;
+        }
+        let exact_pristine = syms
+            .type_id_of_ptr
+            .get(&row.key)
+            .is_some_and(|identity| pristine_syms.type_ptr_of_id.contains_key(identity));
+        if !row.type_deps.is_empty() {
+            match match_template_base(
+                pristine,
+                &row.name,
+                &row.namespace,
+                row.type_deps.len(),
+                comparison_budget,
+            )? {
+                FunctionDeclarationMatch::Unique => {}
+                FunctionDeclarationMatch::Missing => {
+                    return Err(missing_declaration_membership(
+                        0,
+                        row.key,
+                        format!(
+                            "template instance {}::{} with arity {} has no matching pristine template TypeReferences declaration",
+                            row.namespace,
+                            row.name,
+                            row.type_deps.len()
+                        ),
+                    ));
+                }
+                FunctionDeclarationMatch::Ambiguous => {
+                    return Err(missing_declaration_membership(
+                        0,
+                        row.key,
+                        "template instance matches more than one namespace-tolerant pristine template declaration",
+                    ));
+                }
+            }
+        } else if row.module.is_empty() || row.module == "$__T__" {
+            if !exact_pristine {
+                return Err(missing_declaration_membership(
+                    0,
+                    row.key,
+                    "engine/native and $__T__ type rows require an exact pristine TypeReferences identity",
+                ));
+            }
+        } else {
+            let identity = DeclarationIdentity {
+                module: row.module.clone(),
+                namespace: row.namespace.clone(),
+                name: row.name.clone(),
+            };
+            match match_declaration_identities(
+                &inventories,
+                &identity,
+                DeclarationSetKind::Type,
+                comparison_budget,
+            )? {
+                FunctionDeclarationMatch::Unique => {}
+                FunctionDeclarationMatch::Missing => {
+                    return Err(missing_declaration_membership(
+                        0,
+                        row.key,
+                        format!(
+                            "script type {}::{} in module {:?} is absent from Classes and Enums in both the pristine base and current mini",
+                            row.namespace, row.name, row.module
+                        ),
+                    ));
+                }
+                FunctionDeclarationMatch::Ambiguous => {
+                    return Err(missing_declaration_membership(
+                        0,
+                        row.key,
+                        "script type matches more than one namespace-tolerant declaration",
+                    ));
+                }
+            }
+        }
+    }
+
+    for row in &meta.funcs {
+        if !is_novel_func(row.key) {
+            continue;
+        }
+        let identity = syms.func_ident_of_ptr.get(&row.key).ok_or_else(|| {
+            missing_declaration_membership(
+                2,
+                row.key,
+                "function row has no runtime-effective portable identity",
+            )
+        })?;
+        if row.is_imported {
+            // FunctionImports are inventoried so final validation catches deletion of a pristine
+            // import. Admission of genuinely novel imports remains fail-closed: their cross-module
+            // binding needs authority beyond a self-asserted current record.
+            return Err(missing_declaration_membership(
+                2,
+                row.key,
+                format!(
+                    "missing import declaration membership for {}::{} from {:?}: an exact current/pristine Module.FunctionImports runtime signature is required",
+                    row.namespace, row.name, row.module
+                ),
+            ));
+        }
+        if row.is_method || row.module.is_empty() {
+            let exact_pristine = syms
+                .func_id_of_ptr
+                .get(&row.key)
+                .is_some_and(|identity| pristine_syms.func_ptr_of_id.contains_key(identity));
+            let declaration_match =
+                match_function_declarations(&inventories, identity, comparison_budget)?;
+            if declaration_match == FunctionDeclarationMatch::Ambiguous {
+                return Err(missing_declaration_membership(
+                    2,
+                    row.key,
+                    "method/native function matches more than one namespace-tolerant declaration",
+                ));
+            }
+            if declaration_match == FunctionDeclarationMatch::Missing && !exact_pristine {
+                return Err(missing_declaration_membership(
+                    2,
+                    row.key,
+                    "method/native function has neither an exact current/pristine function record nor an exact pristine FunctionReferences identity",
+                ));
+            }
+        } else {
+            if !has_authority(&row.module) {
+                return Err(missing_module_authority(
+                    2,
+                    row.key,
+                    "global function declaration",
+                    &row.module,
+                ));
+            }
+            let declaration_match =
+                match_function_declarations(&inventories, identity, comparison_budget)?;
+            if declaration_match == FunctionDeclarationMatch::Ambiguous {
+                return Err(missing_declaration_membership(
+                    2,
+                    row.key,
+                    "global function matches more than one namespace-tolerant declaration",
+                ));
+            }
+            if declaration_match == FunctionDeclarationMatch::Missing {
+                return Err(missing_declaration_membership(
+                    2,
+                    row.key,
+                    format!(
+                        "global function {}::{} in module {:?} has no exact current/pristine function record with the same runtime signature",
+                        row.namespace, row.name, row.module
+                    ),
+                ));
+            }
+        }
+    }
+
+    for row in &meta.globals {
+        // A string row's Name is the literal value; Module is not consulted for that lookup.
+        if !is_novel_global(row.key) || row.is_string {
+            continue;
+        }
+        if row.module.is_empty() {
+            let exact_pristine = syms
+                .global_id_of_ptr
+                .get(&row.key)
+                .is_some_and(|identity| pristine_syms.global_ptr_of_id.contains_key(identity));
+            if !exact_pristine {
+                return Err(missing_declaration_membership(
+                    4,
+                    row.key,
+                    "native global rows require an exact pristine GlobalReferences identity",
+                ));
+            }
+        } else {
+            let identity = DeclarationIdentity {
+                module: row.module.clone(),
+                namespace: row.namespace.clone(),
+                name: row.name.clone(),
+            };
+            match match_declaration_identities(
+                &inventories,
+                &identity,
+                DeclarationSetKind::Global,
+                comparison_budget,
+            )? {
+                FunctionDeclarationMatch::Unique => {}
+                FunctionDeclarationMatch::Missing => {
+                    return Err(missing_declaration_membership(
+                        4,
+                        row.key,
+                        format!(
+                            "global {}::{} in module {:?} is absent from GlobalVariables in both the pristine base and current mini",
+                            row.namespace, row.name, row.module
+                        ),
+                    ));
+                }
+                FunctionDeclarationMatch::Ambiguous => {
+                    return Err(missing_declaration_membership(
+                        4,
+                        row.key,
+                        "global matches more than one namespace-tolerant declaration",
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_novel_property_membership(
+    meta: &TailMetadata,
+    syms: &SymTables,
+    pristine_syms: &SymTables,
+    pristine: &PristineDeclarationAuthority,
+    current: &DeclarationInventory,
+    is_novel_property: impl Fn(&PropertyRowMeta) -> bool,
+    comparison_budget: &mut IdentityComparisonBudget,
+) -> Result<(), RemapError> {
+    for row in &meta.properties {
+        if !is_novel_property(row) {
+            continue;
+        }
+        let owner_ptr = syms
+            .typeid_to_ptr
+            .get(&row.old_type_id)
+            .or_else(|| pristine_syms.typeid_to_ptr.get(&row.old_type_id))
+            .copied()
+            .ok_or_else(|| {
+                missing_declaration_membership(
+                    6,
+                    row.key,
+                    format!(
+                        "property owner type id {:#x} is unresolved",
+                        row.old_type_id
+                    ),
+                )
+            })?;
+        let descriptor = meta
+            .type_row(owner_ptr)
+            .map(type_declaration_descriptor)
+            .or_else(|| pristine.types_by_ptr.get(&owner_ptr).cloned());
+        let Some(descriptor) = descriptor else {
+            return Err(missing_declaration_membership(
+                6,
+                row.key,
+                format!("property owner pointer {owner_ptr:#x} has no T1 declaration"),
+            ));
+        };
+        if descriptor.kind == TypeDeclarationKind::ScriptLeaf {
+            let property = PropertyDeclarationIdentity {
+                owner: descriptor.identity,
+                name: row.name.clone(),
+            };
+            match match_property_declarations(
+                &[&pristine.declarations, current],
+                &property,
+                comparison_budget,
+            )? {
+                FunctionDeclarationMatch::Unique => {}
+                FunctionDeclarationMatch::Missing => {
+                    return Err(missing_declaration_membership(
+                        6,
+                        row.key,
+                        format!(
+                            "property {:?} is absent from the declaring class in both the pristine base and current mini",
+                            row.name
+                        ),
+                    ));
+                }
+                FunctionDeclarationMatch::Ambiguous => {
+                    return Err(missing_declaration_membership(
+                        6,
+                        row.key,
+                        "property matches more than one namespace-tolerant class declaration",
+                    ));
+                }
+            }
+        } else {
+            let owner_identity = syms
+                .type_id_of_ptr
+                .get(&owner_ptr)
+                .or_else(|| pristine_syms.type_id_of_ptr.get(&owner_ptr));
+            let exact = owner_identity.is_some_and(|owner_identity| {
+                pristine.properties.contains(&PristinePropertyIdentity {
+                    owner_identity: owner_identity.clone(),
+                    name: row.name.clone(),
+                    member_offset: row.member_offset,
+                })
+            });
+            if !exact {
+                return Err(missing_declaration_membership(
+                    6,
+                    row.key,
+                    "engine/template properties require an exact pristine property row",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn has_pristine_property_identity(
+    row: &PropertyRowMeta,
+    syms: &SymTables,
+    pristine_syms: &SymTables,
+    pristine: &PristineDeclarationAuthority,
+) -> bool {
+    syms.typeid_to_ptr
+        .get(&row.old_type_id)
+        .or_else(|| pristine_syms.typeid_to_ptr.get(&row.old_type_id))
+        .and_then(|owner_ptr| {
+            syms.type_id_of_ptr
+                .get(owner_ptr)
+                .or_else(|| pristine_syms.type_id_of_ptr.get(owner_ptr))
+        })
+        .is_some_and(|owner_identity| {
+            pristine.properties.contains(&PristinePropertyIdentity {
+                owner_identity: owner_identity.clone(),
+                name: row.name.clone(),
+                member_offset: row.member_offset,
+            })
+        })
 }
 
 /// Immutable part of sequential StaticNames composition. Independently remapped minis encode
 /// their first private T6 row at `pristine_names.len()`, so a later mini cannot be interpreted
 /// from the already-grown accumulator alone. Build this once from the exact base all minis were
 /// remapped against, then carry only the small name pool and `__STATIC_NAME` lookup sets.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(super) struct StaticNameRebaseContext {
     pristine_names: Vec<String>,
     static_accessor_ptrs: HashSet<i64>,
@@ -1122,6 +3293,35 @@ fn remap_ptr(
 /// (`TypeIdReferenceToPointer`) is keyed only by `(MASK_SEQNBR | MASK_OBJECT)`; handle/const
 /// qualifiers are operand-local and must survive a remap unchanged.
 const TYPE_ID_CORE_MASK: u32 = 0x1fff_ffff; // MASK_SEQNBR | MASK_OBJECT
+const TYPE_ID_OBJECT_MASK: u32 = 0x1c00_0000;
+const TYPE_ID_QUALIFIER_MASK: u32 = 0x6000_0000; // OBJHANDLE | HANDLETOCONST
+const TYPE_ID_SEQUENCE_MASK: u32 = 0x03ff_ffff;
+const LAST_PRIMITIVE_TYPE_ID: i32 = 11;
+
+fn valid_type_id_core(id: i32) -> bool {
+    if (id as u32) & TYPE_ID_SEQUENCE_MASK <= LAST_PRIMITIVE_TYPE_ID as u32
+        || (id as u32) & !TYPE_ID_CORE_MASK != 0
+    {
+        return false;
+    }
+    matches!(
+        (id as u32) & TYPE_ID_OBJECT_MASK,
+        0 | 0x0400_0000 | 0x0800_0000 | 0x1000_0000
+    )
+}
+
+fn valid_datatype_pointer(dep: DataTypeDep, has_concrete_type_ptr: impl Fn(i64) -> bool) -> bool {
+    if dep.is_auto {
+        return dep.token == 5 && dep.ptr == 0;
+    }
+    match dep.token {
+        5 => has_concrete_type_ptr(dep.ptr),
+        // Every primitive/void/? keyword is table-independent.
+        0x3b | 0x41 | 0x44 | 0x45 | 0x46 | 0x47 | 0x4b | 0x4c | 0x4d | 0x4e | 0x50 | 0x51
+        | 0x52 => dep.ptr == 0,
+        _ => false,
+    }
+}
 
 fn split_type_id_operand(id: i32) -> (i32, u32) {
     let raw = id as u32;
@@ -1130,6 +3330,647 @@ fn split_type_id_operand(id: i32) -> (i32, u32) {
 
 fn apply_type_id_operand_flags(core: i32, flags: u32) -> i32 {
     ((core as u32 & TYPE_ID_CORE_MASK) | flags) as i32
+}
+
+/// Validate a prepared mini against the exact cache it will be composed with.
+///
+/// A remapped mini may reference either an existing base symbol or a genuinely new symbol whose
+/// minimal row it retains. Anything else is a stale compiler-generation key which the engine
+/// resolves as null. Validate both executable/module-record operands and dependencies retained in
+/// T1-T4/T7 before the sequential guard records any state.
+pub(super) struct EffectiveReferenceBase {
+    /// Shared with the allow-new/loadout analyzer so the pristine cache's large identity and
+    /// declaration maps are constructed and retained only once.
+    base: Arc<AllowNewBaseContext>,
+    base_property_keys: HashSet<i64>,
+    base_type_ids: IdPointerSummary,
+    base_func_ids: IdPointerSummary,
+}
+
+impl std::fmt::Debug for EffectiveReferenceBase {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EffectiveReferenceBase")
+            .field("base_source_bytes", &self.base.source_bytes)
+            .field("base_property_keys", &self.base_property_keys.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct EffectiveReferenceState {
+    accepted_source_bytes: usize,
+    accepted_identity_bytes: usize,
+    accepted_type_identities: HashMap<i64, Ident>,
+    accepted_func_identities: HashMap<i64, Ident>,
+    accepted_global_identities: HashMap<i64, Ident>,
+    accepted_type_ids: HashMap<i32, i64>,
+    accepted_func_ids: HashMap<i32, i64>,
+}
+
+pub(super) struct ReferenceContribution {
+    type_identities: HashMap<i64, Ident>,
+    func_identities: HashMap<i64, Ident>,
+    global_identities: HashMap<i64, Ident>,
+    type_ids: HashMap<i32, i64>,
+    func_ids: HashMap<i32, i64>,
+    source_bytes: usize,
+    identity_bytes: usize,
+}
+
+impl EffectiveReferenceBase {
+    pub(super) fn build(base: &[u8]) -> Result<Self, RemapError> {
+        preflight_cache_module_work(base)?;
+        Self::from_allow_new_base(Arc::new(build_allow_new_base_context(base)?))
+    }
+
+    fn from_allow_new_base(base: Arc<AllowNewBaseContext>) -> Result<Self, RemapError> {
+        let base_property_keys = base.meta.properties.iter().map(|row| row.key).collect();
+        let base_type_ids = IdPointerSummary::build(&base.syms.typeid_to_ptr);
+        let base_func_ids = IdPointerSummary::build(&base.syms.funcid_to_ptr);
+        Ok(Self {
+            base,
+            base_property_keys,
+            base_type_ids,
+            base_func_ids,
+        })
+    }
+
+    pub(super) fn validate(
+        &self,
+        state: &EffectiveReferenceState,
+        mini: &[u8],
+    ) -> Result<ReferenceContribution, RemapError> {
+        preflight_mini_module_work(mini)?;
+        let base_syms = &self.base.syms;
+        let total_source_bytes = self
+            .base
+            .source_bytes
+            .checked_add(state.accepted_source_bytes)
+            .and_then(|bytes| bytes.checked_add(mini.len()))
+            .ok_or(WireError::IdentityBudgetExceeded {
+                max: MAX_IDENTITY_BUDGET,
+            })?;
+        let already_charged = base_syms
+            .identity_bytes
+            .checked_add(state.accepted_identity_bytes)
+            .ok_or(WireError::IdentityBudgetExceeded {
+                max: MAX_IDENTITY_BUDGET,
+            })?;
+        let mini_syms = SymTables::build_with_type_fallback_and_budget(
+            mini,
+            base_syms,
+            total_source_bytes,
+            already_charged,
+        )?;
+        let meta = TailMetadata::build(mini)?;
+        let current_module_authorities = inner_module_names(mini)?;
+        let mut comparison_budget = IdentityComparisonBudget::new(
+            total_source_bytes
+                .saturating_add(already_charged)
+                .saturating_add(self.base.declarations.declarations.bytes),
+        );
+        let current_declarations = collect_declaration_inventory(
+            mini,
+            &mini_syms,
+            Some(base_syms),
+            Some(&self.base.declarations.script_owners),
+            &meta,
+            &mut comparison_budget,
+        )?
+        .declarations;
+        validate_novel_declaration_membership(
+            &meta,
+            &mini_syms,
+            base_syms,
+            &self.base.declarations,
+            &current_declarations,
+            |module| {
+                self.base.module_authorities.contains(module)
+                    || current_module_authorities.contains(module)
+            },
+            |key| !base_syms.type_ident_of_ptr.contains_key(&key),
+            |key| !base_syms.func_ident_of_ptr.contains_key(&key),
+            |key| !base_syms.global_ident_of_ptr.contains_key(&key),
+            &mut comparison_budget,
+        )?;
+        validate_novel_property_membership(
+            &meta,
+            &mini_syms,
+            base_syms,
+            &self.base.declarations,
+            &current_declarations,
+            |row| !self.base_property_keys.contains(&row.key),
+            &mut comparison_budget,
+        )?;
+
+        // A retained row may repeat an existing key byte-for-byte (the collision layer proves
+        // that), but it may not register an already-known portable symbol identity under
+        // a second key. Non-colliding duplicate registrations are just as fatal as stale refs.
+        ensure_unique_symbol_identities(
+            0,
+            &base_syms.type_ident_of_ptr,
+            &self.base.identity_summaries.types,
+            &state.accepted_type_identities,
+            &mini_syms.type_ident_of_ptr,
+        )?;
+        ensure_unique_symbol_identities(
+            2,
+            &base_syms.func_ident_of_ptr,
+            &self.base.identity_summaries.functions,
+            &state.accepted_func_identities,
+            &mini_syms.func_ident_of_ptr,
+        )?;
+        ensure_unique_symbol_identities_filtered(
+            4,
+            &base_syms.global_ident_of_ptr,
+            &self.base.identity_summaries.globals,
+            &state.accepted_global_identities,
+            &mini_syms.global_ident_of_ptr,
+            |key| {
+                !mini_syms
+                    .global_is_string_of_ptr
+                    .get(&key)
+                    .copied()
+                    .unwrap_or(false)
+            },
+        )?;
+        ensure_unique_id_pointers(
+            1,
+            &base_syms.typeid_to_ptr,
+            &self.base_type_ids,
+            &state.accepted_type_ids,
+            &mini_syms.typeid_to_ptr,
+        )?;
+        ensure_unique_id_pointers(
+            3,
+            &base_syms.funcid_to_ptr,
+            &self.base_func_ids,
+            &state.accepted_func_ids,
+            &mini_syms.funcid_to_ptr,
+        )?;
+
+        let has_type_ptr = |key: i64| {
+            key == 0
+                || base_syms.type_id_of_ptr.contains_key(&key)
+                || mini_syms.type_id_of_ptr.contains_key(&key)
+        };
+        let has_concrete_type_ptr = |key: i64| {
+            key != 0
+                && (base_syms.type_id_of_ptr.contains_key(&key)
+                    || mini_syms.type_id_of_ptr.contains_key(&key))
+        };
+        let has_func_ptr = |key: i64| {
+            key != 0
+                && (base_syms.func_id_of_ptr.contains_key(&key)
+                    || mini_syms.func_id_of_ptr.contains_key(&key))
+        };
+        let has_global_ptr = |key: i64| {
+            key != 0
+                && (base_syms.global_id_of_ptr.contains_key(&key)
+                    || mini_syms.global_id_of_ptr.contains_key(&key))
+        };
+        let has_type_id = |id: i32| {
+            base_syms.typeid_to_ptr.contains_key(&id) || mini_syms.typeid_to_ptr.contains_key(&id)
+        };
+        // T4[0] may define a real function, but raw function-id references use zero as null.
+        let has_func_id = |id: i32| {
+            id != 0
+                && (base_syms.funcid_to_ptr.contains_key(&id)
+                    || mini_syms.funcid_to_ptr.contains_key(&id))
+        };
+        let has_property_key = |key: i64| {
+            self.base_property_keys.contains(&key) || meta.property_by_key.contains_key(&key)
+        };
+        let additional_type_ids =
+            IdPointerSummary::build_additional(&base_syms.typeid_to_ptr, &mini_syms.typeid_to_ptr);
+
+        let tail_dependency = |table, row_key, kind, dependency| {
+            Err(RemapError::UnresolvedTailDependency {
+                table,
+                row_key,
+                kind,
+                dependency,
+            })
+        };
+        let invalid_tail = |table, row_key, kind, detail: String| {
+            Err(RemapError::InvalidTailRow {
+                table,
+                row_key,
+                kind,
+                detail,
+            })
+        };
+
+        for (table, rows) in [
+            (0, &meta.types.iter().map(|row| row.key).collect::<Vec<_>>()),
+            (2, &meta.funcs.iter().map(|row| row.key).collect::<Vec<_>>()),
+            (
+                4,
+                &meta.globals.iter().map(|row| row.key).collect::<Vec<_>>(),
+            ),
+        ] {
+            if rows.contains(&0) {
+                return invalid_tail(
+                    table,
+                    0,
+                    "OldReference key",
+                    "zero is the null sentinel".to_owned(),
+                );
+            }
+        }
+        for row in &meta.types {
+            for &dependency in &row.type_deps {
+                if !valid_datatype_pointer(dependency, has_concrete_type_ptr) {
+                    return tail_dependency(0, row.key, "DataType pointer", dependency.ptr);
+                }
+            }
+        }
+        for row in &meta.type_ids {
+            if !valid_type_id_core(row.id) {
+                return invalid_tail(
+                    1,
+                    row.id as i64,
+                    "type-id key",
+                    "T2 keys must be unqualified non-primitive core ids".to_owned(),
+                );
+            }
+            // T2 is the runtime object/handle TypeId map. Unlike a primitive DataType's optional
+            // `OldReference`, its target can never be the null sentinel.
+            if !has_concrete_type_ptr(row.ptr) {
+                return tail_dependency(1, row.id as i64, "type pointer", row.ptr);
+            }
+        }
+        for row in &meta.funcs {
+            if row.is_method != (row.owner_dep.1 != 0) {
+                return invalid_tail(
+                    2,
+                    row.key,
+                    "method owner",
+                    "bIsMethod must exactly match whether ObjectType is concrete".to_owned(),
+                );
+            }
+            if row.owner_dep.1 != 0 && !has_concrete_type_ptr(row.owner_dep.1) {
+                return tail_dependency(2, row.key, "owner type pointer", row.owner_dep.1);
+            }
+            for &dependency in &row.type_deps {
+                if !valid_datatype_pointer(dependency, has_concrete_type_ptr) {
+                    return tail_dependency(2, row.key, "DataType pointer", dependency.ptr);
+                }
+            }
+        }
+        for row in &meta.func_ids {
+            if !has_func_ptr(row.ptr) {
+                return tail_dependency(3, row.id as i64, "function pointer", row.ptr);
+            }
+        }
+
+        let additional_type_id_count = additional_pointer_id_counts(
+            &base_syms.typeid_to_ptr,
+            &state.accepted_type_ids,
+            &mini_syms.typeid_to_ptr,
+        );
+        for row in &meta.types {
+            // Historical/base rows are grandfathered. Their keyed bytes already matched the
+            // pristine cache exactly, whose reverse-map ambiguity is not this mini's doing.
+            if base_syms.type_ident_of_ptr.contains_key(&row.key)
+                || state.accepted_type_identities.contains_key(&row.key)
+            {
+                continue;
+            }
+            let count = self.base_type_ids.count(row.key).saturating_add(
+                additional_type_id_count
+                    .get(&row.key)
+                    .copied()
+                    .unwrap_or_default(),
+            );
+            if count != 1 {
+                return invalid_tail(
+                    0,
+                    row.key,
+                    "reverse type-id mapping",
+                    "every T1 row must have exactly one effective T2 id".to_owned(),
+                );
+            }
+        }
+        let additional_func_id_count = additional_pointer_id_counts(
+            &base_syms.funcid_to_ptr,
+            &state.accepted_func_ids,
+            &mini_syms.funcid_to_ptr,
+        );
+        for row in &meta.funcs {
+            if base_syms.func_ident_of_ptr.contains_key(&row.key)
+                || state.accepted_func_identities.contains_key(&row.key)
+            {
+                continue;
+            }
+            let count = self.base_func_ids.count(row.key).saturating_add(
+                additional_func_id_count
+                    .get(&row.key)
+                    .copied()
+                    .unwrap_or_default(),
+            );
+            if count != 1 {
+                return invalid_tail(
+                    2,
+                    row.key,
+                    "reverse function-id mapping",
+                    "every T3 row must have exactly one effective T4 id".to_owned(),
+                );
+            }
+        }
+        for row in &meta.properties {
+            if !has_type_id(row.old_type_id) {
+                return tail_dependency(6, row.key, "type id", row.old_type_id as i64);
+            }
+            let expected = property_key(row.old_type_id, row.member_offset);
+            if row.key != expected {
+                return invalid_tail(
+                    6,
+                    row.key,
+                    "property key",
+                    format!("expected {expected:#x} from its type id and member offset"),
+                );
+            }
+        }
+
+        let spans = collect_module_spans(mini)?;
+        for span in &spans.code {
+            let code: Vec<i32> = (0..span.count)
+                .map(|index| {
+                    let off = span.data_off + index * 4;
+                    i32::from_le_bytes(mini[off..off + 4].try_into().unwrap())
+                })
+                .collect();
+            let instructions =
+                disassemble(&code).map_err(|error| RemapError::Disasm(error.to_string()))?;
+            for instruction in &instructions {
+                if matches!(
+                    instruction.op.name,
+                    "ADDSi" | "LoadThisR" | "LoadRObjR" | "LoadVObjR"
+                ) {
+                    let Some(&raw_type_id) = instruction.dwords.first() else {
+                        return Err(RemapError::Disasm(format!(
+                            "{} is missing its owner type-id operand",
+                            instruction.op.name
+                        )));
+                    };
+                    let type_id = raw_type_id as i32;
+                    let member_offset = instruction
+                        .words
+                        .last()
+                        .copied()
+                        .map(|word| i32::from(word as i16))
+                        .ok_or_else(|| {
+                            RemapError::Disasm(format!(
+                                "{} is missing its member-offset operand",
+                                instruction.op.name
+                            ))
+                        })?;
+                    if !has_type_id(type_id)
+                        || !has_property_key(property_key(type_id, member_offset))
+                    {
+                        return Err(RemapError::UnresolvedEffectiveReference {
+                            kind: "property reference",
+                            op: instruction.op.name,
+                            key: property_key(type_id, member_offset),
+                        });
+                    }
+                }
+                for site in ref_sites(instruction.op.name) {
+                    let off = instruction.offset_dw + site.dw_index;
+                    let (valid, key, kind) = match site.kind {
+                        RefKind::GlobalPtr => {
+                            let key = read_qw(&code, off);
+                            (has_global_ptr(key), key, "global pointer")
+                        }
+                        RefKind::FuncPtr => {
+                            let key = read_qw(&code, off);
+                            (has_func_ptr(key), key, "function pointer")
+                        }
+                        RefKind::TypePtr => {
+                            let key = read_qw(&code, off);
+                            (has_concrete_type_ptr(key), key, "type pointer")
+                        }
+                        RefKind::FuncId => {
+                            let id = code[off];
+                            let native_alloc_without_ctor =
+                                if id == 0 && instruction.op.name == "ALLOC" {
+                                    let type_ptr = read_qw(&code, instruction.offset_dw + 1);
+                                    self.base_type_ids
+                                        .unique_id_with(&additional_type_ids, type_ptr)
+                                        .is_some_and(|core| {
+                                            valid_type_id_core(core)
+                                                && matches!(
+                                                    core as u32 & TYPE_ID_OBJECT_MASK,
+                                                    0x0400_0000 | 0x1000_0000
+                                                )
+                                        })
+                                } else {
+                                    false
+                                };
+                            (
+                                has_func_id(id) || native_alloc_without_ctor,
+                                id as i64,
+                                "function id",
+                            )
+                        }
+                        RefKind::TypeId => {
+                            let (id, flags) = split_type_id_operand(code[off]);
+                            let qualifiers_valid = flags & !TYPE_ID_QUALIFIER_MASK == 0;
+                            let qualified_object =
+                                flags == 0 || (id as u32 & TYPE_ID_OBJECT_MASK) != 0;
+                            (
+                                (qualifiers_valid && qualified_object && has_type_id(id))
+                                    || (flags == 0 && (0..=LAST_PRIMITIVE_TYPE_ID).contains(&id)),
+                                id as i64,
+                                "type id",
+                            )
+                        }
+                    };
+                    if !valid {
+                        return Err(RemapError::UnresolvedEffectiveReference {
+                            kind,
+                            op: instruction.op.name,
+                            key,
+                        });
+                    }
+                }
+            }
+        }
+
+        for embed in &spans.embeds {
+            let raw =
+                i64::from_le_bytes(mini[embed.byte_off..embed.byte_off + 8].try_into().unwrap());
+            match embed.kind {
+                EmbedKind::TypePtr(rule)
+                    if match rule {
+                        TypePtrRule::Concrete => !has_concrete_type_ptr(raw),
+                        TypePtrRule::Optional => !has_type_ptr(raw),
+                        TypePtrRule::Null => raw != 0,
+                        TypePtrRule::Invalid => true,
+                    } =>
+                {
+                    return Err(RemapError::UnresolvedEffectiveReference {
+                        kind: "embedded type pointer",
+                        op: "module record",
+                        key: raw,
+                    });
+                }
+                EmbedKind::FuncId => {
+                    if raw == 0 {
+                        continue;
+                    }
+                    let Ok(id) = i32::try_from(raw) else {
+                        return Err(RemapError::UnresolvedEffectiveReference {
+                            kind: "embedded function id",
+                            op: "Factory/BehaviorRefs",
+                            key: raw,
+                        });
+                    };
+                    if has_func_id(id) {
+                        let ptr = mini_syms
+                            .funcid_to_ptr
+                            .get(&id)
+                            .or_else(|| base_syms.funcid_to_ptr.get(&id))
+                            .copied()
+                            .unwrap();
+                        if !has_func_ptr(ptr) {
+                            return Err(RemapError::UnresolvedEffectiveReference {
+                                kind: "embedded function id",
+                                op: "Factory/BehaviorRefs",
+                                key: raw,
+                            });
+                        }
+                    } else {
+                        return Err(RemapError::UnresolvedEffectiveReference {
+                            kind: "embedded function id",
+                            op: "Factory/BehaviorRefs",
+                            key: raw,
+                        });
+                    }
+                }
+                EmbedKind::TypePtr(_) => {}
+            }
+        }
+        let mut persistent_identity_bytes = 0usize;
+        for (&key, identity) in &mini_syms.type_ident_of_ptr {
+            if !base_syms.type_ident_of_ptr.contains_key(&key)
+                && !state.accepted_type_identities.contains_key(&key)
+            {
+                persistent_identity_bytes = persistent_identity_bytes
+                    .checked_add(identity_footprint(key, identity)?)
+                    .ok_or(WireError::IdentityBudgetExceeded {
+                        max: MAX_IDENTITY_BUDGET,
+                    })?;
+            }
+        }
+        for (&key, identity) in &mini_syms.func_ident_of_ptr {
+            if !base_syms.func_ident_of_ptr.contains_key(&key)
+                && !state.accepted_func_identities.contains_key(&key)
+            {
+                persistent_identity_bytes = persistent_identity_bytes
+                    .checked_add(identity_footprint(key, identity)?)
+                    .ok_or(WireError::IdentityBudgetExceeded {
+                        max: MAX_IDENTITY_BUDGET,
+                    })?;
+            }
+        }
+        for (&key, identity) in &mini_syms.global_ident_of_ptr {
+            if !mini_syms
+                .global_is_string_of_ptr
+                .get(&key)
+                .copied()
+                .unwrap_or(false)
+                && !base_syms.global_ident_of_ptr.contains_key(&key)
+                && !state.accepted_global_identities.contains_key(&key)
+            {
+                persistent_identity_bytes = persistent_identity_bytes
+                    .checked_add(identity_footprint(key, identity)?)
+                    .ok_or(WireError::IdentityBudgetExceeded {
+                        max: MAX_IDENTITY_BUDGET,
+                    })?;
+            }
+        }
+        // Retain only genuinely new state. Exact base/prior repeats were already proven
+        // byte-identical and need no second owned map entry (or uncharged duplicate heap copy).
+        let type_identities = mini_syms
+            .type_ident_of_ptr
+            .into_iter()
+            .filter(|(key, _)| {
+                !base_syms.type_ident_of_ptr.contains_key(key)
+                    && !state.accepted_type_identities.contains_key(key)
+            })
+            .collect();
+        let func_identities = mini_syms
+            .func_ident_of_ptr
+            .into_iter()
+            .filter(|(key, _)| {
+                !base_syms.func_ident_of_ptr.contains_key(key)
+                    && !state.accepted_func_identities.contains_key(key)
+            })
+            .collect();
+        let global_is_string_of_ptr = &mini_syms.global_is_string_of_ptr;
+        let global_identities = mini_syms
+            .global_ident_of_ptr
+            .into_iter()
+            .filter(|(key, _)| {
+                !global_is_string_of_ptr.get(key).copied().unwrap_or(false)
+                    && !base_syms.global_ident_of_ptr.contains_key(key)
+                    && !state.accepted_global_identities.contains_key(key)
+            })
+            .collect();
+        let type_ids = mini_syms
+            .typeid_to_ptr
+            .into_iter()
+            .filter(|(id, _)| {
+                !base_syms.typeid_to_ptr.contains_key(id)
+                    && !state.accepted_type_ids.contains_key(id)
+            })
+            .collect();
+        let func_ids = mini_syms
+            .funcid_to_ptr
+            .into_iter()
+            .filter(|(id, _)| {
+                !base_syms.funcid_to_ptr.contains_key(id)
+                    && !state.accepted_func_ids.contains_key(id)
+            })
+            .collect();
+        Ok(ReferenceContribution {
+            type_identities,
+            func_identities,
+            global_identities,
+            type_ids,
+            func_ids,
+            source_bytes: mini.len(),
+            identity_bytes: persistent_identity_bytes,
+        })
+    }
+
+    pub(super) fn validate_composed_declarations(&self, bytes: &[u8]) -> Result<(), RemapError> {
+        validate_composed_module_records_with_pristine(bytes, Some(&self.base.declarations))
+    }
+}
+
+impl EffectiveReferenceState {
+    pub(super) fn record(&mut self, contribution: ReferenceContribution) {
+        self.accepted_source_bytes = self
+            .accepted_source_bytes
+            .checked_add(contribution.source_bytes)
+            .expect("validated reference-source budget cannot overflow while recording");
+        self.accepted_identity_bytes = self
+            .accepted_identity_bytes
+            .checked_add(contribution.identity_bytes)
+            .expect("validated identity budget cannot overflow while recording");
+        self.accepted_type_identities
+            .extend(contribution.type_identities);
+        self.accepted_func_identities
+            .extend(contribution.func_identities);
+        self.accepted_global_identities
+            .extend(contribution.global_identities);
+        self.accepted_type_ids.extend(contribution.type_ids);
+        self.accepted_func_ids.extend(contribution.func_ids);
+    }
 }
 
 /// Remap one function's bytecode dwords IN PLACE. `code` is the function's `Vec<i32>`.
@@ -1185,6 +4026,9 @@ fn remap_bytecode(
                 }
                 RefKind::FuncId => {
                     let regen_id = code[base_off];
+                    if regen_id == 0 {
+                        continue; // null reference sentinel, even when T4 has a real row at 0.
+                    }
                     // id -> regen ptr. If absent, the id isn't a real func ref (defensive) — skip.
                     let Some(&regen_ptr) = regen.funcid_to_ptr.get(&regen_id) else {
                         continue;
@@ -1198,10 +4042,13 @@ fn remap_bytecode(
                         &base.func_ptr_of_id,
                     )?;
                     // base ptr -> base id (the operand is the id, not the ptr).
-                    let new_id =
+                    let new_id = if base.funcid_to_ptr.get(&regen_id) == Some(&nptr) {
+                        regen_id
+                    } else {
                         *base
                             .ptr_to_funcid
                             .get(&nptr)
+                            .filter(|&&id| id != 0)
                             .ok_or_else(|| RemapError::Unresolved {
                                 kind: "function-id(no base id)",
                                 op: ins.op.name,
@@ -1211,7 +4058,8 @@ fn remap_bytecode(
                                     .get(&nptr)
                                     .cloned()
                                     .unwrap_or_default(),
-                            })?;
+                            })?
+                    };
                     code[base_off] = new_id;
                     counts.func_id += 1;
                 }
@@ -1232,10 +4080,12 @@ fn remap_bytecode(
                         &regen.type_name_of_ptr,
                         &base.type_ptr_of_id,
                     )?;
-                    let new_id =
+                    let new_id = if base.typeid_to_ptr.get(&regen_core) == Some(&nptr) {
+                        regen_core
+                    } else {
                         *base
-                            .ptr_to_typeid
-                            .get(&nptr)
+                            .ptr_kind_to_typeid
+                            .get(&(nptr, regen_core as u32 & TYPE_ID_OBJECT_MASK))
                             .ok_or_else(|| RemapError::Unresolved {
                                 kind: "type-id(no base id)",
                                 op: ins.op.name,
@@ -1245,7 +4095,8 @@ fn remap_bytecode(
                                     .get(&nptr)
                                     .cloned()
                                     .unwrap_or_default(),
-                            })?;
+                            })?
+                    };
                     code[base_off] = apply_type_id_operand_flags(new_id, flags);
                     counts.type_id += 1;
                 }
@@ -1284,107 +4135,1742 @@ struct CodeSpan {
 /// byte offset + which table it keys. These carry regen ptr/id keys too and must be remapped.
 #[derive(Clone, Copy)]
 enum EmbedKind {
-    TypePtr,
+    TypePtr(TypePtrRule),
     FuncId,
+}
+#[derive(Clone, Copy)]
+enum TypePtrRule {
+    Concrete,
+    Optional,
+    Null,
+    Invalid,
 }
 struct EmbedRef {
     byte_off: usize,
     kind: EmbedKind,
 }
 
+#[derive(Clone, Debug)]
+struct ModuleFunctionIdSite {
+    byte_off: usize,
+    identity: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct DeclarationIdentity {
+    module: String,
+    namespace: String,
+    name: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct PropertyDeclarationIdentity {
+    owner: DeclarationIdentity,
+    name: String,
+}
+
+#[derive(Clone, Debug)]
+struct FunctionDeclarationIdentity {
+    identity: Ident,
+    footprint: usize,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct DeclarationSkeleton {
+    module: String,
+    name: String,
+}
+
+impl From<&DeclarationIdentity> for DeclarationSkeleton {
+    fn from(identity: &DeclarationIdentity) -> Self {
+        Self {
+            module: identity.module.clone(),
+            name: identity.name.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct PropertyDeclarationSkeleton {
+    owner: DeclarationSkeleton,
+    name: String,
+}
+
+impl From<&PropertyDeclarationIdentity> for PropertyDeclarationSkeleton {
+    fn from(identity: &PropertyDeclarationIdentity) -> Self {
+        Self {
+            owner: DeclarationSkeleton::from(&identity.owner),
+            name: identity.name.clone(),
+        }
+    }
+}
+
+fn function_identity_hash(full: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    full.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Compact declaration-only inventory. It deliberately excludes function bodies and all other
+/// module records; the hard row/string budgets are charged before an entry is retained.
+#[derive(Debug, Default)]
+struct DeclarationInventory {
+    types: HashSet<DeclarationIdentity>,
+    type_buckets: HashMap<DeclarationSkeleton, HashSet<String>>,
+    functions: Vec<FunctionDeclarationIdentity>,
+    function_exact: HashMap<u64, Vec<usize>>,
+    function_buckets: HashMap<String, Vec<usize>>,
+    globals: HashSet<DeclarationIdentity>,
+    global_buckets: HashMap<DeclarationSkeleton, HashSet<String>>,
+    properties: HashSet<PropertyDeclarationIdentity>,
+    property_buckets: HashMap<PropertyDeclarationSkeleton, HashSet<String>>,
+    rows: usize,
+    bytes: usize,
+}
+
+impl DeclarationInventory {
+    fn charge(&mut self, bytes: usize, pos: usize) -> Result<(), WireError> {
+        let rows = self.rows.checked_add(1).ok_or(WireError::BadLen {
+            pos,
+            len: i64::MAX,
+            field: "module declaration rows",
+        })?;
+        if rows > MAX_DECLARATION_AUTHORITY_ROWS {
+            return Err(WireError::BadLen {
+                pos,
+                len: rows as i64,
+                field: "module declaration rows",
+            });
+        }
+        let total = self.bytes.checked_add(bytes).ok_or(WireError::BadLen {
+            pos,
+            len: i64::MAX,
+            field: "module declaration bytes",
+        })?;
+        if total > MAX_DECLARATION_AUTHORITY_BYTES {
+            return Err(WireError::BadLen {
+                pos,
+                len: total as i64,
+                field: "module declaration bytes",
+            });
+        }
+        self.rows = rows;
+        self.bytes = total;
+        Ok(())
+    }
+
+    fn insert_type(&mut self, identity: DeclarationIdentity, pos: usize) -> Result<(), WireError> {
+        if self.types.contains(&identity) {
+            return Err(WireError::BadLen {
+                pos,
+                len: 2,
+                field: "duplicate type declaration",
+            });
+        }
+        let bytes =
+            declaration_identity_bytes(&identity).saturating_add(std::mem::size_of::<String>());
+        self.charge(bytes, pos)?;
+        self.type_buckets
+            .entry(DeclarationSkeleton::from(&identity))
+            .or_default()
+            .insert(identity.namespace.clone());
+        self.types.insert(identity);
+        Ok(())
+    }
+
+    fn insert_global(
+        &mut self,
+        identity: DeclarationIdentity,
+        pos: usize,
+    ) -> Result<(), WireError> {
+        if self.globals.contains(&identity) {
+            return Err(WireError::BadLen {
+                pos,
+                len: 2,
+                field: "duplicate global declaration",
+            });
+        }
+        let bytes =
+            declaration_identity_bytes(&identity).saturating_add(std::mem::size_of::<String>());
+        self.charge(bytes, pos)?;
+        self.global_buckets
+            .entry(DeclarationSkeleton::from(&identity))
+            .or_default()
+            .insert(identity.namespace.clone());
+        self.globals.insert(identity);
+        Ok(())
+    }
+
+    fn insert_function(
+        &mut self,
+        mut identity: FunctionDeclarationIdentity,
+        pos: usize,
+    ) -> Result<(), WireError> {
+        let exact_hash = function_identity_hash(&identity.identity.full);
+        if self.function_exact.get(&exact_hash).is_some_and(|indices| {
+            indices
+                .iter()
+                .any(|&index| self.functions[index].identity.full == identity.identity.full)
+        }) {
+            return Err(WireError::BadLen {
+                pos,
+                len: 2,
+                field: "duplicate function declaration",
+            });
+        }
+        identity.footprint = identity_footprint(pos as i64, &identity.identity)?;
+        // Account for the arena entry and both compact index vectors. The skeleton map owns at
+        // most one additional copy of each distinct skeleton; conservatively charging it per row
+        // keeps the actual heap below the authority budget without another allocation-heavy pass.
+        let bytes = identity
+            .footprint
+            .saturating_add(identity.identity.ns_stripped.len())
+            .saturating_add(2 * std::mem::size_of::<usize>());
+        self.charge(bytes, pos)?;
+        let index = self.functions.len();
+        let skeleton = identity.identity.ns_stripped.clone();
+        self.functions.push(identity);
+        self.function_exact
+            .entry(exact_hash)
+            .or_default()
+            .push(index);
+        self.function_buckets
+            .entry(skeleton)
+            .or_default()
+            .push(index);
+        Ok(())
+    }
+
+    fn insert_property(
+        &mut self,
+        identity: PropertyDeclarationIdentity,
+        pos: usize,
+    ) -> Result<(), WireError> {
+        if self.properties.contains(&identity) {
+            return Err(WireError::BadLen {
+                pos,
+                len: 2,
+                field: "duplicate property declaration",
+            });
+        }
+        let bytes = declaration_identity_bytes(&identity.owner)
+            .checked_add(identity.name.len())
+            .and_then(|bytes| bytes.checked_add(std::mem::size_of::<String>()))
+            .ok_or(WireError::BadLen {
+                pos,
+                len: i64::MAX,
+                field: "module declaration bytes",
+            })?;
+        self.charge(bytes, pos)?;
+        self.property_buckets
+            .entry(PropertyDeclarationSkeleton::from(&identity))
+            .or_default()
+            .insert(identity.owner.namespace.clone());
+        self.properties.insert(identity);
+        Ok(())
+    }
+
+    fn merge(&mut self, other: DeclarationInventory, pos: usize) -> Result<(), WireError> {
+        for identity in other.types {
+            self.insert_type(identity, pos)?;
+        }
+        for identity in other.functions {
+            self.insert_function(identity, pos)?;
+        }
+        for identity in other.globals {
+            self.insert_global(identity, pos)?;
+        }
+        for identity in other.properties {
+            self.insert_property(identity, pos)?;
+        }
+        Ok(())
+    }
+}
+
+fn declaration_identity_bytes(identity: &DeclarationIdentity) -> usize {
+    identity
+        .module
+        .len()
+        .saturating_add(identity.namespace.len())
+        .saturating_add(identity.name.len())
+}
+
 /// Everything the byte-walker collects from the single module entry.
 #[derive(Default)]
 struct ModuleSpans {
+    module: String,
+    inner_module: String,
     code: Vec<CodeSpan>,
     embeds: Vec<EmbedRef>,
+    function_ids: Vec<i32>,
+    function_id_sites: Vec<ModuleFunctionIdSite>,
+    function_id_identity_bytes: usize,
+    capture_function_identities: bool,
+    declarations: Option<DeclarationInventory>,
+    structural_violation: Option<(&'static str, String)>,
+}
+
+struct DeclarationTypeContext<'a> {
+    primary: &'a HashMap<i64, Ident>,
+    fallback: Option<&'a HashMap<i64, Ident>>,
+    script_owners: ScriptOwnerIndex,
+    fallback_script_owners: Option<&'a ScriptOwnerIndex>,
+}
+
+impl DeclarationTypeContext<'_> {
+    fn datatype(&self, key: i64, datatype: ModuleDataType) -> Result<Ident, WireError> {
+        let nested = if datatype.token == 5 {
+            self.primary
+                .get(&datatype.type_info)
+                .or_else(|| {
+                    self.fallback
+                        .and_then(|fallback| fallback.get(&datatype.type_info))
+                })
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            Ident::default()
+        };
+        datatype_identity(
+            key,
+            datatype.flags,
+            datatype.token,
+            datatype.type_info,
+            &nested,
+        )
+    }
+
+    fn object_type(&self, key: i64, datatype: ModuleDataType) -> Result<Ident, WireError> {
+        // Validate the complete return DataType first, then project exactly GetTypeInfo(): factory
+        // T3 ObjectType is the nested T1 identity, not the flags+token DataType identity.
+        self.datatype(key, datatype)?;
+        if datatype.token != 5 || datatype.flags[4] || datatype.type_info == 0 {
+            return Err(WireError::InvalidDataType {
+                key,
+                detail: "factory return requires a concrete object TypeReference",
+            });
+        }
+        self.primary
+            .get(&datatype.type_info)
+            .or_else(|| {
+                self.fallback
+                    .and_then(|fallback| fallback.get(&datatype.type_info))
+            })
+            .cloned()
+            .ok_or(WireError::InvalidDataType {
+                key,
+                detail: "factory return TypeReference is unresolved",
+            })
+    }
+
+    fn script_owner(
+        &self,
+        declaration: &DeclarationIdentity,
+        comparison_budget: &mut IdentityComparisonBudget,
+    ) -> Result<Option<&Ident>, WireError> {
+        if let Some(identity) = self.script_owners.exact(declaration) {
+            return Ok(Some(identity));
+        }
+        if let Some(identity) = self
+            .fallback_script_owners
+            .and_then(|fallback| fallback.exact(declaration))
+        {
+            return Ok(Some(identity));
+        }
+        let skeleton = DeclarationSkeleton::from(declaration);
+        let indices = [Some(&self.script_owners), self.fallback_script_owners];
+        let candidates = indices
+            .into_iter()
+            .flatten()
+            .flat_map(|index| index.buckets.get(&skeleton).into_iter())
+            .flat_map(HashMap::keys)
+            .map(String::as_str);
+        let matched =
+            match match_unique_namespace(&declaration.namespace, candidates, comparison_budget)? {
+                NamespaceMatch::Missing => return Ok(None),
+                NamespaceMatch::Ambiguous => {
+                    return Err(WireError::BadLen {
+                        pos: 0,
+                        len: 2,
+                        field: "ambiguous script class declaration",
+                    });
+                }
+                NamespaceMatch::Unique(namespace) => namespace,
+            };
+        for index in [Some(&self.script_owners), self.fallback_script_owners]
+            .into_iter()
+            .flatten()
+        {
+            if let Some(identity) = index
+                .buckets
+                .get(&skeleton)
+                .and_then(|bucket| bucket.get(matched))
+            {
+                return Ok(Some(identity));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FunctionDeclarationScope<'a> {
+    None,
+    Global,
+    Method(&'a Ident),
+}
+
+struct FunctionDeclarationRecord {
+    identity: FunctionDeclarationIdentity,
+    pos: usize,
+}
+
+fn insert_function_declaration(
+    out: &mut ModuleSpans,
+    record: Option<FunctionDeclarationRecord>,
+) -> Result<(), WireError> {
+    if let (Some(declarations), Some(record)) = (out.declarations.as_mut(), record) {
+        declarations.insert_function(record.identity, record.pos)?;
+    }
+    Ok(())
+}
+
+fn record_structural_violation(out: &mut ModuleSpans, field: &'static str, detail: String) {
+    if out.structural_violation.is_none() {
+        out.structural_violation = Some((field, detail));
+    }
+}
+
+fn require_equal_counts(
+    out: &mut ModuleSpans,
+    field: &'static str,
+    left_name: &'static str,
+    left: usize,
+    right_name: &'static str,
+    right: usize,
+) {
+    if left != right {
+        record_structural_violation(
+            out,
+            field,
+            format!("{left_name} has {left} entries but {right_name} has {right}"),
+        );
+    }
+}
+
+fn validate_collected_module_structure(spans: &ModuleSpans) -> Result<(), RemapError> {
+    if let Some((field, detail)) = spans.structural_violation.as_ref() {
+        return Err(RemapError::InvalidModuleStructure {
+            module: spans.module.clone(),
+            field,
+            detail: detail.clone(),
+        });
+    }
+    let mut ids = HashSet::new();
+    for &id in &spans.function_ids {
+        if !ids.insert(id) {
+            return Err(RemapError::FunctionIdCollision {
+                id,
+                first_module: spans.module.clone(),
+                second_module: spans.module.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct FinalTypeDeclarationQuery {
+    row_key: i64,
+    descriptor: TypeDeclarationDescriptor,
+}
+
+#[derive(Debug)]
+struct FinalGlobalDeclarationQuery {
+    row_key: i64,
+    identity: DeclarationIdentity,
+}
+
+#[derive(Debug)]
+struct FinalPropertyDeclarationQuery {
+    row_key: i64,
+    name: String,
+    old_type_id: i32,
+}
+
+#[derive(Debug, Default)]
+struct FinalDeclarationQueries {
+    types: Vec<FinalTypeDeclarationQuery>,
+    globals: Vec<FinalGlobalDeclarationQuery>,
+    properties: Vec<FinalPropertyDeclarationQuery>,
+    type_ids: HashMap<i32, i64>,
+    rows: usize,
+    bytes: usize,
+}
+
+impl FinalDeclarationQueries {
+    fn charge_rows(&mut self, count: usize, pos: usize) -> Result<(), WireError> {
+        let rows = self.rows.checked_add(count).ok_or(WireError::BadLen {
+            pos,
+            len: i64::MAX,
+            field: "declaration query rows",
+        })?;
+        if rows > MAX_DECLARATION_QUERY_ROWS {
+            return Err(WireError::BadLen {
+                pos,
+                len: rows as i64,
+                field: "declaration query rows",
+            });
+        }
+        self.rows = rows;
+        Ok(())
+    }
+
+    fn charge_bytes(&mut self, count: usize, pos: usize) -> Result<(), WireError> {
+        let bytes = self.bytes.checked_add(count).ok_or(WireError::BadLen {
+            pos,
+            len: i64::MAX,
+            field: "declaration query bytes",
+        })?;
+        if bytes > MAX_DECLARATION_QUERY_BYTES {
+            return Err(WireError::BadLen {
+                pos,
+                len: bytes as i64,
+                field: "declaration query bytes",
+            });
+        }
+        self.bytes = bytes;
+        Ok(())
+    }
+
+    fn read_sia(&mut self, c: &mut Cursor) -> Result<String, WireError> {
+        let pos = c.pos();
+        let raw = c.read_sia_bytes()?;
+        self.charge_bytes(raw.len(), pos)?;
+        Ok(raw.decode_ansi())
+    }
+
+    fn skip_fixed(
+        c: &mut Cursor,
+        count: usize,
+        width: usize,
+        field: &'static str,
+    ) -> Result<(), WireError> {
+        c.ensure_minimum_remaining(count, width, field)?;
+        c.skip(count.checked_mul(width).ok_or(WireError::BadLen {
+            pos: c.pos(),
+            len: count as i64,
+            field,
+        })?)
+    }
+
+    /// Read only the T1/T5/T7 fields needed for declaration membership. T2 is revisited in a
+    /// second pass and retains mappings only for the bounded set of T7 owner ids.
+    fn build(bytes: &[u8]) -> Result<Self, RemapError> {
+        let tail = preflight_tail_tables(bytes)?.tail;
+        let mut c = Cursor::at(bytes, tail);
+        let mut out = Self::default();
+
+        let ntypes = c.read_count("TypeReferences")?;
+        out.charge_rows(ntypes, c.pos().saturating_sub(4))?;
+        c.ensure_minimum_remaining(ntypes, 24, "TypeReferences")?;
+        for _ in 0..ntypes {
+            let row_key = c.read_i64()?;
+            let name = out.read_sia(&mut c)?;
+            let module = out.read_sia(&mut c)?;
+            let namespace = out.read_sia(&mut c)?;
+            let nsub = c.read_count("TypeRef.SubTypes")?;
+            Self::skip_fixed(&mut c, nsub, DATA_TYPE_SIZE, "TypeRef.SubTypes")?;
+            let kind = if nsub != 0 {
+                TypeDeclarationKind::Template
+            } else if module == "$__T__" {
+                TypeDeclarationKind::TemplateSentinel
+            } else if module.is_empty() {
+                TypeDeclarationKind::EngineLeaf
+            } else {
+                TypeDeclarationKind::ScriptLeaf
+            };
+            out.types.push(FinalTypeDeclarationQuery {
+                row_key,
+                descriptor: TypeDeclarationDescriptor {
+                    identity: DeclarationIdentity {
+                        module,
+                        namespace,
+                        name,
+                    },
+                    kind,
+                },
+            });
+        }
+
+        let type_ids_pos = c.pos();
+        let ntypeids = c.read_count("TypeIdRef")?;
+        Self::skip_fixed(&mut c, ntypeids, 12, "TypeIdRef")?;
+
+        let nfuncs = c.read_count("FunctionReferences")?;
+        c.ensure_minimum_remaining(nfuncs, 76, "FunctionReferences")?;
+        for _ in 0..nfuncs {
+            c.skip(8)?;
+            c.read_sia_bytes()?;
+            c.read_sia_bytes()?;
+            c.read_sia_bytes()?;
+            c.skip(3 * 4 + 8)?;
+            let nparams = c.read_count("FuncRef.Params")?;
+            Self::skip_fixed(&mut c, nparams, DATA_TYPE_SIZE, "FuncRef.Params")?;
+            c.skip(DATA_TYPE_SIZE)?;
+        }
+
+        let nfuncids = c.read_count("FuncIdRef")?;
+        Self::skip_fixed(&mut c, nfuncids, 12, "FuncIdRef")?;
+
+        let nglobals = c.read_count("GlobalReferences")?;
+        out.charge_rows(nglobals, c.pos().saturating_sub(4))?;
+        c.ensure_minimum_remaining(nglobals, 24, "GlobalReferences")?;
+        for _ in 0..nglobals {
+            let row_key = c.read_i64()?;
+            let name_pos = c.pos();
+            let name = c.read_sia_bytes()?;
+            out.charge_bytes(name.len(), name_pos)?;
+            let module = out.read_sia(&mut c)?;
+            let namespace = out.read_sia(&mut c)?;
+            let is_string = c.read_bool4()?;
+            if is_string {
+                name.decode_utf8(name_pos)?;
+            } else if !module.is_empty() {
+                out.globals.push(FinalGlobalDeclarationQuery {
+                    row_key,
+                    identity: DeclarationIdentity {
+                        module,
+                        namespace,
+                        name: name.decode_ansi(),
+                    },
+                });
+            }
+        }
+
+        let nstatic = c.read_count("StaticNames")?;
+        for _ in 0..nstatic {
+            c.read_sia_bytes()?;
+        }
+
+        let nproperties = c.read_count("PropertyReferences")?;
+        out.charge_rows(nproperties, c.pos().saturating_sub(4))?;
+        c.ensure_minimum_remaining(nproperties, 16, "PropertyReferences")?;
+        for _ in 0..nproperties {
+            let row_key = c.read_i64()?;
+            let name = out.read_sia(&mut c)?;
+            let old_type_id = c.read_i32()?;
+            out.properties.push(FinalPropertyDeclarationQuery {
+                row_key,
+                name,
+                old_type_id,
+            });
+        }
+        if c.pos() != bytes.len() {
+            return Err(RemapError::TailNotAtEof {
+                got: c.pos(),
+                len: bytes.len(),
+            });
+        }
+
+        let wanted_owner_ids: HashSet<i32> =
+            out.properties.iter().map(|row| row.old_type_id).collect();
+        let mut type_ids = Cursor::at(bytes, type_ids_pos);
+        let count = type_ids.read_count("TypeIdRef")?;
+        for _ in 0..count {
+            let id = type_ids.read_i32()?;
+            let ptr = type_ids.read_i64()?;
+            if wanted_owner_ids.contains(&id) {
+                out.type_ids.insert(id, ptr);
+            }
+        }
+        Ok(out)
+    }
+
+    fn validate(
+        self,
+        declarations: &DeclarationInventory,
+        syms: &SymTables,
+        pristine: Option<&PristineDeclarationAuthority>,
+        comparison_budget: &mut IdentityComparisonBudget,
+    ) -> Result<(), RemapError> {
+        let type_by_ptr: HashMap<i64, &TypeDeclarationDescriptor> = self
+            .types
+            .iter()
+            .map(|row| (row.row_key, &row.descriptor))
+            .collect();
+        for row in &self.types {
+            if row.descriptor.kind == TypeDeclarationKind::ScriptLeaf
+                && match_declaration_identities(
+                    &[declarations],
+                    &row.descriptor.identity,
+                    DeclarationSetKind::Type,
+                    comparison_budget,
+                )? != FunctionDeclarationMatch::Unique
+            {
+                return Err(missing_declaration_membership(
+                    0,
+                    row.row_key,
+                    format!(
+                        "final module output has no Class or Enum for {}::{} in module {:?}",
+                        row.descriptor.identity.namespace,
+                        row.descriptor.identity.name,
+                        row.descriptor.identity.module
+                    ),
+                ));
+            }
+        }
+        for row in &self.globals {
+            if match_declaration_identities(
+                &[declarations],
+                &row.identity,
+                DeclarationSetKind::Global,
+                comparison_budget,
+            )? != FunctionDeclarationMatch::Unique
+            {
+                return Err(missing_declaration_membership(
+                    4,
+                    row.row_key,
+                    format!(
+                        "final module output has no GlobalVariables declaration for {}::{} in module {:?}",
+                        row.identity.namespace, row.identity.name, row.identity.module
+                    ),
+                ));
+            }
+        }
+        if let Some(pristine) = pristine {
+            for (&row_key, identity) in &syms.func_ident_of_ptr {
+                let declaration_match =
+                    match_function_declarations(&[declarations], identity, comparison_budget)?;
+                if declaration_match == FunctionDeclarationMatch::Unique
+                    || (declaration_match == FunctionDeclarationMatch::Missing
+                        && pristine.orphan_functions.contains(&row_key))
+                {
+                    continue;
+                }
+                return Err(missing_declaration_membership(
+                    2,
+                    row_key,
+                    format!(
+                        "final module output has no exact function record for runtime signature {}",
+                        identity.display
+                    ),
+                ));
+            }
+        }
+        for row in &self.properties {
+            let Some(owner_ptr) = self.type_ids.get(&row.old_type_id) else {
+                return Err(missing_declaration_membership(
+                    6,
+                    row.row_key,
+                    format!(
+                        "final property owner type id {:#x} is unresolved",
+                        row.old_type_id
+                    ),
+                ));
+            };
+            let Some(owner) = type_by_ptr.get(owner_ptr) else {
+                return Err(missing_declaration_membership(
+                    6,
+                    row.row_key,
+                    format!("final property owner pointer {owner_ptr:#x} has no T1 row"),
+                ));
+            };
+            if owner.kind != TypeDeclarationKind::ScriptLeaf {
+                continue;
+            }
+            let property = PropertyDeclarationIdentity {
+                owner: owner.identity.clone(),
+                name: row.name.clone(),
+            };
+            if match_property_declarations(&[declarations], &property, comparison_budget)?
+                != FunctionDeclarationMatch::Unique
+            {
+                return Err(missing_declaration_membership(
+                    6,
+                    row.row_key,
+                    format!("final declaring class has no property named {:?}", row.name),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Validate the runtime-indexed records of a fully composed cache before any caller can publish
+/// it. Doing this on the prospective output (rather than on a mini in isolation) naturally lets
+/// an edit reuse ids owned by the module it replaced, while still rejecting collisions with every
+/// untouched or previously composed module.
+fn validate_composed_module_records_with_pristine(
+    bytes: &[u8],
+    pristine: Option<&PristineDeclarationAuthority>,
+) -> Result<(), RemapError> {
+    if bytes.len() < CacheHeader::SIZE {
+        return Err(WireError::Eof {
+            pos: 0,
+            need: CacheHeader::SIZE,
+            have: bytes.len(),
+        }
+        .into());
+    }
+    preflight_cache_module_work(bytes)?;
+    let declaration_queries = FinalDeclarationQueries::build(bytes)?;
+    let syms = SymTables::build(bytes)?;
+    let meta = TailMetadata::build(bytes)?;
+    let mut comparison_budget = IdentityComparisonBudget::new(
+        bytes
+            .len()
+            .saturating_add(syms.identity_bytes)
+            .saturating_add(declaration_queries.bytes),
+    );
+    let declaration_types = declaration_type_context(&meta, &syms, None, None)?;
+    let mut cursor = Cursor::at(bytes, CacheHeader::SIZE);
+    let count = super::walk_modules::module_count(bytes) as usize;
+    cursor.ensure_minimum_remaining(count, 60, "Modules")?;
+    let mut function_ids = HashMap::<i32, String>::new();
+    let mut outer_module_names = HashSet::new();
+    let mut inner_module_names = HashSet::new();
+    let mut declarations = DeclarationInventory::default();
+    for _ in 0..count {
+        let module = cursor.read_fstring()?;
+        if !outer_module_names.insert(module.clone()) {
+            return Err(RemapError::ModuleNameCollision { name: module });
+        }
+        let mut spans = ModuleSpans {
+            module: module.clone(),
+            declarations: Some(DeclarationInventory::default()),
+            ..ModuleSpans::default()
+        };
+        read_module_spans(
+            &mut cursor,
+            bytes,
+            &mut spans,
+            Some(&declaration_types),
+            Some(&mut comparison_budget),
+        )?;
+        if !inner_module_names.insert(spans.inner_module.clone()) {
+            return Err(RemapError::ModuleNameCollision {
+                name: spans.inner_module,
+            });
+        }
+        validate_collected_module_structure(&spans)?;
+        declarations.merge(spans.declarations.take().unwrap_or_default(), cursor.pos())?;
+        for id in spans.function_ids {
+            if let Some(first_module) = function_ids.insert(id, module.clone()) {
+                return Err(RemapError::FunctionIdCollision {
+                    id,
+                    first_module,
+                    second_module: module,
+                });
+            }
+        }
+    }
+    declaration_queries.validate(&declarations, &syms, pristine, &mut comparison_budget)?;
+    Ok(())
+}
+
+pub(super) fn validate_composed_module_records(bytes: &[u8]) -> Result<(), RemapError> {
+    // Low-level splice helpers have no generation-bound pristine authority. They still validate
+    // structural records and T1/T5/T7 declaration closure; the publishing SequentialMiniGuard
+    // performs the additional exact T3/orphan-aware pass before committing its staged state.
+    validate_composed_module_records_with_pristine(bytes, None)
 }
 
 /// Walk the single module entry in `mini` (TMap key + module value) and collect every
 /// function's ByteCode span + every embedded int64 ref. Mirrors `walk_modules::read_module_c`
 /// but records byte offsets.
 fn collect_module_spans(mini: &[u8]) -> Result<ModuleSpans, WireError> {
+    preflight_mini_module_work(mini)?;
     let mut c = Cursor::at(mini, CacheHeader::SIZE);
-    c.read_fstring()?; // TMap key
-    let mut spans = ModuleSpans::default();
-    read_module_spans(&mut c, mini, &mut spans)?;
+    let module = c.read_fstring()?; // TMap key
+    let mut spans = ModuleSpans {
+        module,
+        ..ModuleSpans::default()
+    };
+    read_module_spans(&mut c, mini, &mut spans, None, None)?;
     Ok(spans)
 }
 
+/// Stream each module independently and retain only its bounded declaration inventory. The
+/// detailed walker remains the single format oracle; callers run the allocation-light work
+/// preflight before this helper so its transient span vectors are bounded as well.
+fn declaration_type_context<'a>(
+    meta: &TailMetadata,
+    primary: &'a SymTables,
+    fallback: Option<&'a SymTables>,
+    fallback_script_owners: Option<&'a ScriptOwnerIndex>,
+) -> Result<DeclarationTypeContext<'a>, WireError> {
+    let mut script_owners = ScriptOwnerIndex::default();
+    for row in &meta.types {
+        let descriptor = type_declaration_descriptor(row);
+        if descriptor.kind != TypeDeclarationKind::ScriptLeaf {
+            continue;
+        }
+        if let Some(identity) = primary
+            .type_ident_of_ptr
+            .get(&row.key)
+            .or_else(|| fallback.and_then(|fallback| fallback.type_ident_of_ptr.get(&row.key)))
+        {
+            script_owners.insert(&descriptor.identity, identity, row.start)?;
+        }
+    }
+    Ok(DeclarationTypeContext {
+        primary: &primary.type_ident_of_ptr,
+        fallback: fallback.map(|fallback| &fallback.type_ident_of_ptr),
+        script_owners,
+        fallback_script_owners,
+    })
+}
+
+struct CollectedDeclarationInventory {
+    declarations: DeclarationInventory,
+    function_id_sites: Vec<ModuleFunctionIdSite>,
+}
+
+fn collect_declaration_inventory(
+    bytes: &[u8],
+    primary: &SymTables,
+    fallback: Option<&SymTables>,
+    fallback_script_owners: Option<&ScriptOwnerIndex>,
+    meta: &TailMetadata,
+    comparison_budget: &mut IdentityComparisonBudget,
+) -> Result<CollectedDeclarationInventory, WireError> {
+    if bytes.len() < CacheHeader::SIZE {
+        return Err(WireError::Eof {
+            pos: 0,
+            need: CacheHeader::SIZE,
+            have: bytes.len(),
+        });
+    }
+    let mut cursor = Cursor::at(bytes, CacheHeader::SIZE);
+    let declaration_types =
+        declaration_type_context(meta, primary, fallback, fallback_script_owners)?;
+    let count = super::walk_modules::module_count(bytes) as usize;
+    cursor.ensure_minimum_remaining(count, 60, "Modules")?;
+    let mut inventory = DeclarationInventory::default();
+    let mut function_id_sites = Vec::new();
+    let mut function_id_identity_bytes = 0usize;
+    for _ in 0..count {
+        let module = cursor.read_fstring()?;
+        let mut spans = ModuleSpans {
+            module,
+            declarations: Some(DeclarationInventory::default()),
+            capture_function_identities: true,
+            ..ModuleSpans::default()
+        };
+        read_module_spans(
+            &mut cursor,
+            bytes,
+            &mut spans,
+            Some(&declaration_types),
+            Some(&mut *comparison_budget),
+        )?;
+        inventory.merge(spans.declarations.take().unwrap_or_default(), cursor.pos())?;
+        function_id_identity_bytes = function_id_identity_bytes
+            .checked_add(spans.function_id_identity_bytes)
+            .filter(|&bytes| bytes <= MAX_DECLARATION_AUTHORITY_BYTES)
+            .ok_or(WireError::BadLen {
+                pos: cursor.pos(),
+                len: i64::MAX,
+                field: "module Function.Id identity bytes",
+            })?;
+        function_id_sites.extend(spans.function_id_sites);
+    }
+    Ok(CollectedDeclarationInventory {
+        declarations: inventory,
+        function_id_sites,
+    })
+}
+
+/// Allocation-light summary produced before the detailed module walker constructs any bytecode,
+/// embed, object-position, variable-info, or record vectors.
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct ModuleWorkSummary {
+    pub(super) function_count: usize,
+    pub(super) max_function_bytecode_dwords: usize,
+    pub(super) total_bytecode_dwords: u64,
+    pub(super) work_items: usize,
+    pub(super) module_authority_bytes: usize,
+}
+
+struct ModuleWorkBudget {
+    summary: ModuleWorkSummary,
+    max_functions: usize,
+    max_work_items: usize,
+}
+
+impl ModuleWorkBudget {
+    fn charge(&mut self, count: usize, pos: usize, field: &'static str) -> Result<(), WireError> {
+        let total = self
+            .summary
+            .work_items
+            .checked_add(count)
+            .ok_or(WireError::BadLen {
+                pos,
+                len: i64::MAX,
+                field,
+            })?;
+        if total > self.max_work_items {
+            return Err(WireError::BadLen {
+                pos,
+                len: total as i64,
+                field: "module work items",
+            });
+        }
+        self.summary.work_items = total;
+        Ok(())
+    }
+
+    fn function(&mut self, pos: usize) -> Result<(), WireError> {
+        let count = self
+            .summary
+            .function_count
+            .checked_add(1)
+            .ok_or(WireError::BadLen {
+                pos,
+                len: i64::MAX,
+                field: "module function records",
+            })?;
+        if count > self.max_functions {
+            return Err(WireError::BadLen {
+                pos,
+                len: count as i64,
+                field: "module function records",
+            });
+        }
+        self.summary.function_count = count;
+        self.charge(1, pos, "module function records")
+    }
+
+    fn bytecode(&mut self, count: usize, pos: usize) -> Result<(), WireError> {
+        self.summary.max_function_bytecode_dwords =
+            self.summary.max_function_bytecode_dwords.max(count);
+        self.summary.total_bytecode_dwords = self
+            .summary
+            .total_bytecode_dwords
+            .checked_add(count as u64)
+            .ok_or(WireError::BadLen {
+                pos,
+                len: i64::MAX,
+                field: "total ByteCode dwords",
+            })?;
+        self.charge(count, pos, "ByteCode")
+    }
+
+    fn module_authority_names(
+        &mut self,
+        outer_bytes: usize,
+        inner_bytes: usize,
+        pos: usize,
+    ) -> Result<(), WireError> {
+        let total = self
+            .summary
+            .module_authority_bytes
+            .checked_add(outer_bytes)
+            .and_then(|bytes| bytes.checked_add(inner_bytes))
+            .ok_or(WireError::BadLen {
+                pos,
+                len: i64::MAX,
+                field: "module authority name bytes",
+            })?;
+        if total > MAX_DECLARATION_AUTHORITY_BYTES {
+            return Err(WireError::BadLen {
+                pos,
+                len: total as i64,
+                field: "module authority name bytes",
+            });
+        }
+        self.summary.module_authority_bytes = total;
+        Ok(())
+    }
+}
+
+fn module_work_count(
+    c: &mut Cursor,
+    budget: &mut ModuleWorkBudget,
+    field: &'static str,
+    minimum_width: usize,
+) -> Result<usize, WireError> {
+    let pos = c.pos();
+    let count = c.read_count(field)?;
+    c.ensure_minimum_remaining(count, minimum_width, field)?;
+    budget.charge(count, pos, field)?;
+    Ok(count)
+}
+
+fn module_work_skip_fixed(
+    c: &mut Cursor,
+    budget: &mut ModuleWorkBudget,
+    field: &'static str,
+    width: usize,
+) -> Result<usize, WireError> {
+    let count = module_work_count(c, budget, field, width)?;
+    c.skip(count.checked_mul(width).ok_or(WireError::BadLen {
+        pos: c.pos(),
+        len: count as i64,
+        field,
+    })?)?;
+    Ok(count)
+}
+
+fn module_work_skip_sia_array(
+    c: &mut Cursor,
+    budget: &mut ModuleWorkBudget,
+    field: &'static str,
+) -> Result<usize, WireError> {
+    let count = module_work_count(c, budget, field, 4)?;
+    for _ in 0..count {
+        c.read_sia_bytes()?;
+    }
+    Ok(count)
+}
+
+fn module_work_function(c: &mut Cursor, budget: &mut ModuleWorkBudget) -> Result<(), WireError> {
+    budget.function(c.pos())?;
+    c.read_sia_bytes()?; // Name
+    c.read_sia_bytes()?; // Namespace
+    c.skip(DATA_TYPE_SIZE)?; // ReturnType
+    module_work_skip_fixed(c, budget, "ParameterTypes", DATA_TYPE_SIZE)?;
+    module_work_skip_sia_array(c, budget, "ParameterNames")?;
+    module_work_skip_fixed(c, budget, "ParameterFlags", 4)?;
+    module_work_skip_sia_array(c, budget, "ParameterDefaultArgs")?;
+    c.skip(4)?; // FunctionTraits
+    let bytecode_pos = c.pos();
+    let bytecode = c.read_count("ByteCode")?;
+    c.ensure_minimum_remaining(bytecode, 4, "ByteCode")?;
+    budget.bytecode(bytecode, bytecode_pos)?;
+    c.skip(bytecode.checked_mul(4).ok_or(WireError::BadLen {
+        pos: bytecode_pos,
+        len: bytecode as i64,
+        field: "ByteCode",
+    })?)?;
+    module_work_skip_fixed(c, budget, "ByteCodeReferences", 4)?;
+    c.skip(4)?; // VariableSpace
+    module_work_skip_fixed(c, budget, "ObjVariableTypes", 8)?;
+    module_work_skip_fixed(c, budget, "ObjVariablePos", 4)?;
+    c.skip(4)?; // ObjVariablesOnHeap
+    module_work_skip_fixed(c, budget, "VariableInfoProgramPos", 4)?;
+    module_work_skip_fixed(c, budget, "VariableInfoOffset", 4)?;
+    module_work_skip_fixed(c, budget, "VariableInfoOption", 4)?;
+    c.skip(4 * 3)?; // StackNeeded + Id + DeclaredAt
+    module_work_skip_fixed(c, budget, "LineNumbers", 4)?;
+    if c.read_bool4()? {
+        c.read_sia_bytes()?; // UnrealFunctionName
+        module_work_skip_sia_array(c, budget, "UF.MetaSpec")?;
+        module_work_skip_sia_array(c, budget, "UF.MetaValues")?;
+        c.skip(18 * 4)?;
+    }
+    Ok(())
+}
+
+fn module_work_property(c: &mut Cursor, budget: &mut ModuleWorkBudget) -> Result<(), WireError> {
+    c.read_sia_bytes()?;
+    c.skip(DATA_TYPE_SIZE + 2 * 4)?;
+    if c.read_bool4()? {
+        module_work_skip_sia_array(c, budget, "UP.MetaSpec")?;
+        module_work_skip_sia_array(c, budget, "UP.MetaValues")?;
+        c.skip(9 * 4)?;
+        let replicated = c.read_bool4()?;
+        c.skip(3 * 4)?;
+        if replicated {
+            c.skip(2 * 4)?;
+        }
+        c.skip(3 * 4)?;
+    }
+    Ok(())
+}
+
+fn module_work_class(c: &mut Cursor, budget: &mut ModuleWorkBudget) -> Result<(), WireError> {
+    c.read_sia_bytes()?;
+    c.read_sia_bytes()?;
+    c.skip(4)?;
+    let properties = module_work_count(c, budget, "Class.Properties", 52)?;
+    for _ in 0..properties {
+        module_work_property(c, budget)?;
+    }
+    let methods = module_work_count(c, budget, "Class.Methods", 120)?;
+    for _ in 0..methods {
+        module_work_function(c, budget)?;
+    }
+    module_work_skip_fixed(c, budget, "Class.MethodTable", 4)?;
+    c.skip(16)?;
+    let constructors = module_work_count(c, budget, "Class.Constructors", 120)?;
+    for _ in 0..constructors {
+        module_work_function(c, budget)?;
+    }
+    module_work_skip_fixed(c, budget, "Class.FactoryRefs", 8)?;
+    module_work_skip_fixed(c, budget, "Class.BehaviorRefs", 8)?;
+    let behaviors = module_work_count(c, budget, "Class.BehaviorFunctions", 120)?;
+    for _ in 0..behaviors {
+        module_work_function(c, budget)?;
+    }
+    module_work_skip_fixed(c, budget, "Class.BehaviorFunctionTypes", 4)?;
+    if c.read_bool4()? {
+        c.read_sia_bytes()?;
+        c.read_sia_bytes()?;
+        c.skip(8 * 4)?;
+        c.read_sia_bytes()?;
+        c.skip(4)?;
+        module_work_skip_sia_array(c, budget, "Class.MetaSpec")?;
+        module_work_skip_sia_array(c, budget, "Class.MetaValues")?;
+        c.read_sia_bytes()?;
+    }
+    Ok(())
+}
+
+fn module_work_enum(c: &mut Cursor, budget: &mut ModuleWorkBudget) -> Result<(), WireError> {
+    c.read_sia_bytes()?;
+    c.read_sia_bytes()?;
+    module_work_skip_sia_array(c, budget, "Enum.Names")?;
+    module_work_skip_fixed(c, budget, "Enum.Values", 4)?;
+    Ok(())
+}
+
+fn module_work_global(c: &mut Cursor, budget: &mut ModuleWorkBudget) -> Result<(), WireError> {
+    c.read_sia_bytes()?;
+    c.read_sia_bytes()?;
+    c.skip(DATA_TYPE_SIZE)?;
+    if !c.read_bool4()? {
+        if c.read_bool4()? {
+            c.skip(8)?;
+        } else if c.read_bool4()? {
+            module_work_function(c, budget)?;
+        }
+    }
+    Ok(())
+}
+
+fn module_work_import(c: &mut Cursor, budget: &mut ModuleWorkBudget) -> Result<(), WireError> {
+    c.read_sia_bytes()?;
+    c.read_sia_bytes()?;
+    c.read_sia_bytes()?;
+    module_work_skip_fixed(c, budget, "Import.ParameterTypes", DATA_TYPE_SIZE)?;
+    module_work_skip_fixed(c, budget, "Import.ParameterFlags", 4)?;
+    module_work_skip_sia_array(c, budget, "Import.ParameterDefaultArgs")?;
+    c.skip(DATA_TYPE_SIZE)?;
+    Ok(())
+}
+
+fn stream_module_work_with_limits(
+    bytes: &[u8],
+    max_functions: usize,
+    max_work_items: usize,
+) -> Result<ModuleWorkSummary, WireError> {
+    if bytes.len() < CacheHeader::SIZE {
+        return Err(WireError::Eof {
+            pos: 0,
+            need: CacheHeader::SIZE,
+            have: bytes.len(),
+        });
+    }
+    let mut c = Cursor::at(bytes, CacheHeader::SIZE);
+    let modules = super::walk_modules::module_count(bytes) as usize;
+    c.ensure_minimum_remaining(modules, 60, "Modules")?;
+    if modules > MAX_DECLARATION_AUTHORITY_ROWS {
+        return Err(WireError::BadLen {
+            pos: 0x14,
+            len: modules as i64,
+            field: "module authority Modules",
+        });
+    }
+    let mut budget = ModuleWorkBudget {
+        summary: ModuleWorkSummary::default(),
+        max_functions,
+        max_work_items,
+    };
+    budget.charge(modules, c.pos(), "Modules")?;
+    for _ in 0..modules {
+        let name_pos = c.pos();
+        let outer = c.read_fstring()?;
+        let inner = c.read_sia_bytes()?;
+        budget.module_authority_names(outer.len(), inner.len(), name_pos)?;
+        let functions = module_work_count(&mut c, &mut budget, "Module.Functions", 120)?;
+        for _ in 0..functions {
+            module_work_function(&mut c, &mut budget)?;
+        }
+        let classes = module_work_count(&mut c, &mut budget, "Module.Classes", 64)?;
+        for _ in 0..classes {
+            module_work_class(&mut c, &mut budget)?;
+        }
+        let enums = module_work_count(&mut c, &mut budget, "Module.Enums", 16)?;
+        for _ in 0..enums {
+            module_work_enum(&mut c, &mut budget)?;
+        }
+        let globals = module_work_count(&mut c, &mut budget, "Module.GlobalVariables", 48)?;
+        for _ in 0..globals {
+            module_work_global(&mut c, &mut budget)?;
+        }
+        let imports = module_work_count(&mut c, &mut budget, "Module.FunctionImports", 60)?;
+        for _ in 0..imports {
+            module_work_import(&mut c, &mut budget)?;
+        }
+        c.skip(8)?;
+        module_work_skip_sia_array(&mut c, &mut budget, "Module.ImportedModules")?;
+        c.read_sia_bytes()?;
+        module_work_skip_sia_array(&mut c, &mut budget, "Module.DeclaredEvents")?;
+        module_work_skip_sia_array(&mut c, &mut budget, "Module.DeclaredDelegates")?;
+        c.read_sia_bytes()?;
+        module_work_skip_sia_array(&mut c, &mut budget, "Module.PostInitFunctions")?;
+    }
+    Ok(budget.summary)
+}
+
+/// Scan a prepared one-module mini without materializing any record arrays. The sequential guard
+/// uses the returned maxima/totals to apply its public SpliceError bytecode limits before
+/// reference validation; this helper itself enforces the fixed function/work-allocation caps.
+pub(super) fn preflight_mini_module_work(bytes: &[u8]) -> Result<ModuleWorkSummary, WireError> {
+    stream_module_work_with_limits(
+        bytes,
+        MAX_MINI_STREAMED_FUNCTIONS,
+        MAX_MINI_MODULE_WORK_ITEMS,
+    )
+}
+
+pub(super) fn preflight_cache_module_work(bytes: &[u8]) -> Result<ModuleWorkSummary, WireError> {
+    stream_module_work_with_limits(
+        bytes,
+        MAX_DECLARATION_AUTHORITY_ROWS,
+        MAX_CACHE_MODULE_WORK_ITEMS,
+    )
+}
+
 /// A `FAngelscriptPrecompiledDataType` (36 B): 6×bool(24) + int64 TypeInfo.OldReference(+24) +
-/// int32 Token(+32). The TypeInfo.OldReference is a T1 TYPE ptr (0 for primitives). Record it as
-/// an embedded type-ptr ref (skipped at remap time when 0), then advance past the 36 bytes.
+/// int32 Token(+32). An identifier DataType must carry a concrete T1 pointer; every primitive
+/// DataType must carry the exact null sentinel. Record that distinction for final validation.
 /// CONFIRMED: container-splice.md §0/§3 (void ReturnType has TypeInfo.Old=0). This is the field
 /// that carried the surviving regen-keys — every DataType in function signatures / property /
 /// global / import records embeds one, and the prior remap skipped them wholesale.
-fn embed_datatype(c: &mut Cursor, out: &mut ModuleSpans) -> Result<(), WireError> {
+#[derive(Clone, Copy)]
+struct ModuleDataType {
+    flags: [bool; 6],
+    type_info: i64,
+    token: i32,
+}
+
+fn embed_datatype(c: &mut Cursor, out: &mut ModuleSpans) -> Result<ModuleDataType, WireError> {
     let dt_start = c.pos();
+    let mut flags = [false; 6];
+    for flag in &mut flags {
+        *flag = c.read_bool4()?;
+    }
+    let type_info = c.read_i64()?;
+    let token = c.read_i32()?;
+    let is_auto = flags[4];
+    let rule = match (is_auto, token) {
+        (true, 5) => TypePtrRule::Null,
+        (true, _) => TypePtrRule::Invalid,
+        (false, 5) => TypePtrRule::Concrete,
+        (
+            false,
+            0x3b | 0x41 | 0x44 | 0x45 | 0x46 | 0x47 | 0x4b | 0x4c | 0x4d | 0x4e | 0x50 | 0x51
+            | 0x52,
+        ) => TypePtrRule::Null,
+        _ => TypePtrRule::Invalid,
+    };
     out.embeds.push(EmbedRef {
         byte_off: dt_start + 24,
-        kind: EmbedKind::TypePtr,
+        kind: EmbedKind::TypePtr(rule),
     });
-    c.skip(DATA_TYPE_SIZE)?;
-    Ok(())
+    Ok(ModuleDataType {
+        flags,
+        type_info,
+        token,
+    })
 }
 
 fn read_function_spans(
     c: &mut Cursor,
     bytes: &[u8],
     out: &mut ModuleSpans,
-) -> Result<(), WireError> {
-    c.read_sia()?; // Name
-    c.read_sia()?; // Namespace
-    embed_datatype(c, out)?; // ReturnType
+    declaration_types: Option<&DeclarationTypeContext<'_>>,
+    declaration_scope: FunctionDeclarationScope<'_>,
+) -> Result<Option<FunctionDeclarationRecord>, WireError> {
+    let declaration_pos = c.pos();
+    let name = c.read_sia()?;
+    let namespace = c.read_sia()?;
+    let return_type = embed_datatype(c, out)?;
     let nptypes = c.read_count("ParameterTypes")?;
+    let mut parameter_types = Vec::with_capacity(nptypes);
     for _ in 0..nptypes {
-        embed_datatype(c, out)?;
+        parameter_types.push(embed_datatype(c, out)?);
     }
-    c.skip_tarray_sia("ParameterNames")?;
-    c.skip_tarray_fixed(4, "ParameterFlags")?;
-    c.skip_tarray_sia("ParameterDefaultArgs")?;
-    c.skip(4)?; // FunctionTraits
-                // ByteCode TArray<int32>: record the span.
+    let npnames = c.read_count("ParameterNames")?;
+    for _ in 0..npnames {
+        c.read_sia_bytes()?;
+    }
+    let npflags = c.read_count("ParameterFlags")?;
+    c.skip(npflags * 4)?;
+    let npdefaults = c.read_count("ParameterDefaultArgs")?;
+    for _ in 0..npdefaults {
+        c.read_sia()?;
+    }
+    require_equal_counts(
+        out,
+        "Function.Parameters",
+        "ParameterTypes",
+        nptypes,
+        "ParameterNames",
+        npnames,
+    );
+    require_equal_counts(
+        out,
+        "Function.Parameters",
+        "ParameterTypes",
+        nptypes,
+        "ParameterFlags",
+        npflags,
+    );
+    require_equal_counts(
+        out,
+        "Function.Parameters",
+        "ParameterTypes",
+        nptypes,
+        "ParameterDefaultArgs",
+        npdefaults,
+    );
+    let traits = c.read_i32()?;
+    let (declaration_record, runtime_identity) = if let (true, Some(types)) = (
+        out.declarations.is_some() || out.capture_function_identities,
+        declaration_types,
+    ) {
+        let key = declaration_pos as i64;
+        let special_owner = if matches!(declaration_scope, FunctionDeclarationScope::Global)
+            && matches!(name.as_str(), "$fact" | "$beh3")
+        {
+            Some(types.object_type(key, return_type)?)
+        } else {
+            None
+        };
+        let branch = match declaration_scope {
+            FunctionDeclarationScope::None => None,
+            FunctionDeclarationScope::Global => special_owner
+                .as_ref()
+                .map_or(Some(("global", None)), |owner| {
+                    Some(("method", Some(owner)))
+                }),
+            FunctionDeclarationScope::Method(owner) => Some(("method", Some(owner))),
+        };
+        let params = parameter_types
+            .iter()
+            .copied()
+            .map(|datatype| types.datatype(key, datatype))
+            .collect::<Result<Vec<_>, _>>()?;
+        let ret = types.datatype(key, return_type)?;
+        if let Some((branch, owner)) = branch {
+            let identity = function_declaration_identity(
+                key,
+                branch,
+                &out.inner_module,
+                &namespace,
+                owner,
+                &name,
+                traits & 4 != 0,
+                &params,
+                &ret,
+            )?;
+            let runtime_identity = identity.identity.full.clone();
+            (
+                Some(FunctionDeclarationRecord {
+                    identity,
+                    pos: declaration_pos,
+                }),
+                Some(runtime_identity),
+            )
+        } else {
+            // Global initializer functions have no T3 declaration of their own. Bind their
+            // runtime id to a portable signature plus the stable record ordinal within the
+            // module so independent compiler runs cannot collide across a loadout.
+            let identity = function_declaration_identity(
+                key,
+                "internal",
+                &out.inner_module,
+                &namespace,
+                None,
+                &name,
+                traits & 4 != 0,
+                &params,
+                &ret,
+            )?;
+            let mut encoded = IdentityEncoder::new(key);
+            encoded.field("module-function")?;
+            encoded.field(&identity.identity.full)?;
+            encoded.number(out.function_ids.len())?;
+            (None, Some(encoded.finish()))
+        }
+    } else {
+        (None, None)
+    };
+    // ByteCode TArray<int32>: record the span.
     let count = c.read_count("ByteCode")?;
     let data_off = c.pos();
     out.code.push(CodeSpan { data_off, count });
     c.skip(count * 4)?;
     let _ = bytes; // (bytes used only for span math; offsets are absolute)
     c.skip_tarray_fixed(4, "ByteCodeReferences")?;
-    c.skip(4)?; // VariableSpace
-                // ObjVariableTypes: TArray<int64> of TYPE ptrs (T1) per object local slot — remap each.
+    let variable_space = c.read_i32()?;
+    if variable_space < 0 {
+        record_structural_violation(
+            out,
+            "Function.VariableSpace",
+            format!("VariableSpace must be non-negative, found {variable_space}"),
+        );
+    }
+    // ObjVariableTypes: TArray<int64> of TYPE ptrs (T1) per object local slot — remap each.
     let nobj = c.read_count("ObjVariableTypes")?;
     for _ in 0..nobj {
         out.embeds.push(EmbedRef {
             byte_off: c.pos(),
-            kind: EmbedKind::TypePtr,
+            kind: EmbedKind::TypePtr(TypePtrRule::Concrete),
         });
         c.skip(8)?;
     }
-    c.skip_tarray_fixed(4, "ObjVariablePos")?;
-    c.skip(4)?; // ObjVariablesOnHeap
-    c.skip_tarray_fixed(4, "VariableInfoProgramPos")?;
-    c.skip_tarray_fixed(4, "VariableInfoOffset")?;
-    c.skip_tarray_fixed(4, "VariableInfoOption")?;
-    c.skip(4)?; // StackNeeded
-    c.skip(4)?; // Id
+    let nobjpos = c.read_count("ObjVariablePos")?;
+    c.ensure_minimum_remaining(nobjpos, 4, "ObjVariablePos")?;
+    let mut object_positions = Vec::with_capacity(nobjpos);
+    for _ in 0..nobjpos {
+        object_positions.push(c.read_i32()?);
+    }
+    require_equal_counts(
+        out,
+        "Function.ObjectVariables",
+        "ObjVariableTypes",
+        nobj,
+        "ObjVariablePos",
+        nobjpos,
+    );
+    for &position in &object_positions {
+        if position <= 0 || position > variable_space {
+            record_structural_violation(
+                out,
+                "Function.ObjectVariables",
+                format!(
+                    "object position {position} must be within 1..={variable_space} VariableSpace"
+                ),
+            );
+        }
+    }
+    let object_position_set: HashSet<i32> = object_positions.iter().copied().collect();
+    let object_variables_on_heap = c.read_i32()?;
+    if object_variables_on_heap < 0 || object_variables_on_heap as usize > nobjpos {
+        record_structural_violation(
+            out,
+            "Function.ObjVariablesOnHeap",
+            format!(
+                "heap prefix {object_variables_on_heap} must be within 0..={nobjpos} object variables"
+            ),
+        );
+    }
+    let nvar_program = c.read_count("VariableInfoProgramPos")?;
+    c.ensure_minimum_remaining(nvar_program, 4, "VariableInfoProgramPos")?;
+    let mut variable_program_positions = Vec::with_capacity(nvar_program);
+    for _ in 0..nvar_program {
+        variable_program_positions.push(c.read_i32()?);
+    }
+    let nvar_offset = c.read_count("VariableInfoOffset")?;
+    c.ensure_minimum_remaining(nvar_offset, 4, "VariableInfoOffset")?;
+    let mut variable_offsets = Vec::with_capacity(nvar_offset);
+    for _ in 0..nvar_offset {
+        variable_offsets.push(c.read_i32()?);
+    }
+    let nvar_option = c.read_count("VariableInfoOption")?;
+    c.ensure_minimum_remaining(nvar_option, 4, "VariableInfoOption")?;
+    let mut variable_options = Vec::with_capacity(nvar_option);
+    for _ in 0..nvar_option {
+        variable_options.push(c.read_i32()?);
+    }
+    require_equal_counts(
+        out,
+        "Function.VariableInfo",
+        "ProgramPos",
+        nvar_program,
+        "Offset",
+        nvar_offset,
+    );
+    require_equal_counts(
+        out,
+        "Function.VariableInfo",
+        "ProgramPos",
+        nvar_program,
+        "Option",
+        nvar_option,
+    );
+    if nvar_program == nvar_offset && nvar_program == nvar_option {
+        let mut previous_program_position = None;
+        let mut block_depth = 0usize;
+        for (index, ((&program_position, &variable_offset), &option)) in variable_program_positions
+            .iter()
+            .zip(&variable_offsets)
+            .zip(&variable_options)
+            .enumerate()
+        {
+            if program_position < 0 || program_position as usize > count {
+                record_structural_violation(
+                    out,
+                    "Function.VariableInfo",
+                    format!(
+                        "entry {index} ProgramPos {program_position} must be within 0..={count} ByteCode dwords"
+                    ),
+                );
+            }
+            if previous_program_position.is_some_and(|previous| program_position < previous) {
+                record_structural_violation(
+                    out,
+                    "Function.VariableInfo",
+                    format!(
+                        "entry {index} ProgramPos {program_position} is before the previous position"
+                    ),
+                );
+            }
+            previous_program_position = Some(program_position);
+            match option {
+                0 | 1 => {
+                    if !object_position_set.contains(&variable_offset) {
+                        record_structural_violation(
+                            out,
+                            "Function.VariableInfo",
+                            format!(
+                                "entry {index} object offset {variable_offset} is absent from ObjVariablePos"
+                            ),
+                        );
+                    }
+                }
+                2 => {
+                    if variable_offset != 0 {
+                        record_structural_violation(
+                            out,
+                            "Function.VariableInfo",
+                            format!(
+                                "entry {index} BLOCK_BEGIN must carry offset 0, found {variable_offset}"
+                            ),
+                        );
+                    }
+                    block_depth += 1;
+                }
+                3 => {
+                    if variable_offset != 0 {
+                        record_structural_violation(
+                            out,
+                            "Function.VariableInfo",
+                            format!(
+                                "entry {index} BLOCK_END must carry offset 0, found {variable_offset}"
+                            ),
+                        );
+                    }
+                    match block_depth.checked_sub(1) {
+                        Some(depth) => block_depth = depth,
+                        None => record_structural_violation(
+                            out,
+                            "Function.VariableInfo",
+                            format!("entry {index} closes a block before any block begins"),
+                        ),
+                    }
+                }
+                _ => record_structural_violation(
+                    out,
+                    "Function.VariableInfo",
+                    format!("entry {index} has unknown option {option}; expected 0..=3"),
+                ),
+            }
+        }
+        if block_depth != 0 {
+            record_structural_violation(
+                out,
+                "Function.VariableInfo",
+                format!("{block_depth} variable-info block(s) remain unclosed"),
+            );
+        }
+    }
+    let stack_needed = c.read_i32()?;
+    if stack_needed < variable_space.max(0) {
+        record_structural_violation(
+            out,
+            "Function.StackNeeded",
+            format!(
+                "StackNeeded {stack_needed} must be at least VariableSpace {}",
+                variable_space.max(0)
+            ),
+        );
+    }
+    let id_off = c.pos();
+    out.function_ids.push(c.read_i32()?); // Id
+    if out.capture_function_identities {
+        let identity = runtime_identity.expect("typed function-id scan has a portable identity");
+        out.function_id_identity_bytes = out
+            .function_id_identity_bytes
+            .checked_add(identity.len())
+            .and_then(|bytes| bytes.checked_add(std::mem::size_of::<ModuleFunctionIdSite>()))
+            .filter(|&bytes| bytes <= MAX_DECLARATION_AUTHORITY_BYTES)
+            .ok_or(WireError::BadLen {
+                pos: id_off,
+                len: i64::MAX,
+                field: "module Function.Id identity bytes",
+            })?;
+        out.function_id_sites.push(ModuleFunctionIdSite {
+            byte_off: id_off,
+            identity,
+        });
+    }
     c.skip(4)?; // DeclaredAt
     c.skip_tarray_fixed(4, "LineNumbers")?;
     if c.read_bool4()? {
         c.read_sia()?; // UnrealFunctionName
-        c.skip_tarray_sia("UF.MetaSpec")?;
-        c.skip_tarray_sia("UF.MetaValues")?;
+        let nspec = c.read_count("UF.MetaSpec")?;
+        for _ in 0..nspec {
+            c.read_sia()?;
+        }
+        let nvalues = c.read_count("UF.MetaValues")?;
+        for _ in 0..nvalues {
+            c.read_sia()?;
+        }
+        require_equal_counts(
+            out,
+            "UFunction.Metadata",
+            "MetaSpec",
+            nspec,
+            "MetaValues",
+            nvalues,
+        );
         c.skip(18 * 4)?;
     }
-    Ok(())
+    Ok(declaration_record)
 }
 
-fn read_property_spans(c: &mut Cursor, out: &mut ModuleSpans) -> Result<(), WireError> {
-    c.read_sia()?; // Name
+fn read_property_spans(
+    c: &mut Cursor,
+    out: &mut ModuleSpans,
+    owner: Option<&DeclarationIdentity>,
+) -> Result<(), WireError> {
+    let declaration_pos = c.pos();
+    let name = c.read_sia()?;
+    if let (Some(declarations), Some(owner)) = (out.declarations.as_mut(), owner) {
+        declarations.insert_property(
+            PropertyDeclarationIdentity {
+                owner: owner.clone(),
+                name,
+            },
+            declaration_pos,
+        )?;
+    }
     embed_datatype(c, out)?; // Type
     c.skip(4)?; // bIsPrivate
     c.skip(4)?; // bIsProtected
     if c.read_bool4()? {
-        c.skip_tarray_sia("UP.MetaSpec")?;
-        c.skip_tarray_sia("UP.MetaValues")?;
+        let nspec = c.read_count("UP.MetaSpec")?;
+        for _ in 0..nspec {
+            c.read_sia()?;
+        }
+        let nvalues = c.read_count("UP.MetaValues")?;
+        for _ in 0..nvalues {
+            c.read_sia()?;
+        }
+        require_equal_counts(
+            out,
+            "UProperty.Metadata",
+            "MetaSpec",
+            nspec,
+            "MetaValues",
+            nvalues,
+        );
         c.skip(9 * 4)?;
         let replicated = c.read_bool4()?;
         c.skip(4)?; // bSkipReplication
@@ -1401,36 +5887,123 @@ fn read_property_spans(c: &mut Cursor, out: &mut ModuleSpans) -> Result<(), Wire
     Ok(())
 }
 
-fn read_class_spans(c: &mut Cursor, bytes: &[u8], out: &mut ModuleSpans) -> Result<(), WireError> {
-    c.read_sia()?; // ClassName
-    c.read_sia()?; // Namespace
-    c.skip(4)?; // Flags
+fn read_class_spans(
+    c: &mut Cursor,
+    bytes: &[u8],
+    out: &mut ModuleSpans,
+    declaration_types: Option<&DeclarationTypeContext<'_>>,
+    comparison_budget: Option<&mut IdentityComparisonBudget>,
+) -> Result<(), WireError> {
+    let declaration_pos = c.pos();
+    let name = c.read_sia()?;
+    let namespace = c.read_sia()?;
+    let declaration = DeclarationIdentity {
+        module: out.inner_module.clone(),
+        namespace,
+        name,
+    };
+    if let Some(declarations) = out.declarations.as_mut() {
+        declarations.insert_type(declaration.clone(), declaration_pos)?;
+    }
+    let owner = match declaration_types {
+        Some(types) => Some(types.script_owner(
+            &declaration,
+            comparison_budget.expect("declaration scan has a comparison budget"),
+        )?)
+        .flatten(),
+        None => None,
+    };
+    let flags = c.read_i32()?;
     let nprops = c.read_count("Class.Properties")?;
     for _ in 0..nprops {
-        read_property_spans(c, out)?;
+        read_property_spans(c, out, Some(&declaration))?;
     }
     let nmethods = c.read_count("Class.Methods")?;
+    let mut method_declarations = Vec::with_capacity(nmethods);
     for _ in 0..nmethods {
-        read_function_spans(c, bytes, out)?;
+        method_declarations.push(read_function_spans(
+            c,
+            bytes,
+            out,
+            declaration_types,
+            owner.map_or(
+                FunctionDeclarationScope::None,
+                FunctionDeclarationScope::Method,
+            ),
+        )?);
     }
-    c.skip_tarray_fixed(4, "Class.MethodTable")?;
+    let nmethod_table = c.read_count("Class.MethodTable")?;
+    let mut seen_method_indices = HashSet::new();
+    let mut method_table_valid = true;
+    for slot in 0..nmethod_table {
+        let index = c.read_i32()?;
+        if index == -1 {
+            continue;
+        }
+        if index < 0 || index as usize >= nmethods || !seen_method_indices.insert(index) {
+            method_table_valid = false;
+            record_structural_violation(
+                out,
+                "Class.MethodTable",
+                format!(
+                    "slot {slot} references invalid or duplicate local method index {index} (Methods.Num={nmethods})"
+                ),
+            );
+        }
+    }
+    let is_value_class = flags & 0x2 != 0;
+    if is_value_class && nmethod_table != 0 {
+        method_table_valid = false;
+        record_structural_violation(
+            out,
+            "Class.MethodTable",
+            format!(
+                "value class Methods are created directly and require an empty MethodTable, found {nmethod_table} entries"
+            ),
+        );
+    } else if !is_value_class && seen_method_indices.len() != nmethods {
+        method_table_valid = false;
+        record_structural_violation(
+            out,
+            "Class.MethodTable",
+            format!(
+                "reference class MethodTable covers {} of {nmethods} local Methods; every local method must appear exactly once",
+                seen_method_indices.len()
+            ),
+        );
+    }
+    if method_table_valid {
+        for declaration in method_declarations {
+            insert_function_declaration(out, declaration)?;
+        }
+    }
     // DerivedFrom + ShadowType: int64 TYPE ptrs (T1). Value 0 = none (skipped at remap time).
     out.embeds.push(EmbedRef {
         byte_off: c.pos(),
-        kind: EmbedKind::TypePtr,
+        kind: EmbedKind::TypePtr(TypePtrRule::Optional),
     });
     c.skip(8)?; // DerivedFrom
     out.embeds.push(EmbedRef {
         byte_off: c.pos(),
-        kind: EmbedKind::TypePtr,
+        kind: EmbedKind::TypePtr(TypePtrRule::Optional),
     });
     c.skip(8)?; // ShadowType
     let nctors = c.read_count("Class.Constructors")?;
     for _ in 0..nctors {
-        read_function_spans(c, bytes, out)?;
+        let declaration = read_function_spans(
+            c,
+            bytes,
+            out,
+            declaration_types,
+            owner.map_or(
+                FunctionDeclarationScope::None,
+                FunctionDeclarationScope::Method,
+            ),
+        )?;
+        insert_function_declaration(out, declaration)?;
     }
-    // FactoryRefs + BehaviorRefs: TArray<int64> of FUNC ids (T4); 0/non-id values are
-    // sentinels/behavior-type tags (remap skips anything not in the regen funcid table).
+    // FactoryRefs + BehaviorRefs: TArray<int64> of FUNC ids (T4); zero is the only observed and
+    // admitted sentinel. Behavior type tags live in the separate BehaviorFunctionTypes array.
     let nfact = c.read_count("Class.FactoryRefs")?;
     for _ in 0..nfact {
         out.embeds.push(EmbedRef {
@@ -1447,82 +6020,248 @@ fn read_class_spans(c: &mut Cursor, bytes: &[u8], out: &mut ModuleSpans) -> Resu
         });
         c.skip(8)?;
     }
-    let nbehav = c.read_count("Class.BehaviorFunctions")?;
-    for _ in 0..nbehav {
-        read_function_spans(c, bytes, out)?;
+    if nbeh != 7 {
+        record_structural_violation(
+            out,
+            "Class.BehaviorRefs",
+            format!("runtime requires exactly 7 entries, found {nbeh}"),
+        );
     }
-    c.skip_tarray_fixed(4, "Class.BehaviorFunctionTypes")?;
+    let nbehav = c.read_count("Class.BehaviorFunctions")?;
+    if nbehav > 1 {
+        record_structural_violation(
+            out,
+            "Class.BehaviorFunctions",
+            format!("runtime supports at most one synthesized destructor behavior, found {nbehav}"),
+        );
+    }
+    for _ in 0..nbehav {
+        let declaration = read_function_spans(
+            c,
+            bytes,
+            out,
+            declaration_types,
+            owner.map_or(
+                FunctionDeclarationScope::None,
+                FunctionDeclarationScope::Method,
+            ),
+        )?;
+        insert_function_declaration(out, declaration)?;
+    }
+    let nbehav_types = c.read_count("Class.BehaviorFunctionTypes")?;
+    for index in 0..nbehav_types {
+        let behavior_type = c.read_i32()?;
+        if behavior_type != 2 {
+            record_structural_violation(
+                out,
+                "Class.BehaviorFunctionTypes",
+                format!(
+                    "entry {index} has behavior type {behavior_type}; only asBEHAVE_DESTRUCT (2) is supported"
+                ),
+            );
+        }
+    }
+    require_equal_counts(
+        out,
+        "Class.Behaviors",
+        "BehaviorFunctions",
+        nbehav,
+        "BehaviorFunctionTypes",
+        nbehav_types,
+    );
     if c.read_bool4()? {
         c.read_sia()?; // SuperClass
         c.read_sia()?; // CodeSuperClass
         c.skip(8 * 4)?;
         c.read_sia()?; // StaticClassGVName
         c.skip(4)?; // bPlaceable
-        c.skip_tarray_sia("Class.MetaSpec")?;
-        c.skip_tarray_sia("Class.MetaValues")?;
+        let nspec = c.read_count("Class.MetaSpec")?;
+        for _ in 0..nspec {
+            c.read_sia()?;
+        }
+        let nvalues = c.read_count("Class.MetaValues")?;
+        for _ in 0..nvalues {
+            c.read_sia()?;
+        }
+        require_equal_counts(
+            out,
+            "Class.Metadata",
+            "MetaSpec",
+            nspec,
+            "MetaValues",
+            nvalues,
+        );
         c.read_sia()?; // ComposeOntoClassName
     }
     Ok(())
 }
 
-fn read_enum_spans(c: &mut Cursor) -> Result<(), WireError> {
-    c.read_sia()?; // Name
-    c.read_sia()?; // Namespace
-    c.skip_tarray_sia("Enum.Names")?;
-    c.skip_tarray_fixed(4, "Enum.Values")?;
+fn read_enum_spans(c: &mut Cursor, out: &mut ModuleSpans) -> Result<(), WireError> {
+    let declaration_pos = c.pos();
+    let name = c.read_sia()?;
+    let namespace = c.read_sia()?;
+    if let Some(declarations) = out.declarations.as_mut() {
+        declarations.insert_type(
+            DeclarationIdentity {
+                module: out.inner_module.clone(),
+                namespace,
+                name,
+            },
+            declaration_pos,
+        )?;
+    }
+    let nnames = c.read_count("Enum.Names")?;
+    for _ in 0..nnames {
+        c.read_sia()?;
+    }
+    let nvalues = c.read_count("Enum.Values")?;
+    c.skip(nvalues * 4)?;
+    require_equal_counts(out, "Enum.Entries", "Names", nnames, "Values", nvalues);
     Ok(())
 }
 
-fn read_global_spans(c: &mut Cursor, bytes: &[u8], out: &mut ModuleSpans) -> Result<(), WireError> {
-    c.read_sia()?; // Name
-    c.read_sia()?; // Namespace
+fn read_global_spans(
+    c: &mut Cursor,
+    bytes: &[u8],
+    out: &mut ModuleSpans,
+    declaration_types: Option<&DeclarationTypeContext<'_>>,
+) -> Result<(), WireError> {
+    let declaration_pos = c.pos();
+    let name = c.read_sia()?;
+    let namespace = c.read_sia()?;
+    if let Some(declarations) = out.declarations.as_mut() {
+        declarations.insert_global(
+            DeclarationIdentity {
+                module: out.inner_module.clone(),
+                namespace,
+                name,
+            },
+            declaration_pos,
+        )?;
+    }
     embed_datatype(c, out)?; // Type
     if !c.read_bool4()? {
         // !bIsDefaultInit
         if c.read_bool4()? {
             c.skip(8)?; // PureConstantValue
         } else if c.read_bool4()? {
-            read_function_spans(c, bytes, out)?; // InitFunc carries bytecode too
+            read_function_spans(
+                c,
+                bytes,
+                out,
+                declaration_types,
+                FunctionDeclarationScope::None,
+            )?; // InitFunc carries bytecode but is not a T3 declaration
         }
     }
     Ok(())
 }
 
-fn read_function_import_spans(c: &mut Cursor, out: &mut ModuleSpans) -> Result<(), WireError> {
+fn read_function_import_spans(
+    c: &mut Cursor,
+    out: &mut ModuleSpans,
+    declaration_types: Option<&DeclarationTypeContext<'_>>,
+) -> Result<(), WireError> {
+    let declaration_pos = c.pos();
     c.read_sia()?; // ImportedFromModule
-    c.read_sia()?; // Name
+    let name = c.read_sia()?;
     c.read_sia()?; // Namespace
     let nptypes = c.read_count("Import.ParameterTypes")?;
+    let mut parameter_types = Vec::with_capacity(nptypes);
     for _ in 0..nptypes {
-        embed_datatype(c, out)?;
+        parameter_types.push(embed_datatype(c, out)?);
     }
-    c.skip_tarray_fixed(4, "Import.ParameterFlags")?;
-    c.skip_tarray_sia("Import.ParameterDefaultArgs")?;
-    embed_datatype(c, out)?; // ReturnType
+    let npflags = c.read_count("Import.ParameterFlags")?;
+    c.skip(npflags * 4)?;
+    let npdefaults = c.read_count("Import.ParameterDefaultArgs")?;
+    for _ in 0..npdefaults {
+        c.read_sia()?;
+    }
+    require_equal_counts(
+        out,
+        "Import.Parameters",
+        "ParameterTypes",
+        nptypes,
+        "ParameterFlags",
+        npflags,
+    );
+    require_equal_counts(
+        out,
+        "Import.Parameters",
+        "ParameterTypes",
+        nptypes,
+        "ParameterDefaultArgs",
+        npdefaults,
+    );
+    let return_type = embed_datatype(c, out)?;
+    if let (Some(types), true) = (declaration_types, out.declarations.is_some()) {
+        let key = declaration_pos as i64;
+        let params = parameter_types
+            .into_iter()
+            .map(|datatype| types.datatype(key, datatype))
+            .collect::<Result<Vec<_>, _>>()?;
+        let ret = types.datatype(key, return_type)?;
+        insert_function_declaration(
+            out,
+            Some(FunctionDeclarationRecord {
+                identity: function_declaration_identity(
+                    key,
+                    "imported",
+                    &out.inner_module,
+                    "",
+                    None,
+                    &name,
+                    false,
+                    &params,
+                    &ret,
+                )?,
+                pos: declaration_pos,
+            }),
+        )?;
+    }
     Ok(())
 }
 
-fn read_module_spans(c: &mut Cursor, bytes: &[u8], out: &mut ModuleSpans) -> Result<(), WireError> {
-    c.read_sia()?; // ModuleName
+fn read_module_spans(
+    c: &mut Cursor,
+    bytes: &[u8],
+    out: &mut ModuleSpans,
+    declaration_types: Option<&DeclarationTypeContext<'_>>,
+    mut comparison_budget: Option<&mut IdentityComparisonBudget>,
+) -> Result<(), WireError> {
+    out.inner_module = c.read_sia()?; // ModuleName
     let nfns = c.read_count("Module.Functions")?;
     for _ in 0..nfns {
-        read_function_spans(c, bytes, out)?;
+        let declaration = read_function_spans(
+            c,
+            bytes,
+            out,
+            declaration_types,
+            FunctionDeclarationScope::Global,
+        )?;
+        insert_function_declaration(out, declaration)?;
     }
     let nclasses = c.read_count("Module.Classes")?;
     for _ in 0..nclasses {
-        read_class_spans(c, bytes, out)?;
+        read_class_spans(
+            c,
+            bytes,
+            out,
+            declaration_types,
+            comparison_budget.as_deref_mut(),
+        )?;
     }
     let nenums = c.read_count("Module.Enums")?;
     for _ in 0..nenums {
-        read_enum_spans(c)?;
+        read_enum_spans(c, out)?;
     }
     let nglobals = c.read_count("Module.GlobalVariables")?;
     for _ in 0..nglobals {
-        read_global_spans(c, bytes, out)?;
+        read_global_spans(c, bytes, out, declaration_types)?;
     }
     let nimports = c.read_count("Module.FunctionImports")?;
     for _ in 0..nimports {
-        read_function_import_spans(c, out)?;
+        read_function_import_spans(c, out, declaration_types)?;
     }
     c.skip(8)?; // CodeHash
     c.skip_tarray_sia("Module.ImportedModules")?;
@@ -1538,6 +6277,234 @@ fn read_module_spans(c: &mut Cursor, bytes: &[u8], out: &mut ModuleSpans) -> Res
 // Opt-in new-symbol planner.
 // -------------------------------------------------------------------------------------------------
 
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum NovelPointerKind {
+    Type,
+    Function,
+    Global,
+}
+
+impl NovelPointerKind {
+    const fn hash_domain(self) -> u8 {
+        match self {
+            Self::Type => 0,
+            Self::Function => 1,
+            Self::Global => 2,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[allow(dead_code)] // consumed by the next, splice-level loadout integration tranche
+struct NovelPointerIdentity {
+    kind: NovelPointerKind,
+    identity: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[allow(dead_code)]
+struct NovelTypeIdIdentity {
+    object_kind: u32,
+    identity: String,
+}
+
+/// Exact portable identities observed while validating one input mini. The builder merges these
+/// into one owned union; each mini retains only a compact canonical fingerprint beside its SHA.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[allow(dead_code)]
+struct NovelIdentitySet {
+    pointers: BTreeSet<NovelPointerIdentity>,
+    type_ids: BTreeMap<String, u32>,
+    function_ids: BTreeSet<String>,
+    module_function_ids: BTreeSet<String>,
+}
+
+#[allow(dead_code)]
+impl NovelIdentitySet {
+    fn additional_usage(
+        &self,
+        inventory: &Self,
+        limits: LoadoutPlanLimits,
+    ) -> Result<(usize, usize), RemapError> {
+        let mut entries = 0usize;
+        let mut bytes = 0usize;
+        for identity in &self.pointers {
+            if !inventory.pointers.contains(identity) {
+                entries = entries
+                    .checked_add(1)
+                    .ok_or(RemapError::LoadoutPlanResourceLimit {
+                        resource: "novel assignments",
+                        actual: usize::MAX,
+                        limit: limits.max_assignments,
+                    })?;
+                bytes = bytes.checked_add(identity.identity.len()).ok_or(
+                    RemapError::LoadoutPlanResourceLimit {
+                        resource: "identity bytes",
+                        actual: usize::MAX,
+                        limit: limits.max_identity_bytes,
+                    },
+                )?;
+            }
+        }
+        for (identity, object_kind) in &self.type_ids {
+            if let Some(&prior_kind) = inventory.type_ids.get(identity) {
+                if prior_kind != *object_kind {
+                    return Err(RemapError::LoadoutPlanTypeKindConflict {
+                        identity: identity.clone(),
+                        first: prior_kind,
+                        second: *object_kind,
+                    });
+                }
+            } else {
+                entries = entries
+                    .checked_add(1)
+                    .ok_or(RemapError::LoadoutPlanResourceLimit {
+                        resource: "novel assignments",
+                        actual: usize::MAX,
+                        limit: limits.max_assignments,
+                    })?;
+                bytes = bytes.checked_add(identity.len()).ok_or(
+                    RemapError::LoadoutPlanResourceLimit {
+                        resource: "identity bytes",
+                        actual: usize::MAX,
+                        limit: limits.max_identity_bytes,
+                    },
+                )?;
+            }
+        }
+        for identity in &self.function_ids {
+            if !inventory.function_ids.contains(identity) {
+                entries = entries
+                    .checked_add(1)
+                    .ok_or(RemapError::LoadoutPlanResourceLimit {
+                        resource: "novel assignments",
+                        actual: usize::MAX,
+                        limit: limits.max_assignments,
+                    })?;
+                bytes = bytes.checked_add(identity.len()).ok_or(
+                    RemapError::LoadoutPlanResourceLimit {
+                        resource: "identity bytes",
+                        actual: usize::MAX,
+                        limit: limits.max_identity_bytes,
+                    },
+                )?;
+            }
+        }
+        for identity in &self.module_function_ids {
+            if !inventory.module_function_ids.contains(identity) {
+                entries = entries
+                    .checked_add(1)
+                    .ok_or(RemapError::LoadoutPlanResourceLimit {
+                        resource: "novel assignments",
+                        actual: usize::MAX,
+                        limit: limits.max_assignments,
+                    })?;
+                bytes = bytes.checked_add(identity.len()).ok_or(
+                    RemapError::LoadoutPlanResourceLimit {
+                        resource: "identity bytes",
+                        actual: usize::MAX,
+                        limit: limits.max_identity_bytes,
+                    },
+                )?;
+            }
+        }
+        Ok((entries, bytes))
+    }
+
+    fn merge_into(self, inventory: &mut Self) {
+        inventory.pointers.extend(self.pointers);
+        inventory.type_ids.extend(self.type_ids);
+        inventory.function_ids.extend(self.function_ids);
+        inventory
+            .module_function_ids
+            .extend(self.module_function_ids);
+    }
+
+    fn fingerprint(&self) -> [u8; 32] {
+        fn field(hasher: &mut Sha256, tag: u8, value: &str) {
+            hasher.update([tag]);
+            hasher.update((value.len() as u64).to_le_bytes());
+            hasher.update(value.as_bytes());
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(b"gore-loadout-script-id-identities-v1");
+        for identity in &self.pointers {
+            hasher.update([0, identity.kind.hash_domain()]);
+            field(&mut hasher, 1, &identity.identity);
+        }
+        for (identity, object_kind) in &self.type_ids {
+            hasher.update([2]);
+            hasher.update(object_kind.to_le_bytes());
+            field(&mut hasher, 3, identity);
+        }
+        for identity in &self.function_ids {
+            field(&mut hasher, 4, identity);
+        }
+        for identity in &self.module_function_ids {
+            field(&mut hasher, 5, identity);
+        }
+        hasher.finalize().into()
+    }
+}
+
+#[allow(dead_code)]
+const MAX_LOADOUT_PLAN_MINIS: usize = 256;
+#[allow(dead_code)]
+const MAX_LOADOUT_PLAN_ASSIGNMENTS: usize = 131_072;
+#[allow(dead_code)]
+const MAX_LOADOUT_PLAN_IDENTITY_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+struct LoadoutPlanLimits {
+    max_minis: usize,
+    max_assignments: usize,
+    max_identity_bytes: usize,
+}
+
+#[allow(dead_code)]
+const PRODUCTION_LOADOUT_PLAN_LIMITS: LoadoutPlanLimits = LoadoutPlanLimits {
+    max_minis: MAX_LOADOUT_PLAN_MINIS,
+    max_assignments: MAX_LOADOUT_PLAN_ASSIGNMENTS,
+    max_identity_bytes: MAX_LOADOUT_PLAN_IDENTITY_BYTES,
+};
+
+/// Canonical Script-ID assignments for one loadout, always derived from the unchanged pristine
+/// base plus the union of every inspected mini's portable novel identities. This is deliberately
+/// crate-internal until the composer owns the two-pass orchestration.
+#[allow(dead_code)]
+pub(super) struct LoadoutScriptIdPlan {
+    pristine_base_sha256: [u8; 32],
+    pristine_guid: [u8; 16],
+    pristine_header: [u8; 0x14],
+    base: Arc<AllowNewBaseContext>,
+    effective_base: Arc<EffectiveReferenceBase>,
+    inspected_minis: HashMap<[u8; 32], [u8; 32]>,
+    pointer_assignments: BTreeMap<NovelPointerIdentity, i64>,
+    type_id_assignments: BTreeMap<NovelTypeIdIdentity, i32>,
+    function_id_assignments: BTreeMap<String, i32>,
+    module_function_id_assignments: BTreeMap<String, i32>,
+}
+
+/// Streaming first pass for a loadout. `inspect` retains no mini bytes, so callers may read,
+/// inspect, and drop each artifact before opening the next one.
+#[allow(dead_code)]
+pub(super) struct LoadoutScriptIdPlanBuilder {
+    pristine_base_sha256: [u8; 32],
+    pristine_guid: [u8; 16],
+    pristine_header: [u8; 0x14],
+    base: Arc<AllowNewBaseContext>,
+    effective_base: Arc<EffectiveReferenceBase>,
+    inspected_count: usize,
+    inspected_minis: HashMap<[u8; 32], [u8; 32]>,
+    inventory: NovelIdentitySet,
+    assignment_entries: usize,
+    identity_bytes: usize,
+    limits: LoadoutPlanLimits,
+    domains: CanonicalAllocationDomains,
+}
+
 #[derive(Default)]
 struct NewSymbolPlan {
     new_types: HashSet<i64>,
@@ -1551,7 +6518,12 @@ struct NewSymbolPlan {
     /// Regen engine id -> final engine id (new rows only; existing ids resolve through ptr maps).
     type_ids: HashMap<i32, i32>,
     func_ids: HashMap<i32, i32>,
+    module_function_ids: HashMap<String, i32>,
     used_static_indices: HashSet<i64>,
+    /// Exact member sites used by target bytecode, in the regen generation's core type-id space.
+    /// A pristine script class may declare a property that vanilla bytecode never referenced, so
+    /// its T7 row can be absent from `base` even though the declaration is valid authority.
+    used_property_sites: HashSet<(i32, i32)>,
     static_indices: HashMap<i64, i64>,
     selected_static_rows: Vec<usize>,
     selected_properties: Vec<SelectedProperty>,
@@ -1572,6 +6544,8 @@ fn match_base_ptr(
     regen_name_of_ptr: &HashMap<i64, String>,
     base_ptr_of_id: &HashMap<String, Vec<i64>>,
     base_ident_of_ptr: &HashMap<i64, Ident>,
+    base_summary: &IdentityReverseSummary,
+    comparison_budget: &mut IdentityComparisonBudget,
 ) -> Result<Option<i64>, RemapError> {
     let identity = regen_id_of_ptr
         .get(&regen_key)
@@ -1616,14 +6590,31 @@ fn match_base_ptr(
                 .cloned()
                 .unwrap_or_default(),
         })?;
-    let mut matches = base_ident_of_ptr
-        .iter()
-        .filter_map(|(&key, ident)| regen_ident.oracle_eq(ident).then_some(key));
-    let Some(first) = matches.next() else {
+    let regen_footprint = identity_footprint(regen_key, regen_ident)?;
+    let mut first = None;
+    let mut matches = 0usize;
+    for &(key, candidate_footprint) in base_summary
+        .by_skeleton
+        .get(&regen_ident.ns_stripped)
+        .into_iter()
+        .flatten()
+    {
+        comparison_budget.charge(regen_footprint, candidate_footprint)?;
+        let candidate = base_ident_of_ptr
+            .get(&key)
+            .expect("base identity summary points to its source row");
+        if !regen_ident.oracle_eq(candidate) {
+            continue;
+        }
+        matches = matches.saturating_add(1);
+        if first.is_none() {
+            first = Some(key);
+        }
+    }
+    let Some(first) = first else {
         return Ok(None);
     };
-    if matches.next().is_some() {
-        let n = 2 + matches.count();
+    if matches > 1 {
         return Err(RemapError::Ambiguous {
             kind,
             op,
@@ -1631,7 +6622,7 @@ fn match_base_ptr(
                 .get(&regen_key)
                 .cloned()
                 .unwrap_or_default(),
-            n,
+            n: matches,
         });
     }
     Ok(Some(first))
@@ -1643,8 +6634,27 @@ fn declare_type(
     op: &'static str,
     regen: &SymTables,
     base: &SymTables,
+    base_summaries: &SymbolIdentitySummaries,
+    comparison_budget: &mut IdentityComparisonBudget,
 ) -> Result<(), RemapError> {
     if key == 0 || plan.type_ptrs.contains_key(&key) || plan.new_types.contains(&key) {
+        return Ok(());
+    }
+    // Exact key repeats are already unambiguous even when the pristine cache contains several
+    // historical aliases for the same portable identity. This mirrors the sequential guard's
+    // grandfathering rule without allowing a raw-key collision with a different declaration.
+    if regen.type_id_of_ptr.get(&key) == base.type_id_of_ptr.get(&key)
+        && regen.type_id_of_ptr.contains_key(&key)
+    {
+        plan.type_ptrs.insert(key, key);
+        return Ok(());
+    }
+    // A minimal prepared mini intentionally omits pristine T1 rows while its signatures retain
+    // the already-final pristine pointer. Only accept that direct key when the mini does not
+    // define a competing row of its own; raw-key collisions in a full regen must still resolve by
+    // portable identity.
+    if !regen.type_id_of_ptr.contains_key(&key) && base.type_id_of_ptr.contains_key(&key) {
+        plan.type_ptrs.insert(key, key);
         return Ok(());
     }
     match match_base_ptr(
@@ -1656,6 +6666,8 @@ fn declare_type(
         &regen.type_name_of_ptr,
         &base.type_ptr_of_id,
         &base.type_ident_of_ptr,
+        &base_summaries.types,
+        comparison_budget,
     )? {
         Some(vanilla) => {
             plan.type_ptrs.insert(key, vanilla);
@@ -1673,8 +6685,20 @@ fn declare_func(
     op: &'static str,
     regen: &SymTables,
     base: &SymTables,
+    base_summaries: &SymbolIdentitySummaries,
+    comparison_budget: &mut IdentityComparisonBudget,
 ) -> Result<(), RemapError> {
     if key == 0 || plan.func_ptrs.contains_key(&key) || plan.new_funcs.contains(&key) {
+        return Ok(());
+    }
+    if regen.func_id_of_ptr.get(&key) == base.func_id_of_ptr.get(&key)
+        && regen.func_id_of_ptr.contains_key(&key)
+    {
+        plan.func_ptrs.insert(key, key);
+        return Ok(());
+    }
+    if !regen.func_id_of_ptr.contains_key(&key) && base.func_id_of_ptr.contains_key(&key) {
+        plan.func_ptrs.insert(key, key);
         return Ok(());
     }
     match match_base_ptr(
@@ -1686,6 +6710,8 @@ fn declare_func(
         &regen.func_name_of_ptr,
         &base.func_ptr_of_id,
         &base.func_ident_of_ptr,
+        &base_summaries.functions,
+        comparison_budget,
     )? {
         Some(vanilla) => {
             plan.func_ptrs.insert(key, vanilla);
@@ -1703,8 +6729,46 @@ fn declare_global(
     op: &'static str,
     regen: &SymTables,
     base: &SymTables,
+    base_summaries: &SymbolIdentitySummaries,
+    comparison_budget: &mut IdentityComparisonBudget,
 ) -> Result<(), RemapError> {
     if key == 0 || plan.global_ptrs.contains_key(&key) || plan.new_globals.contains(&key) {
+        return Ok(());
+    }
+    if regen
+        .global_is_string_of_ptr
+        .get(&key)
+        .copied()
+        .unwrap_or(false)
+    {
+        let identity = regen
+            .global_id_of_ptr
+            .get(&key)
+            .ok_or(RemapError::MissingNewRow {
+                kind: "string global identity",
+                key,
+            })?;
+        if let Some(existing) = base
+            .global_ptr_of_id
+            .get(identity)
+            .and_then(|keys| keys.first().copied())
+        {
+            // Equal string-literal T5 rows are runtime-equivalent. Shipping contains thousands
+            // of aliases, so canonicalize a regenerated key to the stable smallest base key.
+            plan.global_ptrs.insert(key, existing);
+        } else {
+            plan.new_globals.insert(key);
+        }
+        return Ok(());
+    }
+    if regen.global_id_of_ptr.get(&key) == base.global_id_of_ptr.get(&key)
+        && regen.global_id_of_ptr.contains_key(&key)
+    {
+        plan.global_ptrs.insert(key, key);
+        return Ok(());
+    }
+    if !regen.global_id_of_ptr.contains_key(&key) && base.global_id_of_ptr.contains_key(&key) {
+        plan.global_ptrs.insert(key, key);
         return Ok(());
     }
     match match_base_ptr(
@@ -1716,6 +6780,8 @@ fn declare_global(
         &regen.global_name_of_ptr,
         &base.global_ptr_of_id,
         &base.global_ident_of_ptr,
+        &base_summaries.globals,
+        comparison_budget,
     )? {
         Some(vanilla) => {
             plan.global_ptrs.insert(key, vanilla);
@@ -1727,21 +6793,39 @@ fn declare_global(
     Ok(())
 }
 
-fn callee_name_from_regen<'a>(
+fn callee_name_from_effective<'a>(
     ins: &super::disasm::Instr,
     code: &[i32],
     regen: &'a SymTables,
+    base: &'a SymTables,
 ) -> Option<&'a str> {
     match ins.op.name {
-        "CALLSYS" | "FuncPtr" | "Thiscall1" => regen
-            .func_name_of_ptr
-            .get(&read_qw(code, ins.offset_dw + 1))
-            .map(String::as_str),
-        "CALL" | "CALLBND" | "CALLINTF" => regen
-            .funcid_to_ptr
-            .get(&code[ins.offset_dw + 1])
-            .and_then(|ptr| regen.func_name_of_ptr.get(ptr))
-            .map(String::as_str),
+        "CALLSYS" | "FuncPtr" | "Thiscall1" => {
+            let ptr = read_qw(code, ins.offset_dw + 1);
+            regen
+                .func_name_of_ptr
+                .get(&ptr)
+                .or_else(|| base.func_name_of_ptr.get(&ptr))
+                .map(String::as_str)
+        }
+        "CALL" | "CALLBND" | "CALLINTF" => {
+            let id = code[ins.offset_dw + 1];
+            (id != 0)
+                .then_some(id)
+                .and_then(|id| {
+                    regen
+                        .funcid_to_ptr
+                        .get(&id)
+                        .or_else(|| base.funcid_to_ptr.get(&id))
+                })
+                .and_then(|ptr| {
+                    regen
+                        .func_name_of_ptr
+                        .get(ptr)
+                        .or_else(|| base.func_name_of_ptr.get(ptr))
+                })
+                .map(String::as_str)
+        }
         _ => None,
     }
 }
@@ -1751,30 +6835,94 @@ fn analyze_bytecode_for_new_symbols(
     plan: &mut NewSymbolPlan,
     regen: &SymTables,
     base: &SymTables,
+    base_summaries: &SymbolIdentitySummaries,
+    comparison_budget: &mut IdentityComparisonBudget,
 ) -> Result<(), RemapError> {
     let instrs = disassemble(code).map_err(|e| RemapError::Disasm(e.to_string()))?;
     for (pos, ins) in instrs.iter().enumerate() {
+        if matches!(
+            ins.op.name,
+            "ADDSi" | "LoadThisR" | "LoadRObjR" | "LoadVObjR"
+        ) {
+            let raw_type_id = ins.dwords.first().copied().ok_or_else(|| {
+                RemapError::Disasm(format!(
+                    "{} is missing its owner type-id operand",
+                    ins.op.name
+                ))
+            })? as i32;
+            let member_offset = ins
+                .words
+                .last()
+                .copied()
+                .map(|word| i32::from(word as i16))
+                .ok_or_else(|| {
+                    RemapError::Disasm(format!(
+                        "{} is missing its member-offset operand",
+                        ins.op.name
+                    ))
+                })?;
+            let (owner_core_id, _) = split_type_id_operand(raw_type_id);
+            plan.used_property_sites
+                .insert((owner_core_id, member_offset));
+        }
         for site in ref_sites(ins.op.name) {
             let off = ins.offset_dw + site.dw_index;
             match site.kind {
-                RefKind::GlobalPtr => {
-                    declare_global(plan, read_qw(code, off), ins.op.name, regen, base)?
-                }
-                RefKind::FuncPtr => {
-                    declare_func(plan, read_qw(code, off), ins.op.name, regen, base)?
-                }
-                RefKind::TypePtr => {
-                    declare_type(plan, read_qw(code, off), ins.op.name, regen, base)?
-                }
+                RefKind::GlobalPtr => declare_global(
+                    plan,
+                    read_qw(code, off),
+                    ins.op.name,
+                    regen,
+                    base,
+                    base_summaries,
+                    comparison_budget,
+                )?,
+                RefKind::FuncPtr => declare_func(
+                    plan,
+                    read_qw(code, off),
+                    ins.op.name,
+                    regen,
+                    base,
+                    base_summaries,
+                    comparison_budget,
+                )?,
+                RefKind::TypePtr => declare_type(
+                    plan,
+                    read_qw(code, off),
+                    ins.op.name,
+                    regen,
+                    base,
+                    base_summaries,
+                    comparison_budget,
+                )?,
                 RefKind::FuncId => {
-                    if let Some(&ptr) = regen.funcid_to_ptr.get(&code[off]) {
-                        declare_func(plan, ptr, ins.op.name, regen, base)?;
+                    let id = code[off];
+                    if id != 0 {
+                        if let Some(&ptr) = regen.funcid_to_ptr.get(&id) {
+                            declare_func(
+                                plan,
+                                ptr,
+                                ins.op.name,
+                                regen,
+                                base,
+                                base_summaries,
+                                comparison_budget,
+                            )?;
+                        }
                     }
                 }
                 RefKind::TypeId => {
                     let (core, _) = split_type_id_operand(code[off]);
                     if let Some(&ptr) = regen.typeid_to_ptr.get(&core) {
-                        declare_type(plan, ptr, ins.op.name, regen, base)?;
+                        declare_type(
+                            plan,
+                            ptr,
+                            ins.op.name,
+                            regen,
+                            base,
+                            base_summaries,
+                            comparison_budget,
+                        )?;
                     }
                 }
             }
@@ -1789,7 +6937,7 @@ fn analyze_bytecode_for_new_symbols(
         } else if ins.op.name == "PshC4"
             && instrs
                 .get(pos + 1)
-                .and_then(|next| callee_name_from_regen(next, code, regen))
+                .and_then(|next| callee_name_from_effective(next, code, regen, base))
                 == Some("__STATIC_NAME")
         {
             plan.used_static_indices
@@ -1801,9 +6949,9 @@ fn analyze_bytecode_for_new_symbols(
 
 fn target_module_names(mini: &[u8]) -> Result<HashSet<String>, WireError> {
     let mut c = Cursor::at(mini, CacheHeader::SIZE);
-    let key = c.read_fstring()?;
+    c.read_fstring()?; // outer TMap key is not a declaring-module identity
     let inner = c.read_sia()?;
-    Ok([key, inner].into_iter().filter(|s| !s.is_empty()).collect())
+    Ok([inner].into_iter().filter(|s| !s.is_empty()).collect())
 }
 
 fn close_type_dependencies(
@@ -1811,34 +6959,77 @@ fn close_type_dependencies(
     meta: &TailMetadata,
     regen: &SymTables,
     base: &SymTables,
+    base_summaries: &SymbolIdentitySummaries,
+    comparison_budget: &mut IdentityComparisonBudget,
 ) -> Result<(), RemapError> {
-    loop {
-        let before = plan.new_types.len() + plan.type_ptrs.len();
-        let new_types: Vec<i64> = plan.new_types.iter().copied().collect();
-        for key in new_types {
-            let row = meta
-                .type_row(key)
-                .ok_or(RemapError::MissingNewRow { kind: "type", key })?;
-            for &(_, dep) in &row.type_deps {
-                if dep != 0 {
-                    declare_type(plan, dep, "TypeRef.SubTypes", regen, base)?;
-                }
+    let mut pending_types: VecDeque<i64> = plan.new_types.iter().copied().collect();
+    let new_funcs: Vec<i64> = plan.new_funcs.iter().copied().collect();
+    for key in new_funcs {
+        let row = meta.func_row(key).ok_or(RemapError::MissingNewRow {
+            kind: "function",
+            key,
+        })?;
+        if row.owner_dep.1 != 0 {
+            let dependency = row.owner_dep.1;
+            let was_new = plan.new_types.contains(&dependency);
+            declare_type(
+                plan,
+                dependency,
+                "FunctionReference.ObjectType",
+                regen,
+                base,
+                base_summaries,
+                comparison_budget,
+            )?;
+            if !was_new && plan.new_types.contains(&dependency) {
+                pending_types.push_back(dependency);
             }
         }
-        let new_funcs: Vec<i64> = plan.new_funcs.iter().copied().collect();
-        for key in new_funcs {
-            let row = meta.func_row(key).ok_or(RemapError::MissingNewRow {
-                kind: "function",
-                key,
-            })?;
-            for &(_, dep) in &row.type_deps {
-                if dep != 0 {
-                    declare_type(plan, dep, "FunctionReference.DataType", regen, base)?;
-                }
+        for dependency in row
+            .type_deps
+            .iter()
+            .map(|dep| dep.ptr)
+            .filter(|&ptr| ptr != 0)
+        {
+            let was_new = plan.new_types.contains(&dependency);
+            declare_type(
+                plan,
+                dependency,
+                "FunctionReference.DataType",
+                regen,
+                base,
+                base_summaries,
+                comparison_budget,
+            )?;
+            if !was_new && plan.new_types.contains(&dependency) {
+                pending_types.push_back(dependency);
             }
         }
-        if before == plan.new_types.len() + plan.type_ptrs.len() {
-            break;
+    }
+
+    while let Some(key) = pending_types.pop_front() {
+        let row = meta
+            .type_row(key)
+            .ok_or(RemapError::MissingNewRow { kind: "type", key })?;
+        for dependency in row
+            .type_deps
+            .iter()
+            .map(|dep| dep.ptr)
+            .filter(|&ptr| ptr != 0)
+        {
+            let was_new = plan.new_types.contains(&dependency);
+            declare_type(
+                plan,
+                dependency,
+                "TypeRef.SubTypes",
+                regen,
+                base,
+                base_summaries,
+                comparison_budget,
+            )?;
+            if !was_new && plan.new_types.contains(&dependency) {
+                pending_types.push_back(dependency);
+            }
         }
     }
     Ok(())
@@ -1850,10 +7041,20 @@ fn seed_target_module_symbols(
     targets: &HashSet<String>,
     regen: &SymTables,
     base: &SymTables,
+    base_summaries: &SymbolIdentitySummaries,
+    comparison_budget: &mut IdentityComparisonBudget,
 ) -> Result<(), RemapError> {
     for row in &meta.types {
         if targets.contains(&row.module) {
-            declare_type(plan, row.key, "target module TypeReferences", regen, base)?;
+            declare_type(
+                plan,
+                row.key,
+                "target module TypeReferences",
+                regen,
+                base,
+                base_summaries,
+                comparison_budget,
+            )?;
         }
     }
     for row in &meta.funcs {
@@ -1864,12 +7065,22 @@ fn seed_target_module_symbols(
                 "target module FunctionReferences",
                 regen,
                 base,
+                base_summaries,
+                comparison_budget,
             )?;
         }
     }
     for row in &meta.globals {
         if targets.contains(&row.module) {
-            declare_global(plan, row.key, "target module GlobalReferences", regen, base)?;
+            declare_global(
+                plan,
+                row.key,
+                "target module GlobalReferences",
+                regen,
+                base,
+                base_summaries,
+                comparison_budget,
+            )?;
         }
     }
     Ok(())
@@ -1887,28 +7098,166 @@ fn stable_hash64(kind: u8, identity: &str) -> u64 {
     h
 }
 
-fn allocate_synthetic_ptr(
-    kind: u8,
-    identity: &str,
-    used: &HashSet<i64>,
-) -> Result<i64, RemapError> {
-    // OldReference is an opaque serialized lookup key. Keep synthetic keys in a stable, positive
-    // high range that real Win64 heap pointers do not occupy, then linear-probe deterministically.
-    let mut candidate =
-        0x6000_0000_0000_0000u64 | (stable_hash64(kind, identity) & 0x0fff_ffff_ffff_ffff);
-    let start = candidate;
-    loop {
-        let signed = candidate as i64;
-        if signed != 0 && !used.contains(&signed) {
-            return Ok(signed);
+const SYNTHETIC_POINTER_HIGH: u64 = 0x6000_0000_0000_0000;
+const SYNTHETIC_POINTER_LOW_MASK: u64 = 0x0fff_ffff_ffff_fff8;
+const SYNTHETIC_POINTER_SLOT_HIGH: u64 = SYNTHETIC_POINTER_LOW_MASK >> 3;
+
+#[derive(Clone, Copy)]
+struct CanonicalAllocationDomains {
+    pointer_slot_high: u64,
+    type_sequence_high: u32,
+    function_id_high: u64,
+}
+
+const PRODUCTION_ALLOCATION_DOMAINS: CanonicalAllocationDomains = CanonicalAllocationDomains {
+    pointer_slot_high: SYNTHETIC_POINTER_SLOT_HIGH,
+    type_sequence_high: TYPE_ID_SEQUENCE_MASK,
+    function_id_high: i32::MAX as u64,
+};
+
+/// Occupied inclusive intervals over one finite integer domain. A lookup jumps directly to the
+/// end of the containing interval, so collision chains and wrap-around stay O(log n) instead of
+/// probing one occupied slot at a time.
+#[derive(Clone, Debug)]
+struct SuccessorAllocator {
+    low: u64,
+    high: u64,
+    occupied: BTreeMap<u64, u64>,
+    occupied_count: u128,
+}
+
+impl SuccessorAllocator {
+    fn new(low: u64, high: u64, occupied: impl IntoIterator<Item = u64>) -> Self {
+        assert!(low <= high, "invalid successor-allocation domain");
+        let mut allocator = Self {
+            low,
+            high,
+            occupied: BTreeMap::new(),
+            occupied_count: 0,
+        };
+        for value in occupied {
+            allocator.occupy(value);
         }
-        candidate = 0x6000_0000_0000_0000 | ((candidate + 1) & 0x0fff_ffff_ffff_ffff);
-        if candidate == start {
-            return Err(RemapError::KeySpaceExhausted {
-                kind: "OldReference",
-            });
+        allocator
+    }
+
+    fn domain_len(&self) -> u128 {
+        u128::from(self.high) - u128::from(self.low) + 1
+    }
+
+    fn occupy(&mut self, value: u64) {
+        if value < self.low || value > self.high {
+            return;
+        }
+        let left = self
+            .occupied
+            .range(..=value)
+            .next_back()
+            .map(|(&start, &end)| (start, end));
+        if left.is_some_and(|(_, end)| value <= end) {
+            return;
+        }
+        let right = self
+            .occupied
+            .range(value..)
+            .next()
+            .map(|(&start, &end)| (start, end));
+        let joins_left = left.is_some_and(|(_, end)| end.checked_add(1) == Some(value));
+        let joins_right = right.is_some_and(|(start, _)| value.checked_add(1) == Some(start));
+
+        match (left, right, joins_left, joins_right) {
+            (Some((left_start, _)), Some((right_start, right_end)), true, true) => {
+                self.occupied.remove(&right_start);
+                *self
+                    .occupied
+                    .get_mut(&left_start)
+                    .expect("left interval remains present") = right_end;
+            }
+            (Some((left_start, _)), _, true, false) => {
+                *self
+                    .occupied
+                    .get_mut(&left_start)
+                    .expect("left interval remains present") = value;
+            }
+            (_, Some((right_start, right_end)), false, true) => {
+                self.occupied.remove(&right_start);
+                self.occupied.insert(value, right_end);
+            }
+            _ => {
+                self.occupied.insert(value, value);
+            }
+        }
+        self.occupied_count += 1;
+    }
+
+    fn first_free_at_or_after(&self, candidate: u64) -> Option<u64> {
+        let containing = self
+            .occupied
+            .range(..=candidate)
+            .next_back()
+            .map(|(&start, &end)| (start, end));
+        match containing {
+            Some((_, end)) if candidate <= end => {
+                end.checked_add(1).filter(|&next| next <= self.high)
+            }
+            _ => Some(candidate),
         }
     }
+
+    fn allocate_from(&mut self, start: u64) -> Option<u64> {
+        if self.occupied_count >= self.domain_len() {
+            return None;
+        }
+        let start = start.clamp(self.low, self.high);
+        let candidate = self
+            .first_free_at_or_after(start)
+            .or_else(|| self.first_free_at_or_after(self.low))?;
+        self.occupy(candidate);
+        Some(candidate)
+    }
+}
+
+fn synthetic_pointer_slot(value: i64, slot_high: u64) -> Option<u64> {
+    let raw = value as u64;
+    if raw & !SYNTHETIC_POINTER_LOW_MASK != SYNTHETIC_POINTER_HIGH {
+        return None;
+    }
+    let slot = (raw & SYNTHETIC_POINTER_LOW_MASK) >> 3;
+    (slot <= slot_high).then_some(slot)
+}
+
+fn synthetic_pointer_start(kind: NovelPointerKind, identity: &str, slot_high: u64) -> u64 {
+    let hashed = stable_hash64(kind.hash_domain(), identity) >> 3;
+    if slot_high == SYNTHETIC_POINTER_SLOT_HIGH {
+        hashed & SYNTHETIC_POINTER_SLOT_HIGH
+    } else {
+        hashed % (slot_high + 1)
+    }
+}
+
+fn synthetic_pointer_from_slot(slot: u64) -> i64 {
+    (SYNTHETIC_POINTER_HIGH | (slot << 3)) as i64
+}
+
+fn allocate_synthetic_ptr(
+    kind: NovelPointerKind,
+    identity: &str,
+    allocator: &mut SuccessorAllocator,
+    domains: CanonicalAllocationDomains,
+) -> Result<i64, RemapError> {
+    // OldReference is an opaque serialized lookup key. Keep synthetic keys in a stable, positive
+    // high range that real Win64 heap pointers do not occupy, then select the same next free slot
+    // as the historical linear probe through the interval-backed successor allocator.
+    // T1/T3/T5 and the derived T7 property keys share one runtime pointer map. T7 keys are
+    // always odd; preserve real Win64 pointer alignment so synthetic keys cannot enter that
+    // derived-key domain.
+    let start = synthetic_pointer_start(kind, identity, domains.pointer_slot_high);
+    allocator
+        .allocate_from(start)
+        .map(synthetic_pointer_from_slot)
+        .ok_or(RemapError::KeySpaceExhausted {
+            kind: "OldReference",
+        })
 }
 
 fn allocate_new_pointer_keys(
@@ -1916,7 +7265,7 @@ fn allocate_new_pointer_keys(
     regen: &SymTables,
     base: &SymTables,
 ) -> Result<(), RemapError> {
-    let mut symbols: Vec<(u8, String, i64)> = Vec::new();
+    let mut symbols: Vec<(NovelPointerKind, String, i64)> = Vec::new();
     for &key in &plan.new_types {
         let identity =
             regen
@@ -1927,7 +7276,7 @@ fn allocate_new_pointer_keys(
                     kind: "type identity",
                     key,
                 })?;
-        symbols.push((0, identity, key));
+        symbols.push((NovelPointerKind::Type, identity, key));
     }
     for &key in &plan.new_funcs {
         let identity =
@@ -1939,7 +7288,7 @@ fn allocate_new_pointer_keys(
                     kind: "function identity",
                     key,
                 })?;
-        symbols.push((1, identity, key));
+        symbols.push((NovelPointerKind::Function, identity, key));
     }
     for &key in &plan.new_globals {
         let identity =
@@ -1951,80 +7300,171 @@ fn allocate_new_pointer_keys(
                     kind: "global identity",
                     key,
                 })?;
-        symbols.push((2, identity, key));
+        symbols.push((NovelPointerKind::Global, identity, key));
     }
     symbols.sort_by(|a, b| (a.0, &a.1, a.2).cmp(&(b.0, &b.1, b.2)));
 
-    let mut used = base.all_ptr_keys.clone();
+    let mut allocator = SuccessorAllocator::new(
+        0,
+        PRODUCTION_ALLOCATION_DOMAINS.pointer_slot_high,
+        base.all_ptr_keys.iter().filter_map(|&key| {
+            synthetic_pointer_slot(key, PRODUCTION_ALLOCATION_DOMAINS.pointer_slot_high)
+        }),
+    );
+    let mut string_global_assignments = HashMap::<String, i64>::new();
     for (kind, identity, raw) in symbols {
+        if kind == NovelPointerKind::Global
+            && regen
+                .global_is_string_of_ptr
+                .get(&raw)
+                .copied()
+                .unwrap_or(false)
+        {
+            if let Some(&assigned) = string_global_assignments.get(&identity) {
+                plan.global_ptrs.insert(raw, assigned);
+                continue;
+            }
+        }
         // Never retain a compiler-run-local raw OldReference merely because it is free in the
         // pristine base. Independent compiler runs recycle those first-free pointer values for
         // different symbols. Identity-derived allocation makes each mini converge on the same
         // key for the same symbol, independent of regen order or raw address assignment.
-        let final_key = allocate_synthetic_ptr(kind, &identity, &used)?;
-        used.insert(final_key);
+        let final_key = allocate_synthetic_ptr(
+            kind,
+            &identity,
+            &mut allocator,
+            PRODUCTION_ALLOCATION_DOMAINS,
+        )?;
         match kind {
-            0 => {
+            NovelPointerKind::Type => {
                 plan.type_ptrs.insert(raw, final_key);
             }
-            1 => {
+            NovelPointerKind::Function => {
                 plan.func_ptrs.insert(raw, final_key);
             }
-            _ => {
+            NovelPointerKind::Global => {
                 plan.global_ptrs.insert(raw, final_key);
+                if regen
+                    .global_is_string_of_ptr
+                    .get(&raw)
+                    .copied()
+                    .unwrap_or(false)
+                {
+                    string_global_assignments.insert(identity, final_key);
+                }
             }
         }
     }
     Ok(())
 }
 
-fn allocate_type_id(raw: i32, identity: &str, used: &HashSet<i32>) -> Result<i32, RemapError> {
-    // AngelScript reserves the upper six bits for object-kind flags and the lower 26 for the
-    // sequence number. Preserve the regen symbol's runtime-kind flags, but derive the sequence
-    // from portable identity: raw sequences are first-free values recycled by independent runs.
-    const SEQ_MASK: u32 = 0x03ff_ffff;
-    let bits = raw as u32;
-    let flags = bits & !SEQ_MASK;
-    let start_seq = stable_hash64(3, identity) as u32 & SEQ_MASK;
-    let mut seq = start_seq;
-    loop {
-        let candidate = (flags | seq) as i32;
-        if !used.contains(&candidate) {
-            return Ok(candidate);
-        }
-        seq = (seq + 1) & SEQ_MASK;
-        if seq == start_seq {
-            return Err(RemapError::KeySpaceExhausted { kind: "type-id" });
-        }
+fn type_sequence_start(identity: &str, sequence_high: u32) -> u64 {
+    let hashed = stable_hash64(3, identity) as u32 & TYPE_ID_SEQUENCE_MASK;
+    if sequence_high == TYPE_ID_SEQUENCE_MASK {
+        hashed.max(LAST_PRIMITIVE_TYPE_ID as u32 + 1) as u64
+    } else {
+        let low = LAST_PRIMITIVE_TYPE_ID as u32 + 1;
+        u64::from(low + hashed % (sequence_high - low + 1))
     }
 }
 
-fn allocate_function_id(identity: &str, used: &HashSet<i32>) -> Result<i32, RemapError> {
+fn allocate_type_id(
+    raw: i32,
+    identity: &str,
+    allocator: &mut SuccessorAllocator,
+    domains: CanonicalAllocationDomains,
+) -> Result<i32, RemapError> {
+    // T2 stores an unqualified core id: object-kind bits plus the lower 26-bit sequence. Handle
+    // qualifiers are operand-local and a qualified/negative T2 key is malformed.
+    let bits = raw as u32;
+    if !valid_type_id_core(raw) {
+        return Err(RemapError::InvalidTailRow {
+            table: 1,
+            row_key: raw as i64,
+            kind: "type-id key",
+            detail: "T2 keys must be unqualified non-primitive core ids".to_owned(),
+        });
+    }
+    let flags = bits & TYPE_ID_OBJECT_MASK;
+    let start = type_sequence_start(identity, domains.type_sequence_high);
+    let sequence = allocator
+        .allocate_from(start)
+        .ok_or(RemapError::KeySpaceExhausted { kind: "type-id" })?;
+    Ok((flags | sequence as u32) as i32)
+}
+
+fn function_id_start(identity: &str, id_high: u64) -> u64 {
+    let hashed = stable_hash64(4, identity) & i32::MAX as u64;
+    if id_high == i32::MAX as u64 {
+        hashed.max(1)
+    } else {
+        1 + hashed % id_high
+    }
+}
+
+fn allocate_function_id(
+    identity: &str,
+    allocator: &mut SuccessorAllocator,
+    domains: CanonicalAllocationDomains,
+) -> Result<i32, RemapError> {
     // Serialized function ids are non-negative i32 lookup keys (0 is a sentinel in several
-    // module-record arrays). Keep synthetic ids in the positive domain and probe deterministically
-    // only against the pristine base plus earlier symbols in this mini.
-    const ID_MASK: u64 = i32::MAX as u64;
-    let mut candidate = stable_hash64(4, identity) & ID_MASK;
-    if candidate == 0 {
-        candidate = 1;
-    }
-    let start = candidate;
-    loop {
-        let id = candidate as i32;
-        if !used.contains(&id) {
-            return Ok(id);
-        }
-        candidate = if candidate == ID_MASK {
-            1
-        } else {
-            candidate + 1
-        };
-        if candidate == start {
-            return Err(RemapError::KeySpaceExhausted {
-                kind: "function-id",
-            });
-        }
-    }
+    // module-record arrays). Keep synthetic ids in the positive domain and select the same next
+    // free id as the historical linear probe.
+    let start = function_id_start(identity, domains.function_id_high);
+    allocator
+        .allocate_from(start)
+        .map(|id| id as i32)
+        .ok_or(RemapError::KeySpaceExhausted {
+            kind: "function-id",
+        })
+}
+
+fn allocate_module_function_id(
+    identity: &str,
+    allocator: &mut SuccessorAllocator,
+    domains: CanonicalAllocationDomains,
+) -> Result<i32, RemapError> {
+    let hashed = stable_hash64(5, identity) & i32::MAX as u64;
+    let start = if domains.function_id_high == i32::MAX as u64 {
+        hashed.max(1)
+    } else {
+        1 + hashed % domains.function_id_high
+    };
+    allocator
+        .allocate_from(start)
+        .map(|id| id as i32)
+        .ok_or(RemapError::KeySpaceExhausted {
+            kind: "module Function.Id",
+        })
+}
+
+fn type_id_allocator(
+    object_kind: u32,
+    base: &SymTables,
+    domains: CanonicalAllocationDomains,
+) -> SuccessorAllocator {
+    SuccessorAllocator::new(
+        u64::from(LAST_PRIMITIVE_TYPE_ID as u32 + 1),
+        u64::from(domains.type_sequence_high),
+        base.typeid_to_ptr.keys().filter_map(|&id| {
+            let raw = id as u32;
+            ((raw & TYPE_ID_OBJECT_MASK) == object_kind)
+                .then_some(u64::from(raw & TYPE_ID_SEQUENCE_MASK))
+        }),
+    )
+}
+
+fn function_id_allocator(
+    base: &SymTables,
+    domains: CanonicalAllocationDomains,
+) -> SuccessorAllocator {
+    SuccessorAllocator::new(
+        1,
+        domains.function_id_high,
+        base.funcid_to_ptr
+            .keys()
+            .filter_map(|&id| u64::try_from(id).ok().filter(|&id| id != 0)),
+    )
 }
 
 fn allocate_engine_ids(
@@ -2033,20 +7473,32 @@ fn allocate_engine_ids(
     regen: &SymTables,
     base: &SymTables,
 ) -> Result<(), RemapError> {
-    let mut used_type_ids: HashSet<i32> = base.typeid_to_ptr.keys().copied().collect();
+    let mut type_allocators = BTreeMap::<u32, SuccessorAllocator>::new();
+    let mut selected_type_rows = Vec::with_capacity(plan.new_types.len());
     for &ptr in &plan.new_types {
-        if !meta.type_ids.iter().any(|row| row.ptr == ptr) {
-            return Err(RemapError::MissingNewRow {
-                kind: "type-id",
-                key: ptr,
-            });
+        match meta.type_id_by_ptr.get(&ptr) {
+            Some(UniqueRowIndex::Unique(index)) => selected_type_rows.push(*index),
+            Some(UniqueRowIndex::Ambiguous) => {
+                return Err(RemapError::InvalidTailRow {
+                    table: 1,
+                    row_key: ptr,
+                    kind: "reverse type-id mapping",
+                    detail: "a new type pointer must have exactly one T2 row".to_owned(),
+                });
+            }
+            None => {
+                return Err(RemapError::MissingNewRow {
+                    kind: "type-id",
+                    key: ptr,
+                });
+            }
         }
     }
-    for row in meta
-        .type_ids
-        .iter()
-        .filter(|row| plan.new_types.contains(&row.ptr))
-    {
+    // Preserve serialized T2 order so this resource fix does not change allocator collision
+    // semantics; allocator redesign is a separate loadout-wide tranche.
+    selected_type_rows.sort_unstable();
+    for index in selected_type_rows {
+        let row = &meta.type_ids[index];
         let identity = regen
             .type_id_of_ptr
             .get(&row.ptr)
@@ -2054,25 +7506,39 @@ fn allocate_engine_ids(
                 kind: "type identity",
                 key: row.ptr,
             })?;
-        let final_id = allocate_type_id(row.id, identity, &used_type_ids)?;
-        used_type_ids.insert(final_id);
+        let object_kind = row.id as u32 & TYPE_ID_OBJECT_MASK;
+        let allocator = type_allocators
+            .entry(object_kind)
+            .or_insert_with(|| type_id_allocator(object_kind, base, PRODUCTION_ALLOCATION_DOMAINS));
+        let final_id =
+            allocate_type_id(row.id, identity, allocator, PRODUCTION_ALLOCATION_DOMAINS)?;
         plan.type_ids.insert(row.id, final_id);
     }
 
-    let mut used_func_ids: HashSet<i32> = base.funcid_to_ptr.keys().copied().collect();
+    let mut func_allocator = function_id_allocator(base, PRODUCTION_ALLOCATION_DOMAINS);
+    let mut selected_func_rows = Vec::with_capacity(plan.new_funcs.len());
     for &ptr in &plan.new_funcs {
-        if !meta.func_ids.iter().any(|row| row.ptr == ptr) {
-            return Err(RemapError::MissingNewRow {
-                kind: "function-id",
-                key: ptr,
-            });
+        match meta.func_id_by_ptr.get(&ptr) {
+            Some(UniqueRowIndex::Unique(index)) => selected_func_rows.push(*index),
+            Some(UniqueRowIndex::Ambiguous) => {
+                return Err(RemapError::InvalidTailRow {
+                    table: 3,
+                    row_key: ptr,
+                    kind: "reverse function-id mapping",
+                    detail: "a new function pointer must have exactly one T4 row".to_owned(),
+                });
+            }
+            None => {
+                return Err(RemapError::MissingNewRow {
+                    kind: "function-id",
+                    key: ptr,
+                });
+            }
         }
     }
-    for row in meta
-        .func_ids
-        .iter()
-        .filter(|row| plan.new_funcs.contains(&row.ptr))
-    {
+    selected_func_rows.sort_unstable();
+    for index in selected_func_rows {
+        let row = &meta.func_ids[index];
         let identity = regen
             .func_id_of_ptr
             .get(&row.ptr)
@@ -2080,9 +7546,346 @@ fn allocate_engine_ids(
                 kind: "function identity",
                 key: row.ptr,
             })?;
-        let final_id = allocate_function_id(identity, &used_func_ids)?;
-        used_func_ids.insert(final_id);
+        let final_id =
+            allocate_function_id(identity, &mut func_allocator, PRODUCTION_ALLOCATION_DOMAINS)?;
         plan.func_ids.insert(row.id, final_id);
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn unique_type_id_row<'a>(
+    meta: &'a TailMetadata,
+    ptr: i64,
+) -> Result<&'a IdPtrRowMeta, RemapError> {
+    match meta.type_id_by_ptr.get(&ptr) {
+        Some(UniqueRowIndex::Unique(index)) => Ok(&meta.type_ids[*index]),
+        Some(UniqueRowIndex::Ambiguous) => Err(RemapError::InvalidTailRow {
+            table: 1,
+            row_key: ptr,
+            kind: "reverse type-id mapping",
+            detail: "a new type pointer must have exactly one T2 row".to_owned(),
+        }),
+        None => Err(RemapError::MissingNewRow {
+            kind: "type-id",
+            key: ptr,
+        }),
+    }
+}
+
+#[allow(dead_code)]
+fn unique_function_id_row<'a>(
+    meta: &'a TailMetadata,
+    ptr: i64,
+) -> Result<&'a IdPtrRowMeta, RemapError> {
+    match meta.func_id_by_ptr.get(&ptr) {
+        Some(UniqueRowIndex::Unique(index)) => Ok(&meta.func_ids[*index]),
+        Some(UniqueRowIndex::Ambiguous) => Err(RemapError::InvalidTailRow {
+            table: 3,
+            row_key: ptr,
+            kind: "reverse function-id mapping",
+            detail: "a new function pointer must have exactly one T4 row".to_owned(),
+        }),
+        None => Err(RemapError::MissingNewRow {
+            kind: "function-id",
+            key: ptr,
+        }),
+    }
+}
+
+#[allow(dead_code)]
+fn novel_identity_set(
+    plan: &NewSymbolPlan,
+    meta: &TailMetadata,
+    regen: &SymTables,
+    spans: &ModuleSpans,
+) -> Result<NovelIdentitySet, RemapError> {
+    let mut identities = NovelIdentitySet::default();
+    for &ptr in &plan.new_types {
+        let identity =
+            regen
+                .type_id_of_ptr
+                .get(&ptr)
+                .cloned()
+                .ok_or(RemapError::MissingNewRow {
+                    kind: "type identity",
+                    key: ptr,
+                })?;
+        let row = unique_type_id_row(meta, ptr)?;
+        if !valid_type_id_core(row.id) {
+            return Err(RemapError::InvalidTailRow {
+                table: 1,
+                row_key: row.id as i64,
+                kind: "type-id key",
+                detail: "T2 keys must be unqualified non-primitive core ids".to_owned(),
+            });
+        }
+        identities.pointers.insert(NovelPointerIdentity {
+            kind: NovelPointerKind::Type,
+            identity: identity.clone(),
+        });
+        let object_kind = row.id as u32 & TYPE_ID_OBJECT_MASK;
+        if let Some(first) = identities.type_ids.insert(identity.clone(), object_kind) {
+            if first != object_kind {
+                return Err(RemapError::LoadoutPlanTypeKindConflict {
+                    identity,
+                    first,
+                    second: object_kind,
+                });
+            }
+        }
+    }
+    for &ptr in &plan.new_funcs {
+        let identity =
+            regen
+                .func_id_of_ptr
+                .get(&ptr)
+                .cloned()
+                .ok_or(RemapError::MissingNewRow {
+                    kind: "function identity",
+                    key: ptr,
+                })?;
+        unique_function_id_row(meta, ptr)?;
+        identities.pointers.insert(NovelPointerIdentity {
+            kind: NovelPointerKind::Function,
+            identity: identity.clone(),
+        });
+        identities.function_ids.insert(identity);
+    }
+    for &ptr in &plan.new_globals {
+        let identity =
+            regen
+                .global_id_of_ptr
+                .get(&ptr)
+                .cloned()
+                .ok_or(RemapError::MissingNewRow {
+                    kind: "global identity",
+                    key: ptr,
+                })?;
+        identities.pointers.insert(NovelPointerIdentity {
+            kind: NovelPointerKind::Global,
+            identity,
+        });
+    }
+    identities.module_function_ids.extend(
+        spans
+            .function_id_sites
+            .iter()
+            .map(|site| site.identity.clone()),
+    );
+    Ok(identities)
+}
+
+#[allow(dead_code)]
+fn allocate_loadout_assignments(
+    base: &AllowNewBaseContext,
+    inventory: NovelIdentitySet,
+    domains: CanonicalAllocationDomains,
+) -> Result<
+    (
+        BTreeMap<NovelPointerIdentity, i64>,
+        BTreeMap<NovelTypeIdIdentity, i32>,
+        BTreeMap<String, i32>,
+        BTreeMap<String, i32>,
+    ),
+    RemapError,
+> {
+    if domains.type_sequence_high < LAST_PRIMITIVE_TYPE_ID as u32 + 1 {
+        return Err(RemapError::KeySpaceExhausted { kind: "type-id" });
+    }
+    if domains.function_id_high == 0 {
+        return Err(RemapError::KeySpaceExhausted {
+            kind: "function-id",
+        });
+    }
+
+    let NovelIdentitySet {
+        pointers,
+        type_ids,
+        function_ids,
+        module_function_ids,
+    } = inventory;
+
+    let mut pointer_allocator = SuccessorAllocator::new(
+        0,
+        domains.pointer_slot_high,
+        base.syms
+            .all_ptr_keys
+            .iter()
+            .filter_map(|&key| synthetic_pointer_slot(key, domains.pointer_slot_high)),
+    );
+    let mut pointer_assignments = BTreeMap::new();
+    for identity in pointers {
+        let assigned = allocate_synthetic_ptr(
+            identity.kind,
+            &identity.identity,
+            &mut pointer_allocator,
+            domains,
+        )?;
+        pointer_assignments.insert(identity, assigned);
+    }
+
+    let mut type_allocators = BTreeMap::<u32, SuccessorAllocator>::new();
+    let mut type_id_assignments = BTreeMap::new();
+    let mut type_identities: Vec<NovelTypeIdIdentity> = type_ids
+        .into_iter()
+        .map(|(identity, object_kind)| NovelTypeIdIdentity {
+            object_kind,
+            identity,
+        })
+        .collect();
+    type_identities.sort();
+    for identity in type_identities {
+        let allocator = type_allocators
+            .entry(identity.object_kind)
+            .or_insert_with(|| type_id_allocator(identity.object_kind, &base.syms, domains));
+        let raw = (identity.object_kind | (LAST_PRIMITIVE_TYPE_ID as u32 + 1)) as i32;
+        let assigned = allocate_type_id(raw, &identity.identity, allocator, domains)?;
+        type_id_assignments.insert(identity, assigned);
+    }
+
+    let mut function_allocator = function_id_allocator(&base.syms, domains);
+    let mut function_id_assignments = BTreeMap::new();
+    for identity in function_ids {
+        let assigned = allocate_function_id(&identity, &mut function_allocator, domains)?;
+        function_id_assignments.insert(identity, assigned);
+    }
+
+    // Module-record Function.Id is a separate AngelScript engine namespace from T4. Shipping has
+    // more than 100k declared module ids whose values have no T4 row, so allocate it separately
+    // while preserving an exact pristine declaration when editing a module.
+    let mut module_function_allocator = SuccessorAllocator::new(
+        1,
+        domains.function_id_high,
+        base.occupied_module_function_ids
+            .iter()
+            .filter_map(|&id| u64::try_from(id).ok().filter(|&id| id != 0)),
+    );
+    let mut module_function_id_assignments = BTreeMap::new();
+    for identity in module_function_ids {
+        let assigned = base
+            .module_function_ids
+            .get(&identity)
+            .copied()
+            .map(Ok)
+            .unwrap_or_else(|| {
+                allocate_module_function_id(&identity, &mut module_function_allocator, domains)
+            })?;
+        module_function_id_assignments.insert(identity, assigned);
+    }
+
+    Ok((
+        pointer_assignments,
+        type_id_assignments,
+        function_id_assignments,
+        module_function_id_assignments,
+    ))
+}
+
+#[allow(dead_code)]
+fn loadout_missing_assignment(kind: &'static str, identity: &str) -> RemapError {
+    RemapError::LoadoutPlanMissingAssignment {
+        kind,
+        identity: identity.to_owned(),
+    }
+}
+
+#[allow(dead_code)]
+fn apply_loadout_assignments(
+    local: &mut NewSymbolPlan,
+    meta: &TailMetadata,
+    regen: &SymTables,
+    spans: &ModuleSpans,
+    loadout: &LoadoutScriptIdPlan,
+) -> Result<(), RemapError> {
+    for &raw in &local.new_types {
+        let identity = regen
+            .type_id_of_ptr
+            .get(&raw)
+            .ok_or(RemapError::MissingNewRow {
+                kind: "type identity",
+                key: raw,
+            })?;
+        let pointer_identity = NovelPointerIdentity {
+            kind: NovelPointerKind::Type,
+            identity: identity.clone(),
+        };
+        let pointer = loadout
+            .pointer_assignments
+            .get(&pointer_identity)
+            .copied()
+            .ok_or_else(|| loadout_missing_assignment("type pointer", identity))?;
+        local.type_ptrs.insert(raw, pointer);
+
+        let row = unique_type_id_row(meta, raw)?;
+        let type_identity = NovelTypeIdIdentity {
+            object_kind: row.id as u32 & TYPE_ID_OBJECT_MASK,
+            identity: identity.clone(),
+        };
+        let type_id = loadout
+            .type_id_assignments
+            .get(&type_identity)
+            .copied()
+            .ok_or_else(|| loadout_missing_assignment("type-id", identity))?;
+        local.type_ids.insert(row.id, type_id);
+    }
+
+    for &raw in &local.new_funcs {
+        let identity = regen
+            .func_id_of_ptr
+            .get(&raw)
+            .ok_or(RemapError::MissingNewRow {
+                kind: "function identity",
+                key: raw,
+            })?;
+        let pointer_identity = NovelPointerIdentity {
+            kind: NovelPointerKind::Function,
+            identity: identity.clone(),
+        };
+        let pointer = loadout
+            .pointer_assignments
+            .get(&pointer_identity)
+            .copied()
+            .ok_or_else(|| loadout_missing_assignment("function pointer", identity))?;
+        local.func_ptrs.insert(raw, pointer);
+
+        let row = unique_function_id_row(meta, raw)?;
+        let function_id = loadout
+            .function_id_assignments
+            .get(identity)
+            .copied()
+            .ok_or_else(|| loadout_missing_assignment("function-id", identity))?;
+        local.func_ids.insert(row.id, function_id);
+    }
+
+    for &raw in &local.new_globals {
+        let identity = regen
+            .global_id_of_ptr
+            .get(&raw)
+            .ok_or(RemapError::MissingNewRow {
+                kind: "global identity",
+                key: raw,
+            })?;
+        let pointer_identity = NovelPointerIdentity {
+            kind: NovelPointerKind::Global,
+            identity: identity.clone(),
+        };
+        let pointer = loadout
+            .pointer_assignments
+            .get(&pointer_identity)
+            .copied()
+            .ok_or_else(|| loadout_missing_assignment("global pointer", identity))?;
+        local.global_ptrs.insert(raw, pointer);
+    }
+    for site in &spans.function_id_sites {
+        let assigned = loadout
+            .module_function_id_assignments
+            .get(&site.identity)
+            .copied()
+            .ok_or_else(|| loadout_missing_assignment("module Function.Id", &site.identity))?;
+        local
+            .module_function_ids
+            .insert(site.identity.clone(), assigned);
     }
     Ok(())
 }
@@ -2134,14 +7937,17 @@ fn mapped_type_id(
         return Ok(raw); // primitive / non-reference
     };
     let final_ptr = mapped_type_ptr(plan, regen_ptr)?;
-    let final_core =
-        base.ptr_to_typeid
-            .get(&final_ptr)
-            .copied()
-            .ok_or(RemapError::MissingNewRow {
-                kind: "base type-id",
-                key: final_ptr,
-            })?;
+    if base.typeid_to_ptr.get(&core) == Some(&final_ptr) {
+        return Ok(apply_type_id_operand_flags(core, flags));
+    }
+    let final_core = base
+        .ptr_kind_to_typeid
+        .get(&(final_ptr, core as u32 & TYPE_ID_OBJECT_MASK))
+        .copied()
+        .ok_or(RemapError::MissingNewRow {
+            kind: "base type-id",
+            key: final_ptr,
+        })?;
     Ok(apply_type_id_operand_flags(final_core, flags))
 }
 
@@ -2151,6 +7957,9 @@ fn mapped_func_id(
     regen: &SymTables,
     base: &SymTables,
 ) -> Result<i32, RemapError> {
+    if raw == 0 {
+        return Ok(0); // null reference sentinel; a real T4 definition may still use key zero.
+    }
     if let Some(&id) = plan.func_ids.get(&raw) {
         return Ok(id);
     }
@@ -2158,13 +7967,59 @@ fn mapped_func_id(
         return Ok(raw); // sentinel / behavior tag
     };
     let final_ptr = mapped_func_ptr(plan, regen_ptr)?;
+    if base.funcid_to_ptr.get(&raw) == Some(&final_ptr) {
+        return Ok(raw);
+    }
     base.ptr_to_funcid
         .get(&final_ptr)
+        .filter(|&&id| id != 0)
         .copied()
         .ok_or(RemapError::MissingNewRow {
             kind: "base function-id",
             key: final_ptr,
         })
+}
+
+fn resolve_embedded_regen_func_id(raw: i64, regen: &SymTables) -> Result<(i32, i64), RemapError> {
+    let id = i32::try_from(raw).map_err(|_| RemapError::UnresolvedEffectiveReference {
+        kind: "embedded function id",
+        op: "Factory/BehaviorRefs",
+        key: raw,
+    })?;
+    let ptr =
+        regen
+            .funcid_to_ptr
+            .get(&id)
+            .copied()
+            .ok_or(RemapError::UnresolvedEffectiveReference {
+                kind: "embedded function id",
+                op: "Factory/BehaviorRefs",
+                key: raw,
+            })?;
+    Ok((id, ptr))
+}
+
+fn resolve_embedded_effective_func_id(
+    raw: i64,
+    regen: &SymTables,
+    base: &SymTables,
+) -> Result<(i32, i64), RemapError> {
+    let id = i32::try_from(raw).map_err(|_| RemapError::UnresolvedEffectiveReference {
+        kind: "embedded function id",
+        op: "Factory/BehaviorRefs",
+        key: raw,
+    })?;
+    let ptr = regen
+        .funcid_to_ptr
+        .get(&id)
+        .or_else(|| base.funcid_to_ptr.get(&id))
+        .copied()
+        .ok_or(RemapError::UnresolvedEffectiveReference {
+            kind: "embedded function id",
+            op: "Factory/BehaviorRefs",
+            key: raw,
+        })?;
+    Ok((id, ptr))
 }
 
 fn plan_static_names(
@@ -2225,14 +8080,15 @@ fn plan_properties(
     let mut selected_keys = HashSet::new();
 
     for row in &regen_meta.properties {
-        let Some(&owner_ptr) = regen.typeid_to_ptr.get(&row.old_type_id) else {
-            continue;
-        };
-        let owner_is_new = plan.new_types.contains(&owner_ptr);
-        let owner_is_target = type_module
-            .get(&owner_ptr)
+        let owner_ptr = regen.typeid_to_ptr.get(&row.old_type_id).copied();
+        let owner_is_new = owner_ptr.is_some_and(|ptr| plan.new_types.contains(&ptr));
+        let owner_is_target = owner_ptr
+            .and_then(|ptr| type_module.get(&ptr))
             .is_some_and(|module| targets.contains(*module));
-        if !owner_is_new && !owner_is_target {
+        let property_is_used = plan
+            .used_property_sites
+            .contains(&(row.old_type_id, row.member_offset));
+        if !owner_is_new && !owner_is_target && !property_is_used {
             continue;
         }
         let final_id = mapped_type_id(plan, row.old_type_id, regen, base)?;
@@ -2257,6 +8113,16 @@ fn plan_properties(
             key: final_key,
             type_id: final_id,
         });
+    }
+    for &(owner_type_id, member_offset) in &plan.used_property_sites {
+        let final_id = mapped_type_id(plan, owner_type_id, regen, base)?;
+        let final_key = property_key(final_id, member_offset);
+        if !base_by_key.contains_key(&final_key) && !selected_keys.contains(&final_key) {
+            return Err(RemapError::MissingNewRow {
+                kind: "property",
+                key: property_key(owner_type_id, member_offset),
+            });
+        }
     }
     Ok(())
 }
@@ -2285,7 +8151,7 @@ fn patch_bytecode_with_new_symbols(
         } else if ins.op.name == "PshC4"
             && instrs
                 .get(pos + 1)
-                .and_then(|next| callee_name_from_regen(next, &original, regen))
+                .and_then(|next| callee_name_from_effective(next, &original, regen, base))
                 == Some("__STATIC_NAME")
         {
             let raw = original[ins.offset_dw + 1] as i64;
@@ -2315,7 +8181,9 @@ fn patch_bytecode_with_new_symbols(
                 }
                 RefKind::FuncId => {
                     code[off] = mapped_func_id(plan, original[off], regen, base)?;
-                    counts.func_id += usize::from(regen.funcid_to_ptr.contains_key(&original[off]));
+                    counts.func_id += usize::from(
+                        original[off] != 0 && regen.funcid_to_ptr.contains_key(&original[off]),
+                    );
                 }
                 RefKind::TypeId => {
                     code[off] = mapped_type_id(plan, original[off], regen, base)?;
@@ -2331,6 +8199,35 @@ fn patch_bytecode_with_new_symbols(
 fn patch_i64_at(row: &mut [u8], row_start: usize, absolute: usize, value: i64) {
     let rel = absolute - row_start;
     row[rel..rel + 8].copy_from_slice(&value.to_le_bytes());
+}
+
+fn append_canonical_sia(out: &mut Vec<u8>, value: &str) -> Result<(), RemapError> {
+    if value.is_empty() {
+        out.extend_from_slice(&0i32.to_le_bytes());
+        return Ok(());
+    }
+    let length = i32::try_from(value.len()).map_err(|_| WireError::BadLen {
+        pos: 0,
+        len: i64::MAX,
+        field: "canonical string-global identity",
+    })?;
+    out.extend_from_slice(&length.to_le_bytes());
+    out.extend_from_slice(value.as_bytes());
+    out.push(0);
+    Ok(())
+}
+
+fn append_canonical_string_global(
+    out: &mut Vec<u8>,
+    key: i64,
+    value: &str,
+) -> Result<(), RemapError> {
+    out.extend_from_slice(&key.to_le_bytes());
+    append_canonical_sia(out, value)?;
+    append_canonical_sia(out, "")?; // runtime ignores Module for bIsString
+    append_canonical_sia(out, "")?; // Namespace is not part of literal identity
+    out.extend_from_slice(&1i32.to_le_bytes());
+    Ok(())
 }
 
 fn emit_minimal_new_symbol_tail(
@@ -2354,8 +8251,13 @@ fn emit_minimal_new_symbol_tail(
             row.start,
             mapped_type_ptr(plan, row.key)?,
         );
-        for &(off, dep) in &row.type_deps {
-            patch_i64_at(&mut bytes, row.start, off, mapped_type_ptr(plan, dep)?);
+        for &dep in &row.type_deps {
+            patch_i64_at(
+                &mut bytes,
+                row.start,
+                dep.off,
+                mapped_type_ptr(plan, dep.ptr)?,
+            );
         }
         out.extend_from_slice(&bytes);
     }
@@ -2397,8 +8299,19 @@ fn emit_minimal_new_symbol_tail(
             row.start,
             mapped_func_ptr(plan, row.key)?,
         );
-        for &(off, dep) in &row.type_deps {
-            patch_i64_at(&mut bytes, row.start, off, mapped_type_ptr(plan, dep)?);
+        patch_i64_at(
+            &mut bytes,
+            row.start,
+            row.owner_dep.0,
+            mapped_type_ptr(plan, row.owner_dep.1)?,
+        );
+        for &dep in &row.type_deps {
+            patch_i64_at(
+                &mut bytes,
+                row.start,
+                dep.off,
+                mapped_type_ptr(plan, dep.ptr)?,
+            );
         }
         out.extend_from_slice(&bytes);
     }
@@ -2426,20 +8339,26 @@ fn emit_minimal_new_symbol_tail(
         out.extend_from_slice(&bytes);
     }
 
-    let selected_globals: Vec<&GlobalRowMeta> = meta
-        .globals
-        .iter()
-        .filter(|row| plan.new_globals.contains(&row.key))
-        .collect();
+    let mut selected_globals = Vec::<(&GlobalRowMeta, i64)>::new();
+    let mut selected_string_keys = HashSet::new();
+    for row in &meta.globals {
+        if !plan.new_globals.contains(&row.key) {
+            continue;
+        }
+        let key = mapped_global_ptr(plan, row.key)?;
+        if row.is_string && !selected_string_keys.insert(key) {
+            continue;
+        }
+        selected_globals.push((row, key));
+    }
     out.extend_from_slice(&(selected_globals.len() as u32).to_le_bytes());
-    for row in selected_globals {
+    for (row, key) in selected_globals {
+        if row.is_string {
+            append_canonical_string_global(&mut out, key, &row.name)?;
+            continue;
+        }
         let mut bytes = source[row.start..row.end].to_vec();
-        patch_i64_at(
-            &mut bytes,
-            row.start,
-            row.start,
-            mapped_global_ptr(plan, row.key)?,
-        );
+        patch_i64_at(&mut bytes, row.start, row.start, key);
         out.extend_from_slice(&bytes);
     }
 
@@ -2480,71 +8399,248 @@ fn emit_minimal_new_symbol_tail(
     Ok(out)
 }
 
-fn remap_module_allow_new(
-    extracted_mini: &[u8],
-    base: &[u8],
-) -> Result<(Vec<u8>, RemapCounts), RemapError> {
-    let mini_n = super::walk_modules::module_count(extracted_mini);
-    if mini_n != 1 {
-        return Err(RemapError::NotSingle(mini_n));
+struct AllowNewBaseContext {
+    syms: SymTables,
+    meta: TailMetadata,
+    identity_summaries: SymbolIdentitySummaries,
+    module_authorities: HashSet<String>,
+    declarations: PristineDeclarationAuthority,
+    module_function_ids: HashMap<String, i32>,
+    occupied_module_function_ids: HashSet<i32>,
+    source_bytes: usize,
+}
+
+fn build_allow_new_base_context(base: &[u8]) -> Result<AllowNewBaseContext, RemapError> {
+    let syms = SymTables::build(base)?;
+    let meta = TailMetadata::build(base)?;
+    let identity_summaries = SymbolIdentitySummaries {
+        types: IdentityReverseSummary::build(&syms.type_ident_of_ptr)?,
+        functions: IdentityReverseSummary::build(&syms.func_ident_of_ptr)?,
+        globals: IdentityReverseSummary::build_filtered(&syms.global_ident_of_ptr, |key| {
+            !syms
+                .global_is_string_of_ptr
+                .get(&key)
+                .copied()
+                .unwrap_or(false)
+        })?,
+    };
+    let module_authorities = inner_module_names(base)?;
+    let mut comparison_budget =
+        IdentityComparisonBudget::new(base.len().saturating_add(syms.identity_bytes));
+    let collected =
+        collect_declaration_inventory(base, &syms, None, None, &meta, &mut comparison_budget)?;
+    let CollectedDeclarationInventory {
+        declarations: declaration_inventory,
+        function_id_sites,
+    } = collected;
+    let mut module_function_ids = HashMap::new();
+    let mut occupied_module_function_ids = HashSet::new();
+    for site in function_id_sites {
+        let id = i32::from_le_bytes(base[site.byte_off..site.byte_off + 4].try_into().unwrap());
+        module_function_ids.insert(site.identity, id);
+        occupied_module_function_ids.insert(id);
     }
+    let declarations = PristineDeclarationAuthority::build(
+        &meta,
+        &syms,
+        declaration_inventory,
+        &mut comparison_budget,
+    )?;
+    Ok(AllowNewBaseContext {
+        syms,
+        meta,
+        identity_summaries,
+        module_authorities,
+        declarations,
+        module_function_ids,
+        occupied_module_function_ids,
+        source_bytes: base.len(),
+    })
+}
 
-    let regen = SymTables::build(extracted_mini)?;
-    let base_syms = SymTables::build(base)?;
-    let regen_meta = TailMetadata::build(extracted_mini)?;
-    let base_meta = TailMetadata::build(base)?;
-    let spans = collect_module_spans(extracted_mini)?;
+struct AnalyzedNewSymbolMini {
+    regen: SymTables,
+    meta: TailMetadata,
+    spans: ModuleSpans,
+    targets: HashSet<String>,
+    current_declarations: DeclarationInventory,
+    plan: NewSymbolPlan,
+    comparison_budget: IdentityComparisonBudget,
+}
+
+fn analyze_new_symbol_mini(
+    extracted_mini: &[u8],
+    base: &AllowNewBaseContext,
+) -> Result<AnalyzedNewSymbolMini, RemapError> {
+    let total_source_bytes = base.source_bytes.checked_add(extracted_mini.len()).ok_or(
+        WireError::IdentityBudgetExceeded {
+            max: MAX_IDENTITY_BUDGET,
+        },
+    )?;
+    let regen = SymTables::build_with_type_fallback_and_budget(
+        extracted_mini,
+        &base.syms,
+        total_source_bytes,
+        base.syms.identity_bytes,
+    )?;
+    let meta = TailMetadata::build(extracted_mini)?;
+    let mut comparison_budget = IdentityComparisonBudget::new(
+        total_source_bytes
+            .saturating_add(regen.identity_bytes)
+            .saturating_add(base.declarations.declarations.bytes),
+    );
+    let collected = collect_declaration_inventory(
+        extracted_mini,
+        &regen,
+        Some(&base.syms),
+        Some(&base.declarations.script_owners),
+        &meta,
+        &mut comparison_budget,
+    )?;
+    let current_declarations = collected.declarations;
+    let mut spans = collect_module_spans(extracted_mini)?;
+    spans.function_id_sites = collected.function_id_sites;
     let targets = target_module_names(extracted_mini)?;
-
-    let mod_start = CacheHeader::SIZE;
-    let mod_end = module_region_end(extracted_mini)?;
-    let mut module_bytes = extracted_mini[mod_start..mod_end].to_vec();
     let mut plan = NewSymbolPlan::default();
 
     // A declaration can be new even when no bytecode calls it yet. Seed every row declared by the
     // edited module, then add all directly referenced symbols and recursively close type deps.
-    seed_target_module_symbols(&mut plan, &regen_meta, &targets, &regen, &base_syms)?;
+    seed_target_module_symbols(
+        &mut plan,
+        &meta,
+        &targets,
+        &regen,
+        &base.syms,
+        &base.identity_summaries,
+        &mut comparison_budget,
+    )?;
     for span in &spans.code {
-        let rel = span.data_off - mod_start;
         let code: Vec<i32> = (0..span.count)
             .map(|k| {
-                let off = rel + k * 4;
-                i32::from_le_bytes(module_bytes[off..off + 4].try_into().unwrap())
+                let off = span.data_off + k * 4;
+                i32::from_le_bytes(extracted_mini[off..off + 4].try_into().unwrap())
             })
             .collect();
-        analyze_bytecode_for_new_symbols(&code, &mut plan, &regen, &base_syms)?;
+        analyze_bytecode_for_new_symbols(
+            &code,
+            &mut plan,
+            &regen,
+            &base.syms,
+            &base.identity_summaries,
+            &mut comparison_budget,
+        )?;
     }
     for embed in &spans.embeds {
-        let rel = embed.byte_off - mod_start;
-        let raw = i64::from_le_bytes(module_bytes[rel..rel + 8].try_into().unwrap());
+        let raw = i64::from_le_bytes(
+            extracted_mini[embed.byte_off..embed.byte_off + 8]
+                .try_into()
+                .unwrap(),
+        );
         if raw == 0 {
             continue;
         }
         match embed.kind {
-            EmbedKind::TypePtr => {
-                declare_type(&mut plan, raw, "embedded DataType", &regen, &base_syms)?
-            }
+            EmbedKind::TypePtr(_) => declare_type(
+                &mut plan,
+                raw,
+                "embedded DataType",
+                &regen,
+                &base.syms,
+                &base.identity_summaries,
+                &mut comparison_budget,
+            )?,
             EmbedKind::FuncId => {
-                if let Some(&ptr) = regen.funcid_to_ptr.get(&(raw as i32)) {
-                    declare_func(&mut plan, ptr, "Factory/BehaviorRefs", &regen, &base_syms)?;
-                }
+                let (_, ptr) = resolve_embedded_effective_func_id(raw, &regen, &base.syms)?;
+                declare_func(
+                    &mut plan,
+                    ptr,
+                    "Factory/BehaviorRefs",
+                    &regen,
+                    &base.syms,
+                    &base.identity_summaries,
+                    &mut comparison_budget,
+                )?;
             }
         }
     }
-    close_type_dependencies(&mut plan, &regen_meta, &regen, &base_syms)?;
-    allocate_new_pointer_keys(&mut plan, &regen, &base_syms)?;
-    allocate_engine_ids(&mut plan, &regen_meta, &regen, &base_syms)?;
-    plan_static_names(&mut plan, &regen_meta, &base_meta)?;
-    plan_properties(
+    close_type_dependencies(
         &mut plan,
-        &regen_meta,
-        &base_meta,
-        &targets,
+        &meta,
         &regen,
-        &base_syms,
+        &base.syms,
+        &base.identity_summaries,
+        &mut comparison_budget,
+    )?;
+    validate_novel_declaration_membership(
+        &meta,
+        &regen,
+        &base.syms,
+        &base.declarations,
+        &current_declarations,
+        |module| base.module_authorities.contains(module) || targets.contains(module),
+        |key| plan.new_types.contains(&key),
+        |key| plan.new_funcs.contains(&key),
+        |key| plan.new_globals.contains(&key),
+        &mut comparison_budget,
+    )?;
+    Ok(AnalyzedNewSymbolMini {
+        regen,
+        meta,
+        spans,
+        targets,
+        current_declarations,
+        plan,
+        comparison_budget,
+    })
+}
+
+fn finish_new_symbol_remap(
+    extracted_mini: &[u8],
+    pristine_header: &[u8],
+    base: &AllowNewBaseContext,
+    analyzed: AnalyzedNewSymbolMini,
+) -> Result<(Vec<u8>, RemapCounts), RemapError> {
+    let AnalyzedNewSymbolMini {
+        regen,
+        meta,
+        spans,
+        targets,
+        current_declarations,
+        mut plan,
+        mut comparison_budget,
+    } = analyzed;
+
+    plan_static_names(&mut plan, &meta, &base.meta)?;
+    plan_properties(&mut plan, &meta, &base.meta, &targets, &regen, &base.syms)?;
+    let selected_property_indices: HashSet<usize> = plan
+        .selected_properties
+        .iter()
+        .map(|row| row.index)
+        .collect();
+    validate_novel_property_membership(
+        &meta,
+        &regen,
+        &base.syms,
+        &base.declarations,
+        &current_declarations,
+        |row| {
+            selected_property_indices.contains(&row.index)
+                && !has_pristine_property_identity(row, &regen, &base.syms, &base.declarations)
+        },
+        &mut comparison_budget,
     )?;
 
+    let mod_start = CacheHeader::SIZE;
+    let mod_end = module_region_end(extracted_mini)?;
+    let mut module_bytes = extracted_mini[mod_start..mod_end].to_vec();
     let mut total = RemapCounts::default();
+    for site in &spans.function_id_sites {
+        let Some(&assigned) = plan.module_function_ids.get(&site.identity) else {
+            continue;
+        };
+        let rel = site.byte_off - mod_start;
+        module_bytes[rel..rel + 4].copy_from_slice(&assigned.to_le_bytes());
+    }
     for span in &spans.code {
         let rel = span.data_off - mod_start;
         let mut code: Vec<i32> = (0..span.count)
@@ -2553,7 +8649,7 @@ fn remap_module_allow_new(
                 i32::from_le_bytes(module_bytes[off..off + 4].try_into().unwrap())
             })
             .collect();
-        let counts = patch_bytecode_with_new_symbols(&mut code, &plan, &regen, &base_syms)?;
+        let counts = patch_bytecode_with_new_symbols(&mut code, &plan, &regen, &base.syms)?;
         total.add(&counts);
         for (k, &dw) in code.iter().enumerate() {
             let off = rel + k * 4;
@@ -2568,19 +8664,16 @@ fn remap_module_allow_new(
             continue;
         }
         match embed.kind {
-            EmbedKind::TypePtr => {
+            EmbedKind::TypePtr(_) => {
                 module_bytes[rel..rel + 8]
                     .copy_from_slice(&mapped_type_ptr(&plan, raw)?.to_le_bytes());
                 total.embed_type_ptr += 1;
             }
             EmbedKind::FuncId => {
-                let raw_id = raw as i32;
-                if regen.funcid_to_ptr.contains_key(&raw_id) {
-                    let mapped = mapped_func_id(&plan, raw_id, &regen, &base_syms)?;
-                    let value = (raw & !0xffff_ffffi64) | mapped as u32 as i64;
-                    module_bytes[rel..rel + 8].copy_from_slice(&value.to_le_bytes());
-                    total.embed_func_id += 1;
-                }
+                let (raw_id, _) = resolve_embedded_effective_func_id(raw, &regen, &base.syms)?;
+                let mapped = mapped_func_id(&plan, raw_id, &regen, &base.syms)?;
+                module_bytes[rel..rel + 8].copy_from_slice(&i64::from(mapped).to_le_bytes());
+                total.embed_func_id += 1;
             }
         }
     }
@@ -2603,7 +8696,7 @@ fn remap_module_allow_new(
             allowed_new_raw.insert(raw);
         }
     }
-    let surviving: Vec<SurvivingKey> = scan_surviving_regen_keys(&module_bytes, &regen, &base_syms)
+    let surviving: Vec<SurvivingKey> = scan_surviving_regen_keys(&module_bytes, &regen, &base.syms)
         .into_iter()
         .filter(|hit| !allowed_new_raw.contains(&hit.value))
         .collect();
@@ -2621,13 +8714,284 @@ fn remap_module_allow_new(
         });
     }
 
-    let tail = emit_minimal_new_symbol_tail(extracted_mini, &regen_meta, &plan)?;
+    let tail = emit_minimal_new_symbol_tail(extracted_mini, &meta, &plan)?;
     let mut out = Vec::with_capacity(CacheHeader::SIZE + module_bytes.len() + tail.len());
-    out.extend_from_slice(&extracted_mini[..0x14]);
+    // A prepared mini is generation-bound to the exact target cache. This also makes the
+    // low-level extract-remap output directly consumable by the strict sequential guard.
+    out.extend_from_slice(&pristine_header[..0x14]);
     out.extend_from_slice(&1u32.to_le_bytes());
     out.extend_from_slice(&module_bytes);
     out.extend_from_slice(&tail);
     Ok((out, total))
+}
+
+#[allow(dead_code)]
+fn sha256_bytes(bytes: &[u8]) -> [u8; 32] {
+    Sha256::digest(bytes).into()
+}
+
+#[allow(dead_code)]
+fn loadout_cache_header(bytes: &[u8], artifact: &'static str) -> Result<CacheHeader, RemapError> {
+    CacheHeader::parse(bytes).map_err(|error| RemapError::LoadoutPlanInvalidHeader {
+        artifact,
+        detail: error.to_string(),
+    })
+}
+
+#[allow(dead_code)]
+impl LoadoutScriptIdPlanBuilder {
+    /// Parse and retain the pristine base context exactly once. Mini bytes are never retained by
+    /// the builder and may be dropped immediately after [`Self::inspect`] returns.
+    pub(super) fn new(pristine_base: &[u8]) -> Result<Self, RemapError> {
+        Self::new_with_config(
+            pristine_base,
+            PRODUCTION_LOADOUT_PLAN_LIMITS,
+            PRODUCTION_ALLOCATION_DOMAINS,
+        )
+    }
+
+    fn new_with_config(
+        pristine_base: &[u8],
+        limits: LoadoutPlanLimits,
+        domains: CanonicalAllocationDomains,
+    ) -> Result<Self, RemapError> {
+        let header = loadout_cache_header(pristine_base, "pristine base")?;
+        preflight_cache_module_work(pristine_base)?;
+        let mut pristine_header = [0u8; 0x14];
+        pristine_header.copy_from_slice(&pristine_base[..0x14]);
+        let base = Arc::new(build_allow_new_base_context(pristine_base)?);
+        let effective_base = Arc::new(EffectiveReferenceBase::from_allow_new_base(Arc::clone(
+            &base,
+        ))?);
+        Ok(Self {
+            pristine_base_sha256: sha256_bytes(pristine_base),
+            pristine_guid: header.hash,
+            pristine_header,
+            base,
+            effective_base,
+            inspected_count: 0,
+            inspected_minis: HashMap::new(),
+            inventory: NovelIdentitySet::default(),
+            assignment_entries: 0,
+            identity_bytes: 0,
+            limits,
+            domains,
+        })
+    }
+
+    /// Validate and add one mini atomically. No builder state changes until the complete semantic
+    /// inspection and all cumulative resource checks have succeeded.
+    pub(super) fn inspect(&mut self, mini: &[u8]) -> Result<(), RemapError> {
+        let header = loadout_cache_header(mini, "mini")?;
+        if header.hash != self.pristine_guid {
+            return Err(RemapError::LoadoutPlanGuidMismatch {
+                pristine: self.pristine_guid,
+                mini: header.hash,
+            });
+        }
+        if header.type_count != 1 {
+            return Err(RemapError::NotSingle(header.type_count));
+        }
+        let next_minis =
+            self.inspected_count
+                .checked_add(1)
+                .ok_or(RemapError::LoadoutPlanResourceLimit {
+                    resource: "inspected minis",
+                    actual: usize::MAX,
+                    limit: self.limits.max_minis,
+                })?;
+        if next_minis > self.limits.max_minis {
+            return Err(RemapError::LoadoutPlanResourceLimit {
+                resource: "inspected minis",
+                actual: next_minis,
+                limit: self.limits.max_minis,
+            });
+        }
+        let digest = sha256_bytes(mini);
+        if self.inspected_minis.contains_key(&digest) {
+            // Every manifest entry consumes one mini slot, while exact bytes only need semantic
+            // inspection once. Commit the count only after all validation and limit checks pass.
+            self.inspected_count = next_minis;
+            return Ok(());
+        }
+
+        // Validate executable/module-record references against exactly pristine + this mini.
+        // Prior inspected minis are deliberately absent: the assignment union cannot authorize
+        // a cross-mini dependency.
+        self.effective_base
+            .validate(&EffectiveReferenceState::default(), mini)?;
+        let analyzed = analyze_new_symbol_mini(mini, &self.base)?;
+        let identities = novel_identity_set(
+            &analyzed.plan,
+            &analyzed.meta,
+            &analyzed.regen,
+            &analyzed.spans,
+        )?;
+        let fingerprint = identities.fingerprint();
+        let (additional_entries, additional_bytes) =
+            identities.additional_usage(&self.inventory, self.limits)?;
+        let next_entries = self
+            .assignment_entries
+            .checked_add(additional_entries)
+            .ok_or(RemapError::LoadoutPlanResourceLimit {
+                resource: "novel assignments",
+                actual: usize::MAX,
+                limit: self.limits.max_assignments,
+            })?;
+        if next_entries > self.limits.max_assignments {
+            return Err(RemapError::LoadoutPlanResourceLimit {
+                resource: "novel assignments",
+                actual: next_entries,
+                limit: self.limits.max_assignments,
+            });
+        }
+        let next_identity_bytes = self.identity_bytes.checked_add(additional_bytes).ok_or(
+            RemapError::LoadoutPlanResourceLimit {
+                resource: "identity bytes",
+                actual: usize::MAX,
+                limit: self.limits.max_identity_bytes,
+            },
+        )?;
+        if next_identity_bytes > self.limits.max_identity_bytes {
+            return Err(RemapError::LoadoutPlanResourceLimit {
+                resource: "identity bytes",
+                actual: next_identity_bytes,
+                limit: self.limits.max_identity_bytes,
+            });
+        }
+
+        identities.merge_into(&mut self.inventory);
+        self.inspected_count = next_minis;
+        self.inspected_minis.insert(digest, fingerprint);
+        self.assignment_entries = next_entries;
+        self.identity_bytes = next_identity_bytes;
+        Ok(())
+    }
+
+    /// Freeze the stable identity union and allocate one canonical mapping for all inspected
+    /// minis. The retained base context moves into the finished plan for O(1) reuse per rewrite.
+    pub(super) fn finish(self) -> Result<LoadoutScriptIdPlan, RemapError> {
+        let Self {
+            pristine_base_sha256,
+            pristine_guid,
+            pristine_header,
+            base,
+            effective_base,
+            inspected_minis,
+            inventory,
+            domains,
+            ..
+        } = self;
+        let (
+            pointer_assignments,
+            type_id_assignments,
+            function_id_assignments,
+            module_function_id_assignments,
+        ) = allocate_loadout_assignments(&base, inventory, domains)?;
+        Ok(LoadoutScriptIdPlan {
+            pristine_base_sha256,
+            pristine_guid,
+            pristine_header,
+            base,
+            effective_base,
+            inspected_minis,
+            pointer_assignments,
+            type_id_assignments,
+            function_id_assignments,
+            module_function_id_assignments,
+        })
+    }
+}
+
+/// Convenience wrapper for small in-memory callers. Manager integration should use
+/// [`LoadoutScriptIdPlanBuilder`] directly so each mini can be dropped after inspection.
+#[allow(dead_code)]
+pub(super) fn build_loadout_script_id_plan(
+    pristine_base: &[u8],
+    minis: &[&[u8]],
+) -> Result<LoadoutScriptIdPlan, RemapError> {
+    let mut builder = LoadoutScriptIdPlanBuilder::new(pristine_base)?;
+    for &mini in minis {
+        builder.inspect(mini)?;
+    }
+    builder.finish()
+}
+
+/// Apply a previously inspected loadout assignment to one exact mini. Both the pristine base and
+/// mini bytes are SHA-bound; the independently recomputed portable identity set must also match
+/// before any rewritten output is materialized.
+#[allow(dead_code)]
+pub(super) fn remap_module_to_base_with_loadout_plan(
+    extracted_mini: &[u8],
+    pristine_base: &[u8],
+    loadout: &LoadoutScriptIdPlan,
+) -> Result<(Vec<u8>, RemapCounts), RemapError> {
+    let base_header = loadout_cache_header(pristine_base, "pristine base")?;
+    if base_header.hash != loadout.pristine_guid
+        || sha256_bytes(pristine_base) != loadout.pristine_base_sha256
+    {
+        return Err(RemapError::LoadoutPlanBaseMismatch);
+    }
+    let mini_header = loadout_cache_header(extracted_mini, "mini")?;
+    if mini_header.hash != loadout.pristine_guid {
+        return Err(RemapError::LoadoutPlanGuidMismatch {
+            pristine: loadout.pristine_guid,
+            mini: mini_header.hash,
+        });
+    }
+    if mini_header.type_count != 1 {
+        return Err(RemapError::NotSingle(mini_header.type_count));
+    }
+    let bound_identity_fingerprint = loadout
+        .inspected_minis
+        .get(&sha256_bytes(extracted_mini))
+        .ok_or(RemapError::LoadoutPlanMiniNotInspected)?;
+    loadout
+        .effective_base
+        .validate(&EffectiveReferenceState::default(), extracted_mini)?;
+
+    let base = &loadout.base;
+    let mut analyzed = analyze_new_symbol_mini(extracted_mini, base)?;
+    let actual_identities = novel_identity_set(
+        &analyzed.plan,
+        &analyzed.meta,
+        &analyzed.regen,
+        &analyzed.spans,
+    )?;
+    if actual_identities.fingerprint() != *bound_identity_fingerprint {
+        return Err(RemapError::LoadoutPlanIdentityMismatch);
+    }
+    apply_loadout_assignments(
+        &mut analyzed.plan,
+        &analyzed.meta,
+        &analyzed.regen,
+        &analyzed.spans,
+        loadout,
+    )?;
+    finish_new_symbol_remap(extracted_mini, &loadout.pristine_header, base, analyzed)
+}
+
+fn remap_module_allow_new(
+    extracted_mini: &[u8],
+    base: &[u8],
+) -> Result<(Vec<u8>, RemapCounts), RemapError> {
+    let mini_n = super::walk_modules::module_count(extracted_mini);
+    if mini_n != 1 {
+        return Err(RemapError::NotSingle(mini_n));
+    }
+    preflight_mini_module_work(extracted_mini)?;
+    preflight_cache_module_work(base)?;
+
+    let base_context = build_allow_new_base_context(base)?;
+    let mut analyzed = analyze_new_symbol_mini(extracted_mini, &base_context)?;
+    allocate_new_pointer_keys(&mut analyzed.plan, &analyzed.regen, &base_context.syms)?;
+    allocate_engine_ids(
+        &mut analyzed.plan,
+        &analyzed.meta,
+        &analyzed.regen,
+        &base_context.syms,
+    )?;
+    finish_new_symbol_remap(extracted_mini, base, &base_context, analyzed)
 }
 
 /// Public entry: rewrite `extracted_mini`'s module bytecode refs to `base`'s keys, returning a
@@ -2636,6 +9000,8 @@ pub fn remap_module_to_base(
     extracted_mini: &[u8],
     base: &[u8],
 ) -> Result<(Vec<u8>, RemapCounts), RemapError> {
+    preflight_mini_module_work(extracted_mini)?;
+    preflight_cache_module_work(base)?;
     let mini_n = super::walk_modules::module_count(extracted_mini);
     if mini_n != 1 {
         return Err(RemapError::NotSingle(mini_n));
@@ -2679,7 +9045,7 @@ pub fn remap_module_to_base(
             continue; // null / none sentinel — leave as-is.
         }
         match em.kind {
-            EmbedKind::TypePtr => {
+            EmbedKind::TypePtr(_) => {
                 let nk = remap_ptr(
                     "type(embed)",
                     "ObjVar/DerivedFrom/ShadowType",
@@ -2692,14 +9058,9 @@ pub fn remap_module_to_base(
                 total.embed_type_ptr += 1;
             }
             EmbedKind::FuncId => {
-                // FactoryRefs/BehaviorRefs hold func-IDS in int64 slots, interleaved with
-                // sentinels/behavior-type tags. A value present in the regen func-id table IS a
-                // real func ref to remap; anything else (a behavior-type enum, a small tag) is
-                // NOT and is left untouched.
-                let regen_id = regen_key as i32;
-                let Some(&regen_ptr) = regen.funcid_to_ptr.get(&regen_id) else {
-                    continue;
-                };
+                // FactoryRefs/BehaviorRefs hold sign-extended int32 T4 ids in int64 slots; zero is
+                // their only sentinel. Behavior type tags live in BehaviorFunctionTypes.
+                let (regen_id, regen_ptr) = resolve_embedded_regen_func_id(regen_key, &regen)?;
                 let nptr = remap_ptr(
                     "function-id(embed)",
                     "Factory/BehaviorRefs",
@@ -2708,10 +9069,13 @@ pub fn remap_module_to_base(
                     &regen.func_name_of_ptr,
                     &base_syms.func_ptr_of_id,
                 )?;
-                let new_id =
+                let new_id = if base_syms.funcid_to_ptr.get(&regen_id) == Some(&nptr) {
+                    regen_id
+                } else {
                     *base_syms
                         .ptr_to_funcid
                         .get(&nptr)
+                        .filter(|&&id| id != 0)
                         .ok_or_else(|| RemapError::Unresolved {
                             kind: "function-id(embed,no base id)",
                             op: "Factory/BehaviorRefs",
@@ -2721,10 +9085,9 @@ pub fn remap_module_to_base(
                                 .get(&nptr)
                                 .cloned()
                                 .unwrap_or_default(),
-                        })?;
-                // Preserve the high 32 bits (the regen slot stored the id in the low dword; the
-                // high dword was 0 for a real id — keep whatever was there for safety on tags).
-                let new_val = (regen_key & !0xFFFF_FFFFi64) | (new_id as u32 as i64);
+                        })?
+                };
+                let new_val = i64::from(new_id);
                 module_bytes[o..o + 8].copy_from_slice(&new_val.to_le_bytes());
                 total.embed_func_id += 1;
             }
@@ -2751,7 +9114,9 @@ pub fn remap_module_to_base(
 
     // Emit: FGuid+magic (from mini) + Modules count=1 + module bytes + 7 empty tables.
     let mut out = Vec::with_capacity(CacheHeader::SIZE + module_bytes.len() + 28);
-    out.extend_from_slice(&extracted_mini[..0x14]); // FGuid + magic
+    // Canonicalize the prepared artifact to the exact target generation. Callers that use this
+    // low-level API directly therefore receive the same generation binding as compile-module.
+    out.extend_from_slice(&base[..0x14]); // target FGuid + magic
     out.extend_from_slice(&1u32.to_le_bytes()); // Modules count = 1
     out.extend_from_slice(&module_bytes);
     out.extend_from_slice(&[0u8; 28]); // 7 tables × int32 count 0
@@ -2841,10 +9206,9 @@ impl PartialEq for OperandId {
 
 impl OperandId {
     /// Human-readable form for the SEMANTIC-DIFF report (e.g. `CALLSYS Story::GiveXP`).
-    /// The identity string embeds unit-separator chars; render them as `::`-ish for readability.
     pub fn display(&self) -> String {
         match self {
-            OperandId::Named { ident, .. } => ident.full.replace(SEP, " » "),
+            OperandId::Named { ident, .. } => ident.display.clone(),
             OperandId::Primitive(id) => format!("prim#{id}"),
             OperandId::RawPtr(p) => format!("<unresolved-ptr {p:#x}>"),
             OperandId::RawId(i) => format!("<unresolved-id {i}>"),
@@ -2854,35 +9218,23 @@ impl OperandId {
     /// For a resolved FUNCTION identity (a `CALLSYS`/`CALL` callee), return the callee's
     /// (owner-type-name, method-name) as borrowed slices of the composed `Ident.full`.
     ///
-    /// A T3 FunctionReference identity is composed (see `SymTables::build`) as the SEP-joined
-    /// fields `module | namespace | <owner.full> | name | is_method | params | ret`, where
-    /// `<owner.full>` is itself a TYPE identity of EXACTLY 4 SEP-fields
-    /// (`owner_module | owner_ns | owner_name | Nsub:subs`). So on a raw `split(SEP)` the layout is
-    /// positionally fixed regardless of field CONTENT:
-    ///   [0]=module [1]=ns [2]=owner_module [3]=owner_ns [4]=owner_name [5]=owner_subs
-    ///   [6]=name(the method) [7]=is_method [8..]=params/ret.
-    /// This is the cache-INDEPENDENT keying the scope-strip needs (the raw CALLSYS func-PTR drifts
-    /// across builds, but the resolved owner+method identity does not). Returns `None` for a
-    /// non-`Named` operand or a malformed identity with too few fields (defensive).
+    /// Recursive template identities contain nested separators, so the owner and method are
+    /// retained as structured metadata when T3 is parsed rather than recovered positionally from
+    /// the display identity. This remains cache-independent while avoiding delimiter ambiguity.
     pub fn func_owner_method(&self) -> Option<(&str, &str)> {
         match self {
             OperandId::Named {
                 kind: RefKind::FuncPtr | RefKind::FuncId,
                 ident,
-            } => {
-                let mut it = ident.full.split(SEP);
-                let owner = it.nth(4)?; // fields 0..=4, leaving cursor after field 4
-                let method = it.nth(1)?; // field 6 (skip field 5 = owner_subs)
-                Some((owner, method))
-            }
+            } => ident
+                .function_owner
+                .as_deref()
+                .zip(ident.function_name.as_deref()),
             _ => None,
         }
     }
 
-    /// TEST-ONLY constructor: build a `Named` FUNC-ptr identity from an owner-type name + method
-    /// name, composing the exact SEP layout `SEP SEP SEP SEP owner SEP 0: SEP method SEP 1` so
-    /// [`func_owner_method`](Self::func_owner_method) round-trips. Used by the bytediff N5 unit
-    /// tests (which construct synthetic `NormInstr` CALLSYS callees).
+    /// TEST-ONLY constructor for the bytediff N5 unit tests.
     #[doc(hidden)]
     pub fn named_func_for_test(owner: &str, method: &str) -> OperandId {
         let full = format!("{SEP}{SEP}{SEP}{SEP}{owner}{SEP}0:{SEP}{method}{SEP}1");
@@ -2892,6 +9244,9 @@ impl OperandId {
                 full: full.clone(),
                 ns_stripped: full,
                 namespaces: vec![],
+                display: format!("{owner}::{method}"),
+                function_owner: Some(owner.to_owned()),
+                function_name: Some(method.to_owned()),
             },
         }
     }
@@ -2943,6 +9298,7 @@ impl RefIdentity {
     /// itself (verbatim copy of the remapper's primitive-passthrough rule, `ref-remap.md §2.5`).
     pub fn resolve_id(&self, kind: RefKind, id: i32) -> OperandId {
         match kind {
+            RefKind::FuncId if id == 0 => OperandId::RawId(0),
             RefKind::FuncId => match self.syms.funcid_to_ptr.get(&id) {
                 Some(ptr) => match self.syms.func_ident_of_ptr.get(ptr) {
                     Some(ident) => OperandId::Named {
@@ -2969,6 +9325,10 @@ impl RefIdentity {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "remap_loadout_plan_tests.rs"]
+mod loadout_plan_tests;
 
 #[cfg(test)]
 mod bytediff_n1_tests {
@@ -3038,7 +9398,299 @@ mod bytediff_n1_tests {
             full: full.to_string(),
             ns_stripped: ns_stripped.to_string(),
             namespaces: namespaces.iter().map(|s| s.to_string()).collect(),
+            display: full.to_string(),
+            function_owner: None,
+            function_name: None,
         }
+    }
+
+    fn fixed_comparison_budget(max: usize) -> IdentityComparisonBudget {
+        IdentityComparisonBudget {
+            remaining: max,
+            max,
+        }
+    }
+
+    #[test]
+    fn base_pointer_lookup_is_exact_first_and_skeleton_bounded() {
+        let regen_key = 99;
+        let regen_identity = ident("M|::Thing", "M|Thing", &[""]);
+        let base_identity = ident("M|Outer::Thing", "M|Thing", &["Outer"]);
+        let unrelated = ident("Other|Unrelated", "Other|Unrelated", &["Huge"]);
+        let regen_id_of_ptr = HashMap::from([(regen_key, regen_identity.full.clone())]);
+        let regen_ident_of_ptr = HashMap::from([(regen_key, regen_identity.clone())]);
+        let regen_names = HashMap::from([(regen_key, "Thing".to_owned())]);
+        let mut base_ident_of_ptr = HashMap::from([(7, base_identity.clone())]);
+        for key in 1000..2000 {
+            base_ident_of_ptr.insert(key, unrelated.clone());
+        }
+        let base_summary = IdentityReverseSummary::build(&base_ident_of_ptr).unwrap();
+
+        let work = identity_footprint(regen_key, &regen_identity)
+            .unwrap()
+            .checked_add(identity_footprint(7, &base_identity).unwrap())
+            .unwrap();
+        let mut drift_budget = fixed_comparison_budget(work);
+        assert_eq!(
+            match_base_ptr(
+                "type",
+                "test",
+                regen_key,
+                &regen_id_of_ptr,
+                &regen_ident_of_ptr,
+                &regen_names,
+                &HashMap::new(),
+                &base_ident_of_ptr,
+                &base_summary,
+                &mut drift_budget,
+            )
+            .unwrap(),
+            Some(7)
+        );
+        assert_eq!(drift_budget.remaining, 0);
+
+        // An exact full identity bypasses namespace-oracle work entirely, even when the phase's
+        // comparison budget has already been consumed.
+        let exact_ptrs = HashMap::from([(regen_identity.full.clone(), vec![7])]);
+        let mut exhausted = fixed_comparison_budget(0);
+        assert_eq!(
+            match_base_ptr(
+                "type",
+                "test",
+                regen_key,
+                &regen_id_of_ptr,
+                &regen_ident_of_ptr,
+                &regen_names,
+                &exact_ptrs,
+                &base_ident_of_ptr,
+                &base_summary,
+                &mut exhausted,
+            )
+            .unwrap(),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn base_pointer_lookup_rejects_drift_ambiguity_and_bounded_work() {
+        let regen_key = 99;
+        let regen_identity = ident("M|::Thing", "M|Thing", &[""]);
+        let first = ident("M|One::Thing", "M|Thing", &["One"]);
+        let second = ident("M|Two::Thing", "M|Thing", &["Two"]);
+        let regen_id_of_ptr = HashMap::from([(regen_key, regen_identity.full.clone())]);
+        let regen_ident_of_ptr = HashMap::from([(regen_key, regen_identity)]);
+        let regen_names = HashMap::from([(regen_key, "Thing".to_owned())]);
+        let base_ident_of_ptr = HashMap::from([(7, first), (8, second)]);
+        let base_summary = IdentityReverseSummary::build(&base_ident_of_ptr).unwrap();
+        let mut budget = fixed_comparison_budget(64 * 1024);
+        assert!(matches!(
+            match_base_ptr(
+                "type",
+                "test",
+                regen_key,
+                &regen_id_of_ptr,
+                &regen_ident_of_ptr,
+                &regen_names,
+                &HashMap::new(),
+                &base_ident_of_ptr,
+                &base_summary,
+                &mut budget,
+            ),
+            Err(RemapError::Ambiguous { n: 2, .. })
+        ));
+
+        let mut tiny_budget = fixed_comparison_budget(1);
+        assert!(matches!(
+            match_base_ptr(
+                "type",
+                "test",
+                regen_key,
+                &regen_id_of_ptr,
+                &regen_ident_of_ptr,
+                &regen_names,
+                &HashMap::new(),
+                &base_ident_of_ptr,
+                &base_summary,
+                &mut tiny_budget,
+            ),
+            Err(RemapError::Wire(
+                WireError::IdentityComparisonBudgetExceeded { max: 1 }
+            ))
+        ));
+    }
+
+    #[test]
+    fn declaration_and_property_namespace_matching_is_exact_first_and_bounded() {
+        let mut first = DeclarationInventory::default();
+        let mut second = DeclarationInventory::default();
+        let exact = DeclarationIdentity {
+            module: "M".to_owned(),
+            namespace: "Owner".to_owned(),
+            name: "Thing".to_owned(),
+        };
+        let drift = DeclarationIdentity {
+            module: "M".to_owned(),
+            namespace: "Outer::Owner".to_owned(),
+            name: "Thing".to_owned(),
+        };
+        first.insert_type(exact.clone(), 0).unwrap();
+        first.insert_global(exact.clone(), 0).unwrap();
+        first
+            .insert_property(
+                PropertyDeclarationIdentity {
+                    owner: exact.clone(),
+                    name: "Value".to_owned(),
+                },
+                0,
+            )
+            .unwrap();
+        second.insert_type(drift.clone(), 0).unwrap();
+        second.insert_global(drift.clone(), 0).unwrap();
+        second
+            .insert_property(
+                PropertyDeclarationIdentity {
+                    owner: drift,
+                    name: "Value".to_owned(),
+                },
+                0,
+            )
+            .unwrap();
+
+        // Exact identity wins across the union and consumes no namespace comparison work.
+        let inventories = [&first, &second];
+        let mut exact_budget = fixed_comparison_budget(0);
+        assert_eq!(
+            match_declaration_identities(
+                &inventories,
+                &exact,
+                DeclarationSetKind::Type,
+                &mut exact_budget,
+            )
+            .unwrap(),
+            FunctionDeclarationMatch::Unique
+        );
+        assert_eq!(
+            match_declaration_identities(
+                &inventories,
+                &exact,
+                DeclarationSetKind::Global,
+                &mut exact_budget,
+            )
+            .unwrap(),
+            FunctionDeclarationMatch::Unique
+        );
+        assert_eq!(
+            match_property_declarations(
+                &inventories,
+                &PropertyDeclarationIdentity {
+                    owner: exact.clone(),
+                    name: "Value".to_owned(),
+                },
+                &mut exact_budget,
+            )
+            .unwrap(),
+            FunctionDeclarationMatch::Unique
+        );
+
+        let missing_namespace = DeclarationIdentity {
+            namespace: String::new(),
+            ..exact.clone()
+        };
+        let mut ambiguity_budget = fixed_comparison_budget(64 * 1024);
+        assert_eq!(
+            match_declaration_identities(
+                &inventories,
+                &missing_namespace,
+                DeclarationSetKind::Type,
+                &mut ambiguity_budget,
+            )
+            .unwrap(),
+            FunctionDeclarationMatch::Ambiguous
+        );
+        let mut tiny_budget = fixed_comparison_budget(1);
+        assert!(matches!(
+            match_property_declarations(
+                &inventories,
+                &PropertyDeclarationIdentity {
+                    owner: missing_namespace,
+                    name: "Value".to_owned(),
+                },
+                &mut tiny_budget,
+            ),
+            Err(WireError::IdentityComparisonBudgetExceeded { max: 1 })
+        ));
+    }
+
+    #[test]
+    fn template_and_script_owner_indexes_share_namespace_budget() {
+        let mut current_owners = ScriptOwnerIndex::default();
+        let mut fallback_owners = ScriptOwnerIndex::default();
+        let owner_one = DeclarationIdentity {
+            module: "M".to_owned(),
+            namespace: "One".to_owned(),
+            name: "Class".to_owned(),
+        };
+        let owner_two = DeclarationIdentity {
+            namespace: "Two".to_owned(),
+            ..owner_one.clone()
+        };
+        let one_identity = ident("M|One|Class", "M||Class", &["One"]);
+        let two_identity = ident("M|Two|Class", "M||Class", &["Two"]);
+        current_owners.insert(&owner_one, &one_identity, 0).unwrap();
+        fallback_owners
+            .insert(&owner_two, &two_identity, 0)
+            .unwrap();
+        let primary = HashMap::new();
+        let context = DeclarationTypeContext {
+            primary: &primary,
+            fallback: None,
+            script_owners: current_owners,
+            fallback_script_owners: Some(&fallback_owners),
+        };
+
+        let mut exact_budget = fixed_comparison_budget(0);
+        assert_eq!(
+            context
+                .script_owner(&owner_one, &mut exact_budget)
+                .unwrap()
+                .unwrap()
+                .full,
+            one_identity.full
+        );
+        let missing_namespace = DeclarationIdentity {
+            namespace: String::new(),
+            ..owner_one
+        };
+        let mut owner_budget = fixed_comparison_budget(64 * 1024);
+        assert!(matches!(
+            context.script_owner(&missing_namespace, &mut owner_budget),
+            Err(WireError::BadLen {
+                field: "ambiguous script class declaration",
+                ..
+            })
+        ));
+
+        let pristine = PristineDeclarationAuthority {
+            declarations: DeclarationInventory::default(),
+            types_by_ptr: HashMap::new(),
+            template_bases: HashMap::from([(
+                ("Array".to_owned(), 1),
+                HashSet::from(["One".to_owned(), "Two".to_owned()]),
+            )]),
+            properties: HashSet::new(),
+            orphan_functions: HashSet::new(),
+            script_owners: ScriptOwnerIndex::default(),
+        };
+        let mut template_budget = fixed_comparison_budget(64 * 1024);
+        assert_eq!(
+            match_template_base(&pristine, "Array", "", 1, &mut template_budget).unwrap(),
+            FunctionDeclarationMatch::Ambiguous
+        );
+        let mut exact_template_budget = fixed_comparison_budget(0);
+        assert_eq!(
+            match_template_base(&pristine, "Array", "One", 1, &mut exact_template_budget,).unwrap(),
+            FunctionDeclarationMatch::Unique
+        );
     }
 
     /// GAP-A: a vanilla symbol WITH a namespace and a regen symbol with an EMPTY namespace but
@@ -3192,6 +9844,9 @@ mod bytediff_n1_tests {
                 full,
                 ns_stripped: stripped,
                 namespaces: vec![],
+                display: "FScopeCycleCounter::$beh0".to_owned(),
+                function_owner: Some("FScopeCycleCounter".to_owned()),
+                function_name: Some("$beh0".to_owned()),
             },
         };
         assert_eq!(
@@ -3208,6 +9863,9 @@ mod bytediff_n1_tests {
                 full: full2.clone(),
                 ns_stripped: full2,
                 namespaces: vec![],
+                display: "FStatID::$beh2".to_owned(),
+                function_owner: Some("FStatID".to_owned()),
+                function_name: Some("$beh2".to_owned()),
             },
         };
         assert_eq!(id2.func_owner_method(), Some(("FStatID", "$beh2")));
@@ -3223,6 +9881,9 @@ mod bytediff_n1_tests {
                 full: full3.clone(),
                 ns_stripped: full3,
                 namespaces: vec![],
+                display: "AGothicCharacterState::IsTrulyPartOfGuild".to_owned(),
+                function_owner: Some("AGothicCharacterState".to_owned()),
+                function_name: Some("IsTrulyPartOfGuild".to_owned()),
             },
         };
         assert_eq!(
@@ -3238,6 +9899,9 @@ mod bytediff_n1_tests {
                 full: format!("a{sep}b"),
                 ns_stripped: String::new(),
                 namespaces: vec![],
+                display: "a::b".to_owned(),
+                function_owner: None,
+                function_name: None,
             },
         };
         assert_eq!(short.func_owner_method(), None);

--- a/crates/gore-as/src/cache/remap_loadout_plan_tests.rs
+++ b/crates/gore-as/src/cache/remap_loadout_plan_tests.rs
@@ -1,0 +1,1617 @@
+use std::collections::HashMap;
+
+use super::*;
+use crate::cache::header::CACHE_MAGIC;
+
+const SCRIPT_OBJECT_KIND: u32 = 0x0800_0000;
+const APP_OBJECT_KIND: u32 = 0x0400_0000;
+
+#[derive(Default)]
+struct TailRows {
+    types: Vec<Vec<u8>>,
+    type_ids: Vec<Vec<u8>>,
+    funcs: Vec<Vec<u8>>,
+    func_ids: Vec<Vec<u8>>,
+    globals: Vec<Vec<u8>>,
+    static_names: Vec<Vec<u8>>,
+    properties: Vec<Vec<u8>>,
+}
+
+fn sia(value: &str) -> Vec<u8> {
+    if value.is_empty() {
+        return 0i32.to_le_bytes().to_vec();
+    }
+    let mut out = (value.len() as i32).to_le_bytes().to_vec();
+    out.extend_from_slice(value.as_bytes());
+    out.push(0);
+    out
+}
+
+fn fstring(value: &str) -> Vec<u8> {
+    let mut out = ((value.len() + 1) as i32).to_le_bytes().to_vec();
+    out.extend_from_slice(value.as_bytes());
+    out.push(0);
+    out
+}
+
+fn datatype(type_ptr: i64, token: i32) -> Vec<u8> {
+    let mut out = vec![0u8; 6 * 4];
+    out.extend_from_slice(&type_ptr.to_le_bytes());
+    out.extend_from_slice(&token.to_le_bytes());
+    out
+}
+
+fn type_row(key: i64, name: &str, module: &str) -> Vec<u8> {
+    let mut out = key.to_le_bytes().to_vec();
+    out.extend_from_slice(&sia(name));
+    out.extend_from_slice(&sia(module));
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&0i32.to_le_bytes()); // subtypes
+    out
+}
+
+fn id_row(id: i32, ptr: i64) -> Vec<u8> {
+    let mut out = id.to_le_bytes().to_vec();
+    out.extend_from_slice(&ptr.to_le_bytes());
+    out
+}
+
+fn string_global_row(key: i64, value: &str) -> Vec<u8> {
+    let mut out = key.to_le_bytes().to_vec();
+    out.extend_from_slice(&sia(value));
+    out.extend_from_slice(&sia("")); // string literal lookup ignores Module
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&1i32.to_le_bytes());
+    out
+}
+
+fn nonstring_global_row(key: i64, name: &str, module: &str) -> Vec<u8> {
+    let mut out = key.to_le_bytes().to_vec();
+    out.extend_from_slice(&sia(name));
+    out.extend_from_slice(&sia(module));
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&0i32.to_le_bytes());
+    out
+}
+
+fn property_row(type_id: i32, member_offset: i32, name: &str) -> Vec<u8> {
+    let key = ((type_id as u32 as u64) << 1) | ((member_offset as u32 as u64) << 33) | 1;
+    let mut out = (key as i64).to_le_bytes().to_vec();
+    out.extend_from_slice(&sia(name));
+    out.extend_from_slice(&type_id.to_le_bytes());
+    out
+}
+
+fn module_global_record(name: &str) -> Vec<u8> {
+    let mut out = sia(name);
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&datatype(0, 0x52));
+    out.extend_from_slice(&1i32.to_le_bytes()); // default initialization, no payload
+    out
+}
+
+fn function_tail_row(key: i64, name: &str, module: &str, params: &[i64]) -> Vec<u8> {
+    let mut out = key.to_le_bytes().to_vec();
+    out.extend_from_slice(&sia(name));
+    out.extend_from_slice(&sia(module));
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&0i32.to_le_bytes()); // const
+    out.extend_from_slice(&0i32.to_le_bytes()); // imported
+    out.extend_from_slice(&0i32.to_le_bytes()); // method
+    out.extend_from_slice(&0i64.to_le_bytes()); // owner
+    out.extend_from_slice(&(params.len() as i32).to_le_bytes());
+    for &param in params {
+        out.extend_from_slice(&datatype(param, 5));
+    }
+    out.extend_from_slice(&datatype(0, 0x52)); // void return
+    out
+}
+
+fn function_record(name: &str, params: &[i64], runtime_id: i32) -> Vec<u8> {
+    function_record_with_code(name, params, runtime_id, &[10])
+}
+
+fn function_record_with_code(name: &str, params: &[i64], runtime_id: i32, code: &[i32]) -> Vec<u8> {
+    let mut out = sia(name);
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&datatype(0, 0x52)); // void return
+    out.extend_from_slice(&(params.len() as i32).to_le_bytes());
+    for &param in params {
+        out.extend_from_slice(&datatype(param, 5));
+    }
+    out.extend_from_slice(&(params.len() as i32).to_le_bytes());
+    for index in 0..params.len() {
+        out.extend_from_slice(&sia(&format!("parameter{index}")));
+    }
+    out.extend_from_slice(&(params.len() as i32).to_le_bytes());
+    for _ in params {
+        out.extend_from_slice(&0i32.to_le_bytes());
+    }
+    out.extend_from_slice(&(params.len() as i32).to_le_bytes());
+    for _ in params {
+        out.extend_from_slice(&sia(""));
+    }
+    out.extend_from_slice(&0i32.to_le_bytes()); // traits
+    out.extend_from_slice(&(code.len() as i32).to_le_bytes());
+    for dword in code {
+        out.extend_from_slice(&dword.to_le_bytes());
+    }
+    out.extend_from_slice(&0i32.to_le_bytes()); // bytecode refs
+    out.extend_from_slice(&0i32.to_le_bytes()); // variable space
+    out.extend_from_slice(&0i32.to_le_bytes()); // object variable types
+    out.extend_from_slice(&0i32.to_le_bytes()); // object variable positions
+    out.extend_from_slice(&0i32.to_le_bytes()); // object vars on heap
+    out.extend_from_slice(&0i32.to_le_bytes()); // var-info program positions
+    out.extend_from_slice(&0i32.to_le_bytes()); // var-info offsets
+    out.extend_from_slice(&0i32.to_le_bytes()); // var-info options
+    out.extend_from_slice(&0i32.to_le_bytes()); // stack needed
+    out.extend_from_slice(&runtime_id.to_le_bytes());
+    out.extend_from_slice(&0i32.to_le_bytes()); // declared at
+    out.extend_from_slice(&0i32.to_le_bytes()); // line numbers
+    out.extend_from_slice(&0i32.to_le_bytes()); // no Unreal metadata
+    out
+}
+
+fn class_record(name: &str) -> Vec<u8> {
+    let mut out = sia(name);
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&0i32.to_le_bytes()); // flags
+    out.extend_from_slice(&0i32.to_le_bytes()); // properties
+    out.extend_from_slice(&0i32.to_le_bytes()); // methods
+    out.extend_from_slice(&0i32.to_le_bytes()); // method table
+    out.extend_from_slice(&0i64.to_le_bytes()); // derived from
+    out.extend_from_slice(&0i64.to_le_bytes()); // shadow type
+    out.extend_from_slice(&0i32.to_le_bytes()); // constructors
+    out.extend_from_slice(&0i32.to_le_bytes()); // factory refs
+    out.extend_from_slice(&7i32.to_le_bytes()); // behavior refs
+    for _ in 0..7 {
+        out.extend_from_slice(&0i64.to_le_bytes());
+    }
+    out.extend_from_slice(&0i32.to_le_bytes()); // behavior functions
+    out.extend_from_slice(&0i32.to_le_bytes()); // behavior types
+    out.extend_from_slice(&0i32.to_le_bytes()); // no Unreal metadata
+    out
+}
+
+fn class_record_with_factory_ref(name: &str, function_id: i64) -> Vec<u8> {
+    let mut out = sia(name);
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&0i32.to_le_bytes()); // flags
+    out.extend_from_slice(&0i32.to_le_bytes()); // properties
+    out.extend_from_slice(&0i32.to_le_bytes()); // methods
+    out.extend_from_slice(&0i32.to_le_bytes()); // method table
+    out.extend_from_slice(&0i64.to_le_bytes()); // derived from
+    out.extend_from_slice(&0i64.to_le_bytes()); // shadow type
+    out.extend_from_slice(&0i32.to_le_bytes()); // constructors
+    out.extend_from_slice(&1i32.to_le_bytes()); // factory refs
+    out.extend_from_slice(&function_id.to_le_bytes());
+    out.extend_from_slice(&7i32.to_le_bytes()); // behavior refs
+    for _ in 0..7 {
+        out.extend_from_slice(&0i64.to_le_bytes());
+    }
+    out.extend_from_slice(&0i32.to_le_bytes()); // behavior functions
+    out.extend_from_slice(&0i32.to_le_bytes()); // behavior types
+    out.extend_from_slice(&0i32.to_le_bytes()); // no Unreal metadata
+    out
+}
+
+fn append_rows(out: &mut Vec<u8>, rows: &[Vec<u8>]) {
+    out.extend_from_slice(&(rows.len() as u32).to_le_bytes());
+    for row in rows {
+        out.extend_from_slice(row);
+    }
+}
+
+fn cache(module: &str, functions: &[Vec<u8>], classes: &[Vec<u8>], rows: TailRows) -> Vec<u8> {
+    cache_with_module_globals(module, functions, classes, &[], rows)
+}
+
+fn cache_with_module_globals(
+    module: &str,
+    functions: &[Vec<u8>],
+    classes: &[Vec<u8>],
+    module_globals: &[Vec<u8>],
+    rows: TailRows,
+) -> Vec<u8> {
+    let mut out = vec![0u8; 16];
+    out.extend_from_slice(&CACHE_MAGIC.to_le_bytes());
+    out.extend_from_slice(&1u32.to_le_bytes());
+    out.extend_from_slice(&fstring(module));
+    out.extend_from_slice(&sia(module));
+    out.extend_from_slice(&(functions.len() as i32).to_le_bytes());
+    for function in functions {
+        out.extend_from_slice(function);
+    }
+    out.extend_from_slice(&(classes.len() as i32).to_le_bytes());
+    for class in classes {
+        out.extend_from_slice(class);
+    }
+    out.extend_from_slice(&0i32.to_le_bytes()); // enums
+    out.extend_from_slice(&(module_globals.len() as i32).to_le_bytes());
+    for global in module_globals {
+        out.extend_from_slice(global);
+    }
+    out.extend_from_slice(&0i32.to_le_bytes()); // imports
+    out.extend_from_slice(&0i64.to_le_bytes()); // code hash
+    out.extend_from_slice(&0i32.to_le_bytes()); // imported modules
+    out.extend_from_slice(&sia("")); // statics class
+    out.extend_from_slice(&0i32.to_le_bytes()); // events
+    out.extend_from_slice(&0i32.to_le_bytes()); // delegates
+    out.extend_from_slice(&sia(&format!("{module}.as")));
+    out.extend_from_slice(&0i32.to_le_bytes()); // post-init functions
+    append_rows(&mut out, &rows.types);
+    append_rows(&mut out, &rows.type_ids);
+    append_rows(&mut out, &rows.funcs);
+    append_rows(&mut out, &rows.func_ids);
+    append_rows(&mut out, &rows.globals);
+    append_rows(&mut out, &rows.static_names);
+    append_rows(&mut out, &rows.properties);
+    out
+}
+
+fn empty_base() -> Vec<u8> {
+    cache("Pristine", &[], &[], TailRows::default())
+}
+
+#[derive(Clone)]
+struct SymbolMiniSpec<'a> {
+    module: &'a str,
+    type_name: &'a str,
+    function_name: &'a str,
+    type_ptr: i64,
+    function_ptr: i64,
+    type_id: i32,
+    function_id: i32,
+    runtime_id: i32,
+}
+
+fn symbol_mini(spec: &SymbolMiniSpec<'_>) -> Vec<u8> {
+    symbol_mini_with_code(spec, &[10])
+}
+
+fn symbol_mini_with_code(spec: &SymbolMiniSpec<'_>, code: &[i32]) -> Vec<u8> {
+    cache(
+        spec.module,
+        &[function_record_with_code(
+            spec.function_name,
+            &[],
+            spec.runtime_id,
+            code,
+        )],
+        &[class_record(spec.type_name)],
+        TailRows {
+            types: vec![type_row(spec.type_ptr, spec.type_name, spec.module)],
+            type_ids: vec![id_row(spec.type_id, spec.type_ptr)],
+            funcs: vec![function_tail_row(
+                spec.function_ptr,
+                spec.function_name,
+                spec.module,
+                &[],
+            )],
+            func_ids: vec![id_row(spec.function_id, spec.function_ptr)],
+            ..TailRows::default()
+        },
+    )
+}
+
+fn string_global_mini(
+    module: &str,
+    function_name: &str,
+    function_ptr: i64,
+    function_id: i32,
+    global_keys: &[i64],
+    value: &str,
+) -> Vec<u8> {
+    let mut code = Vec::new();
+    for &key in global_keys {
+        code.push(1); // PshGPtr
+        code.push(key as u32 as i32);
+        code.push((key as u64 >> 32) as u32 as i32);
+    }
+    code.push(10); // RET
+    cache(
+        module,
+        &[function_record_with_code(
+            function_name,
+            &[],
+            function_id,
+            &code,
+        )],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(function_ptr, function_name, module, &[])],
+            func_ids: vec![id_row(function_id, function_ptr)],
+            globals: global_keys
+                .iter()
+                .map(|&key| string_global_row(key, value))
+                .collect(),
+            ..TailRows::default()
+        },
+    )
+}
+
+fn analyzed_identities(base: &AllowNewBaseContext, mini: &[u8]) -> NovelIdentitySet {
+    preflight_mini_module_work(mini).unwrap();
+    let analyzed = analyze_new_symbol_mini(mini, base).unwrap();
+    novel_identity_set(
+        &analyzed.plan,
+        &analyzed.meta,
+        &analyzed.regen,
+        &analyzed.spans,
+    )
+    .unwrap()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AssignedIds {
+    type_ptr: i64,
+    type_id: i32,
+    function_ptr: i64,
+    function_id: i32,
+}
+
+fn assigned_ids(mini: &[u8]) -> AssignedIds {
+    let meta = TailMetadata::build(mini).unwrap();
+    assert_eq!(meta.types.len(), 1);
+    assert_eq!(meta.type_ids.len(), 1);
+    assert_eq!(meta.funcs.len(), 1);
+    assert_eq!(meta.func_ids.len(), 1);
+    AssignedIds {
+        type_ptr: meta.types[0].key,
+        type_id: meta.type_ids[0].id,
+        function_ptr: meta.funcs[0].key,
+        function_id: meta.func_ids[0].id,
+    }
+}
+
+fn module_function_ids(mini: &[u8]) -> Vec<i32> {
+    collect_module_spans(mini).unwrap().function_ids
+}
+
+fn global_ptr_operands(mini: &[u8]) -> Vec<i64> {
+    let spans = collect_module_spans(mini).unwrap();
+    let mut pointers = Vec::new();
+    for span in spans.code {
+        let code: Vec<i32> = (0..span.count)
+            .map(|index| {
+                let off = span.data_off + index * 4;
+                i32::from_le_bytes(mini[off..off + 4].try_into().unwrap())
+            })
+            .collect();
+        for instruction in disassemble(&code).unwrap() {
+            if instruction.op.name == "PshGPtr" {
+                pointers.push(read_qw(&code, instruction.offset_dw + 1));
+            }
+        }
+    }
+    pointers
+}
+
+fn small_domains() -> CanonicalAllocationDomains {
+    CanonicalAllocationDomains {
+        pointer_slot_high: 63,
+        type_sequence_high: 15,
+        function_id_high: 4,
+    }
+}
+
+#[test]
+fn exact_base_keys_are_preserved_even_when_portable_identity_has_aliases() {
+    const TYPE_KEY: i64 = 0x10_100;
+    const FUNC_KEY: i64 = 0x20_100;
+    const GLOBAL_KEY: i64 = 0x30_100;
+    let base = cache(
+        "Pristine",
+        &[],
+        &[],
+        TailRows {
+            types: vec![
+                type_row(TYPE_KEY, "AliasType", ""),
+                type_row(TYPE_KEY + 8, "AliasType", ""),
+            ],
+            funcs: vec![
+                function_tail_row(FUNC_KEY, "AliasFunction", "Pristine", &[]),
+                function_tail_row(FUNC_KEY + 8, "AliasFunction", "Pristine", &[]),
+            ],
+            globals: vec![
+                nonstring_global_row(GLOBAL_KEY, "AliasGlobal", "Pristine"),
+                nonstring_global_row(GLOBAL_KEY + 8, "AliasGlobal", "Pristine"),
+            ],
+            ..TailRows::default()
+        },
+    );
+    let regen = cache(
+        "Prepared",
+        &[],
+        &[],
+        TailRows {
+            types: vec![type_row(TYPE_KEY, "AliasType", "")],
+            funcs: vec![function_tail_row(
+                FUNC_KEY,
+                "AliasFunction",
+                "Pristine",
+                &[],
+            )],
+            globals: vec![nonstring_global_row(GLOBAL_KEY, "AliasGlobal", "Pristine")],
+            ..TailRows::default()
+        },
+    );
+    let base_syms = SymTables::build(&base).unwrap();
+    let regen_syms = SymTables::build(&regen).unwrap();
+    let summaries = SymbolIdentitySummaries {
+        types: IdentityReverseSummary::build(&base_syms.type_ident_of_ptr).unwrap(),
+        functions: IdentityReverseSummary::build(&base_syms.func_ident_of_ptr).unwrap(),
+        globals: IdentityReverseSummary::build(&base_syms.global_ident_of_ptr).unwrap(),
+    };
+    let mut comparisons = IdentityComparisonBudget::new(base.len() + regen.len());
+    let mut plan = NewSymbolPlan::default();
+    declare_type(
+        &mut plan,
+        TYPE_KEY,
+        "test",
+        &regen_syms,
+        &base_syms,
+        &summaries,
+        &mut comparisons,
+    )
+    .unwrap();
+    declare_func(
+        &mut plan,
+        FUNC_KEY,
+        "test",
+        &regen_syms,
+        &base_syms,
+        &summaries,
+        &mut comparisons,
+    )
+    .unwrap();
+    declare_global(
+        &mut plan,
+        GLOBAL_KEY,
+        "test",
+        &regen_syms,
+        &base_syms,
+        &summaries,
+        &mut comparisons,
+    )
+    .unwrap();
+    assert_eq!(plan.type_ptrs.get(&TYPE_KEY), Some(&TYPE_KEY));
+    assert_eq!(plan.func_ptrs.get(&FUNC_KEY), Some(&FUNC_KEY));
+    assert_eq!(plan.global_ptrs.get(&GLOBAL_KEY), Some(&GLOBAL_KEY));
+}
+
+#[test]
+fn reverse_id_aliases_preserve_exact_t2_and_nonzero_t4_operands() {
+    const TYPE_PTR: i64 = 0x40_100;
+    const FUNC_PTR: i64 = 0x50_100;
+    const TYPE_ID: i32 = (SCRIPT_OBJECT_KIND | 500) as i32;
+    const TYPE_ALIAS: i32 = (SCRIPT_OBJECT_KIND | 501) as i32;
+    const TYPE_REPACKED: i32 = (SCRIPT_OBJECT_KIND | 502) as i32;
+    const WRONG_KIND_ALIAS: i32 = (APP_OBJECT_KIND | 499) as i32;
+    const FUNC_ID: i32 = 600;
+    let base = cache(
+        "Pristine",
+        &[],
+        &[],
+        TailRows {
+            types: vec![type_row(TYPE_PTR, "AliasType", "")],
+            type_ids: vec![
+                id_row(TYPE_ID, TYPE_PTR),
+                id_row(TYPE_ALIAS, TYPE_PTR),
+                id_row(WRONG_KIND_ALIAS, TYPE_PTR),
+            ],
+            funcs: vec![function_tail_row(
+                FUNC_PTR,
+                "AliasFunction",
+                "Pristine",
+                &[],
+            )],
+            func_ids: vec![id_row(FUNC_ID, FUNC_PTR), id_row(0, FUNC_PTR)],
+            ..TailRows::default()
+        },
+    );
+    let regen = cache(
+        "Prepared",
+        &[],
+        &[],
+        TailRows {
+            types: vec![type_row(TYPE_PTR + 8, "AliasType", "")],
+            type_ids: vec![
+                id_row(TYPE_ID, TYPE_PTR + 8),
+                id_row(TYPE_REPACKED, TYPE_PTR + 8),
+            ],
+            funcs: vec![function_tail_row(
+                FUNC_PTR + 8,
+                "AliasFunction",
+                "Pristine",
+                &[],
+            )],
+            func_ids: vec![id_row(FUNC_ID, FUNC_PTR + 8)],
+            ..TailRows::default()
+        },
+    );
+    let mut code = vec![76, TYPE_ID, 76, TYPE_REPACKED, 9, FUNC_ID, 10];
+    remap_bytecode(
+        &mut code,
+        &SymTables::build(&regen).unwrap(),
+        &SymTables::build(&base).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(code, [76, TYPE_ID, 76, TYPE_ID, 9, FUNC_ID, 10]);
+}
+
+#[test]
+fn nonzero_function_reference_never_falls_back_to_a_zero_only_t4_alias() {
+    const BASE_PTR: i64 = 0x51_100;
+    const REGEN_PTR: i64 = 0x51_200;
+    const REGEN_ID: i32 = 601;
+    let base = cache(
+        "Pristine",
+        &[],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(
+                BASE_PTR,
+                "ZeroOnlyAlias",
+                "Pristine",
+                &[],
+            )],
+            func_ids: vec![id_row(0, BASE_PTR)],
+            ..TailRows::default()
+        },
+    );
+    let regen = cache(
+        "Prepared",
+        &[],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(
+                REGEN_PTR,
+                "ZeroOnlyAlias",
+                "Pristine",
+                &[],
+            )],
+            func_ids: vec![id_row(REGEN_ID, REGEN_PTR)],
+            ..TailRows::default()
+        },
+    );
+    let mut code = vec![9, REGEN_ID, 10];
+    assert!(matches!(
+        remap_bytecode(
+            &mut code,
+            &SymTables::build(&regen).unwrap(),
+            &SymTables::build(&base).unwrap(),
+        ),
+        Err(RemapError::Unresolved {
+            kind: "function-id(no base id)",
+            ..
+        })
+    ));
+    assert_eq!(code, [9, REGEN_ID, 10]);
+}
+
+#[test]
+fn pristine_property_lookup_uses_semantic_index_without_alias_bucket_scan() {
+    const TYPE_PTR: i64 = 0x60_100;
+    const TYPE_ID: i32 = (APP_OBJECT_KIND | 610) as i32;
+    let base = cache(
+        "Pristine",
+        &[],
+        &[],
+        TailRows {
+            types: vec![
+                type_row(TYPE_PTR, "EngineAlias", ""),
+                type_row(TYPE_PTR + 8, "EngineAlias", ""),
+            ],
+            type_ids: vec![id_row(TYPE_ID, TYPE_PTR)],
+            properties: vec![property_row(TYPE_ID, 24, "Health")],
+            ..TailRows::default()
+        },
+    );
+    let meta = TailMetadata::build(&base).unwrap();
+    let mut syms = SymTables::build(&base).unwrap();
+    let mut comparisons = IdentityComparisonBudget::new(base.len() + syms.identity_bytes);
+    let collected =
+        collect_declaration_inventory(&base, &syms, None, None, &meta, &mut comparisons).unwrap();
+    let authority =
+        PristineDeclarationAuthority::build(&meta, &syms, collected.declarations, &mut comparisons)
+            .unwrap();
+
+    // The semantic property index is complete now; the large pointer-alias reverse bucket is no
+    // longer part of the lookup path.
+    syms.type_ptr_of_id.clear();
+    let prepared = cache(
+        "Prepared",
+        &[],
+        &[],
+        TailRows {
+            properties: vec![property_row(TYPE_ID, 24, "Health")],
+            ..TailRows::default()
+        },
+    );
+    let prepared_meta = TailMetadata::build(&prepared).unwrap();
+    let prepared_syms = SymTables::build(&prepared).unwrap();
+    assert!(has_pristine_property_identity(
+        &prepared_meta.properties[0],
+        &prepared_syms,
+        &syms,
+        &authority,
+    ));
+}
+
+fn collision_pair(base: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    let builder = LoadoutScriptIdPlanBuilder::new_with_config(
+        base,
+        PRODUCTION_LOADOUT_PLAN_LIMITS,
+        small_domains(),
+    )
+    .unwrap();
+    let mut buckets: HashMap<(u64, u64), Vec<u8>> = HashMap::new();
+    for index in 0..=32 {
+        let module = format!("CollisionMod{index}");
+        let type_name = format!("CollisionType{index}");
+        let function_name = format!("CollisionFunction{index}");
+        let mini = symbol_mini(&SymbolMiniSpec {
+            module: &module,
+            type_name: &type_name,
+            function_name: &function_name,
+            type_ptr: 0x1000,
+            function_ptr: 0x2000,
+            type_id: (SCRIPT_OBJECT_KIND | 12) as i32,
+            function_id: 1,
+            runtime_id: 10_000 + index,
+        });
+        let identities = analyzed_identities(&builder.base, &mini);
+        let (type_identity, _) = identities.type_ids.first_key_value().unwrap();
+        let function_identity = identities.function_ids.first().unwrap();
+        let bucket = (
+            type_sequence_start(type_identity, small_domains().type_sequence_high),
+            function_id_start(function_identity, small_domains().function_id_high),
+        );
+        if let Some(prior) = buckets.insert(bucket, mini.clone()) {
+            return (prior, mini);
+        }
+    }
+    panic!("pigeonhole collision was not found")
+}
+
+#[test]
+fn incremental_plan_separates_colliding_t2_and_t4_starts() {
+    let base = empty_base();
+    let (first, second) = collision_pair(&base);
+    let base_context = build_allow_new_base_context(&base).unwrap();
+    let first_identities = analyzed_identities(&base_context, &first);
+    let second_identities = analyzed_identities(&base_context, &second);
+    let (first_type, _) = first_identities.type_ids.first_key_value().unwrap();
+    let (second_type, _) = second_identities.type_ids.first_key_value().unwrap();
+    assert_eq!(
+        type_sequence_start(first_type, small_domains().type_sequence_high),
+        type_sequence_start(second_type, small_domains().type_sequence_high)
+    );
+    assert_eq!(
+        function_id_start(
+            first_identities.function_ids.first().unwrap(),
+            small_domains().function_id_high,
+        ),
+        function_id_start(
+            second_identities.function_ids.first().unwrap(),
+            small_domains().function_id_high,
+        )
+    );
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new_with_config(
+        &base,
+        PRODUCTION_LOADOUT_PLAN_LIMITS,
+        small_domains(),
+    )
+    .unwrap();
+    builder.inspect(&first).unwrap();
+    builder.inspect(&second).unwrap();
+    let plan = builder.finish().unwrap();
+    let first_out = remap_module_to_base_with_loadout_plan(&first, &base, &plan)
+        .unwrap()
+        .0;
+    let second_out = remap_module_to_base_with_loadout_plan(&second, &base, &plan)
+        .unwrap()
+        .0;
+    let first_ids = assigned_ids(&first_out);
+    let second_ids = assigned_ids(&second_out);
+    assert_ne!(first_ids.type_ptr, second_ids.type_ptr);
+    assert_ne!(first_ids.function_ptr, second_ids.function_ptr);
+    assert_ne!(first_ids.type_id, second_ids.type_id);
+    assert_ne!(first_ids.function_id, second_ids.function_id);
+}
+
+#[test]
+fn builder_and_strict_validator_share_one_pristine_base_context() {
+    let base = empty_base();
+    let builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    assert!(Arc::ptr_eq(&builder.base, &builder.effective_base.base));
+    let plan = builder.finish().unwrap();
+    assert!(Arc::ptr_eq(&plan.base, &plan.effective_base.base));
+}
+
+#[test]
+fn identity_union_deduplicates_and_ignores_inspection_order_and_raw_packaging() {
+    let base = empty_base();
+    let shared = SymbolMiniSpec {
+        module: "SharedMod",
+        type_name: "SharedType",
+        function_name: "SharedFunction",
+        type_ptr: 0x1110,
+        function_ptr: 0x2110,
+        type_id: (SCRIPT_OBJECT_KIND | 100) as i32,
+        function_id: 100,
+        runtime_id: 300,
+    };
+    let shared_repacked = SymbolMiniSpec {
+        type_ptr: 0x7770,
+        function_ptr: 0x8880,
+        type_id: (SCRIPT_OBJECT_KIND | 777) as i32,
+        function_id: 777,
+        runtime_id: 301,
+        ..shared.clone()
+    };
+    let other = SymbolMiniSpec {
+        module: "OtherMod",
+        type_name: "OtherType",
+        function_name: "OtherFunction",
+        type_ptr: 0x3110,
+        function_ptr: 0x4110,
+        type_id: (SCRIPT_OBJECT_KIND | 200) as i32,
+        function_id: 200,
+        runtime_id: 400,
+    };
+    let shared = symbol_mini(&shared);
+    let shared_repacked = symbol_mini(&shared_repacked);
+    let other = symbol_mini(&other);
+
+    let mut forward = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    forward.inspect(&shared).unwrap();
+    forward.inspect(&other).unwrap();
+    let forward = forward.finish().unwrap();
+
+    let mut reversed = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    reversed.inspect(&other).unwrap();
+    reversed.inspect(&shared_repacked).unwrap();
+    let reversed = reversed.finish().unwrap();
+    assert_eq!(forward.pointer_assignments, reversed.pointer_assignments);
+    assert_eq!(forward.type_id_assignments, reversed.type_id_assignments);
+    assert_eq!(
+        forward.function_id_assignments,
+        reversed.function_id_assignments
+    );
+
+    let mut deduplicated = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    deduplicated.inspect(&shared).unwrap();
+    deduplicated.inspect(&shared_repacked).unwrap();
+    let deduplicated = deduplicated.finish().unwrap();
+    assert_eq!(deduplicated.pointer_assignments.len(), 2);
+    assert_eq!(deduplicated.type_id_assignments.len(), 1);
+    assert_eq!(deduplicated.function_id_assignments.len(), 1);
+    let shared_out = remap_module_to_base_with_loadout_plan(&shared, &base, &deduplicated)
+        .unwrap()
+        .0;
+    let repacked_out =
+        remap_module_to_base_with_loadout_plan(&shared_repacked, &base, &deduplicated)
+            .unwrap()
+            .0;
+    assert_eq!(assigned_ids(&shared_out), assigned_ids(&repacked_out));
+    assert_eq!(
+        module_function_ids(&shared_out),
+        module_function_ids(&repacked_out)
+    );
+}
+
+#[test]
+fn loadout_rekeys_colliding_module_function_ids_before_sequential_composition() {
+    let base = empty_base();
+    let first = symbol_mini(&SymbolMiniSpec {
+        module: "RuntimeIdA",
+        type_name: "RuntimeTypeA",
+        function_name: "RuntimeFunctionA",
+        type_ptr: 0x11_100,
+        function_ptr: 0x11_200,
+        type_id: (SCRIPT_OBJECT_KIND | 170) as i32,
+        function_id: 170,
+        runtime_id: 777,
+    });
+    let second = symbol_mini(&SymbolMiniSpec {
+        module: "RuntimeIdB",
+        type_name: "RuntimeTypeB",
+        function_name: "RuntimeFunctionB",
+        type_ptr: 0x22_100,
+        function_ptr: 0x22_200,
+        type_id: (SCRIPT_OBJECT_KIND | 171) as i32,
+        function_id: 171,
+        runtime_id: 777,
+    });
+
+    let mut forward = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    forward.inspect(&first).unwrap();
+    forward.inspect(&second).unwrap();
+    let forward = forward.finish().unwrap();
+    let first_out = remap_module_to_base_with_loadout_plan(&first, &base, &forward)
+        .unwrap()
+        .0;
+    let second_out = remap_module_to_base_with_loadout_plan(&second, &base, &forward)
+        .unwrap()
+        .0;
+
+    let first_runtime = module_function_ids(&first_out);
+    let second_runtime = module_function_ids(&second_out);
+    assert_ne!(first_runtime, second_runtime);
+
+    let mut reversed = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    reversed.inspect(&second).unwrap();
+    reversed.inspect(&first).unwrap();
+    let reversed = reversed.finish().unwrap();
+    assert_eq!(
+        forward.module_function_id_assignments,
+        reversed.module_function_id_assignments
+    );
+
+    let mut guard = crate::cache::splice::SequentialMiniGuard::new(&base).unwrap();
+    let running = guard.compose_add(&base, &first_out).unwrap();
+    guard
+        .compose_add(&running, &second_out)
+        .expect("loadout-planned Function.Id values must compose without collision");
+}
+
+#[test]
+fn builder_limits_are_checked_before_atomic_commit_and_allow_retry() {
+    let base = empty_base();
+    let first_spec = SymbolMiniSpec {
+        module: "LimitA",
+        type_name: "LimitTypeA",
+        function_name: "LimitFunctionA",
+        type_ptr: 0x1010,
+        function_ptr: 0x2020,
+        type_id: (SCRIPT_OBJECT_KIND | 20) as i32,
+        function_id: 20,
+        runtime_id: 20,
+    };
+    let duplicate_spec = SymbolMiniSpec {
+        type_ptr: 0x3030,
+        function_ptr: 0x4040,
+        type_id: (SCRIPT_OBJECT_KIND | 30) as i32,
+        function_id: 30,
+        runtime_id: 30,
+        ..first_spec.clone()
+    };
+    let second_spec = SymbolMiniSpec {
+        module: "LimitB",
+        type_name: "LimitTypeB",
+        function_name: "LimitFunctionB",
+        type_ptr: 0x5050,
+        function_ptr: 0x6060,
+        type_id: (SCRIPT_OBJECT_KIND | 40) as i32,
+        function_id: 40,
+        runtime_id: 40,
+    };
+    let first = symbol_mini(&first_spec);
+    let duplicate = symbol_mini(&duplicate_spec);
+    let second = symbol_mini(&second_spec);
+    let context = build_allow_new_base_context(&base).unwrap();
+    let first_identities = analyzed_identities(&context, &first);
+    let second_identities = analyzed_identities(&context, &second);
+    let (_, first_bytes) = first_identities
+        .additional_usage(&NovelIdentitySet::default(), PRODUCTION_LOADOUT_PLAN_LIMITS)
+        .unwrap();
+    let mut combined = first_identities.clone();
+    second_identities.clone().merge_into(&mut combined);
+    let combined_entries = combined.pointers.len()
+        + combined.type_ids.len()
+        + combined.function_ids.len()
+        + combined.module_function_ids.len();
+    let (_, combined_bytes) = combined
+        .additional_usage(&NovelIdentitySet::default(), PRODUCTION_LOADOUT_PLAN_LIMITS)
+        .unwrap();
+
+    let mut assignment_limited = LoadoutScriptIdPlanBuilder::new_with_config(
+        &base,
+        LoadoutPlanLimits {
+            max_minis: 2,
+            max_assignments: combined_entries - 1,
+            max_identity_bytes: usize::MAX,
+        },
+        PRODUCTION_ALLOCATION_DOMAINS,
+    )
+    .unwrap();
+    assignment_limited.inspect(&first).unwrap();
+    assert!(matches!(
+        assignment_limited.inspect(&second),
+        Err(RemapError::LoadoutPlanResourceLimit {
+            resource: "novel assignments",
+            actual,
+            limit,
+        }) if actual == combined_entries && limit + 1 == actual
+    ));
+    assert_eq!(assignment_limited.inspected_minis.len(), 1);
+    assignment_limited.inspect(&duplicate).unwrap();
+    assert_eq!(assignment_limited.assignment_entries, 5);
+
+    let mut byte_limited = LoadoutScriptIdPlanBuilder::new_with_config(
+        &base,
+        LoadoutPlanLimits {
+            max_minis: 2,
+            max_assignments: usize::MAX,
+            max_identity_bytes: combined_bytes - 1,
+        },
+        PRODUCTION_ALLOCATION_DOMAINS,
+    )
+    .unwrap();
+    byte_limited.inspect(&first).unwrap();
+    assert_eq!(byte_limited.identity_bytes, first_bytes);
+    assert!(matches!(
+        byte_limited.inspect(&second),
+        Err(RemapError::LoadoutPlanResourceLimit {
+            resource: "identity bytes",
+            actual,
+            limit,
+        }) if actual == combined_bytes && limit + 1 == actual
+    ));
+    assert_eq!(byte_limited.inspected_minis.len(), 1);
+    byte_limited.inspect(&duplicate).unwrap();
+
+    let mut mini_limited = LoadoutScriptIdPlanBuilder::new_with_config(
+        &base,
+        LoadoutPlanLimits {
+            max_minis: 2,
+            max_assignments: usize::MAX,
+            max_identity_bytes: usize::MAX,
+        },
+        PRODUCTION_ALLOCATION_DOMAINS,
+    )
+    .unwrap();
+    mini_limited.inspect(&first).unwrap();
+    mini_limited.inspect(&duplicate).unwrap();
+    assert!(matches!(
+        mini_limited.inspect(&second),
+        Err(RemapError::LoadoutPlanResourceLimit {
+            resource: "inspected minis",
+            actual: 3,
+            limit: 2,
+        })
+    ));
+    assert_eq!(mini_limited.inspected_minis.len(), 2);
+
+    let mut duplicate_limited = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    for _ in 0..MAX_LOADOUT_PLAN_MINIS {
+        duplicate_limited.inspect(&first).unwrap();
+    }
+    assert_eq!(duplicate_limited.inspected_count, MAX_LOADOUT_PLAN_MINIS);
+    assert_eq!(duplicate_limited.inspected_minis.len(), 1);
+    assert!(matches!(
+        duplicate_limited.inspect(&first),
+        Err(RemapError::LoadoutPlanResourceLimit {
+            resource: "inspected minis",
+            actual,
+            limit: MAX_LOADOUT_PLAN_MINIS,
+        }) if actual == MAX_LOADOUT_PLAN_MINIS + 1
+    ));
+    assert_eq!(duplicate_limited.inspected_count, MAX_LOADOUT_PLAN_MINIS);
+    assert_eq!(duplicate_limited.inspected_minis.len(), 1);
+}
+
+#[test]
+fn header_sha_and_identity_bindings_reject_changes_before_output() {
+    let base = empty_base();
+    let spec = SymbolMiniSpec {
+        module: "BoundMod",
+        type_name: "BoundType",
+        function_name: "BoundFunction",
+        type_ptr: 0x1110,
+        function_ptr: 0x2220,
+        type_id: (SCRIPT_OBJECT_KIND | 50) as i32,
+        function_id: 50,
+        runtime_id: 50,
+    };
+    let mini = symbol_mini(&spec);
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    let mut wrong_magic = mini.clone();
+    wrong_magic[16..20].copy_from_slice(&0u32.to_le_bytes());
+    assert!(matches!(
+        builder.inspect(&wrong_magic),
+        Err(RemapError::LoadoutPlanInvalidHeader {
+            artifact: "mini",
+            ..
+        })
+    ));
+    let mut wrong_guid = mini.clone();
+    wrong_guid[0] = 1;
+    assert!(matches!(
+        builder.inspect(&wrong_guid),
+        Err(RemapError::LoadoutPlanGuidMismatch { .. })
+    ));
+    assert!(builder.inspected_minis.is_empty());
+    builder.inspect(&mini).unwrap(); // corrected retry succeeds
+    let mut plan = builder.finish().unwrap();
+
+    let mut changed = mini.clone();
+    let position = changed
+        .windows(spec.type_name.len())
+        .position(|window| window == spec.type_name.as_bytes())
+        .unwrap();
+    changed[position] ^= 1;
+    let unchanged = changed.clone();
+    assert!(matches!(
+        remap_module_to_base_with_loadout_plan(&changed, &base, &plan),
+        Err(RemapError::LoadoutPlanMiniNotInspected)
+    ));
+    assert_eq!(changed, unchanged);
+
+    let mut wrong_base = base.clone();
+    wrong_base[0] = 2;
+    assert!(matches!(
+        remap_module_to_base_with_loadout_plan(&mini, &wrong_base, &plan),
+        Err(RemapError::LoadoutPlanBaseMismatch)
+    ));
+
+    *plan.inspected_minis.get_mut(&sha256_bytes(&mini)).unwrap() = [0xff; 32];
+    assert!(matches!(
+        remap_module_to_base_with_loadout_plan(&mini, &base, &plan),
+        Err(RemapError::LoadoutPlanIdentityMismatch)
+    ));
+}
+
+#[test]
+fn same_type_identity_with_different_object_kind_is_rejected_atomically() {
+    let base = empty_base();
+    let first_spec = SymbolMiniSpec {
+        module: "KindMod",
+        type_name: "KindType",
+        function_name: "KindFunction",
+        type_ptr: 0x1110,
+        function_ptr: 0x2220,
+        type_id: (SCRIPT_OBJECT_KIND | 60) as i32,
+        function_id: 60,
+        runtime_id: 60,
+    };
+    let conflicting_spec = SymbolMiniSpec {
+        type_ptr: 0x3330,
+        function_ptr: 0x4440,
+        type_id: (APP_OBJECT_KIND | 70) as i32,
+        function_id: 70,
+        runtime_id: 70,
+        ..first_spec.clone()
+    };
+    let corrected_spec = SymbolMiniSpec {
+        type_id: (SCRIPT_OBJECT_KIND | 70) as i32,
+        ..conflicting_spec.clone()
+    };
+    let first = symbol_mini(&first_spec);
+    let conflicting = symbol_mini(&conflicting_spec);
+    let corrected = symbol_mini(&corrected_spec);
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    builder.inspect(&first).unwrap();
+    assert!(matches!(
+        builder.inspect(&conflicting),
+        Err(RemapError::LoadoutPlanTypeKindConflict {
+            first: SCRIPT_OBJECT_KIND,
+            second: APP_OBJECT_KIND,
+            ..
+        })
+    ));
+    assert_eq!(builder.inspected_minis.len(), 1);
+    builder.inspect(&corrected).unwrap();
+    let plan = builder.finish().unwrap();
+    assert_eq!(plan.type_id_assignments.len(), 1);
+}
+
+#[test]
+fn planned_second_pass_resolves_pristine_signature_type_without_local_t1_row() {
+    const BASE_TYPE_PTR: i64 = 0x5510;
+    const BASE_TYPE_ID: i32 = (SCRIPT_OBJECT_KIND | 80) as i32;
+    let base = cache(
+        "Pristine",
+        &[],
+        &[class_record("PristineType")],
+        TailRows {
+            types: vec![type_row(BASE_TYPE_PTR, "PristineType", "Pristine")],
+            type_ids: vec![id_row(BASE_TYPE_ID, BASE_TYPE_PTR)],
+            ..TailRows::default()
+        },
+    );
+    let mini = cache(
+        "DependencyMod",
+        &[function_record("UsesPristine", &[BASE_TYPE_PTR], 90)],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(
+                0x9910,
+                "UsesPristine",
+                "DependencyMod",
+                &[BASE_TYPE_PTR],
+            )],
+            func_ids: vec![id_row(90, 0x9910)],
+            ..TailRows::default()
+        },
+    );
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    builder.inspect(&mini).unwrap();
+    let plan = builder.finish().unwrap();
+    let output = remap_module_to_base_with_loadout_plan(&mini, &base, &plan)
+        .unwrap()
+        .0;
+    let meta = TailMetadata::build(&output).unwrap();
+    assert!(meta.types.is_empty(), "pristine T1 must remain omitted");
+    assert_eq!(meta.funcs.len(), 1);
+    assert_eq!(meta.funcs[0].type_deps[0].ptr, BASE_TYPE_PTR);
+}
+
+#[test]
+fn plan_union_does_not_authorize_a_dependency_declared_only_by_another_mini() {
+    const PROVIDER_TYPE_PTR: i64 = 0x7710;
+    const CONSUMER_FUNC_PTR: i64 = 0x8810;
+    let base = empty_base();
+    let provider = symbol_mini(&SymbolMiniSpec {
+        module: "ProviderMod",
+        type_name: "ProviderType",
+        function_name: "ProviderFunction",
+        type_ptr: PROVIDER_TYPE_PTR,
+        function_ptr: 0x7720,
+        type_id: (SCRIPT_OBJECT_KIND | 100) as i32,
+        function_id: 100,
+        runtime_id: 100,
+    });
+    let consumer = cache(
+        "ConsumerMod",
+        &[function_record(
+            "ConsumesProvider",
+            &[PROVIDER_TYPE_PTR],
+            101,
+        )],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(
+                CONSUMER_FUNC_PTR,
+                "ConsumesProvider",
+                "ConsumerMod",
+                &[PROVIDER_TYPE_PTR],
+            )],
+            func_ids: vec![id_row(101, CONSUMER_FUNC_PTR)],
+            ..TailRows::default()
+        },
+    );
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    builder.inspect(&provider).unwrap();
+    let inventory_before = builder.inventory.clone();
+    let entries_before = builder.assignment_entries;
+    let bytes_before = builder.identity_bytes;
+    assert!(matches!(
+        builder.inspect(&consumer),
+        Err(RemapError::Wire(WireError::InvalidDataType {
+            key: CONSUMER_FUNC_PTR,
+            detail: "identifier requires a concrete TypeReference",
+        }))
+    ));
+    assert_eq!(builder.inspected_count, 1);
+    assert_eq!(builder.inspected_minis.len(), 1);
+    assert_eq!(builder.inventory, inventory_before);
+    assert_eq!(builder.assignment_entries, entries_before);
+    assert_eq!(builder.identity_bytes, bytes_before);
+}
+
+#[test]
+fn unknown_executable_ids_fail_before_builder_commit_and_allow_retry() {
+    const UNKNOWN_FUNC_ID: i32 = 0x12_345;
+    const UNKNOWN_TYPE_ID: i32 = (SCRIPT_OBJECT_KIND | 0x12_345) as i32;
+    let base = empty_base();
+    let spec = SymbolMiniSpec {
+        module: "StrictRefs",
+        type_name: "StrictType",
+        function_name: "StrictFunction",
+        type_ptr: 0x9110,
+        function_ptr: 0x9220,
+        type_id: (SCRIPT_OBJECT_KIND | 110) as i32,
+        function_id: 110,
+        runtime_id: 110,
+    };
+    let unknown_call = symbol_mini_with_code(&spec, &[9, UNKNOWN_FUNC_ID, 10]);
+    let unknown_type_id = symbol_mini_with_code(&spec, &[76, UNKNOWN_TYPE_ID, 10]);
+    let corrected = symbol_mini(&spec);
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+
+    assert!(matches!(
+        builder.inspect(&unknown_call),
+        Err(RemapError::UnresolvedEffectiveReference {
+            kind: "function id",
+            op: "CALL",
+            key,
+        }) if key == i64::from(UNKNOWN_FUNC_ID)
+    ));
+    assert_eq!(builder.inspected_count, 0);
+    assert!(builder.inspected_minis.is_empty());
+    assert!(builder.inventory.pointers.is_empty());
+
+    assert!(matches!(
+        builder.inspect(&unknown_type_id),
+        Err(RemapError::UnresolvedEffectiveReference {
+            kind: "type id",
+            op: "TYPEID",
+            key,
+        }) if key == i64::from(UNKNOWN_TYPE_ID)
+    ));
+    assert_eq!(builder.inspected_count, 0);
+    assert!(builder.inspected_minis.is_empty());
+    assert!(builder.inventory.pointers.is_empty());
+
+    builder.inspect(&corrected).unwrap();
+    assert_eq!(builder.inspected_count, 1);
+    assert_eq!(builder.inspected_minis.len(), 1);
+}
+
+#[test]
+fn duplicate_portable_identity_under_two_raw_keys_is_rejected_before_emit() {
+    let base = empty_base();
+    let duplicate_types = cache(
+        "AliasTypes",
+        &[],
+        &[class_record("AliasType")],
+        TailRows {
+            types: vec![
+                type_row(0xc110, "AliasType", "AliasTypes"),
+                type_row(0xc220, "AliasType", "AliasTypes"),
+            ],
+            type_ids: vec![
+                id_row((SCRIPT_OBJECT_KIND | 130) as i32, 0xc110),
+                id_row((SCRIPT_OBJECT_KIND | 131) as i32, 0xc220),
+            ],
+            ..TailRows::default()
+        },
+    );
+    let duplicate_functions = cache(
+        "AliasFunctions",
+        &[function_record("AliasFunction", &[], 132)],
+        &[],
+        TailRows {
+            funcs: vec![
+                function_tail_row(0xd110, "AliasFunction", "AliasFunctions", &[]),
+                function_tail_row(0xd220, "AliasFunction", "AliasFunctions", &[]),
+            ],
+            func_ids: vec![id_row(132, 0xd110), id_row(133, 0xd220)],
+            ..TailRows::default()
+        },
+    );
+    let duplicate_globals = cache_with_module_globals(
+        "AliasGlobals",
+        &[],
+        &[],
+        &[module_global_record("AliasGlobal")],
+        TailRows {
+            globals: vec![
+                nonstring_global_row(0xe110, "AliasGlobal", "AliasGlobals"),
+                nonstring_global_row(0xe220, "AliasGlobal", "AliasGlobals"),
+            ],
+            ..TailRows::default()
+        },
+    );
+
+    for (mini, table) in [
+        (duplicate_types, 0),
+        (duplicate_functions, 2),
+        (duplicate_globals, 4),
+    ] {
+        let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+        assert!(matches!(
+            builder.inspect(&mini),
+            Err(RemapError::InvalidTailRow {
+                table: actual_table,
+                kind: "symbol identity",
+                ..
+            }) if actual_table == table
+        ));
+        assert_eq!(builder.inspected_count, 0);
+        assert!(builder.inspected_minis.is_empty());
+        assert!(builder.inventory.pointers.is_empty());
+    }
+}
+
+#[test]
+fn string_global_aliases_share_one_canonical_row_within_and_across_minis() {
+    let base = empty_base();
+    let aliases = string_global_mini(
+        "StringAliases",
+        "UsesAliases",
+        0xf110,
+        140,
+        &[0xf210, 0xf220],
+        "None",
+    );
+    let repacked = string_global_mini(
+        "StringRepacked",
+        "UsesRepackedAlias",
+        0xf330,
+        141,
+        &[0xf440],
+        "None",
+    );
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    builder.inspect(&aliases).unwrap();
+    builder.inspect(&repacked).unwrap();
+    let plan = builder.finish().unwrap();
+    let aliases_output = remap_module_to_base_with_loadout_plan(&aliases, &base, &plan)
+        .unwrap()
+        .0;
+    let repacked_output = remap_module_to_base_with_loadout_plan(&repacked, &base, &plan)
+        .unwrap()
+        .0;
+
+    let aliases_meta = TailMetadata::build(&aliases_output).unwrap();
+    let repacked_meta = TailMetadata::build(&repacked_output).unwrap();
+    assert_eq!(aliases_meta.globals.len(), 1);
+    assert_eq!(repacked_meta.globals.len(), 1);
+    let aliases_row = &aliases_meta.globals[0];
+    let repacked_row = &repacked_meta.globals[0];
+    assert!(aliases_row.is_string && repacked_row.is_string);
+    assert_eq!(aliases_row.name, "None");
+    assert_eq!(aliases_row.module, "");
+    assert_eq!(aliases_row.namespace, "");
+    assert_eq!(aliases_row.key, repacked_row.key);
+    assert_eq!(
+        &aliases_output[aliases_row.start..aliases_row.end],
+        &repacked_output[repacked_row.start..repacked_row.end]
+    );
+    assert_eq!(
+        global_ptr_operands(&aliases_output),
+        [aliases_row.key, aliases_row.key]
+    );
+    assert_eq!(global_ptr_operands(&repacked_output), [aliases_row.key]);
+
+    let reference_base = EffectiveReferenceBase::build(&base).unwrap();
+    let mut reference_state = EffectiveReferenceState::default();
+    let first_contribution = reference_base
+        .validate(&reference_state, &aliases_output)
+        .unwrap();
+    reference_state.record(first_contribution);
+    reference_base
+        .validate(&reference_state, &repacked_output)
+        .expect("canonical string alias must remain valid after the first mini");
+
+    let ordinary = remap_module_allow_new(&aliases, &base).unwrap().0;
+    let ordinary_meta = TailMetadata::build(&ordinary).unwrap();
+    assert_eq!(ordinary_meta.globals.len(), 1);
+    assert_eq!(global_ptr_operands(&ordinary).len(), 2);
+    assert_eq!(
+        global_ptr_operands(&ordinary)[0],
+        global_ptr_operands(&ordinary)[1]
+    );
+}
+
+#[test]
+fn string_global_matching_large_base_alias_bucket_uses_the_smallest_key() {
+    const FIRST_BASE_KEY: i64 = 0x1010;
+    const BASE_ALIAS_COUNT: i64 = 2_500; // above the measured Shipping maximum of 2,442
+    let base_aliases: Vec<Vec<u8>> = (0..BASE_ALIAS_COUNT)
+        .rev()
+        .map(|index| string_global_row(FIRST_BASE_KEY + index * 8, "SharedLiteral"))
+        .collect();
+    // A real Shipping cache has a large module body behind this alias bucket. Keep the synthetic
+    // source/identity ratio representative so this lookup test does not trip the separate
+    // small-source identity-amplification guard first.
+    let source_padding = "x".repeat(256 * 1024);
+    let base = cache(
+        "Pristine",
+        &[],
+        &[],
+        TailRows {
+            globals: base_aliases,
+            static_names: vec![sia(&source_padding)],
+            ..TailRows::default()
+        },
+    );
+    let mini = string_global_mini(
+        "LiteralConsumer",
+        "UsesBaseLiteral",
+        0x3030,
+        150,
+        &[0x4040],
+        "SharedLiteral",
+    );
+
+    let ordinary = remap_module_allow_new(&mini, &base).unwrap().0;
+    assert_eq!(global_ptr_operands(&ordinary), [FIRST_BASE_KEY]);
+    assert!(TailMetadata::build(&ordinary).unwrap().globals.is_empty());
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    builder.inspect(&mini).unwrap();
+    let plan = builder.finish().unwrap();
+    let planned = remap_module_to_base_with_loadout_plan(&mini, &base, &plan)
+        .unwrap()
+        .0;
+    assert_eq!(global_ptr_operands(&planned), [FIRST_BASE_KEY]);
+    assert!(TailMetadata::build(&planned).unwrap().globals.is_empty());
+}
+
+#[test]
+fn effective_reference_state_rejects_global_alias_from_a_prior_mini_atomically() {
+    let base = empty_base();
+    let first = cache_with_module_globals(
+        "SharedGlobalModule",
+        &[],
+        &[],
+        &[module_global_record("SharedGlobal")],
+        TailRows {
+            globals: vec![nonstring_global_row(
+                0xe310,
+                "SharedGlobal",
+                "SharedGlobalModule",
+            )],
+            ..TailRows::default()
+        },
+    );
+    let second = cache_with_module_globals(
+        "SharedGlobalModule",
+        &[],
+        &[],
+        &[module_global_record("SharedGlobal")],
+        TailRows {
+            globals: vec![nonstring_global_row(
+                0xe320,
+                "SharedGlobal",
+                "SharedGlobalModule",
+            )],
+            ..TailRows::default()
+        },
+    );
+    let reference_base = EffectiveReferenceBase::build(&base).unwrap();
+    let mut state = EffectiveReferenceState::default();
+    let first_contribution = reference_base.validate(&state, &first).unwrap();
+    state.record(first_contribution);
+    let state_before = state.clone();
+    assert!(matches!(
+        reference_base.validate(&state, &second),
+        Err(RemapError::InvalidTailRow {
+            table: 4,
+            kind: "symbol identity",
+            ..
+        })
+    ));
+    assert_eq!(
+        state.accepted_global_identities,
+        state_before.accepted_global_identities
+    );
+    assert_eq!(
+        state.accepted_identity_bytes,
+        state_before.accepted_identity_bytes
+    );
+    assert_eq!(
+        state.accepted_source_bytes,
+        state_before.accepted_source_bytes
+    );
+}
+
+#[test]
+fn prepared_base_only_func_id_preserves_factory_ref_and_static_name() {
+    const BASE_FUNC_PTR: i64 = 0xa110;
+    const BASE_FUNC_ID: i32 = 120;
+    const MINI_TYPE_PTR: i64 = 0xb110;
+    const MINI_TYPE_ID: i32 = (SCRIPT_OBJECT_KIND | 121) as i32;
+    const MINI_FUNC_PTR: i64 = 0xb220;
+    const MINI_FUNC_ID: i32 = 121;
+    let base = cache(
+        "Pristine",
+        &[function_record("__STATIC_NAME", &[], BASE_FUNC_ID)],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(
+                BASE_FUNC_PTR,
+                "__STATIC_NAME",
+                "Pristine",
+                &[],
+            )],
+            func_ids: vec![id_row(BASE_FUNC_ID, BASE_FUNC_PTR)],
+            ..TailRows::default()
+        },
+    );
+    let mini = cache(
+        "PreparedConsumer",
+        &[function_record_with_code(
+            "UsesStaticName",
+            &[],
+            MINI_FUNC_ID,
+            &[2, 0, 9, BASE_FUNC_ID, 10],
+        )],
+        &[class_record_with_factory_ref(
+            "PreparedClass",
+            i64::from(BASE_FUNC_ID),
+        )],
+        TailRows {
+            types: vec![type_row(MINI_TYPE_PTR, "PreparedClass", "PreparedConsumer")],
+            type_ids: vec![id_row(MINI_TYPE_ID, MINI_TYPE_PTR)],
+            funcs: vec![function_tail_row(
+                MINI_FUNC_PTR,
+                "UsesStaticName",
+                "PreparedConsumer",
+                &[],
+            )],
+            func_ids: vec![id_row(MINI_FUNC_ID, MINI_FUNC_PTR)],
+            static_names: vec![sia("FreshStaticName")],
+            ..TailRows::default()
+        },
+    );
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    builder.inspect(&mini).unwrap();
+    let plan = builder.finish().unwrap();
+    let output = remap_module_to_base_with_loadout_plan(&mini, &base, &plan)
+        .unwrap()
+        .0;
+    let meta = TailMetadata::build(&output).unwrap();
+    assert_eq!(meta.static_names.len(), 1);
+    assert_eq!(meta.static_names[0].name, "FreshStaticName");
+    let spans = collect_module_spans(&output).unwrap();
+    let embedded_func_ids: Vec<i64> = spans
+        .embeds
+        .iter()
+        .filter(|embed| matches!(embed.kind, EmbedKind::FuncId))
+        .map(|embed| {
+            i64::from_le_bytes(
+                output[embed.byte_off..embed.byte_off + 8]
+                    .try_into()
+                    .unwrap(),
+            )
+        })
+        .filter(|&id| id != 0)
+        .collect();
+    assert_eq!(embedded_func_ids, [i64::from(BASE_FUNC_ID)]);
+}
+
+#[test]
+fn successor_allocator_wraps_and_reports_small_domain_exhaustion() {
+    let mut allocator = SuccessorAllocator::new(1, 3, [2, 3]);
+    assert_eq!(allocator.allocate_from(2), Some(1));
+    assert_eq!(allocator.allocate_from(1), None);
+
+    let domains = CanonicalAllocationDomains {
+        function_id_high: 2,
+        ..small_domains()
+    };
+    let mut full = SuccessorAllocator::new(1, 2, [1, 2]);
+    assert!(matches!(
+        allocate_function_id("exhausted", &mut full, domains),
+        Err(RemapError::KeySpaceExhausted {
+            kind: "function-id"
+        })
+    ));
+}
+
+#[test]
+fn real_shipping_builds_complete_semantic_property_and_function_id_indexes() {
+    let Some(path) = std::env::var_os("GORE_AS_REAL_CACHE") else {
+        eprintln!("skip: set GORE_AS_REAL_CACHE");
+        return;
+    };
+    let bytes = std::fs::read(path).expect("read real Shipping cache");
+    let context = build_allow_new_base_context(&bytes).expect("index real Shipping cache");
+    for row in &context.meta.properties {
+        let Some(owner_ptr) = context.syms.typeid_to_ptr.get(&row.old_type_id) else {
+            continue;
+        };
+        let Some(owner_identity) = context.syms.type_id_of_ptr.get(owner_ptr) else {
+            continue;
+        };
+        assert!(context
+            .declarations
+            .properties
+            .contains(&PristinePropertyIdentity {
+                owner_identity: owner_identity.clone(),
+                name: row.name.clone(),
+                member_offset: row.member_offset,
+            }));
+    }
+    assert!(
+        !context.module_function_ids.is_empty(),
+        "Shipping must expose module Function.Id assignments"
+    );
+    assert_eq!(
+        context.module_function_ids.len(),
+        context.occupied_module_function_ids.len(),
+        "Shipping module Function.Id values must be globally unique"
+    );
+}

--- a/crates/gore-as/src/cache/splice.rs
+++ b/crates/gore-as/src/cache/splice.rs
@@ -595,8 +595,8 @@ impl SequentialMiniGuard {
     /// Validate `mini`, return the StaticNames-rebased bytes, and record its rows atomically.
     ///
     /// This advances validation history only; callers publishing a composed cache should prefer
-    /// [`Self::compose_add`] or [`Self::compose_edit`], which commit history only after the entire
-    /// prospective cache passes structural validation.
+    /// [`Self::compose_add`], [`Self::compose_edit`], or [`Self::compose_edit_or_add`], which commit
+    /// history only after the entire prospective cache passes structural validation.
     pub fn check_and_record(&mut self, mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
         let (prepared, delta) = self.stage(mini)?;
         self.commit(delta);
@@ -655,6 +655,48 @@ impl SequentialMiniGuard {
         )?;
         let (prepared, delta) = self.stage(mini)?;
         let composed = replace_module(running, &prepared, target)?;
+        self.base
+            .reference_context
+            .validate_composed_declarations(&composed)
+            .map_err(SpliceError::ComposedModule)?;
+        let mut delta = delta;
+        delta.usage.composed_scan_bytes = scan_bytes;
+        self.commit(delta);
+        self.expected_running_sha256 = Sha256::digest(&composed).into();
+        Ok(composed)
+    }
+
+    /// Validate one winning replacement and edit `target` when it exists, or append the prepared
+    /// module when it does not. This is for a reduced same-target loadout where a shadowed earlier
+    /// `add` established that the winning `edit` may legitimately target a module absent from the
+    /// pristine base. The mini is staged once and guard history advances only after the chosen
+    /// composition passes every final validation.
+    pub fn compose_edit_or_add(
+        &mut self,
+        running: &[u8],
+        mini: &[u8],
+        target: &str,
+    ) -> Result<Vec<u8>, SpliceError> {
+        self.require_running_state(running)?;
+        let prospective = checked_composed_capacity(&[running.len(), mini.len()])?;
+        // In the missing-target branch, `replace_module` first performs its bounded target scan
+        // before `splice_auto` builds and validates the appended output. Charge that additional
+        // pass conservatively before staging so repeated upserts cannot bypass the cumulative cap.
+        let scan_bytes = u64::try_from(prospective)
+            .unwrap_or(u64::MAX)
+            .saturating_mul(3);
+        checked_usage_add(
+            self.usage.composed_scan_bytes,
+            scan_bytes,
+            "composed validation scan bytes",
+            MAX_SEQUENTIAL_COMPOSED_SCAN_BYTES,
+        )?;
+        let (prepared, delta) = self.stage(mini)?;
+        let composed = match replace_module(running, &prepared, target) {
+            Ok(composed) => composed,
+            Err(SpliceError::NameNotFound(_)) => splice_auto(running, &prepared)?,
+            Err(error) => return Err(error),
+        };
         self.base
             .reference_context
             .validate_composed_declarations(&composed)

--- a/crates/gore-as/src/cache/splice.rs
+++ b/crates/gore-as/src/cache/splice.rs
@@ -2,8 +2,8 @@
 //!
 //! Per `work/reversing/gore-as/findings/container-splice.md` §5: insert the mini-cache's
 //! single module entry immediately before the base cache's global tail tables, and bump
-//! the `Modules` count at 0x14 by one. The load path has no integrity check (§6), so no
-//! checksum/GUID fix is needed.
+//! the `Modules` count at 0x14 by one. The runtime may not enforce the FGuid, but GORE does:
+//! prepared minis are bound to the exact base generation before composition.
 //!
 //! [`splice`] is the strict **case-(b)** fast path: the mini module references no global
 //! types (its 7 tail tables are 28 zero bytes). [`splice_auto`] also supports **case-(a)**
@@ -11,15 +11,44 @@
 //! collision checks.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
 
 use super::header::CacheHeader;
 use super::tables::{parse_tail_tables, TailTables, N_TABLES};
 use super::walk_modules::{module_count, module_names, module_ranges, module_region_end};
-use super::wire::WireError;
+use super::wire::{Cursor, WireError};
 use thiserror::Error;
+
+// One Manager loadout may enable 1,000 mods, but a production AngelScript loadout with hundreds
+// of independently compiled modules is already pathological. Keep the repeated validation work
+// firmly bounded while leaving two orders of magnitude above current real fixtures.
+const MAX_SEQUENTIAL_MINIS: u64 = 256;
+const MAX_SEQUENTIAL_KEYED_ROWS: u64 = 131_072;
+const MAX_SEQUENTIAL_KEYED_ROW_BYTES: u64 = 64 * 1024 * 1024;
+// The pristine Shipping cache currently has ~180k keyed tail rows. Base preflight needs a wider
+// envelope than the much smaller cumulative contribution budget for independently compiled minis.
+const MAX_BASE_KEYED_ROWS: u64 = 1_000_000;
+const MAX_BASE_KEYED_ROW_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_SEQUENTIAL_T6_NAMES: u64 = 65_536;
+const MAX_SEQUENTIAL_T6_NAME_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_COMPOSED_CACHE_BYTES: u64 = 1024 * 1024 * 1024;
+// Each guarded composition currently performs two full prospective-output validation walks (the
+// low-level mechanical pass and the generation-bound declaration pass). Bound their cumulative
+// bytes so 256 tiny minis cannot force hundreds of GiB of repeated scans over a near-GiB cache.
+const MAX_SEQUENTIAL_COMPOSED_SCAN_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+// Validation currently materializes each function's bytecode once for disassembly. Cap both one
+// function and the complete mini well below the Manager's 1-GiB archive ceiling so worst-case input
+// cannot create a second near-GiB allocation. The shipped cache is ~124 MiB in total; prepared
+// one-module minis are orders of magnitude smaller.
+const MAX_MINI_FUNCTION_BYTECODE_DWORDS: u64 = 4 * 1024 * 1024;
+const MAX_MINI_TOTAL_BYTECODE_DWORDS: u64 = 16 * 1024 * 1024;
 
 #[derive(Debug, Error)]
 pub enum SpliceError {
+    #[error("cache header error: {0}")]
+    Header(#[from] super::header::HeaderError),
     #[error("walk error: {0}")]
     Wire(#[from] WireError),
     #[error("mini-cache must contain exactly 1 module, found {0}")]
@@ -30,6 +59,12 @@ pub enum SpliceError {
     MiniHasGlobalRefs(usize),
     #[error("module name {0:?} already exists in the base cache (splicing would overwrite it)")]
     NameCollision(String),
+    #[error(
+        "inner module identity {0:?} already exists in the base cache (the runtime would overwrite it)"
+    )]
+    InnerNameCollision(String),
+    #[error("module-map key {0:?} occurs more than once in the cache")]
+    ModuleKeyCollision(String),
     #[error("module name {0:?} not found in the base cache (nothing to replace)")]
     NameNotFound(String),
     #[error(
@@ -52,6 +87,170 @@ pub enum SpliceError {
     SequentialKeyCollision { table: usize, key: i64 },
     #[error("cannot rebase sequential StaticNames: {0}")]
     StaticNameRebase(#[from] super::remap::RemapError),
+    #[error(
+        "mini-cache GUID {mini:?} does not match target base GUID {base:?}; remap the module against this exact game cache before applying it"
+    )]
+    MiniGuidMismatch { base: [u8; 16], mini: [u8; 16] },
+    #[error("mini-cache reference validation failed: {0}")]
+    MiniReference(#[source] super::remap::RemapError),
+    #[error("composed cache record validation failed: {0}")]
+    ComposedModule(#[source] super::remap::RemapError),
+    #[error("loadout-wide script ID planning failed: {0}")]
+    LoadoutPlan(#[source] super::remap::RemapError),
+    #[error("standalone script cache byte limit exceeded: {actual} > {limit}")]
+    StandaloneCacheTooLarge { actual: u64, limit: u64 },
+    #[error(
+        "running cache is not the exact state expected by this sequential guard; restart composition from its pristine base"
+    )]
+    RunningStateMismatch,
+    #[error("sequential mini-cache {resource} limit exceeded: {actual} > {limit}")]
+    SequentialLimitExceeded {
+        resource: &'static str,
+        actual: u64,
+        limit: u64,
+    },
+}
+
+/// Streaming first pass for assigning one collision-stable pointer/engine-ID mapping to every
+/// independently prepared mini-cache in a loadout. `inspect` retains no mini bytes, so callers may
+/// read and drop one artifact at a time.
+pub struct LoadoutScriptIdPlanBuilder(super::remap::LoadoutScriptIdPlanBuilder);
+
+/// Opaque, immutable canonical assignment plan produced by [`LoadoutScriptIdPlanBuilder`].
+///
+/// The plan retains a parsed pristine-base context. Callers that also need a
+/// [`SequentialMiniGuard`] should canonicalize their inspected minis first, drop this plan, and
+/// only then construct the guard so both large contexts are never resident together.
+pub struct LoadoutScriptIdPlan(super::remap::LoadoutScriptIdPlan);
+
+fn loadout_splice_error(error: super::remap::RemapError) -> SpliceError {
+    match error {
+        super::remap::RemapError::LoadoutPlanGuidMismatch { pristine, mini } => {
+            SpliceError::MiniGuidMismatch {
+                base: pristine,
+                mini,
+            }
+        }
+        super::remap::RemapError::NotSingle(count) => SpliceError::MiniNotSingle(count),
+        other => SpliceError::LoadoutPlan(other),
+    }
+}
+
+impl LoadoutScriptIdPlanBuilder {
+    /// Parse the unchanged pristine base once and start a loadout-wide identity inventory.
+    pub fn new(pristine_base: &[u8]) -> Result<Self, SpliceError> {
+        super::remap::LoadoutScriptIdPlanBuilder::new(pristine_base)
+            .map(Self)
+            .map_err(loadout_splice_error)
+    }
+
+    /// Inspect one exact mini atomically without retaining its bytes.
+    pub fn inspect(&mut self, mini: &[u8]) -> Result<(), SpliceError> {
+        self.0.inspect(mini).map_err(loadout_splice_error)
+    }
+
+    /// Freeze the portable-identity union and allocate its deterministic canonical mapping.
+    pub fn finish(self) -> Result<LoadoutScriptIdPlan, SpliceError> {
+        self.0
+            .finish()
+            .map(LoadoutScriptIdPlan)
+            .map_err(loadout_splice_error)
+    }
+}
+
+/// Canonicalize one exact mini previously inspected by `plan` against the same pristine base.
+/// Both byte inputs are SHA-256-bound by the plan; the returned cache is still validated by
+/// [`SequentialMiniGuard`] when it is composed.
+pub fn remap_module_to_base_with_loadout_plan(
+    mini: &[u8],
+    pristine_base: &[u8],
+    plan: &LoadoutScriptIdPlan,
+) -> Result<Vec<u8>, SpliceError> {
+    super::remap::remap_module_to_base_with_loadout_plan(mini, pristine_base, &plan.0)
+        .map(|(bytes, _counts)| bytes)
+        .map_err(loadout_splice_error)
+}
+
+fn check_bytecode_work(work: super::remap::ModuleWorkSummary) -> Result<(), SpliceError> {
+    let max_function = u64::try_from(work.max_function_bytecode_dwords).unwrap_or(u64::MAX);
+    if max_function > MAX_MINI_FUNCTION_BYTECODE_DWORDS {
+        return Err(SpliceError::SequentialLimitExceeded {
+            resource: "mini function bytecode dwords",
+            actual: max_function,
+            limit: MAX_MINI_FUNCTION_BYTECODE_DWORDS,
+        });
+    }
+    if work.total_bytecode_dwords > MAX_MINI_TOTAL_BYTECODE_DWORDS {
+        return Err(SpliceError::SequentialLimitExceeded {
+            resource: "mini total bytecode dwords",
+            actual: work.total_bytecode_dwords,
+            limit: MAX_MINI_TOTAL_BYTECODE_DWORDS,
+        });
+    }
+    Ok(())
+}
+
+fn finish_composition(out: Vec<u8>) -> Result<Vec<u8>, SpliceError> {
+    match super::remap::validate_composed_module_records(&out) {
+        Err(super::remap::RemapError::ModuleNameCollision { name }) => {
+            return Err(SpliceError::InnerNameCollision(name));
+        }
+        Err(error) => return Err(SpliceError::ComposedModule(error)),
+        Ok(()) => {}
+    }
+    Ok(out)
+}
+
+/// Validate a complete `PrecompiledScript*.Cache` replacement without interpreting its runtime
+/// identities. This is deliberately narrower than [`SequentialMiniGuard`]: a standalone full
+/// replacement owns its GUID and reference universe, so GORE only validates the supported header,
+/// the complete module/tail wire shape, finite parser work, and exact EOF.
+///
+/// The input is never rewritten. Callers that publish it must retain and copy the original bytes.
+pub fn validate_standalone_script_cache(bytes: &[u8]) -> Result<(), SpliceError> {
+    CacheHeader::parse(bytes)?;
+    let actual = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    if actual > MAX_COMPOSED_CACHE_BYTES {
+        return Err(SpliceError::StandaloneCacheTooLarge {
+            actual,
+            limit: MAX_COMPOSED_CACHE_BYTES,
+        });
+    }
+    super::remap::preflight_cache_module_work(bytes)?;
+    // The tail preflight re-walks the module region, bounds all seven streaming table shapes and
+    // their projected allocation work, and rejects any trailing byte after the final T7 row.
+    super::remap::preflight_tail_tables(bytes)?;
+    // Every non-T6 tail container is a TMap. Duplicate keys are malformed even when this cache
+    // owns an unrelated GUID/reference universe: Unreal cannot deserialize two distinct entries
+    // under one map key. T1/T3/T5 OldReference keys and derived T7 property keys also share the
+    // runtime key domain enforced by the sequential overlay guard, so a standalone replacement
+    // must not be a weaker way to publish the same collision.
+    let tail = module_region_end(bytes)?;
+    let tables = parse_tail_tables(bytes, tail)?;
+    let mut pointer_domain = HashSet::new();
+    for (table, rows) in tables.tables.iter().enumerate() {
+        if table == 5 {
+            continue;
+        }
+        let mut within_table = HashSet::new();
+        for &key in &rows.keys {
+            if !within_table.insert(key)
+                || (matches!(table, 0 | 2 | 4 | 6) && !pointer_domain.insert(key))
+            {
+                return Err(SpliceError::KeyCollision { table, key });
+            }
+        }
+    }
+    // `Modules` is serialized as a TMap. Duplicate outer keys cannot survive deserialization as
+    // two distinct entries, so reject that malformed container shape without imposing the
+    // generation-specific declaration rules used for GORE-composed caches.
+    let mut module_keys = HashSet::new();
+    for name in module_names(bytes)? {
+        if !module_keys.insert(name.clone()) {
+            return Err(SpliceError::ModuleKeyCollision(name));
+        }
+    }
+    Ok(())
 }
 
 /// Stateful preflight for folding independently compiled mini-caches onto one running cache.
@@ -62,38 +261,443 @@ pub enum SpliceError {
 /// bytecode indices are rebased onto the names contributed by preceding minis. All validation is
 /// completed before the guard records a mini, keeping retry state atomic on error.
 #[derive(Debug)]
+struct SequentialMiniBase {
+    base_guid: [u8; 16],
+    reference_context: super::remap::EffectiveReferenceBase,
+    /// Exact base rows by key. A mini may repeat one byte-for-byte, but may never use `mini wins`
+    /// to retarget existing base users of that key.
+    base_rows: [HashMap<i64, Vec<u8>>; N_TABLES],
+    base_ptr_tables: HashMap<i64, usize>,
+    static_context: super::remap::StaticNameRebaseContext,
+}
+
+#[derive(Debug)]
 pub struct SequentialMiniGuard {
+    /// Large pristine-cache indexes are immutable and shared by staged compositions.
+    base: Arc<SequentialMiniBase>,
+    reference_state: super::remap::EffectiveReferenceState,
     /// Key -> canonical serialized row. An exact repeat is the same identity with the same fully
     /// remapped dependencies and is safe to deduplicate; a different row at that key is a hard
     /// hash/raw collision.
     contributed_rows: [HashMap<i64, Vec<u8>>; N_TABLES],
-    /// T1/T3/T5 OldReference keys share one runtime-pointer domain even though they live in
-    /// separate serialized TMaps. A cross-table reuse is therefore just as unsafe as a collision
-    /// within one table.
+    /// T1/T3/T5 OldReference keys and derived T7 property keys share one runtime-pointer domain
+    /// even though they live in separate serialized TMaps. A cross-table reuse is therefore just
+    /// as unsafe as a collision within one table.
     contributed_ptr_tables: HashMap<i64, usize>,
-    static_context: super::remap::StaticNameRebaseContext,
     contributed_static_names: Vec<String>,
+    /// Collision-resistant binding to the pristine base or the last cache returned by compose_*.
+    expected_running_sha256: [u8; 32],
+    usage: SequentialUsage,
+    composition_state_valid: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct SequentialUsage {
+    minis: u64,
+    keyed_rows: u64,
+    keyed_row_bytes: u64,
+    static_names: u64,
+    static_name_bytes: u64,
+    composed_scan_bytes: u64,
+}
+
+struct SequentialMiniDelta {
+    rows: [HashMap<i64, Vec<u8>>; N_TABLES],
+    ptr_tables: HashMap<i64, usize>,
+    static_names: Vec<String>,
+    reference: super::remap::ReferenceContribution,
+    usage: SequentialUsage,
+}
+
+fn checked_usage_add(
+    current: u64,
+    added: u64,
+    resource: &'static str,
+    limit: u64,
+) -> Result<u64, SpliceError> {
+    let actual = current.checked_add(added).unwrap_or(u64::MAX);
+    if actual > limit {
+        return Err(SpliceError::SequentialLimitExceeded {
+            resource,
+            actual,
+            limit,
+        });
+    }
+    Ok(actual)
+}
+
+fn checked_composed_capacity(parts: &[usize]) -> Result<usize, SpliceError> {
+    let actual = parts
+        .iter()
+        .try_fold(0usize, |sum, &part| sum.checked_add(part))
+        .and_then(|sum| u64::try_from(sum).ok())
+        .unwrap_or(u64::MAX);
+    if actual > MAX_COMPOSED_CACHE_BYTES {
+        return Err(SpliceError::SequentialLimitExceeded {
+            resource: "composed cache bytes",
+            actual,
+            limit: MAX_COMPOSED_CACHE_BYTES,
+        });
+    }
+    Ok(actual as usize)
+}
+
+impl SequentialUsage {
+    fn with_static_names(mut self, names: &[String]) -> Result<Self, SpliceError> {
+        self.static_names = u64::try_from(names.len()).unwrap_or(u64::MAX);
+        self.static_name_bytes = names.iter().try_fold(0u64, |total, name| {
+            checked_usage_add(
+                total,
+                u64::try_from(name.len()).unwrap_or(u64::MAX),
+                "StaticNames bytes",
+                MAX_SEQUENTIAL_T6_NAME_BYTES,
+            )
+        })?;
+        Ok(self)
+    }
+
+    fn project(self, delta: Self) -> Result<Self, SpliceError> {
+        Ok(Self {
+            minis: checked_usage_add(self.minis, delta.minis, "mini count", MAX_SEQUENTIAL_MINIS)?,
+            keyed_rows: checked_usage_add(
+                self.keyed_rows,
+                delta.keyed_rows,
+                "keyed row count",
+                MAX_SEQUENTIAL_KEYED_ROWS,
+            )?,
+            keyed_row_bytes: checked_usage_add(
+                self.keyed_row_bytes,
+                delta.keyed_row_bytes,
+                "keyed row bytes",
+                MAX_SEQUENTIAL_KEYED_ROW_BYTES,
+            )?,
+            static_names: checked_usage_add(
+                self.static_names,
+                delta.static_names,
+                "StaticNames count",
+                MAX_SEQUENTIAL_T6_NAMES,
+            )?,
+            static_name_bytes: checked_usage_add(
+                self.static_name_bytes,
+                delta.static_name_bytes,
+                "StaticNames bytes",
+                MAX_SEQUENTIAL_T6_NAME_BYTES,
+            )?,
+            composed_scan_bytes: checked_usage_add(
+                self.composed_scan_bytes,
+                delta.composed_scan_bytes,
+                "composed validation scan bytes",
+                MAX_SEQUENTIAL_COMPOSED_SCAN_BYTES,
+            )?,
+        })
+    }
+}
+
+/// Bound table work before the allocating parser builds key/offset vectors. Prepared minis are
+/// intentionally minimal, so a single mini never needs more rows/names than the whole sequential
+/// state can retain.
+fn preflight_sequential_tail_with_limits(
+    bytes: &[u8],
+    start: usize,
+    max_keyed_rows: u64,
+    max_keyed_row_bytes: u64,
+) -> Result<(), SpliceError> {
+    let mut c = Cursor::at(bytes, start);
+    let mut keyed_rows = 0u64;
+    let mut keyed_bytes = 0u64;
+
+    let mut keyed_table = |c: &mut Cursor<'_>,
+                           field: &'static str,
+                           key_bytes: usize,
+                           read_value: fn(&mut Cursor<'_>) -> Result<(), WireError>|
+     -> Result<(), SpliceError> {
+        let count = c.read_count(field)?;
+        keyed_rows = checked_usage_add(
+            keyed_rows,
+            u64::try_from(count).unwrap_or(u64::MAX),
+            "keyed row count",
+            max_keyed_rows,
+        )?;
+        let entries_start = c.pos();
+        for _ in 0..count {
+            c.skip(key_bytes)?;
+            read_value(c)?;
+        }
+        keyed_bytes = checked_usage_add(
+            keyed_bytes,
+            u64::try_from(c.pos() - entries_start).unwrap_or(u64::MAX),
+            "keyed row bytes",
+            max_keyed_row_bytes,
+        )?;
+        Ok(())
+    };
+
+    keyed_table(&mut c, "TypeReferences", 8, preflight_type_reference)?;
+    keyed_table(&mut c, "TypeIdReferenceToPointer", 4, |c| c.skip(8))?;
+    keyed_table(
+        &mut c,
+        "FunctionReferences",
+        8,
+        preflight_function_reference,
+    )?;
+    keyed_table(&mut c, "FunctionIdReferenceToPointer", 4, |c| c.skip(8))?;
+    keyed_table(&mut c, "GlobalReferences", 8, preflight_global_reference)?;
+
+    let static_count = c.read_count("StaticNames")?;
+    checked_usage_add(
+        0,
+        u64::try_from(static_count).unwrap_or(u64::MAX),
+        "StaticNames count",
+        MAX_SEQUENTIAL_T6_NAMES,
+    )?;
+    let mut static_bytes = 0u64;
+    for _ in 0..static_count {
+        let value = c.read_sia()?;
+        static_bytes = checked_usage_add(
+            static_bytes,
+            u64::try_from(value.len()).unwrap_or(u64::MAX),
+            "StaticNames bytes",
+            MAX_SEQUENTIAL_T6_NAME_BYTES,
+        )?;
+    }
+    keyed_table(
+        &mut c,
+        "PropertyReferences",
+        8,
+        preflight_property_reference,
+    )?;
+    Ok(())
+}
+
+fn preflight_sequential_tail(bytes: &[u8], start: usize) -> Result<(), SpliceError> {
+    preflight_sequential_tail_with_limits(
+        bytes,
+        start,
+        MAX_SEQUENTIAL_KEYED_ROWS,
+        MAX_SEQUENTIAL_KEYED_ROW_BYTES,
+    )
+}
+
+fn preflight_type_reference(c: &mut Cursor<'_>) -> Result<(), WireError> {
+    c.read_sia()?;
+    c.read_sia()?;
+    c.read_sia()?;
+    c.skip_tarray_fixed(36, "TypeRef.SubTypes")
+}
+
+fn preflight_function_reference(c: &mut Cursor<'_>) -> Result<(), WireError> {
+    c.read_sia()?;
+    c.read_sia()?;
+    c.read_sia()?;
+    c.skip(20)?;
+    c.skip_tarray_fixed(36, "FuncRef.ParameterTypes")?;
+    c.skip(36)
+}
+
+fn preflight_global_reference(c: &mut Cursor<'_>) -> Result<(), WireError> {
+    let name_pos = c.pos();
+    let name = c.read_sia_bytes()?;
+    c.read_sia()?;
+    c.read_sia()?;
+    if c.read_bool4()? {
+        name.decode_utf8(name_pos)?;
+    }
+    Ok(())
+}
+
+fn preflight_property_reference(c: &mut Cursor<'_>) -> Result<(), WireError> {
+    c.read_sia()?;
+    c.skip(4)
 }
 
 impl SequentialMiniGuard {
     /// Bind the guard to the exact base all incoming minis were independently remapped against.
     pub fn new(base: &[u8]) -> Result<Self, SpliceError> {
+        let header = CacheHeader::parse(base)?;
+        // A raw-file component can replace the effective script base before Manager composition.
+        // Reject an oversized or record-amplified base before any StaticName, identity, module-name,
+        // or tail-row collections are materialized.
+        checked_composed_capacity(&[base.len()])?;
+        super::remap::preflight_cache_module_work(base)?;
+        let base_tail = module_region_end(base)?;
+        preflight_sequential_tail_with_limits(
+            base,
+            base_tail,
+            MAX_BASE_KEYED_ROWS,
+            MAX_BASE_KEYED_ROW_BYTES,
+        )?;
+        let static_context = match super::remap::StaticNameRebaseContext::build(base) {
+            Err(super::remap::RemapError::ModuleNameCollision { name }) => {
+                return Err(SpliceError::InnerNameCollision(name));
+            }
+            Err(error) => return Err(SpliceError::StaticNameRebase(error)),
+            Ok(context) => context,
+        };
+        let reference_context = match super::remap::EffectiveReferenceBase::build(base) {
+            Err(super::remap::RemapError::ModuleNameCollision { name }) => {
+                return Err(SpliceError::InnerNameCollision(name));
+            }
+            Err(error) => return Err(SpliceError::StaticNameRebase(error)),
+            Ok(context) => context,
+        };
+        let base_guid = header.hash;
+        let base_tables = parse_tail_tables(base, base_tail)?;
+        if base_tables.end != base.len() {
+            return Err(SpliceError::TailNotAtEof {
+                which: "base",
+                got: base_tables.end,
+                len: base.len(),
+            });
+        }
+        let mut base_rows: [HashMap<i64, Vec<u8>>; N_TABLES] =
+            std::array::from_fn(|_| HashMap::new());
+        let mut base_ptr_tables = HashMap::new();
+        for (table, rows) in base_tables.tables.iter().enumerate() {
+            if table == 5 {
+                continue;
+            }
+            for (row_index, &key) in rows.keys.iter().enumerate() {
+                let start = rows.entry_starts[row_index];
+                let end = rows
+                    .entry_starts
+                    .get(row_index + 1)
+                    .copied()
+                    .unwrap_or(rows.entries_end);
+                if base_rows[table]
+                    .insert(key, base[start..end].to_vec())
+                    .is_some()
+                {
+                    return Err(SpliceError::KeyCollision { table, key });
+                }
+                if matches!(table, 0 | 2 | 4 | 6) && base_ptr_tables.insert(key, table).is_some() {
+                    return Err(SpliceError::KeyCollision { table, key });
+                }
+            }
+        }
         Ok(Self {
+            base: Arc::new(SequentialMiniBase {
+                base_guid,
+                reference_context,
+                base_rows,
+                base_ptr_tables,
+                static_context,
+            }),
+            reference_state: super::remap::EffectiveReferenceState::default(),
             contributed_rows: std::array::from_fn(|_| HashMap::new()),
             contributed_ptr_tables: HashMap::new(),
-            static_context: super::remap::StaticNameRebaseContext::build(base)?,
             contributed_static_names: Vec::new(),
+            expected_running_sha256: Sha256::digest(base).into(),
+            usage: SequentialUsage::default(),
+            composition_state_valid: true,
         })
     }
 
     /// Validate `mini`, return the StaticNames-rebased bytes, and record its rows atomically.
-    /// Callers must splice/replace with the returned bytes, not the input mini.
+    ///
+    /// This advances validation history only; callers publishing a composed cache should prefer
+    /// [`Self::compose_add`] or [`Self::compose_edit`], which commit history only after the entire
+    /// prospective cache passes structural validation.
     pub fn check_and_record(&mut self, mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
-        let count = module_count(mini);
+        let (prepared, delta) = self.stage(mini)?;
+        self.commit(delta);
+        self.composition_state_valid = false;
+        Ok(prepared)
+    }
+
+    /// Validate and append one mini to `running`, then atomically advance guard history.
+    pub fn compose_add(&mut self, running: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
+        self.require_running_state(running)?;
+        // Refuse an oversized prospective cache before `stage` parses bytecode or materializes
+        // any per-function `Vec<i32>`. The exact low-level splice checks again after parsing; this
+        // conservative bound is intentionally early and cannot under-estimate the output.
+        let prospective = checked_composed_capacity(&[running.len(), mini.len()])?;
+        let scan_bytes = u64::try_from(prospective)
+            .unwrap_or(u64::MAX)
+            .saturating_mul(2);
+        checked_usage_add(
+            self.usage.composed_scan_bytes,
+            scan_bytes,
+            "composed validation scan bytes",
+            MAX_SEQUENTIAL_COMPOSED_SCAN_BYTES,
+        )?;
+        let (prepared, delta) = self.stage(mini)?;
+        let composed = splice_auto(running, &prepared)?;
+        self.base
+            .reference_context
+            .validate_composed_declarations(&composed)
+            .map_err(SpliceError::ComposedModule)?;
+        let mut delta = delta;
+        delta.usage.composed_scan_bytes = scan_bytes;
+        self.commit(delta);
+        self.expected_running_sha256 = Sha256::digest(&composed).into();
+        Ok(composed)
+    }
+
+    /// Validate and replace `target` in `running`, then atomically advance guard history.
+    pub fn compose_edit(
+        &mut self,
+        running: &[u8],
+        mini: &[u8],
+        target: &str,
+    ) -> Result<Vec<u8>, SpliceError> {
+        self.require_running_state(running)?;
+        // See `compose_add`: edits may replace bytes, but `running + mini` is a safe early upper
+        // bound and prevents a near-limit mini from allocating a second near-GiB bytecode vector.
+        let prospective = checked_composed_capacity(&[running.len(), mini.len()])?;
+        let scan_bytes = u64::try_from(prospective)
+            .unwrap_or(u64::MAX)
+            .saturating_mul(2);
+        checked_usage_add(
+            self.usage.composed_scan_bytes,
+            scan_bytes,
+            "composed validation scan bytes",
+            MAX_SEQUENTIAL_COMPOSED_SCAN_BYTES,
+        )?;
+        let (prepared, delta) = self.stage(mini)?;
+        let composed = replace_module(running, &prepared, target)?;
+        self.base
+            .reference_context
+            .validate_composed_declarations(&composed)
+            .map_err(SpliceError::ComposedModule)?;
+        let mut delta = delta;
+        delta.usage.composed_scan_bytes = scan_bytes;
+        self.commit(delta);
+        self.expected_running_sha256 = Sha256::digest(&composed).into();
+        Ok(composed)
+    }
+
+    fn require_running_state(&self, running: &[u8]) -> Result<(), SpliceError> {
+        if !self.composition_state_valid
+            || <[u8; 32]>::from(Sha256::digest(running)) != self.expected_running_sha256
+        {
+            return Err(SpliceError::RunningStateMismatch);
+        }
+        Ok(())
+    }
+
+    fn stage(&self, mini: &[u8]) -> Result<(Vec<u8>, SequentialMiniDelta), SpliceError> {
+        // `check_and_record` reaches stage directly, so enforce the public one-cache size ceiling
+        // before StaticName rebasing clones the complete mini.
+        checked_composed_capacity(&[mini.len()])?;
+        checked_usage_add(self.usage.minis, 1, "mini count", MAX_SEQUENTIAL_MINIS)?;
+        let header = CacheHeader::parse(mini)?;
+        let count = header.type_count;
         if count != 1 {
             return Err(SpliceError::MiniNotSingle(count));
         }
+        let mini_guid = header.hash;
+        if mini_guid != self.base.base_guid {
+            return Err(SpliceError::MiniGuidMismatch {
+                base: self.base.base_guid,
+                mini: mini_guid,
+            });
+        }
+        // This streaming pass runs before any detailed record or bytecode vectors are built. It
+        // bounds both the largest function and the complete mini-cache bytecode payload so a
+        // near-limit archive cannot force a second near-limit allocation during validation.
+        check_bytecode_work(super::remap::preflight_mini_module_work(mini)?)?;
         let tail = module_region_end(mini)?;
+        preflight_sequential_tail(mini, tail)?;
         let tables = parse_tail_tables(mini, tail)?;
         if tables.end != mini.len() {
             return Err(SpliceError::TailNotAtEof {
@@ -115,7 +719,7 @@ impl SequentialMiniGuard {
                 if !within_mini.insert(key) {
                     return Err(SpliceError::SequentialKeyCollision { table, key });
                 }
-                if matches!(table, 0 | 2 | 4) {
+                if matches!(table, 0 | 2 | 4 | 6) {
                     let cross_table_within = within_ptr_domain
                         .insert(key, table)
                         .is_some_and(|prior| prior != table);
@@ -123,17 +727,31 @@ impl SequentialMiniGuard {
                         .contributed_ptr_tables
                         .get(&key)
                         .is_some_and(|&prior| prior != table);
+                    let cross_table_base = self
+                        .base
+                        .base_ptr_tables
+                        .get(&key)
+                        .is_some_and(|&prior| prior != table);
                     if cross_table_within || cross_table_prior {
                         return Err(SpliceError::SequentialKeyCollision { table, key });
                     }
+                    if cross_table_base {
+                        return Err(SpliceError::KeyCollision { table, key });
+                    }
+                }
+                let start = rows.entry_starts[row_index];
+                let end = rows
+                    .entry_starts
+                    .get(row_index + 1)
+                    .copied()
+                    .unwrap_or(rows.entries_end);
+                if self.base.base_rows[table]
+                    .get(&key)
+                    .is_some_and(|base_row| base_row.as_slice() != &mini[start..end])
+                {
+                    return Err(SpliceError::KeyCollision { table, key });
                 }
                 if let Some(prior) = self.contributed_rows[table].get(&key) {
-                    let start = rows.entry_starts[row_index];
-                    let end = rows
-                        .entry_starts
-                        .get(row_index + 1)
-                        .copied()
-                        .unwrap_or(rows.entries_end);
                     if prior.as_slice() != &mini[start..end] {
                         return Err(SpliceError::SequentialKeyCollision { table, key });
                     }
@@ -141,14 +759,27 @@ impl SequentialMiniGuard {
             }
         }
 
+        let reference_contribution = self
+            .base
+            .reference_context
+            .validate(&self.reference_state, mini)
+            .map_err(SpliceError::MiniReference)?;
+
         // Rebase before mutating either collision state or the accumulated T6 pool. A malformed
         // operand therefore leaves this guard reusable for a corrected mini.
         let (rebased, appended_names) = super::remap::rebase_static_names_for_composition(
             mini,
-            &self.static_context,
+            &self.base.static_context,
             &self.contributed_static_names,
         )?;
 
+        let mut delta_rows: [HashMap<i64, Vec<u8>>; N_TABLES] =
+            std::array::from_fn(|_| HashMap::new());
+        let mut delta_ptr_tables = HashMap::new();
+        let mut delta_usage = SequentialUsage {
+            minis: 1,
+            ..SequentialUsage::default()
+        };
         for (table, rows) in tables.tables.iter().enumerate() {
             if table != STATIC_NAMES {
                 for (row_index, &key) in rows.keys.iter().enumerate() {
@@ -158,21 +789,66 @@ impl SequentialMiniGuard {
                         .get(row_index + 1)
                         .copied()
                         .unwrap_or(rows.entries_end);
-                    self.contributed_rows[table]
-                        .entry(key)
-                        .or_insert_with(|| mini[start..end].to_vec());
-                    if matches!(table, 0 | 2 | 4) {
-                        self.contributed_ptr_tables.entry(key).or_insert(table);
+                    // Exact base/prior repeats were already proven byte-identical and add no
+                    // state. Keeping only novel rows makes commit linear in this mini's delta.
+                    if self.base.base_rows[table].contains_key(&key)
+                        || self.contributed_rows[table].contains_key(&key)
+                    {
+                        continue;
+                    }
+                    delta_rows[table].insert(key, mini[start..end].to_vec());
+                    delta_usage.keyed_rows = checked_usage_add(
+                        delta_usage.keyed_rows,
+                        1,
+                        "keyed row count",
+                        MAX_SEQUENTIAL_KEYED_ROWS,
+                    )?;
+                    delta_usage.keyed_row_bytes = checked_usage_add(
+                        delta_usage.keyed_row_bytes,
+                        u64::try_from(end - start).unwrap_or(u64::MAX),
+                        "keyed row bytes",
+                        MAX_SEQUENTIAL_KEYED_ROW_BYTES,
+                    )?;
+                    if matches!(table, 0 | 2 | 4 | 6) {
+                        delta_ptr_tables.insert(key, table);
                     }
                 }
             }
         }
-        self.contributed_static_names.extend(appended_names);
-        Ok(rebased)
+        let delta_usage = delta_usage.with_static_names(&appended_names)?;
+        self.usage.project(delta_usage)?;
+        Ok((
+            rebased,
+            SequentialMiniDelta {
+                rows: delta_rows,
+                ptr_tables: delta_ptr_tables,
+                static_names: appended_names,
+                reference: reference_contribution,
+                usage: delta_usage,
+            },
+        ))
+    }
+
+    fn commit(&mut self, delta: SequentialMiniDelta) {
+        let usage = self
+            .usage
+            .project(delta.usage)
+            .expect("validated sequential usage cannot overflow while recording");
+        for (target, rows) in self.contributed_rows.iter_mut().zip(delta.rows) {
+            target.extend(rows);
+        }
+        self.contributed_ptr_tables.extend(delta.ptr_tables);
+        self.contributed_static_names.extend(delta.static_names);
+        self.reference_state.record(delta.reference);
+        self.usage = usage;
     }
 }
 
-/// Append `mini`'s single (primitive-only) module to `base`, returning the new cache bytes.
+/// Append `mini`'s single referenceless module to `base`, returning the new cache bytes.
+///
+/// This is a low-level composition primitive. It validates the mechanical container shape but
+/// does not establish generation binding or executable-reference authority. Publishing callers
+/// must use [`SequentialMiniGuard::compose_add`] instead.
 pub fn splice(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
     let mini_n = module_count(mini);
     if mini_n != 1 {
@@ -196,17 +872,23 @@ pub fn splice(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
     let base_tail = module_region_end(base)?;
     let base_count = module_count(base);
 
-    let mut out = Vec::with_capacity(base.len() + mod_bytes.len());
+    let capacity = checked_composed_capacity(&[base.len(), mod_bytes.len()])?;
+    let mut out = Vec::with_capacity(capacity);
     out.extend_from_slice(&base[..0x14]); // FGuid + magic
     out.extend_from_slice(&(base_count + 1).to_le_bytes()); // bumped Modules count
     out.extend_from_slice(&base[CacheHeader::SIZE..base_tail]); // all existing modules
     out.extend_from_slice(mod_bytes); // the new module, before the tail tables
     out.extend_from_slice(&base[base_tail..]); // global tail tables, unchanged
-    Ok(out)
+    finish_composition(out)
 }
 
 /// Auto-select the splice path: case-(b) fast append for a referenceless mini, else the
 /// case-(a) global-table merge for a class/native-ref-bearing mini.
+///
+/// This is a low-level composition primitive. Before calling it, validate the mini with a
+/// [`SequentialMiniGuard`] bound to the pristine base and compose the prepared bytes returned by
+/// the guard. The caller owns sequential guard history; this function deliberately does not
+/// construct or advance a guard itself.
 pub fn splice_auto(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
     let mini_n = module_count(mini);
     if mini_n != 1 {
@@ -223,6 +905,10 @@ pub fn splice_auto(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
 /// Case-(a): append the mini's module AND merge its 7 global tail-table entries into the
 /// base cache (per `case-a-tables-and-exec.md` §3). Used when the mini references native
 /// types/functions (its tail tables are non-empty), e.g. a class or a PrintString call.
+///
+/// This is a low-level composition primitive. Publishing callers must use
+/// [`SequentialMiniGuard::compose_add`] so the mini is validated against its pristine base before
+/// any rows are merged.
 pub fn splice_case_a(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
     let mini_n = module_count(mini);
     if mini_n != 1 {
@@ -258,14 +944,16 @@ pub fn splice_case_a(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
     let mod_bytes = &mini[CacheHeader::SIZE..mini_tail];
     let base_count = module_count(base);
 
-    let mut out = Vec::with_capacity(base.len() + mod_bytes.len() + (mini.len() - mini_tail));
+    let capacity =
+        checked_composed_capacity(&[base.len(), mod_bytes.len(), mini.len() - mini_tail])?;
+    let mut out = Vec::with_capacity(capacity);
     out.extend_from_slice(&base[..0x14]);
     out.extend_from_slice(&(base_count + 1).to_le_bytes());
     out.extend_from_slice(&base[CacheHeader::SIZE..base_tail]); // existing modules
     out.extend_from_slice(mod_bytes); // new module, before tables
 
     append_merged_tables(&mut out, base, &base_tt, mini, &mini_tt);
-    Ok(out)
+    finish_composition(out)
 }
 
 /// Append the 7 merged tail tables (base ++ mini, deduped) to `out`.
@@ -320,16 +1008,24 @@ fn append_merged_tables(
 /// Extract one module from `cache` into a standalone 1-module mini-cache: its `Modules`
 /// TMap entry followed by the cache's FULL global tail tables. Used to pull a dependency-
 /// heavy module (which can't be compiled standalone) out of a full-tree regen so it can be
-/// [`replace_module`]'d into the vanilla base. The loader has no integrity check, so the
-/// carried-over FGuid is harmless; the full tail tables guarantee every ref the module's
-/// bytecode uses is present, and `replace_module`'s merge folds them into the base.
+/// [`replace_module`]'d into the vanilla base. Extraction retains the source cache's FGuid; use
+/// [`remap_module_to_base`] before targeting a different base. The full tail tables guarantee
+/// every ref the module's bytecode uses is present, and `replace_module`'s merge folds them into
+/// the base.
 pub fn extract_module(cache: &[u8], target_name: &str) -> Result<Vec<u8>, SpliceError> {
+    super::remap::preflight_cache_module_work(cache)?;
+    super::remap::preflight_tail_tables(cache)?;
     let ranges = module_ranges(cache)?;
-    let (_, start, end) = ranges
+    let matches: Vec<_> = ranges
         .iter()
-        .find(|(n, _, _)| n == target_name)
+        .filter(|(n, _, _)| n == target_name)
         .cloned()
-        .ok_or_else(|| SpliceError::NameNotFound(target_name.to_string()))?;
+        .collect();
+    let (_, start, end) = match matches.as_slice() {
+        [entry] => entry.clone(),
+        [] => return Err(SpliceError::NameNotFound(target_name.to_string())),
+        _ => return Err(SpliceError::AmbiguousTarget(target_name.to_string())),
+    };
     let tail_off = module_region_end(cache)?;
     let mut out = Vec::with_capacity(0x18 + (end - start) + (cache.len() - tail_off));
     out.extend_from_slice(&cache[..0x14]); // FGuid + magic
@@ -381,6 +1077,11 @@ pub fn remap_module_to_base_with_options(
 /// NOTE: the OLD module's now-orphaned tail-table entries are NOT removed — they are
 /// name-resolved at load and harmless (per `container-splice.md` §4); only the new
 /// entries are appended.
+///
+/// This is a low-level composition primitive. Before calling it, validate `new_mini` with a
+/// [`SequentialMiniGuard`] bound to the pristine base and replace with the prepared bytes returned
+/// by the guard. The caller owns sequential guard history; this function deliberately does not
+/// construct or advance a guard itself.
 pub fn replace_module(
     base: &[u8],
     new_mini: &[u8],
@@ -396,37 +1097,45 @@ pub fn replace_module(
     // can differ. Match the key first, then fall back to the inner name so a modder using the
     // emitted module name as `target` doesn't get a spurious NameNotFound.
     let ranges = module_ranges(base)?;
-    let idx = match ranges.iter().position(|(name, _, _)| name == target_name) {
-        Some(i) => {
+    let inner_names = module_inner_names(base, &ranges)?;
+    let outer_matches: Vec<usize> = ranges
+        .iter()
+        .enumerate()
+        .filter_map(|(index, (name, _, _))| (name == target_name).then_some(index))
+        .collect();
+    let idx = match outer_matches.as_slice() {
+        [i] => {
+            let i = *i;
             // The TMap key matched. Guard against the pathological case where `target` ALSO
             // equals a DIFFERENT module's inner name: silently replacing the key match could
             // be the wrong module, so refuse and require the exact key.
-            let collides = super::model::parse_modules(base)?
+            let collides = inner_names
                 .iter()
                 .enumerate()
-                .any(|(j, m)| j != i && j < ranges.len() && m.name == target_name);
+                .any(|(j, name)| j != i && name == target_name);
             if collides {
                 return Err(SpliceError::AmbiguousTarget(target_name.to_string()));
             }
             i
         }
-        None => {
+        [] => {
             // Fall back to the inner `ModuleName`, but ONLY if it's unambiguous: if several
             // entries share that inner name (different TMap keys), we can't tell which to
             // replace, so refuse rather than corrupt the wrong byte range. Propagate a
             // base-parse failure instead of masking it as NameNotFound.
-            let mods = super::model::parse_modules(base)?;
-            let inner: Vec<usize> = mods
+            let inner: Vec<usize> = inner_names
                 .iter()
                 .enumerate()
-                .filter(|(i, m)| *i < ranges.len() && m.name == target_name)
+                .filter(|(i, name)| *i < ranges.len() && *name == target_name)
                 .map(|(i, _)| i)
                 .collect();
             match inner.as_slice() {
                 [i] => *i,
-                _ => return Err(SpliceError::NameNotFound(target_name.to_string())),
+                [] => return Err(SpliceError::NameNotFound(target_name.to_string())),
+                _ => return Err(SpliceError::AmbiguousTarget(target_name.to_string())),
             }
         }
+        _ => return Err(SpliceError::AmbiguousTarget(target_name.to_string())),
     };
     let (_, target_start, target_end) = ranges[idx].clone();
 
@@ -473,10 +1182,60 @@ pub fn replace_module(
 
     // out = base[0..target_start] ++ MOD_BYTES ++ base[target_end..base_tail] ++ MERGED.
     // Header (incl. Modules count @0x14) stays byte-identical: count is unchanged.
-    let mut out = Vec::with_capacity(base.len() + mod_bytes.len() + (new_mini.len() - mini_tail));
+    let capacity =
+        checked_composed_capacity(&[base.len(), mod_bytes.len(), new_mini.len() - mini_tail])?;
+    let mut out = Vec::with_capacity(capacity);
     out.extend_from_slice(&base[..target_start]); // header + modules before target
     out.extend_from_slice(mod_bytes); // replacement module
     out.extend_from_slice(&base[target_end..base_tail]); // modules after target
     append_merged_tables(&mut out, base, &base_tt, new_mini, &mini_tt);
-    Ok(out)
+    finish_composition(out)
+}
+
+/// Read only each module's inner runtime identity from the already located TMap-entry ranges.
+/// This avoids `model::parse_modules`, which would clone every function bytecode array merely to
+/// resolve an edit target in a potentially hundreds-of-megabytes cache.
+fn module_inner_names(
+    bytes: &[u8],
+    ranges: &[(String, usize, usize)],
+) -> Result<Vec<String>, WireError> {
+    ranges
+        .iter()
+        .map(|(_, start, _)| {
+            let mut cursor = Cursor::at(bytes, *start);
+            cursor.read_fstring()?;
+            cursor.read_sia()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod resource_limit_tests {
+    use super::*;
+
+    #[test]
+    fn composed_capacity_accepts_the_limit_and_rejects_larger_or_overflowing_inputs() {
+        assert_eq!(
+            checked_composed_capacity(&[MAX_COMPOSED_CACHE_BYTES as usize]).unwrap(),
+            MAX_COMPOSED_CACHE_BYTES as usize
+        );
+
+        assert!(matches!(
+            checked_composed_capacity(&[MAX_COMPOSED_CACHE_BYTES as usize, 1]),
+            Err(SpliceError::SequentialLimitExceeded {
+                resource: "composed cache bytes",
+                actual,
+                limit: MAX_COMPOSED_CACHE_BYTES,
+            }) if actual == MAX_COMPOSED_CACHE_BYTES + 1
+        ));
+
+        assert!(matches!(
+            checked_composed_capacity(&[usize::MAX, 1]),
+            Err(SpliceError::SequentialLimitExceeded {
+                resource: "composed cache bytes",
+                actual: u64::MAX,
+                limit: MAX_COMPOSED_CACHE_BYTES,
+            })
+        ));
+    }
 }

--- a/crates/gore-as/src/cache/tables.rs
+++ b/crates/gore-as/src/cache/tables.rs
@@ -59,10 +59,16 @@ fn read_function_reference(c: &mut Cursor) -> Result<(), WireError> {
 }
 
 fn read_global_reference(c: &mut Cursor) -> Result<(), WireError> {
-    c.read_sia()?; // Name
+    // The game writes only string-literal names with AssignAsUTF8. The discriminator follows the
+    // three strings, so retain the validated bytes until it is available instead of guessing from
+    // the payload.
+    let name_pos = c.pos();
+    let name = c.read_sia_bytes()?; // Name
     c.read_sia()?; // Module
     c.read_sia()?; // Namespace
-    c.skip(4)?; // bIsString
+    if c.read_bool4()? {
+        name.decode_utf8(name_pos)?;
+    }
     Ok(())
 }
 
@@ -172,4 +178,66 @@ pub fn parse_tail_tables(bytes: &[u8], start: usize) -> Result<TailTables, WireE
         end: c.pos(),
         tables,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn push_sia_bytes(out: &mut Vec<u8>, value: &[u8]) {
+        if value.is_empty() {
+            out.extend_from_slice(&0i32.to_le_bytes());
+        } else {
+            out.extend_from_slice(&(value.len() as i32).to_le_bytes());
+            out.extend_from_slice(value);
+            out.push(0);
+        }
+    }
+
+    fn tail_with_global_name(name: &[u8], is_string: i32) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&0i32.to_le_bytes()); // TypeReferences
+        out.extend_from_slice(&0i32.to_le_bytes()); // TypeIdReferenceToPointer
+        out.extend_from_slice(&0i32.to_le_bytes()); // FunctionReferences
+        out.extend_from_slice(&0i32.to_le_bytes()); // FunctionIdReferenceToPointer
+        out.extend_from_slice(&1i32.to_le_bytes()); // GlobalReferences
+        out.extend_from_slice(&0x3000i64.to_le_bytes());
+        push_sia_bytes(&mut out, name);
+        push_sia_bytes(&mut out, b""); // Module
+        push_sia_bytes(&mut out, b""); // Namespace
+        out.extend_from_slice(&is_string.to_le_bytes());
+        out.extend_from_slice(&0i32.to_le_bytes()); // StaticNames
+        out.extend_from_slice(&0i32.to_le_bytes()); // PropertyReferences
+        out
+    }
+
+    #[test]
+    fn global_name_encoding_is_selected_only_after_b_is_string() {
+        let utf8 = tail_with_global_name("Grüße 世界".as_bytes(), 1);
+        assert_eq!(parse_tail_tables(&utf8, 0).unwrap().end, utf8.len());
+
+        let ansi = tail_with_global_name(&[0xff], 0);
+        assert_eq!(parse_tail_tables(&ansi, 0).unwrap().end, ansi.len());
+
+        let invalid_utf8 = tail_with_global_name(&[0xff], 1);
+        assert!(matches!(
+            parse_tail_tables(&invalid_utf8, 0),
+            Err(WireError::InvalidSia {
+                detail: "script string literal is not valid UTF-8",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn global_string_discriminator_must_be_a_canonical_archive_bool() {
+        assert!(matches!(
+            parse_tail_tables(&tail_with_global_name(b"literal", 2), 0),
+            Err(WireError::BadLen {
+                field: "bool",
+                len: 2,
+                ..
+            })
+        ));
+    }
 }

--- a/crates/gore-as/src/cache/walk_modules.rs
+++ b/crates/gore-as/src/cache/walk_modules.rs
@@ -28,16 +28,7 @@ const MIN_FUNCTION_IMPORT_SIZE: usize = 60;
 /// Parse the cache header + all `Modules`, returning `TAIL_OFF` (offset of the first
 /// global tail table = end of the last module).
 pub fn module_region_end(bytes: &[u8]) -> Result<usize, WireError> {
-    if bytes.len() < CacheHeader::SIZE {
-        return Err(WireError::Eof {
-            pos: 0,
-            need: CacheHeader::SIZE,
-            have: bytes.len(),
-        });
-    }
-    let mut c = Cursor::at(bytes, CacheHeader::SIZE); // skip FGuid+magic+count (0x18)
-                                                      // Re-read the count from its known offset (0x14) rather than trusting header parse.
-    let count = module_count(bytes) as usize;
+    let (mut c, count) = checked_module_cursor(bytes)?;
     for _ in 0..count {
         // Modules is TMap<FString key, FAngelscriptPrecompiledModule value>.
         c.read_fstring()?; // key (UE FString)
@@ -57,8 +48,7 @@ pub fn module_count(bytes: &[u8]) -> u32 {
 
 /// Collect every module's name (the `Modules` TMap key) in order.
 pub fn module_names(bytes: &[u8]) -> Result<Vec<String>, WireError> {
-    let mut c = Cursor::at(bytes, CacheHeader::SIZE);
-    let count = module_count(bytes) as usize;
+    let (mut c, count) = checked_module_cursor(bytes)?;
     let mut names = Vec::with_capacity(count);
     for _ in 0..count {
         names.push(c.read_fstring()?); // key
@@ -72,8 +62,7 @@ pub fn module_names(bytes: &[u8]) -> Result<Vec<String>, WireError> {
 /// module value (the cursor after `read_module`). Mirrors [`module_names`] but records
 /// positions — used by the splice to locate and replace a module's byte blob.
 pub fn module_ranges(bytes: &[u8]) -> Result<Vec<(String, usize, usize)>, WireError> {
-    let mut c = Cursor::at(bytes, CacheHeader::SIZE);
-    let count = module_count(bytes) as usize;
+    let (mut c, count) = checked_module_cursor(bytes)?;
     let mut ranges = Vec::with_capacity(count);
     for _ in 0..count {
         let start = c.pos();
@@ -149,6 +138,20 @@ pub fn collect_function_bytecodes(bytes: &[u8]) -> Result<Vec<FuncCode>, WireErr
 ///
 /// Function ordering and metadata are identical to [`collect_function_bytecodes`].
 pub fn collect_function_bytecode_spans(bytes: &[u8]) -> Result<Vec<FuncCodeSpan>, WireError> {
+    let (mut c, count) = checked_module_cursor(bytes)?;
+    let mut out = Vec::new();
+    for _ in 0..count {
+        c.read_fstring()?; // key
+        read_module_c(&mut c, &mut out)?;
+    }
+    Ok(out)
+}
+
+/// Start a module walk only after proving that the declared count can fit even the minimum
+/// serialized entry width. Besides bounding the loop, this proof must happen before callers use
+/// the not-yet-validated count as a `Vec` capacity: a 24-byte header with `u32::MAX` modules is
+/// malformed, not a request to reserve hundreds of gigabytes.
+fn checked_module_cursor(bytes: &[u8]) -> Result<(Cursor<'_>, usize), WireError> {
     if bytes.len() < CacheHeader::SIZE {
         return Err(WireError::Eof {
             pos: 0,
@@ -156,15 +159,10 @@ pub fn collect_function_bytecode_spans(bytes: &[u8]) -> Result<Vec<FuncCodeSpan>
             have: bytes.len(),
         });
     }
-    let mut c = Cursor::at(bytes, CacheHeader::SIZE);
+    let c = Cursor::at(bytes, CacheHeader::SIZE);
     let count = module_count(bytes) as usize;
     c.ensure_minimum_remaining(count, MIN_MODULE_ENTRY_SIZE, "Modules")?;
-    let mut out = Vec::new();
-    for _ in 0..count {
-        c.read_fstring()?; // key
-        read_module_c(&mut c, &mut out)?;
-    }
-    Ok(out)
+    Ok((c, count))
 }
 
 fn read_count_with_minimum(

--- a/crates/gore-as/src/cache/wire.rs
+++ b/crates/gore-as/src/cache/wire.rs
@@ -9,6 +9,8 @@
 
 use thiserror::Error;
 
+const MAX_SERIALIZED_STRING_UNITS: usize = 1_000_000;
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum WireError {
     #[error("unexpected end of data at pos {pos}: needed {need} more bytes, have {have}")]
@@ -23,6 +25,96 @@ pub enum WireError {
         len: i64,
         field: &'static str,
     },
+    #[error("cyclic TypeReferences subtype graph at key {key:#x}")]
+    CyclicTypeReference { key: i64 },
+    #[error("TypeReferences subtype nesting exceeds {max} levels at key {key:#x}")]
+    TypeReferenceDepth { key: i64, max: usize },
+    #[error("portable symbol identity for key {key:#x} exceeds the {max}-byte limit")]
+    IdentityTooLarge { key: i64, max: usize },
+    #[error("portable symbol identities exceed the cache-wide {max}-byte construction budget")]
+    IdentityBudgetExceeded { max: usize },
+    #[error("portable symbol identity matching exceeds the cache-wide {max}-byte work budget")]
+    IdentityComparisonBudgetExceeded { max: usize },
+    #[error("DataType in symbol row {key:#x} is not a canonical runtime type ({detail})")]
+    InvalidDataType { key: i64, detail: &'static str },
+    #[error("TypeReference row {key:#x} is not canonical ({detail})")]
+    InvalidTypeReference { key: i64, detail: &'static str },
+    #[error("FunctionReference row {key:#x} is not canonical ({detail})")]
+    InvalidFunctionReference { key: i64, detail: &'static str },
+    #[error("invalid FStringInArchive at pos {pos} ({detail})")]
+    InvalidSia { pos: usize, detail: &'static str },
+    #[error("invalid FString at pos {pos} ({detail})")]
+    InvalidFString { pos: usize, detail: &'static str },
+}
+
+/// Decode Unreal's ANSI payload without collapsing distinct input bytes. Windows builds use the
+/// Windows-1252 code page for `TCHAR_TO_ANSI`; the five undefined CP-1252 slots deliberately map
+/// to their matching C1 controls so all 256 byte values remain one-to-one.
+fn decode_windows_1252(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|&byte| match byte {
+            0x80 => '\u{20ac}',
+            0x81 => '\u{0081}',
+            0x82 => '\u{201a}',
+            0x83 => '\u{0192}',
+            0x84 => '\u{201e}',
+            0x85 => '\u{2026}',
+            0x86 => '\u{2020}',
+            0x87 => '\u{2021}',
+            0x88 => '\u{02c6}',
+            0x89 => '\u{2030}',
+            0x8a => '\u{0160}',
+            0x8b => '\u{2039}',
+            0x8c => '\u{0152}',
+            0x8d => '\u{008d}',
+            0x8e => '\u{017d}',
+            0x8f => '\u{008f}',
+            0x90 => '\u{0090}',
+            0x91 => '\u{2018}',
+            0x92 => '\u{2019}',
+            0x93 => '\u{201c}',
+            0x94 => '\u{201d}',
+            0x95 => '\u{2022}',
+            0x96 => '\u{2013}',
+            0x97 => '\u{2014}',
+            0x98 => '\u{02dc}',
+            0x99 => '\u{2122}',
+            0x9a => '\u{0161}',
+            0x9b => '\u{203a}',
+            0x9c => '\u{0153}',
+            0x9d => '\u{009d}',
+            0x9e => '\u{017e}',
+            0x9f => '\u{0178}',
+            other => char::from(other),
+        })
+        .collect()
+}
+
+/// Raw, validated FStringInArchive payload. Most fields are `TCHAR_TO_ANSI` and use the normal
+/// Windows-1252 projection; script-literal GlobalReferences explicitly use `AssignAsUTF8` and
+/// must decode the same bytes as UTF-8 after their `bIsString` discriminator is known.
+pub struct SiaBytes<'a> {
+    raw: &'a [u8],
+}
+
+impl SiaBytes<'_> {
+    pub fn decode_ansi(&self) -> String {
+        decode_windows_1252(self.raw)
+    }
+
+    pub fn decode_utf8(&self, pos: usize) -> Result<String, WireError> {
+        std::str::from_utf8(self.raw)
+            .map(str::to_owned)
+            .map_err(|_| WireError::InvalidSia {
+                pos,
+                detail: "script string literal is not valid UTF-8",
+            })
+    }
+
+    pub fn len(&self) -> usize {
+        self.raw.len()
+    }
 }
 
 /// A little-endian byte cursor over a cache buffer.
@@ -116,55 +208,134 @@ impl<'a> Cursor<'a> {
         Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
     }
 
-    /// A UE `bool` = 4-byte int32; any nonzero is `true`.
+    /// A serialized UE `bool` must be the canonical int32 0/1 representation. Accepting other
+    /// nonzero values would let byte-distinct rows share the same runtime meaning.
     pub fn read_bool4(&mut self) -> Result<bool, WireError> {
-        Ok(self.read_i32()? != 0)
+        let pos = self.pos;
+        match self.read_i32()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            value => Err(WireError::BadLen {
+                pos,
+                len: value as i64,
+                field: "bool",
+            }),
+        }
     }
 
-    /// `FStringInArchive`: int32 Length(chars); if Length>0 read Length+1 bytes (incl NUL).
-    /// Negative length = UTF-16 (`-Length` code units, 2 bytes each).
+    /// `FStringInArchive`: custom ANSI-only `int32 Length(chars)` followed by `Length+1` bytes,
+    /// including exactly one trailing NUL. This is not UE's general UTF-16-capable FString.
     pub fn read_sia(&mut self) -> Result<String, WireError> {
+        Ok(self.read_sia_bytes()?.decode_ansi())
+    }
+
+    /// Validate and return one SIA payload without assuming its contextual character encoding.
+    pub fn read_sia_bytes(&mut self) -> Result<SiaBytes<'a>, WireError> {
+        let start = self.pos;
         let len = self.read_i32()?;
         match len.cmp(&0) {
-            std::cmp::Ordering::Equal => Ok(String::new()),
+            std::cmp::Ordering::Equal => Ok(SiaBytes { raw: &[] }),
             std::cmp::Ordering::Greater => {
+                if len as usize > MAX_SERIALIZED_STRING_UNITS {
+                    return Err(WireError::BadLen {
+                        pos: start,
+                        len: len as i64,
+                        field: "FStringInArchive",
+                    });
+                }
                 let n = len as usize + 1; // +1 trailing NUL
                 let raw = self.take(n)?;
-                Ok(String::from_utf8_lossy(&raw[..raw.len().saturating_sub(1)]).into_owned())
+                if raw.last() != Some(&0) {
+                    return Err(WireError::InvalidSia {
+                        pos: start,
+                        detail: "missing trailing NUL",
+                    });
+                }
+                let content = &raw[..raw.len() - 1];
+                if content.contains(&0) {
+                    return Err(WireError::InvalidSia {
+                        pos: start,
+                        detail: "embedded NUL",
+                    });
+                }
+                Ok(SiaBytes { raw: content })
             }
-            std::cmp::Ordering::Less => self.read_utf16(-(len as i64)),
+            std::cmp::Ordering::Less => Err(WireError::InvalidSia {
+                pos: start,
+                detail: "negative/UTF-16 length is not supported by FStringInArchive",
+            }),
         }
     }
 
     /// UE `FString`: int32 Len(= chars+1, incl NUL); then Len bytes.
     /// Negative = UTF-16 (`-Len` code units incl NUL terminator).
     pub fn read_fstring(&mut self) -> Result<String, WireError> {
+        let start = self.pos;
         let len = self.read_i32()?;
         match len.cmp(&0) {
             std::cmp::Ordering::Equal => Ok(String::new()),
             std::cmp::Ordering::Greater => {
+                if len as usize > MAX_SERIALIZED_STRING_UNITS + 1 {
+                    return Err(WireError::BadLen {
+                        pos: start,
+                        len: len as i64,
+                        field: "FString",
+                    });
+                }
                 let raw = self.take(len as usize)?;
-                Ok(String::from_utf8_lossy(&raw[..raw.len().saturating_sub(1)]).into_owned())
+                if raw.last() != Some(&0) {
+                    return Err(WireError::InvalidFString {
+                        pos: start,
+                        detail: "missing trailing NUL",
+                    });
+                }
+                let content = &raw[..raw.len() - 1];
+                if content.contains(&0) {
+                    return Err(WireError::InvalidFString {
+                        pos: start,
+                        detail: "embedded NUL",
+                    });
+                }
+                Ok(decode_windows_1252(content))
             }
-            std::cmp::Ordering::Less => self.read_utf16((-(len as i64)).saturating_sub(1)),
+            std::cmp::Ordering::Less => self.read_utf16_fstring(start, -(len as i64)),
         }
     }
 
-    fn read_utf16(&mut self, code_units: i64) -> Result<String, WireError> {
-        if !(0..=1_000_000).contains(&code_units) {
+    fn read_utf16_fstring(
+        &mut self,
+        start: usize,
+        total_code_units: i64,
+    ) -> Result<String, WireError> {
+        if !(1..=MAX_SERIALIZED_STRING_UNITS as i64 + 1).contains(&total_code_units) {
             return Err(WireError::BadLen {
-                pos: self.pos,
-                len: code_units,
+                pos: start,
+                len: -total_code_units,
                 field: "utf16",
             });
         }
-        let n = code_units as usize * 2;
-        let raw = self.take(n + 2)?; // +2 for the wide NUL terminator
-        let units: Vec<u16> = raw[..n]
+        let raw = self.take(total_code_units as usize * 2)?;
+        let units: Vec<u16> = raw
             .chunks_exact(2)
             .map(|c| u16::from_le_bytes([c[0], c[1]]))
             .collect();
-        Ok(String::from_utf16_lossy(&units))
+        if units.last() != Some(&0) {
+            return Err(WireError::InvalidFString {
+                pos: start,
+                detail: "missing trailing UTF-16 NUL",
+            });
+        }
+        let content = &units[..units.len() - 1];
+        if content.contains(&0) {
+            return Err(WireError::InvalidFString {
+                pos: start,
+                detail: "embedded UTF-16 NUL",
+            });
+        }
+        String::from_utf16(content).map_err(|_| WireError::InvalidFString {
+            pos: start,
+            detail: "invalid UTF-16",
+        })
     }
 
     /// `TArray<T>` header: read int32 count, sanity-check against `field`.
@@ -214,5 +385,92 @@ impl<'a> Cursor<'a> {
             v.push(self.read_sia()?);
         }
         Ok(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cursor, WireError};
+
+    #[test]
+    fn ansi_strings_are_canonical_and_windows_1252_is_injective() {
+        let sia = [1i32.to_le_bytes().as_slice(), &[0xe4, 0]].concat();
+        assert_eq!(Cursor::new(&sia).read_sia().unwrap(), "ä");
+
+        let ansi = [3i32.to_le_bytes().as_slice(), &[0x80, 0x81, 0]].concat();
+        assert_eq!(Cursor::new(&ansi).read_fstring().unwrap(), "€\u{81}");
+
+        for (raw, expected) in [
+            (
+                [1i32.to_le_bytes().as_slice(), b"x"].concat(),
+                WireError::InvalidFString {
+                    pos: 0,
+                    detail: "missing trailing NUL",
+                },
+            ),
+            (
+                [2i32.to_le_bytes().as_slice(), &[0, 0]].concat(),
+                WireError::InvalidFString {
+                    pos: 0,
+                    detail: "embedded NUL",
+                },
+            ),
+        ] {
+            assert_eq!(Cursor::new(&raw).read_fstring(), Err(expected));
+        }
+    }
+
+    #[test]
+    fn utf16_fstrings_require_one_terminal_nul_and_valid_units() {
+        let valid = [
+            (-2i32).to_le_bytes().as_slice(),
+            &('ä' as u16).to_le_bytes(),
+            &0u16.to_le_bytes(),
+        ]
+        .concat();
+        assert_eq!(Cursor::new(&valid).read_fstring().unwrap(), "ä");
+
+        let missing_nul = [
+            (-2i32).to_le_bytes().as_slice(),
+            &('a' as u16).to_le_bytes(),
+            &('b' as u16).to_le_bytes(),
+        ]
+        .concat();
+        assert!(matches!(
+            Cursor::new(&missing_nul).read_fstring(),
+            Err(WireError::InvalidFString {
+                detail: "missing trailing UTF-16 NUL",
+                ..
+            })
+        ));
+
+        let embedded_nul = [
+            (-3i32).to_le_bytes().as_slice(),
+            &('a' as u16).to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+        ]
+        .concat();
+        assert!(matches!(
+            Cursor::new(&embedded_nul).read_fstring(),
+            Err(WireError::InvalidFString {
+                detail: "embedded UTF-16 NUL",
+                ..
+            })
+        ));
+
+        let invalid_surrogate = [
+            (-2i32).to_le_bytes().as_slice(),
+            &0xd800u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+        ]
+        .concat();
+        assert!(matches!(
+            Cursor::new(&invalid_surrogate).read_fstring(),
+            Err(WireError::InvalidFString {
+                detail: "invalid UTF-16",
+                ..
+            })
+        ));
     }
 }

--- a/crates/gore-as/tests/disasm_test.rs
+++ b/crates/gore-as/tests/disasm_test.rs
@@ -1,4 +1,4 @@
-use gore_as::cache::disasm::disassemble;
+use gore_as::cache::disasm::{disassemble, MAX_DISASSEMBLED_INSTRUCTIONS};
 use gore_as::cache::walk_modules::collect_function_bytecodes;
 
 const SAMPLES: &str = concat!(
@@ -59,9 +59,13 @@ fn all_richtest_functions_disassemble_clean() {
     }
 }
 
-/// Strong ISA validation: disassemble every function in the real 122 MB cache and
-/// report the clean rate. Wrong opcode sizes would desync -> Truncated/Unknown.
-/// Set GORE_AS_REAL_CACHE to run.
+/// Strong ISA validation: disassemble every function in a real Shipping cache
+/// and report both the clean rate and largest observed function. The audited
+/// 2026-08-14 cache had 389,358 instructions / 852,642 dwords in its largest
+/// function, comfortably below the production resource limits.
+///
+/// Wrong opcode sizes would desync -> Truncated/Unknown. Set
+/// GORE_AS_REAL_CACHE to run.
 #[test]
 fn real_cache_functions_disassemble() {
     let Ok(path) = std::env::var("GORE_AS_REAL_CACHE") else {
@@ -73,9 +77,16 @@ fn real_cache_functions_disassemble() {
     let total = funcs.len();
     let mut ok = 0usize;
     let mut errs: Vec<String> = Vec::new();
+    let mut largest: Option<(&str, usize, usize)> = None;
     for f in &funcs {
         match disassemble(&f.bytecode) {
-            Ok(_) => ok += 1,
+            Ok(instrs) => {
+                ok += 1;
+                if largest.is_none_or(|(_, instruction_count, _)| instrs.len() > instruction_count)
+                {
+                    largest = Some((&f.func, instrs.len(), f.bytecode.len()));
+                }
+            }
             Err(e) => {
                 if errs.len() < 10 {
                     errs.push(format!("{}: {e}", f.func));
@@ -86,6 +97,12 @@ fn real_cache_functions_disassemble() {
     eprintln!("real cache: {ok}/{total} functions disassembled clean");
     for e in &errs {
         eprintln!("  ERR {e}");
+    }
+    if let Some((function, instruction_count, dword_count)) = largest {
+        eprintln!(
+            "largest function: {function} ({instruction_count} instructions, {dword_count} dwords)"
+        );
+        assert!(instruction_count <= MAX_DISASSEMBLED_INSTRUCTIONS);
     }
     // Expect the vast majority to disassemble; a perfect ISA gives 100%.
     assert!(

--- a/crates/gore-as/tests/remap_new_symbols_test.rs
+++ b/crates/gore-as/tests/remap_new_symbols_test.rs
@@ -5,12 +5,14 @@ use gore_as::cache::remap::{
     remap_module_to_base, remap_module_to_base_with_options, RemapError, RemapOptions,
 };
 use gore_as::cache::splice::{
-    extract_module, replace_module, splice_auto, SequentialMiniGuard, SpliceError,
+    extract_module, remap_module_to_base_with_loadout_plan, replace_module, splice, splice_auto,
+    LoadoutScriptIdPlanBuilder, SequentialMiniGuard, SpliceError,
 };
 use gore_as::cache::tables::parse_tail_tables;
 use gore_as::cache::walk_modules::{
     collect_function_bytecodes, module_count, module_names, module_region_end,
 };
+use gore_as::cache::wire::WireError;
 
 const MODULE: &str = "EditedModule";
 
@@ -66,7 +68,14 @@ fn fstring(s: &str) -> Vec<u8> {
 }
 
 fn datatype(type_ptr: i64, token: i32) -> Vec<u8> {
-    let mut out = vec![0u8; 24]; // six serialized bools
+    datatype_flags(type_ptr, token, [false; 6])
+}
+
+fn datatype_flags(type_ptr: i64, token: i32, flags: [bool; 6]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(36);
+    for flag in flags {
+        out.extend_from_slice(&i32::from(flag).to_le_bytes());
+    }
     out.extend_from_slice(&type_ptr.to_le_bytes());
     out.extend_from_slice(&token.to_le_bytes());
     out
@@ -77,13 +86,27 @@ fn type_row(key: i64, name: &str, module: &str, subtypes: &[i64]) -> Vec<u8> {
 }
 
 fn type_row_ns(key: i64, name: &str, module: &str, namespace: &str, subtypes: &[i64]) -> Vec<u8> {
+    let datatypes = subtypes
+        .iter()
+        .map(|&ptr| datatype(ptr, 5))
+        .collect::<Vec<_>>();
+    type_row_datatypes(key, name, module, namespace, &datatypes)
+}
+
+fn type_row_datatypes(
+    key: i64,
+    name: &str,
+    module: &str,
+    namespace: &str,
+    subtypes: &[Vec<u8>],
+) -> Vec<u8> {
     let mut out = key.to_le_bytes().to_vec();
     out.extend_from_slice(&sia(name));
     out.extend_from_slice(&sia(module));
     out.extend_from_slice(&sia(namespace));
     out.extend_from_slice(&(subtypes.len() as i32).to_le_bytes());
-    for &ptr in subtypes {
-        out.extend_from_slice(&datatype(ptr, 5));
+    for datatype in subtypes {
+        out.extend_from_slice(datatype);
     }
     out
 }
@@ -107,33 +130,93 @@ fn func_row_ns(
     params: &[i64],
     ret: i64,
 ) -> Vec<u8> {
+    func_row_flags(
+        key,
+        name,
+        module,
+        namespace,
+        false,
+        false,
+        owner != 0,
+        owner,
+        params,
+        ret,
+    )
+}
+
+fn func_row_flags(
+    key: i64,
+    name: &str,
+    module: &str,
+    namespace: &str,
+    is_const: bool,
+    is_imported: bool,
+    is_method: bool,
+    owner: i64,
+    params: &[i64],
+    ret: i64,
+) -> Vec<u8> {
+    let params = params
+        .iter()
+        .map(|&ptr| datatype(ptr, 5))
+        .collect::<Vec<_>>();
+    let ret = if ret == 0 {
+        datatype(0, 0x52)
+    } else {
+        datatype(ret, 5)
+    };
+    func_row_datatypes(
+        key,
+        name,
+        module,
+        namespace,
+        is_const,
+        is_imported,
+        is_method,
+        owner,
+        &params,
+        &ret,
+    )
+}
+
+fn func_row_datatypes(
+    key: i64,
+    name: &str,
+    module: &str,
+    namespace: &str,
+    is_const: bool,
+    is_imported: bool,
+    is_method: bool,
+    owner: i64,
+    params: &[Vec<u8>],
+    ret: &[u8],
+) -> Vec<u8> {
     let mut out = key.to_le_bytes().to_vec();
     out.extend_from_slice(&sia(name));
     out.extend_from_slice(&sia(module));
     out.extend_from_slice(&sia(namespace));
-    out.extend_from_slice(&0i32.to_le_bytes()); // const
-    out.extend_from_slice(&0i32.to_le_bytes()); // imported
-    let is_method = i32::from(owner != 0);
-    out.extend_from_slice(&is_method.to_le_bytes());
+    out.extend_from_slice(&i32::from(is_const).to_le_bytes());
+    out.extend_from_slice(&i32::from(is_imported).to_le_bytes());
+    out.extend_from_slice(&i32::from(is_method).to_le_bytes());
     out.extend_from_slice(&owner.to_le_bytes());
     out.extend_from_slice(&(params.len() as i32).to_le_bytes());
-    for &ptr in params {
-        out.extend_from_slice(&datatype(ptr, 5));
+    for datatype in params {
+        out.extend_from_slice(datatype);
     }
-    out.extend_from_slice(&if ret == 0 {
-        datatype(0, 0x40)
-    } else {
-        datatype(ret, 5)
-    });
+    out.extend_from_slice(ret);
     out
 }
 
 fn global_row(key: i64, name: &str, module: &str) -> Vec<u8> {
+    global_row_ns(key, name, module, "", false)
+}
+
+fn global_row_ns(key: i64, name: &str, module: &str, namespace: &str, is_string: bool) -> Vec<u8> {
     let mut out = key.to_le_bytes().to_vec();
     out.extend_from_slice(&sia(name));
     out.extend_from_slice(&sia(module));
-    out.extend_from_slice(&sia(""));
-    out.extend_from_slice(&0i32.to_le_bytes());
+    out.extend_from_slice(&sia(namespace));
+    out.extend_from_slice(&i32::from(is_string).to_le_bytes());
     out
 }
 
@@ -148,15 +231,41 @@ fn property_row(type_id: i32, offset: i32, name: &str) -> Vec<u8> {
     out
 }
 
-fn function(bytecode: &[i32]) -> Vec<u8> {
-    let mut out = sia("Edited");
-    out.extend_from_slice(&sia(""));
-    out.extend_from_slice(&datatype(0, 0x40)); // void return
-    out.extend_from_slice(&0i32.to_le_bytes()); // parameter types
-    out.extend_from_slice(&0i32.to_le_bytes()); // parameter names
-    out.extend_from_slice(&0i32.to_le_bytes()); // parameter flags
-    out.extend_from_slice(&0i32.to_le_bytes()); // default args
-    out.extend_from_slice(&0i32.to_le_bytes()); // traits
+const DEFAULT_MODULE_FUNCTION_ID: i32 = 0x1234_5678;
+
+fn function(bytecode: &[i32], id: i32) -> Vec<u8> {
+    function_with_signature("Edited", "", &[], &datatype(0, 0x52), false, bytecode, id)
+}
+
+fn function_with_signature(
+    name: &str,
+    namespace: &str,
+    parameter_types: &[Vec<u8>],
+    return_type: &[u8],
+    is_const: bool,
+    bytecode: &[i32],
+    id: i32,
+) -> Vec<u8> {
+    let mut out = sia(name);
+    out.extend_from_slice(&sia(namespace));
+    out.extend_from_slice(return_type);
+    out.extend_from_slice(&(parameter_types.len() as i32).to_le_bytes());
+    for parameter_type in parameter_types {
+        out.extend_from_slice(parameter_type);
+    }
+    out.extend_from_slice(&(parameter_types.len() as i32).to_le_bytes());
+    for index in 0..parameter_types.len() {
+        out.extend_from_slice(&sia(&format!("parameter{index}")));
+    }
+    out.extend_from_slice(&(parameter_types.len() as i32).to_le_bytes());
+    for _ in parameter_types {
+        out.extend_from_slice(&0i32.to_le_bytes());
+    }
+    out.extend_from_slice(&(parameter_types.len() as i32).to_le_bytes());
+    for _ in parameter_types {
+        out.extend_from_slice(&sia(""));
+    }
+    out.extend_from_slice(&(if is_const { 4i32 } else { 0 }).to_le_bytes());
     out.extend_from_slice(&(bytecode.len() as i32).to_le_bytes());
     for &dw in bytecode {
         out.extend_from_slice(&dw.to_le_bytes());
@@ -170,10 +279,335 @@ fn function(bytecode: &[i32]) -> Vec<u8> {
     out.extend_from_slice(&0i32.to_le_bytes()); // var info offset
     out.extend_from_slice(&0i32.to_le_bytes()); // var info option
     out.extend_from_slice(&0i32.to_le_bytes()); // stack needed
-    out.extend_from_slice(&0x1234_5678i32.to_le_bytes()); // function-local hash/id (not T4)
+    out.extend_from_slice(&id.to_le_bytes()); // runtime Function.Id (not T4)
     out.extend_from_slice(&0i32.to_le_bytes()); // declared at
     out.extend_from_slice(&0i32.to_le_bytes()); // line numbers
     out.extend_from_slice(&0i32.to_le_bytes()); // is UFunction
+    out
+}
+
+#[derive(Clone, Copy, Default)]
+struct FunctionShape {
+    parameter_types: usize,
+    parameter_names: usize,
+    parameter_flags: usize,
+    parameter_defaults: usize,
+    variable_space: i32,
+    object_types: usize,
+    object_positions: usize,
+    serialized_object_positions: Option<i32>,
+    object_position_values: &'static [i32],
+    object_heap_mask: i32,
+    variable_program_positions: usize,
+    serialized_variable_program_positions: Option<i32>,
+    variable_program_values: &'static [i32],
+    variable_offsets: usize,
+    variable_offset_values: &'static [i32],
+    variable_options: usize,
+    variable_option_values: &'static [i32],
+    stack_needed: i32,
+    unreal_metadata: Option<(usize, usize)>,
+}
+
+fn shaped_function(id: i32, shape: FunctionShape) -> Vec<u8> {
+    let mut out = sia("Shaped");
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&datatype(0, 0x52));
+    out.extend_from_slice(&(shape.parameter_types as i32).to_le_bytes());
+    for _ in 0..shape.parameter_types {
+        out.extend_from_slice(&datatype(0, 0x52));
+    }
+    out.extend_from_slice(&(shape.parameter_names as i32).to_le_bytes());
+    for _ in 0..shape.parameter_names {
+        out.extend_from_slice(&sia("parameter"));
+    }
+    out.extend_from_slice(&(shape.parameter_flags as i32).to_le_bytes());
+    for _ in 0..shape.parameter_flags {
+        out.extend_from_slice(&0i32.to_le_bytes());
+    }
+    out.extend_from_slice(&(shape.parameter_defaults as i32).to_le_bytes());
+    for _ in 0..shape.parameter_defaults {
+        out.extend_from_slice(&sia(""));
+    }
+    out.extend_from_slice(&0i32.to_le_bytes()); // traits
+    out.extend_from_slice(&1i32.to_le_bytes()); // bytecode
+    out.extend_from_slice(&10i32.to_le_bytes()); // RET
+    out.extend_from_slice(&0i32.to_le_bytes()); // bytecode refs
+    out.extend_from_slice(&shape.variable_space.to_le_bytes());
+    out.extend_from_slice(&(shape.object_types as i32).to_le_bytes());
+    for _ in 0..shape.object_types {
+        out.extend_from_slice(&0i64.to_le_bytes());
+    }
+    out.extend_from_slice(
+        &shape
+            .serialized_object_positions
+            .unwrap_or(shape.object_positions as i32)
+            .to_le_bytes(),
+    );
+    for index in 0..shape.object_positions {
+        out.extend_from_slice(
+            &shape
+                .object_position_values
+                .get(index)
+                .copied()
+                .unwrap_or(0)
+                .to_le_bytes(),
+        );
+    }
+    out.extend_from_slice(&shape.object_heap_mask.to_le_bytes());
+    for (count, serialized_count, values) in [
+        (
+            shape.variable_program_positions,
+            shape.serialized_variable_program_positions,
+            shape.variable_program_values,
+        ),
+        (shape.variable_offsets, None, shape.variable_offset_values),
+        (shape.variable_options, None, shape.variable_option_values),
+    ] {
+        out.extend_from_slice(&serialized_count.unwrap_or(count as i32).to_le_bytes());
+        for index in 0..count {
+            out.extend_from_slice(&values.get(index).copied().unwrap_or(0).to_le_bytes());
+        }
+    }
+    out.extend_from_slice(&shape.stack_needed.to_le_bytes());
+    out.extend_from_slice(&id.to_le_bytes());
+    out.extend_from_slice(&0i32.to_le_bytes()); // declared at
+    out.extend_from_slice(&0i32.to_le_bytes()); // line numbers
+    out.extend_from_slice(&i32::from(shape.unreal_metadata.is_some()).to_le_bytes());
+    if let Some((specs, values)) = shape.unreal_metadata {
+        out.extend_from_slice(&sia("Shaped"));
+        out.extend_from_slice(&(specs as i32).to_le_bytes());
+        for _ in 0..specs {
+            out.extend_from_slice(&sia("Spec"));
+        }
+        out.extend_from_slice(&(values as i32).to_le_bytes());
+        for _ in 0..values {
+            out.extend_from_slice(&sia("Value"));
+        }
+        out.extend_from_slice(&[0u8; 18 * 4]);
+    }
+    out
+}
+
+fn property_with_metadata(specs: usize, values: usize) -> Vec<u8> {
+    let mut out = sia("Property");
+    out.extend_from_slice(&datatype(0, 0x52));
+    out.extend_from_slice(&0i32.to_le_bytes()); // private
+    out.extend_from_slice(&0i32.to_le_bytes()); // protected
+    out.extend_from_slice(&1i32.to_le_bytes()); // has Unreal property data
+    out.extend_from_slice(&(specs as i32).to_le_bytes());
+    for _ in 0..specs {
+        out.extend_from_slice(&sia("Spec"));
+    }
+    out.extend_from_slice(&(values as i32).to_le_bytes());
+    for _ in 0..values {
+        out.extend_from_slice(&sia("Value"));
+    }
+    out.extend_from_slice(&[0u8; 9 * 4]);
+    out.extend_from_slice(&0i32.to_le_bytes()); // replicated
+    out.extend_from_slice(&[0u8; 6 * 4]);
+    out
+}
+
+fn property_record_named(name: &str) -> Vec<u8> {
+    let mut out = sia(name);
+    out.extend_from_slice(&datatype(0, 0x52));
+    out.extend_from_slice(&0i32.to_le_bytes()); // private
+    out.extend_from_slice(&0i32.to_le_bytes()); // protected
+    out.extend_from_slice(&0i32.to_le_bytes()); // no Unreal property data
+    out
+}
+
+fn structural_class_record(
+    properties: &[Vec<u8>],
+    methods: &[Vec<u8>],
+    method_table: &[i32],
+    behavior_refs: &[i64],
+    behavior_functions: &[Vec<u8>],
+    behavior_types: &[i32],
+    metadata: Option<(usize, usize)>,
+) -> Vec<u8> {
+    structural_class_record_full(
+        properties,
+        methods,
+        method_table,
+        &[],
+        &[],
+        behavior_refs,
+        behavior_functions,
+        behavior_types,
+        metadata,
+    )
+}
+
+fn structural_class_record_full(
+    properties: &[Vec<u8>],
+    methods: &[Vec<u8>],
+    method_table: &[i32],
+    constructors: &[Vec<u8>],
+    factory_refs: &[i64],
+    behavior_refs: &[i64],
+    behavior_functions: &[Vec<u8>],
+    behavior_types: &[i32],
+    metadata: Option<(usize, usize)>,
+) -> Vec<u8> {
+    structural_class_record_full_named(
+        "StructuralClass",
+        "",
+        properties,
+        methods,
+        method_table,
+        constructors,
+        factory_refs,
+        behavior_refs,
+        behavior_functions,
+        behavior_types,
+        metadata,
+    )
+}
+
+fn structural_class_record_full_named(
+    name: &str,
+    namespace: &str,
+    properties: &[Vec<u8>],
+    methods: &[Vec<u8>],
+    method_table: &[i32],
+    constructors: &[Vec<u8>],
+    factory_refs: &[i64],
+    behavior_refs: &[i64],
+    behavior_functions: &[Vec<u8>],
+    behavior_types: &[i32],
+    metadata: Option<(usize, usize)>,
+) -> Vec<u8> {
+    let mut out = sia(name);
+    out.extend_from_slice(&sia(namespace));
+    out.extend_from_slice(&0i32.to_le_bytes()); // flags
+    out.extend_from_slice(&(properties.len() as i32).to_le_bytes());
+    for property in properties {
+        out.extend_from_slice(property);
+    }
+    out.extend_from_slice(&(methods.len() as i32).to_le_bytes());
+    for method in methods {
+        out.extend_from_slice(method);
+    }
+    out.extend_from_slice(&(method_table.len() as i32).to_le_bytes());
+    for index in method_table {
+        out.extend_from_slice(&index.to_le_bytes());
+    }
+    out.extend_from_slice(&0i64.to_le_bytes()); // derived from
+    out.extend_from_slice(&0i64.to_le_bytes()); // shadow type
+    out.extend_from_slice(&(constructors.len() as i32).to_le_bytes());
+    for constructor in constructors {
+        out.extend_from_slice(constructor);
+    }
+    out.extend_from_slice(&(factory_refs.len() as i32).to_le_bytes());
+    for reference in factory_refs {
+        out.extend_from_slice(&reference.to_le_bytes());
+    }
+    out.extend_from_slice(&(behavior_refs.len() as i32).to_le_bytes());
+    for reference in behavior_refs {
+        out.extend_from_slice(&reference.to_le_bytes());
+    }
+    out.extend_from_slice(&(behavior_functions.len() as i32).to_le_bytes());
+    for function in behavior_functions {
+        out.extend_from_slice(function);
+    }
+    out.extend_from_slice(&(behavior_types.len() as i32).to_le_bytes());
+    for behavior_type in behavior_types {
+        out.extend_from_slice(&behavior_type.to_le_bytes());
+    }
+    out.extend_from_slice(&i32::from(metadata.is_some()).to_le_bytes());
+    if let Some((specs, values)) = metadata {
+        out.extend_from_slice(&sia("Super"));
+        out.extend_from_slice(&sia("CodeSuper"));
+        out.extend_from_slice(&[0u8; 8 * 4]);
+        out.extend_from_slice(&sia("StaticClass"));
+        out.extend_from_slice(&0i32.to_le_bytes()); // placeable
+        out.extend_from_slice(&(specs as i32).to_le_bytes());
+        for _ in 0..specs {
+            out.extend_from_slice(&sia("Spec"));
+        }
+        out.extend_from_slice(&(values as i32).to_le_bytes());
+        for _ in 0..values {
+            out.extend_from_slice(&sia("Value"));
+        }
+        out.extend_from_slice(&sia("")); // compose onto
+    }
+    out
+}
+
+fn enum_record(names: usize, values: usize) -> Vec<u8> {
+    enum_record_named("StructuralEnum", "", names, values)
+}
+
+fn enum_record_named(name: &str, namespace: &str, names: usize, values: usize) -> Vec<u8> {
+    let mut out = sia(name);
+    out.extend_from_slice(&sia(namespace));
+    out.extend_from_slice(&(names as i32).to_le_bytes());
+    for _ in 0..names {
+        out.extend_from_slice(&sia("Entry"));
+    }
+    out.extend_from_slice(&(values as i32).to_le_bytes());
+    for _ in 0..values {
+        out.extend_from_slice(&0i32.to_le_bytes());
+    }
+    out
+}
+
+fn import_record(parameter_types: usize, flags: usize, defaults: usize) -> Vec<u8> {
+    import_record_named(
+        "ImportedModule",
+        "ImportedFunction",
+        "",
+        parameter_types,
+        flags,
+        defaults,
+    )
+}
+
+fn import_record_named(
+    imported_from_module: &str,
+    name: &str,
+    namespace: &str,
+    parameter_types: usize,
+    flags: usize,
+    defaults: usize,
+) -> Vec<u8> {
+    let mut out = sia(imported_from_module);
+    out.extend_from_slice(&sia(name));
+    out.extend_from_slice(&sia(namespace));
+    out.extend_from_slice(&(parameter_types as i32).to_le_bytes());
+    for _ in 0..parameter_types {
+        out.extend_from_slice(&datatype(0, 0x52));
+    }
+    out.extend_from_slice(&(flags as i32).to_le_bytes());
+    for _ in 0..flags {
+        out.extend_from_slice(&0i32.to_le_bytes());
+    }
+    out.extend_from_slice(&(defaults as i32).to_le_bytes());
+    for _ in 0..defaults {
+        out.extend_from_slice(&sia(""));
+    }
+    out.extend_from_slice(&datatype(0, 0x52));
+    out
+}
+
+fn global_init_record(init_function: &[u8]) -> Vec<u8> {
+    let mut out = sia("InitializedGlobal");
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&datatype(0, 0x52));
+    out.extend_from_slice(&0i32.to_le_bytes()); // not default-init
+    out.extend_from_slice(&0i32.to_le_bytes()); // not a pure constant
+    out.extend_from_slice(&1i32.to_le_bytes()); // has init function
+    out.extend_from_slice(init_function);
+    out
+}
+
+fn global_record_named(name: &str, namespace: &str) -> Vec<u8> {
+    let mut out = sia(name);
+    out.extend_from_slice(&sia(namespace));
+    out.extend_from_slice(&datatype(0, 0x52));
+    out.extend_from_slice(&1i32.to_le_bytes()); // default-init: no payload follows
     out
 }
 
@@ -184,7 +618,7 @@ fn class_record() -> Vec<u8> {
     out.extend_from_slice(&0i32.to_le_bytes()); // properties
     out.extend_from_slice(&0i32.to_le_bytes()); // methods
     out.extend_from_slice(&2i32.to_le_bytes()); // MethodTable: local Methods[] indices
-    out.extend_from_slice(&7i32.to_le_bytes());
+    out.extend_from_slice(&(-1i32).to_le_bytes());
     out.extend_from_slice(&(-1i32).to_le_bytes());
     out.extend_from_slice(&REGEN_TYPE_PTR.to_le_bytes()); // DerivedFrom: existing type
     out.extend_from_slice(&NEW_TYPE_PTR.to_le_bytes()); // ShadowType: new type
@@ -192,25 +626,64 @@ fn class_record() -> Vec<u8> {
     out.extend_from_slice(&2i32.to_le_bytes()); // FactoryRefs (T4 ids)
     out.extend_from_slice(&(REGEN_FUNC_ID as i64).to_le_bytes());
     out.extend_from_slice(&(NEW_FUNC_ID as i64).to_le_bytes());
-    out.extend_from_slice(&2i32.to_le_bytes()); // BehaviorRefs (T4 ids)
+    out.extend_from_slice(&7i32.to_le_bytes()); // BehaviorRefs (T4 ids)
     out.extend_from_slice(&(REGEN_FUNC_ID as i64).to_le_bytes());
     out.extend_from_slice(&(NEW_FUNC_ID as i64).to_le_bytes());
+    for _ in 0..5 {
+        out.extend_from_slice(&0i64.to_le_bytes());
+    }
     out.extend_from_slice(&0i32.to_le_bytes()); // behavior functions
     out.extend_from_slice(&0i32.to_le_bytes()); // behavior function types
     out.extend_from_slice(&0i32.to_le_bytes()); // has Unreal class data
     out
 }
 
-fn module_value(bytecode: &[i32], class: Option<&[u8]>) -> Vec<u8> {
-    let mut out = sia(MODULE);
-    out.extend_from_slice(&1i32.to_le_bytes());
-    out.extend_from_slice(&function(bytecode));
-    out.extend_from_slice(&(class.is_some() as i32).to_le_bytes());
-    if let Some(class) = class {
-        out.extend_from_slice(class);
+fn class_record_with_embedded_refs(derived_from: i64, factory_ref: i64) -> Vec<u8> {
+    let mut out = sia("EditedClass");
+    out.extend_from_slice(&sia(""));
+    out.extend_from_slice(&0i32.to_le_bytes()); // flags
+    out.extend_from_slice(&0i32.to_le_bytes()); // properties
+    out.extend_from_slice(&0i32.to_le_bytes()); // methods
+    out.extend_from_slice(&0i32.to_le_bytes()); // method table
+    out.extend_from_slice(&derived_from.to_le_bytes());
+    out.extend_from_slice(&0i64.to_le_bytes()); // shadow type
+    out.extend_from_slice(&0i32.to_le_bytes()); // constructors
+    out.extend_from_slice(&1i32.to_le_bytes()); // factory refs
+    out.extend_from_slice(&factory_ref.to_le_bytes());
+    out.extend_from_slice(&7i32.to_le_bytes()); // behavior refs
+    for _ in 0..7 {
+        out.extend_from_slice(&0i64.to_le_bytes());
     }
-    for _ in 0..3 {
-        out.extend_from_slice(&0i32.to_le_bytes()); // enums/globals/imports
+    out.extend_from_slice(&0i32.to_le_bytes()); // behavior functions
+    out.extend_from_slice(&0i32.to_le_bytes()); // behavior function types
+    out.extend_from_slice(&0i32.to_le_bytes()); // has Unreal class data
+    out
+}
+
+fn module_value_with_records(
+    functions: &[Vec<u8>],
+    classes: &[Vec<u8>],
+    enums: &[Vec<u8>],
+    globals: &[Vec<u8>],
+    imports: &[Vec<u8>],
+) -> Vec<u8> {
+    module_value_with_name_and_records(MODULE, functions, classes, enums, globals, imports)
+}
+
+fn module_value_with_name_and_records(
+    module_name: &str,
+    functions: &[Vec<u8>],
+    classes: &[Vec<u8>],
+    enums: &[Vec<u8>],
+    globals: &[Vec<u8>],
+    imports: &[Vec<u8>],
+) -> Vec<u8> {
+    let mut out = sia(module_name);
+    for records in [functions, classes, enums, globals, imports] {
+        out.extend_from_slice(&(records.len() as i32).to_le_bytes());
+        for record in records {
+            out.extend_from_slice(record);
+        }
     }
     out.extend_from_slice(&0i64.to_le_bytes()); // code hash
     out.extend_from_slice(&0i32.to_le_bytes()); // imported modules
@@ -229,12 +702,270 @@ fn append_table(out: &mut Vec<u8>, rows: &[Vec<u8>]) {
     }
 }
 
-fn cache_with_class(bytecode: &[i32], tables: Tables, class: Option<&[u8]>) -> Vec<u8> {
+fn test_sia_at(bytes: &[u8], mut pos: usize) -> Option<(String, usize)> {
+    let len = i32::from_le_bytes(bytes.get(pos..pos + 4)?.try_into().ok()?);
+    pos += 4;
+    if len == 0 {
+        return Some((String::new(), pos));
+    }
+    let len = usize::try_from(len).ok()?;
+    let raw = bytes.get(pos..pos.checked_add(len + 1)?)?;
+    if raw.last() != Some(&0) || raw[..len].contains(&0) {
+        return None;
+    }
+    Some((
+        String::from_utf8_lossy(&raw[..len]).into_owned(),
+        pos + len + 1,
+    ))
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct SyntheticT3Signature {
+    name: String,
+    module: String,
+    namespace: String,
+    is_const: bool,
+    is_imported: bool,
+    is_method: bool,
+    owner: i64,
+    parameter_types: Vec<Vec<u8>>,
+    return_type: Vec<u8>,
+}
+
+fn test_t3_signature(row: &[u8]) -> Option<SyntheticT3Signature> {
+    let (name, pos) = test_sia_at(row, 8)?;
+    let (module, pos) = test_sia_at(row, pos)?;
+    let (namespace, mut pos) = test_sia_at(row, pos)?;
+    let read_bool = |pos: &mut usize| {
+        let value = i32::from_le_bytes(row.get(*pos..*pos + 4)?.try_into().ok()?);
+        *pos += 4;
+        match value {
+            0 => Some(false),
+            1 => Some(true),
+            _ => None,
+        }
+    };
+    let is_const = read_bool(&mut pos)?;
+    let is_imported = read_bool(&mut pos)?;
+    let is_method = read_bool(&mut pos)?;
+    let owner = i64::from_le_bytes(row.get(pos..pos + 8)?.try_into().ok()?);
+    pos += 8;
+    let parameter_count = i32::from_le_bytes(row.get(pos..pos + 4)?.try_into().ok()?);
+    pos += 4;
+    let parameter_count = usize::try_from(parameter_count).ok()?;
+    let mut parameter_types = Vec::with_capacity(parameter_count);
+    for _ in 0..parameter_count {
+        let end = pos.checked_add(36)?;
+        parameter_types.push(row.get(pos..end)?.to_vec());
+        pos = end;
+    }
+    let end = pos.checked_add(36)?;
+    let return_type = row.get(pos..end)?.to_vec();
+    (end == row.len()).then_some(SyntheticT3Signature {
+        name,
+        module,
+        namespace,
+        is_const,
+        is_imported,
+        is_method,
+        owner,
+        parameter_types,
+        return_type,
+    })
+}
+
+fn default_module_function_declares(signature: &SyntheticT3Signature, module_name: &str) -> bool {
+    signature.name == "Edited"
+        && signature.module == module_name
+        && signature.namespace.is_empty()
+        && !signature.is_const
+        && !signature.is_imported
+        && !signature.is_method
+        && signature.owner == 0
+        && signature.parameter_types.is_empty()
+        && signature.return_type == datatype(0, 0x52)
+}
+
+#[derive(Default)]
+struct SyntheticDeclarations {
+    functions: Vec<Vec<u8>>,
+    classes: Vec<Vec<u8>>,
+    globals: Vec<Vec<u8>>,
+    imports: Vec<Vec<u8>>,
+}
+
+fn synthetic_property_names_for_owner(tables: &Tables, owner_ptr: i64) -> Vec<String> {
+    let owner_ids = tables
+        .type_ids
+        .iter()
+        .filter_map(|row| {
+            let id = i32::from_le_bytes(row.get(..4)?.try_into().ok()?);
+            let ptr = i64::from_le_bytes(row.get(4..12)?.try_into().ok()?);
+            (ptr == owner_ptr).then_some(id)
+        })
+        .collect::<std::collections::HashSet<_>>();
+    let mut names = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for row in &tables.properties {
+        let Some((name, pos)) = test_sia_at(row, 8) else {
+            continue;
+        };
+        let Some(old_type_id) = row
+            .get(pos..pos + 4)
+            .and_then(|bytes| bytes.try_into().ok())
+            .map(i32::from_le_bytes)
+        else {
+            continue;
+        };
+        if owner_ids.contains(&old_type_id) && seen.insert(name.clone()) {
+            names.push(name);
+        }
+    }
+    names
+}
+
+fn synthetic_declarations_for_tables(
+    module_name: &str,
+    tables: &Tables,
+    function_id_seed: i32,
+) -> SyntheticDeclarations {
+    let signatures = tables
+        .funcs
+        .iter()
+        .filter_map(|row| test_t3_signature(row))
+        .collect::<Vec<_>>();
+    let mut functions = Vec::new();
+    let mut methods_by_owner: std::collections::HashMap<i64, Vec<Vec<u8>>> =
+        std::collections::HashMap::new();
+    let mut seen_functions = std::collections::HashSet::new();
+    for signature in &signatures {
+        // Imported rows need FunctionImports authority and native/template methods need pristine
+        // engine authority. The generic cache fixture must not invent either.
+        if signature.is_imported || !seen_functions.insert(signature.clone()) {
+            continue;
+        }
+        let id = function_id_seed
+            .wrapping_neg()
+            .wrapping_sub(i32::try_from(seen_functions.len()).unwrap());
+        let declaration = function_with_signature(
+            &signature.name,
+            &signature.namespace,
+            &signature.parameter_types,
+            &signature.return_type,
+            signature.is_const,
+            &[10],
+            id,
+        );
+        if signature.is_method {
+            methods_by_owner
+                .entry(signature.owner)
+                .or_default()
+                .push(declaration);
+        } else if signature.module == module_name
+            && !default_module_function_declares(signature, module_name)
+        {
+            functions.push(declaration);
+        }
+    }
+
+    let mut classes = Vec::new();
+    let mut seen_types = std::collections::HashSet::new();
+    for row in &tables.types {
+        let Some(key) = row
+            .get(..8)
+            .and_then(|bytes| bytes.try_into().ok())
+            .map(i64::from_le_bytes)
+        else {
+            continue;
+        };
+        let Some((name, pos)) = test_sia_at(row, 8) else {
+            continue;
+        };
+        let Some((module, pos)) = test_sia_at(row, pos) else {
+            continue;
+        };
+        let Some((namespace, pos)) = test_sia_at(row, pos) else {
+            continue;
+        };
+        let Some(subtypes) = row
+            .get(pos..pos + 4)
+            .and_then(|bytes| bytes.try_into().ok())
+            .map(i32::from_le_bytes)
+        else {
+            continue;
+        };
+        if subtypes == 0
+            && module == module_name
+            && seen_types.insert((name.clone(), namespace.clone()))
+        {
+            let methods = methods_by_owner.remove(&key).unwrap_or_default();
+            let method_table = (0..methods.len())
+                .map(|index| i32::try_from(index).unwrap())
+                .collect::<Vec<_>>();
+            let properties = synthetic_property_names_for_owner(tables, key)
+                .into_iter()
+                .map(|name| property_record_named(&name))
+                .collect::<Vec<_>>();
+            classes.push(structural_class_record_full_named(
+                &name,
+                &namespace,
+                &properties,
+                &methods,
+                &method_table,
+                &[],
+                &[],
+                &[0; 7],
+                &[],
+                &[],
+                None,
+            ));
+        }
+    }
+
+    let mut globals = Vec::new();
+    let mut seen_globals = std::collections::HashSet::new();
+    for row in &tables.globals {
+        let Some((name, pos)) = test_sia_at(row, 8) else {
+            continue;
+        };
+        let Some((module, pos)) = test_sia_at(row, pos) else {
+            continue;
+        };
+        let Some((namespace, pos)) = test_sia_at(row, pos) else {
+            continue;
+        };
+        let Some(is_string) = row
+            .get(pos..pos + 4)
+            .and_then(|bytes| bytes.try_into().ok())
+            .map(i32::from_le_bytes)
+        else {
+            continue;
+        };
+        if is_string == 0
+            && module == module_name
+            && seen_globals.insert((name.clone(), namespace.clone()))
+        {
+            globals.push(global_record_named(&name, &namespace));
+        }
+    }
+    SyntheticDeclarations {
+        functions,
+        classes,
+        globals,
+        imports: Vec::new(),
+    }
+}
+
+fn cache_from_module_value(module: &[u8], tables: Tables) -> Vec<u8> {
+    cache_from_named_module_value(MODULE, module, tables)
+}
+
+fn cache_from_named_module_value(module_name: &str, module: &[u8], tables: Tables) -> Vec<u8> {
     let mut out = vec![0u8; 16];
     out.extend_from_slice(&CACHE_MAGIC.to_le_bytes());
     out.extend_from_slice(&1u32.to_le_bytes());
-    out.extend_from_slice(&fstring(MODULE));
-    out.extend_from_slice(&module_value(bytecode, class));
+    out.extend_from_slice(&fstring(module_name));
+    out.extend_from_slice(module);
     append_table(&mut out, &tables.types);
     append_table(&mut out, &tables.type_ids);
     append_table(&mut out, &tables.funcs);
@@ -245,8 +976,121 @@ fn cache_with_class(bytecode: &[i32], tables: Tables, class: Option<&[u8]>) -> V
     out
 }
 
+fn cache_with_class_and_function_id(
+    bytecode: &[i32],
+    tables: Tables,
+    class: Option<&[u8]>,
+    function_id: i32,
+) -> Vec<u8> {
+    let mut declarations = synthetic_declarations_for_tables(MODULE, &tables, function_id);
+    if let Some(class) = class {
+        declarations.classes.push(class.to_vec());
+    }
+    let mut functions = vec![function(bytecode, function_id)];
+    functions.extend(declarations.functions);
+    let module = module_value_with_name_and_records(
+        MODULE,
+        &functions,
+        &declarations.classes,
+        &[],
+        &declarations.globals,
+        &declarations.imports,
+    );
+    cache_from_module_value(&module, tables)
+}
+
+fn cache_with_class(bytecode: &[i32], tables: Tables, class: Option<&[u8]>) -> Vec<u8> {
+    cache_with_class_and_function_id(bytecode, tables, class, DEFAULT_MODULE_FUNCTION_ID)
+}
+
+fn cache_with_function_id(bytecode: &[i32], tables: Tables, function_id: i32) -> Vec<u8> {
+    cache_with_class_and_function_id(bytecode, tables, None, function_id)
+}
+
+fn cache_with_records(
+    functions: &[Vec<u8>],
+    classes: &[Vec<u8>],
+    enums: &[Vec<u8>],
+    imports: &[Vec<u8>],
+) -> Vec<u8> {
+    cache_with_all_records(functions, classes, enums, &[], imports)
+}
+
+fn cache_with_all_records(
+    functions: &[Vec<u8>],
+    classes: &[Vec<u8>],
+    enums: &[Vec<u8>],
+    globals: &[Vec<u8>],
+    imports: &[Vec<u8>],
+) -> Vec<u8> {
+    cache_from_module_value(
+        &module_value_with_records(functions, classes, enums, globals, imports),
+        Tables::default(),
+    )
+}
+
 fn cache(bytecode: &[i32], tables: Tables) -> Vec<u8> {
     cache_with_class(bytecode, tables, None)
+}
+
+fn cache_with_named_module(module_name: &str, bytecode: &[i32], tables: Tables) -> Vec<u8> {
+    cache_with_module_key_name_and_function_id(
+        module_name,
+        module_name,
+        bytecode,
+        tables,
+        DEFAULT_MODULE_FUNCTION_ID,
+    )
+}
+
+fn cache_with_module_key_and_name(
+    module_key: &str,
+    module_name: &str,
+    bytecode: &[i32],
+    tables: Tables,
+) -> Vec<u8> {
+    cache_with_module_key_name_and_function_id(
+        module_key,
+        module_name,
+        bytecode,
+        tables,
+        DEFAULT_MODULE_FUNCTION_ID,
+    )
+}
+
+fn cache_with_module_key_name_and_function_id(
+    module_key: &str,
+    module_name: &str,
+    bytecode: &[i32],
+    tables: Tables,
+    function_id: i32,
+) -> Vec<u8> {
+    let declarations = synthetic_declarations_for_tables(module_name, &tables, function_id);
+    let mut functions = vec![function(bytecode, function_id)];
+    functions.extend(declarations.functions);
+    let module = module_value_with_name_and_records(
+        module_name,
+        &functions,
+        &declarations.classes,
+        &[],
+        &declarations.globals,
+        &declarations.imports,
+    );
+    cache_from_named_module_value(module_key, &module, tables)
+}
+
+fn cache_with_module_key_name_and_records(
+    module_key: &str,
+    module_name: &str,
+    functions: &[Vec<u8>],
+    classes: &[Vec<u8>],
+    enums: &[Vec<u8>],
+    globals: &[Vec<u8>],
+    tables: Tables,
+) -> Vec<u8> {
+    let module =
+        module_value_with_name_and_records(module_name, functions, classes, enums, globals, &[]);
+    cache_from_named_module_value(module_key, &module, tables)
 }
 
 fn qw_op(opcode: i32, value: i64, out: &mut Vec<i32>) {
@@ -255,7 +1099,7 @@ fn qw_op(opcode: i32, value: i64, out: &mut Vec<i32>) {
     out.push(((value as u64) >> 32) as u32 as i32);
 }
 
-fn base_cache() -> Vec<u8> {
+fn base_cache_with_function_id(function_id: i32) -> Vec<u8> {
     let tables = Tables {
         types: vec![type_row(BASE_TYPE_PTR, "ExistingType", MODULE, &[])],
         type_ids: vec![id_row(BASE_TYPE_ID, BASE_TYPE_PTR)],
@@ -271,15 +1115,18 @@ fn base_cache() -> Vec<u8> {
         static_names: vec![sia("VanillaName"), sia("SharedName")],
         properties: vec![property_row(BASE_TYPE_ID, 4, "ExistingField")],
     };
-    cache(&[10], tables) // RET
+    cache_with_function_id(&[10], tables, function_id) // RET
+}
+
+fn base_cache() -> Vec<u8> {
+    base_cache_with_function_id(DEFAULT_MODULE_FUNCTION_ID)
 }
 
 fn regen_tables(existing_property: &str) -> Tables {
     Tables {
         types: vec![
             type_row(REGEN_TYPE_PTR, "ExistingType", MODULE, &[]),
-            // NewType depends on ExistingType; the carried T1 row must rewrite this dependency.
-            type_row(NEW_TYPE_PTR, "NewType", MODULE, &[REGEN_TYPE_PTR]),
+            type_row(NEW_TYPE_PTR, "NewType", MODULE, &[]),
         ],
         type_ids: vec![
             id_row(REGEN_TYPE_ID, REGEN_TYPE_PTR),
@@ -315,7 +1162,10 @@ fn regen_tables(existing_property: &str) -> Tables {
     }
 }
 
-fn regen_cache_with_existing_property(existing_property: &str) -> Vec<u8> {
+fn regen_cache_with_existing_property_and_function_id(
+    existing_property: &str,
+    function_id: i32,
+) -> Vec<u8> {
     let mut code = Vec::new();
     qw_op(75, NEW_TYPE_PTR, &mut code); // OBJTYPE new type ptr
     code.extend([76, NEW_TYPE_ID | 0x6000_0000]); // flagged TYPEID for new type
@@ -330,11 +1180,154 @@ fn regen_cache_with_existing_property(existing_property: &str) -> Vec<u8> {
     qw_op(61, REGEN_STATIC_FUNC_PTR, &mut code); // __STATIC_NAME
     code.push(10); // RET
     let class = class_record();
-    cache_with_class(&code, regen_tables(existing_property), Some(&class))
+    cache_with_class_and_function_id(
+        &code,
+        regen_tables(existing_property),
+        Some(&class),
+        function_id,
+    )
+}
+
+fn regen_cache_with_existing_property(existing_property: &str) -> Vec<u8> {
+    regen_cache_with_existing_property_and_function_id(
+        existing_property,
+        DEFAULT_MODULE_FUNCTION_ID,
+    )
 }
 
 fn regen_cache() -> Vec<u8> {
     regen_cache_with_existing_property("ExistingField")
+}
+
+fn regen_cache_with_function_id(function_id: i32) -> Vec<u8> {
+    regen_cache_with_existing_property_and_function_id("ExistingField", function_id)
+}
+
+fn embedded_function_id_caches(base_id: i32, regen_id: i32, embedded: i64) -> (Vec<u8>, Vec<u8>) {
+    const FUNCTION_MODULE: &str = "SharedFunctionModule";
+    let base = cache(
+        &[10],
+        Tables {
+            funcs: vec![func_row(
+                BASE_FUNC_PTR,
+                "EmbeddedFn",
+                FUNCTION_MODULE,
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(base_id, BASE_FUNC_PTR)],
+            ..Tables::default()
+        },
+    );
+    let class = class_record_with_embedded_refs(0, embedded);
+    let regen = cache_with_class(
+        &[10],
+        Tables {
+            funcs: vec![func_row(
+                REGEN_FUNC_PTR,
+                "EmbeddedFn",
+                FUNCTION_MODULE,
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(regen_id, REGEN_FUNC_PTR)],
+            ..Tables::default()
+        },
+        Some(&class),
+    );
+    (base, regen)
+}
+
+fn duplicate_tail_key_tables(table: usize, conflicting: bool) -> Tables {
+    const TYPE_PTR: i64 = 0x7c00;
+    const OTHER_PTR: i64 = 0x7c08;
+    const TYPE_ID: i32 = 0x0800_7c00;
+    const FUNC_PTR: i64 = 0x7d00;
+    const OTHER_FUNC_PTR: i64 = 0x7d08;
+    const FUNC_ID: i32 = 0x0001_7d00;
+    const GLOBAL_PTR: i64 = 0x7e00;
+    match table {
+        0 => {
+            let first = type_row(TYPE_PTR, "DuplicateType", MODULE, &[]);
+            Tables {
+                types: vec![
+                    first.clone(),
+                    if conflicting {
+                        type_row(TYPE_PTR, "ConflictingType", MODULE, &[])
+                    } else {
+                        first
+                    },
+                ],
+                type_ids: vec![id_row(TYPE_ID, TYPE_PTR)],
+                ..Tables::default()
+            }
+        }
+        1 => Tables {
+            types: vec![type_row(TYPE_PTR, "DuplicateTypeId", MODULE, &[])],
+            type_ids: vec![
+                id_row(TYPE_ID, TYPE_PTR),
+                id_row(TYPE_ID, if conflicting { OTHER_PTR } else { TYPE_PTR }),
+            ],
+            ..Tables::default()
+        },
+        2 => {
+            let first = func_row(FUNC_PTR, "Edited", MODULE, 0, &[], 0);
+            Tables {
+                funcs: vec![
+                    first.clone(),
+                    if conflicting {
+                        func_row(FUNC_PTR, "ConflictingFunction", MODULE, 0, &[], 0)
+                    } else {
+                        first
+                    },
+                ],
+                func_ids: vec![id_row(FUNC_ID, FUNC_PTR)],
+                ..Tables::default()
+            }
+        }
+        3 => Tables {
+            funcs: vec![func_row(FUNC_PTR, "Edited", MODULE, 0, &[], 0)],
+            func_ids: vec![
+                id_row(FUNC_ID, FUNC_PTR),
+                id_row(
+                    FUNC_ID,
+                    if conflicting {
+                        OTHER_FUNC_PTR
+                    } else {
+                        FUNC_PTR
+                    },
+                ),
+            ],
+            ..Tables::default()
+        },
+        4 => {
+            let first = global_row(GLOBAL_PTR, "DuplicateGlobal", MODULE);
+            Tables {
+                globals: vec![
+                    first.clone(),
+                    if conflicting {
+                        global_row(GLOBAL_PTR, "ConflictingGlobal", MODULE)
+                    } else {
+                        first
+                    },
+                ],
+                ..Tables::default()
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn contains_single_factory_ref(cache: &[u8], id: i64) -> bool {
+    let mut needle = 1i32.to_le_bytes().to_vec();
+    needle.extend_from_slice(&id.to_le_bytes());
+    needle.extend_from_slice(&7i32.to_le_bytes());
+    let module_end = module_region_end(cache).unwrap();
+    cache[..module_end]
+        .windows(needle.len())
+        .any(|window| window == needle)
 }
 
 fn replace_ascii_same_len(bytes: &mut [u8], from: &str, to: &str) {
@@ -356,7 +1349,11 @@ fn replace_ascii_same_len(bytes: &mut [u8], from: &str, to: &str) {
 fn regen_existing_flagged_typeid_cache() -> Vec<u8> {
     cache(
         &[76, REGEN_TYPE_ID | 0x6000_0000, 10],
-        regen_tables("ExistingField"),
+        Tables {
+            types: vec![type_row(REGEN_TYPE_PTR, "ExistingType", MODULE, &[])],
+            type_ids: vec![id_row(REGEN_TYPE_ID, REGEN_TYPE_PTR)],
+            ..Tables::default()
+        },
     )
 }
 
@@ -367,19 +1364,5412 @@ fn keyed_mini(table: usize, key: i64, label: &str) -> Vec<u8> {
 fn keyed_mini_with_value_delta(table: usize, key: i64, label: &str, delta: i64) -> Vec<u8> {
     let mut tables = Tables::default();
     match table {
-        0 => tables.types.push(type_row(key, label, MODULE, &[])),
-        1 => tables
-            .type_ids
-            .push(id_row(key as i32, key + 0x1000 + delta)),
-        2 => tables.funcs.push(func_row(key, label, MODULE, 0, &[], 0)),
-        3 => tables
-            .func_ids
-            .push(id_row(key as i32, key + 0x2000 + delta)),
+        0 => {
+            tables.types.push(type_row(key, label, MODULE, &[]));
+            tables.type_ids.push(id_row((key as i32).max(12), key));
+        }
+        1 => {
+            let dependency = key + 0x1000 + delta;
+            tables
+                .types
+                .push(type_row(dependency, "TypeIdDependency", MODULE, &[]));
+            tables.type_ids.push(id_row(key as i32, dependency));
+        }
+        2 => {
+            tables.funcs.push(func_row(key, label, MODULE, 0, &[], 0));
+            tables.func_ids.push(id_row((key as i32).max(1), key));
+        }
+        3 => {
+            let dependency = key + 0x2000 + delta;
+            tables
+                .funcs
+                .push(func_row(dependency, "FuncIdDependency", MODULE, 0, &[], 0));
+            tables.func_ids.push(id_row(key as i32, dependency));
+        }
         4 => tables.globals.push(global_row(key, label, MODULE)),
-        6 => tables.properties.push(property_row(key as i32, 4, label)),
+        6 => {
+            let dependency = key + 0x3000;
+            tables
+                .types
+                .push(type_row(dependency, "PropertyOwner", MODULE, &[]));
+            tables.type_ids.push(id_row(key as i32, dependency));
+            tables.properties.push(property_row(key as i32, 4, label));
+        }
         _ => unreachable!(),
     }
     cache(&[10], tables)
+}
+
+fn cache_with_function_return_datatype(type_ptr: i64, token: i32) -> Vec<u8> {
+    cache_with_function_return_datatype_flags(type_ptr, token, [false; 6])
+}
+
+fn cache_with_function_return_datatype_flags(
+    type_ptr: i64,
+    token: i32,
+    flags: [bool; 6],
+) -> Vec<u8> {
+    let mut mini = cache(&[10], Tables::default());
+    let original = datatype(0, 0x52);
+    let replacement = datatype_flags(type_ptr, token, flags);
+    let start = mini
+        .windows(original.len())
+        .position(|window| window == original.as_slice())
+        .expect("minimal function return DataType");
+    mini[start..start + replacement.len()].copy_from_slice(&replacement);
+    mini
+}
+
+fn assert_guard_rejects_reference(base: &[u8], mini: &[u8], case: &str) {
+    let mut guard = SequentialMiniGuard::new(base).unwrap();
+    let error = match guard.check_and_record(mini) {
+        Ok(_) => panic!("{case}: invalid reference unexpectedly passed"),
+        Err(error) => error,
+    };
+    assert!(
+        matches!(error, SpliceError::MiniReference(_)),
+        "{case}: unexpected error: {error:?}"
+    );
+}
+
+fn assert_guard_and_allow_new_reject_declaration(
+    base: &[u8],
+    mini: &[u8],
+    table: usize,
+    row_key: i64,
+    case: &str,
+) {
+    let guard_error = match SequentialMiniGuard::new(base)
+        .unwrap()
+        .check_and_record(mini)
+    {
+        Ok(_) => panic!("{case}: guard accepted a tail row without a declaration"),
+        Err(error) => error,
+    };
+    assert!(
+        matches!(
+            guard_error,
+            SpliceError::MiniReference(RemapError::InvalidTailRow {
+                table: actual_table,
+                row_key: actual_key,
+                kind,
+                ..
+            }) if actual_table == table
+                && actual_key == row_key
+                && kind == "declaration membership"
+        ),
+        "{case}: unexpected guard error: {guard_error:?}"
+    );
+
+    let remap_error = match remap_module_to_base_with_options(
+        mini,
+        base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    ) {
+        Ok(_) => panic!("{case}: allow-new accepted a tail row without a declaration"),
+        Err(error) => error,
+    };
+    assert!(
+        matches!(
+            remap_error,
+            RemapError::InvalidTailRow {
+                table: actual_table,
+                row_key: actual_key,
+                kind,
+                ..
+            } if actual_table == table
+                && actual_key == row_key
+                && kind == "declaration membership"
+        ),
+        "{case}: unexpected allow-new error: {remap_error:?}"
+    );
+}
+
+fn type_symbol_mini(ptr: i64, id: i32, name: &str, subtypes: &[i64]) -> Vec<u8> {
+    cache(
+        &[10],
+        Tables {
+            types: vec![type_row(ptr, name, MODULE, subtypes)],
+            type_ids: vec![id_row(id, ptr)],
+            ..Tables::default()
+        },
+    )
+}
+
+fn function_symbol_mini(ptr: i64, id: i32, name: &str, owner: i64, params: &[i64]) -> Vec<u8> {
+    cache(
+        &[10],
+        Tables {
+            funcs: vec![func_row(ptr, name, MODULE, owner, params, 0)],
+            func_ids: vec![id_row(id, ptr)],
+            ..Tables::default()
+        },
+    )
+}
+
+#[test]
+fn sequential_guard_rejects_a_mini_from_another_cache_guid() {
+    let mut base = base_cache();
+    base[..16].copy_from_slice(&[0x11; 16]);
+    let mut mini = cache(&[10], Tables::default());
+    mini[..16].copy_from_slice(&[0x22; 16]);
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard.check_and_record(&mini).unwrap_err();
+    match error {
+        SpliceError::MiniGuidMismatch {
+            base: actual_base,
+            mini: actual_mini,
+        } => {
+            assert_eq!(actual_base, [0x11; 16]);
+            assert_eq!(actual_mini, [0x22; 16]);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_stale_callsys_even_when_guid_matches() {
+    let base = base_cache();
+    let stale_key = 0x7fff_1234_5678i64;
+    let mut code = Vec::new();
+    qw_op(61, stale_key, &mut code);
+    code.push(10);
+    let mini = cache(&code, Tables::default());
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard.check_and_record(&mini).unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::UnresolvedEffectiveReference {
+            kind: "function pointer",
+            op: "CALLSYS",
+            key
+        }) if key == stale_key
+    ));
+}
+
+#[test]
+fn sequential_guard_rejects_an_unresolved_tail_row_dependency() {
+    let base = base_cache();
+    let stale_type_ptr = 0x7fff_3456_789ai64;
+    let mini = cache(
+        &[10],
+        Tables {
+            type_ids: vec![id_row(0x0800_6abc, stale_type_ptr)],
+            ..Tables::default()
+        },
+    );
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard.check_and_record(&mini).unwrap_err();
+    assert!(
+        matches!(
+            error,
+            SpliceError::MiniReference(RemapError::UnresolvedTailDependency {
+                table: 1,
+                kind: "type pointer",
+                dependency,
+                ..
+            }) if dependency == stale_type_ptr
+        ),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[test]
+fn sequential_guard_rejects_a_null_type_pointer_in_t2() {
+    let base = base_cache();
+    let object_id = 0x0800_4321;
+    let mini = cache(
+        &[76, object_id, 10],
+        Tables {
+            type_ids: vec![id_row(object_id, 0)],
+            ..Tables::default()
+        },
+    );
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard.check_and_record(&mini).unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::UnresolvedTailDependency {
+            table: 1,
+            dependency: 0,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn sequential_guard_rejects_a_large_unknown_embedded_function_id() {
+    let base = base_cache();
+    let stale_id = 0x1234_5678i64;
+    let class = class_record_with_embedded_refs(0, stale_id);
+    let mini = cache_with_class(&[10], Tables::default(), Some(&class));
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard.check_and_record(&mini).unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::UnresolvedEffectiveReference {
+            kind: "embedded function id",
+            op: "Factory/BehaviorRefs",
+            key
+        }) if key == stale_id
+    ));
+}
+
+#[test]
+fn sequential_guard_rejects_a_mini_row_that_retargets_a_base_key() {
+    let base = base_cache();
+    let mini = cache(
+        &[10],
+        Tables {
+            funcs: vec![func_row(
+                BASE_FUNC_PTR,
+                "DifferentIdentity",
+                MODULE,
+                BASE_TYPE_PTR,
+                &[],
+                0,
+            )],
+            ..Tables::default()
+        },
+    );
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard.check_and_record(&mini).unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::KeyCollision {
+            table: 2,
+            key: BASE_FUNC_PTR
+        }
+    ));
+}
+
+#[test]
+fn sequential_guard_rejects_a_missing_function_id_operand() {
+    let base = base_cache();
+    let missing_id = 0x12345;
+    let mini = cache(&[9, missing_id, 10], Tables::default());
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard.check_and_record(&mini).unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::UnresolvedEffectiveReference {
+            kind: "function id",
+            op: "CALL",
+            key
+        }) if key == i64::from(missing_id)
+    ));
+}
+
+#[test]
+fn sequential_guard_rejects_an_unmapped_runtime_object_type_id() {
+    let base = base_cache();
+    let missing_object_id = 0x0800_4321;
+    let mini = cache(&[76, missing_object_id, 10], Tables::default());
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard.check_and_record(&mini).unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::UnresolvedEffectiveReference {
+            kind: "type id",
+            op: "TYPEID",
+            key
+        }) if key == i64::from(missing_object_id)
+    ));
+}
+
+#[test]
+fn sequential_guard_rejects_invalid_type_id_operand_shapes() {
+    let base = base_cache();
+    let cases = [
+        ("unknown mask-clear core 12", 12),
+        ("qualifier on primitive core", 1 | 0x4000_0000),
+        (
+            "unsupported high-bit qualifier",
+            (BASE_TYPE_ID as u32 | 0x8000_0000) as i32,
+        ),
+    ];
+
+    for (case, raw_id) in cases {
+        let mini = cache(&[76, raw_id, 10], Tables::default());
+        assert_guard_rejects_reference(&base, &mini, case);
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_zero_old_reference_rows() {
+    let base = base_cache();
+    let cases = [
+        (
+            "T1 zero OldReference",
+            cache(
+                &[10],
+                Tables {
+                    types: vec![type_row(0, "ZeroType", MODULE, &[])],
+                    ..Tables::default()
+                },
+            ),
+        ),
+        (
+            "T3 zero OldReference",
+            cache(
+                &[10],
+                Tables {
+                    funcs: vec![func_row(0, "ZeroFunction", MODULE, 0, &[], 0)],
+                    ..Tables::default()
+                },
+            ),
+        ),
+        (
+            "T5 zero OldReference",
+            cache(
+                &[10],
+                Tables {
+                    globals: vec![global_row(0, "ZeroGlobal", MODULE)],
+                    ..Tables::default()
+                },
+            ),
+        ),
+    ];
+
+    for (case, mini) in cases {
+        assert_guard_rejects_reference(&base, &mini, case);
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_reserved_or_qualified_type_id_rows() {
+    let base = base_cache();
+    let reserved = cache(
+        &[10],
+        Tables {
+            type_ids: vec![id_row(11, BASE_TYPE_PTR)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(&base, &reserved, "reserved primitive T2 id");
+
+    let cases = [
+        (
+            "qualified T2 id",
+            (0x0800_4321u32 | 0x2000_0000) as i32,
+            0x7001,
+        ),
+        (
+            "negative T2 id",
+            (0x0800_4322u32 | 0x8000_0000) as i32,
+            0x7002,
+        ),
+        (
+            "combined handle-qualified T2 id",
+            0x0800_4323 | 0x6000_0000,
+            0x7003,
+        ),
+        (
+            "object-kind T2 id with reserved primitive sequence",
+            0x0800_0001,
+            0x7004,
+        ),
+    ];
+    for (case, id, ptr) in cases {
+        let mini = cache(
+            &[10],
+            Tables {
+                types: vec![type_row(ptr, case, MODULE, &[])],
+                type_ids: vec![id_row(id, ptr)],
+                ..Tables::default()
+            },
+        );
+        assert_guard_rejects_reference(&base, &mini, case);
+    }
+}
+
+#[test]
+fn sequential_guard_normalizes_runtime_ignored_datatype_flags_in_t1_and_t3() {
+    const LEAF: i64 = 0x7f00;
+    const BASE_TYPE: i64 = 0x7f08;
+    const MINI_TYPE: i64 = 0x7f10;
+    const BASE_FUNC: i64 = 0x7f18;
+    const MINI_FUNC: i64 = 0x7f20;
+    let cases = [
+        (
+            "primitive ignored flags",
+            datatype_flags(0, 0x4c, [false; 6]),
+            datatype_flags(0, 0x4c, [false, false, true, true, false, true]),
+        ),
+        (
+            "non-handle identifier const-handle flag",
+            datatype_flags(LEAF, 5, [false; 6]),
+            datatype_flags(LEAF, 5, [false, false, false, true, false, false]),
+        ),
+        (
+            "identifier if-handle-then-const flag",
+            datatype_flags(LEAF, 5, [false, false, true, false, false, false]),
+            datatype_flags(LEAF, 5, [false, false, true, false, false, true]),
+        ),
+    ];
+
+    for (case, base_datatype, mini_datatype) in cases {
+        let base = cache(
+            &[10],
+            Tables {
+                types: vec![
+                    type_row(LEAF, "FlagLeaf", MODULE, &[]),
+                    type_row_datatypes(
+                        BASE_TYPE,
+                        "FlaggedWrapper",
+                        MODULE,
+                        "",
+                        &[base_datatype.clone()],
+                    ),
+                ],
+                type_ids: vec![id_row(0x0800_7f00, LEAF), id_row(0x0800_7f08, BASE_TYPE)],
+                ..Tables::default()
+            },
+        );
+        let mini = cache(
+            &[10],
+            Tables {
+                types: vec![type_row_datatypes(
+                    MINI_TYPE,
+                    "FlaggedWrapper",
+                    MODULE,
+                    "",
+                    &[mini_datatype.clone()],
+                )],
+                type_ids: vec![id_row(0x0800_7f10, MINI_TYPE)],
+                ..Tables::default()
+            },
+        );
+        let error = SequentialMiniGuard::new(&base)
+            .unwrap()
+            .check_and_record(&mini)
+            .expect_err(case);
+        assert!(
+            matches!(
+                error,
+                SpliceError::MiniReference(RemapError::InvalidTailRow {
+                    table: 0,
+                    kind: "symbol identity",
+                    ..
+                })
+            ),
+            "{case}: unexpected T1 error: {error:?}"
+        );
+
+        let return_type = datatype(0, 0x52);
+        let base = cache(
+            &[10],
+            Tables {
+                types: vec![type_row(LEAF, "FlagLeaf", MODULE, &[])],
+                type_ids: vec![id_row(0x0800_7f00, LEAF)],
+                funcs: vec![func_row_datatypes(
+                    BASE_FUNC,
+                    "FlaggedFunction",
+                    MODULE,
+                    "",
+                    false,
+                    false,
+                    false,
+                    0,
+                    &[base_datatype],
+                    &return_type,
+                )],
+                func_ids: vec![id_row(0x7f18, BASE_FUNC)],
+                ..Tables::default()
+            },
+        );
+        let mini = cache(
+            &[10],
+            Tables {
+                funcs: vec![func_row_datatypes(
+                    MINI_FUNC,
+                    "FlaggedFunction",
+                    MODULE,
+                    "",
+                    false,
+                    false,
+                    false,
+                    0,
+                    &[mini_datatype],
+                    &return_type,
+                )],
+                func_ids: vec![id_row(0x7f20, MINI_FUNC)],
+                ..Tables::default()
+            },
+        );
+        let error = SequentialMiniGuard::new(&base)
+            .unwrap()
+            .check_and_record(&mini)
+            .expect_err(case);
+        assert!(
+            matches!(
+                error,
+                SpliceError::MiniReference(RemapError::InvalidTailRow {
+                    table: 2,
+                    kind: "symbol identity",
+                    ..
+                })
+            ),
+            "{case}: unexpected T3 error: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_noncanonical_auto_and_zero_token_datatypes_in_t1_and_t3() {
+    let cases = [
+        (
+            "auto primitive",
+            datatype_flags(0, 0x52, [false, false, false, false, true, false]),
+        ),
+        ("zero token", datatype_flags(0, 0, [false; 6])),
+    ];
+
+    for (ordinal, (case, datatype_bytes)) in cases.into_iter().enumerate() {
+        let type_ptr = 0x7f40 + ordinal as i64 * 8;
+        let mini = cache(
+            &[10],
+            Tables {
+                types: vec![type_row_datatypes(
+                    type_ptr,
+                    case,
+                    MODULE,
+                    "",
+                    &[datatype_bytes.clone()],
+                )],
+                type_ids: vec![id_row(0x0800_7f40 + ordinal as i32, type_ptr)],
+                ..Tables::default()
+            },
+        );
+        let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+            .unwrap()
+            .check_and_record(&mini)
+            .expect_err(case);
+        assert!(
+            matches!(
+                error,
+                SpliceError::MiniReference(RemapError::Wire(WireError::InvalidDataType { .. }))
+            ),
+            "{case}: unexpected T1 error: {error:?}"
+        );
+
+        let func_ptr = 0x7f60 + ordinal as i64 * 8;
+        let mini = cache(
+            &[10],
+            Tables {
+                funcs: vec![func_row_datatypes(
+                    func_ptr,
+                    case,
+                    MODULE,
+                    "",
+                    false,
+                    false,
+                    false,
+                    0,
+                    &[datatype_bytes],
+                    &datatype(0, 0x52),
+                )],
+                func_ids: vec![id_row(0x7f60 + ordinal as i32, func_ptr)],
+                ..Tables::default()
+            },
+        );
+        let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+            .unwrap()
+            .check_and_record(&mini)
+            .expect_err(case);
+        assert!(
+            matches!(
+                error,
+                SpliceError::MiniReference(RemapError::Wire(WireError::InvalidDataType { .. }))
+            ),
+            "{case}: unexpected T3 error: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_malformed_sia_encodings() {
+    let malformed = [
+        (
+            "negative/UTF-16 length is not supported by FStringInArchive",
+            (-1i32).to_le_bytes().to_vec(),
+        ),
+        (
+            "embedded NUL",
+            [3i32.to_le_bytes().as_slice(), b"A\0B\0"].concat(),
+        ),
+        (
+            "missing trailing NUL",
+            [3i32.to_le_bytes().as_slice(), b"ABCX"].concat(),
+        ),
+    ];
+
+    for (detail, encoded_name) in malformed {
+        let mini = cache(
+            &[10],
+            Tables {
+                static_names: vec![encoded_name],
+                ..Tables::default()
+            },
+        );
+        let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+            .unwrap()
+            .check_and_record(&mini)
+            .expect_err(detail);
+        assert!(
+            matches!(
+                error,
+                SpliceError::Wire(WireError::InvalidSia {
+                    detail: actual,
+                    ..
+                }) if actual == detail
+            ),
+            "{detail}: unexpected error: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_length_frames_identity_fields_containing_the_display_separator() {
+    let mini = cache(
+        &[10],
+        Tables {
+            types: vec![
+                type_row_ns(0x7f80, "X\u{1f}Y", MODULE, "N", &[]),
+                type_row_ns(0x7f88, "Y", MODULE, "N\u{1f}X", &[]),
+            ],
+            type_ids: vec![id_row(0x0800_7f80, 0x7f80), id_row(0x0800_7f88, 0x7f88)],
+            ..Tables::default()
+        },
+    );
+    SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("length framing must keep delimiter-containing field tuples distinct");
+}
+
+#[test]
+fn sequential_guard_allows_zero_ctor_only_for_native_alloc() {
+    let alloc_mini = |ptr, id, name| {
+        let mut code = Vec::new();
+        qw_op(64, ptr, &mut code);
+        code.extend([0, 10]);
+        cache(
+            &code,
+            Tables {
+                types: vec![type_row(ptr, name, MODULE, &[])],
+                type_ids: vec![id_row(id, ptr)],
+                ..Tables::default()
+            },
+        )
+    };
+    for (case, ptr, id) in [
+        ("APPOBJECT", 0x7fa0, 0x0400_7fa0),
+        ("TEMPLATE", 0x7fa8, 0x1000_7fa8),
+    ] {
+        SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+            .unwrap()
+            .check_and_record(&alloc_mini(ptr, id, case))
+            .unwrap_or_else(|error| panic!("{case} permits ALLOC's null ctor sentinel: {error:?}"));
+    }
+
+    for (case, ptr, id) in [
+        ("ENUM/mask0", 0x7fb0, 0x0000_7fb0),
+        ("SCRIPTOBJECT", 0x7fb8, 0x0800_7fb8),
+    ] {
+        let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+            .unwrap()
+            .check_and_record(&alloc_mini(ptr, id, case))
+            .unwrap_err();
+        assert!(
+            matches!(
+                error,
+                SpliceError::MiniReference(RemapError::UnresolvedEffectiveReference {
+                    kind: "function id",
+                    op: "ALLOC",
+                    key: 0,
+                })
+            ),
+            "{case}: unexpected error: {error:?}"
+        );
+    }
+
+    let call_mini = cache(&[9, 0, 10], Tables::default());
+    let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&call_mini)
+        .expect_err("CALL never treats zero as a native-constructor sentinel");
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::UnresolvedEffectiveReference {
+            kind: "function id",
+            op: "CALL",
+            key: 0,
+        })
+    ));
+}
+
+#[test]
+fn allow_new_type_id_allocator_skips_reserved_low_sequences() {
+    const RAW_PTR: i64 = 0x7fb0;
+    const RAW_ID: i32 = 0x0800_7fb0;
+    // The canonical leaf identity for this name hashes to T2 sequence 4 with the fixed kind-3
+    // FNV allocator. It must be advanced past AngelScript's primitive range to sequence 12.
+    let regen = cache(
+        &[76, RAW_ID, 10],
+        Tables {
+            types: vec![type_row(RAW_PTR, "LowSeq4793533", MODULE, &[])],
+            type_ids: vec![id_row(RAW_ID, RAW_PTR)],
+            ..Tables::default()
+        },
+    );
+    let (mini, counts) = remap_module_to_base_with_options(
+        &regen,
+        &cache(&[10], Tables::default()),
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .unwrap();
+    assert_eq!(counts.type_id, 1);
+    let tail = parse_tail_tables(&mini, module_region_end(&mini).unwrap()).unwrap();
+    assert_eq!(tail.tables[1].keys, vec![0x0800_000c]);
+}
+
+#[test]
+fn allow_new_rejects_ambiguous_t2_and_t4_rows_for_one_new_pointer() {
+    const TYPE_PTR: i64 = 0x7fc0;
+    const TYPE_ID_A: i32 = 0x0800_7fc0;
+    const TYPE_ID_B: i32 = 0x0800_7fc1;
+    const FUNC_PTR: i64 = 0x7fd0;
+    const FUNC_ID_A: i32 = 0x0001_7fd0;
+    const FUNC_ID_B: i32 = 0x0001_7fd1;
+    let base = cache(&[10], Tables::default());
+
+    let duplicate_reverse_type = cache(
+        &[76, TYPE_ID_A, 10],
+        Tables {
+            types: vec![type_row(TYPE_PTR, "ReverseType", MODULE, &[])],
+            type_ids: vec![id_row(TYPE_ID_A, TYPE_PTR), id_row(TYPE_ID_B, TYPE_PTR)],
+            ..Tables::default()
+        },
+    );
+    let type_error = remap_module_to_base_with_options(
+        &duplicate_reverse_type,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect_err("one new T1 pointer cannot be registered by two T2 ids");
+    assert!(matches!(
+        type_error,
+        RemapError::InvalidTailRow {
+            table: 1,
+            kind: "reverse type-id mapping",
+            ..
+        }
+    ));
+
+    let duplicate_reverse_function = cache(
+        &[10],
+        Tables {
+            funcs: vec![func_row(FUNC_PTR, "Edited", MODULE, 0, &[], 0)],
+            func_ids: vec![id_row(FUNC_ID_A, FUNC_PTR), id_row(FUNC_ID_B, FUNC_PTR)],
+            ..Tables::default()
+        },
+    );
+    let function_error = remap_module_to_base_with_options(
+        &duplicate_reverse_function,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect_err("one new T3 pointer cannot be registered by two T4 ids");
+    assert!(matches!(
+        function_error,
+        RemapError::InvalidTailRow {
+            table: 3,
+            kind: "reverse function-id mapping",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn sequential_guard_accepts_one_zero_t4_id_but_rejects_its_aliases() {
+    let base = cache(&[10], Tables::default());
+    let ptr = 0x7100;
+    let row = func_row(ptr, "ZeroIdFunction", MODULE, 0, &[], 0);
+    let unique = cache(
+        &[10],
+        Tables {
+            funcs: vec![row.clone()],
+            func_ids: vec![id_row(0, ptr)],
+            ..Tables::default()
+        },
+    );
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&unique)
+        .expect("T4 id zero is a legal unique FunctionIdReferenceToPointer key");
+
+    let alias = cache(
+        &[10],
+        Tables {
+            funcs: vec![row.clone()],
+            func_ids: vec![id_row(0, ptr), id_row(1, ptr)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(&base, &alias, "T4 id zero may not alias another id");
+
+    let duplicate_key = cache(
+        &[10],
+        Tables {
+            funcs: vec![
+                row,
+                func_row(ptr + 1, "OtherZeroIdFunction", MODULE, 0, &[], 0),
+            ],
+            func_ids: vec![id_row(0, ptr), id_row(0, ptr + 1)],
+            ..Tables::default()
+        },
+    );
+    let error = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&duplicate_key)
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::SequentialKeyCollision { table: 3, key: 0 }
+    ));
+}
+
+#[test]
+fn t4_zero_row_does_not_resolve_raw_zero_function_id_operand() {
+    let ptr = 0x7110;
+    let row = func_row(ptr, "ZeroMappedFunction", "ExternalModule", 0, &[], 0);
+    let known_module_base = cache_with_named_module(
+        "ExternalModule",
+        &[10],
+        Tables {
+            funcs: vec![row.clone()],
+            func_ids: vec![id_row(0, ptr)],
+            ..Tables::default()
+        },
+    );
+    let mini = cache(
+        &[2, 0, 9, 0, 10], // PshC4 0 + CALL 0 must not look like __STATIC_NAME.
+        Tables {
+            funcs: vec![row],
+            func_ids: vec![id_row(0, ptr)],
+            static_names: vec![sia("ZeroMustNotBeAStaticAccessor")],
+            ..Tables::default()
+        },
+    );
+    let error = SequentialMiniGuard::new(&known_module_base)
+        .unwrap()
+        .check_and_record(&mini)
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::UnresolvedEffectiveReference {
+            kind: "function id",
+            op: "CALL",
+            key: 0,
+        })
+    ));
+
+    let (remapped, counts) = remap_module_to_base_with_options(
+        &mini,
+        &known_module_base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new must preserve raw CALL 0 without declaring its T4[0] row");
+    assert_eq!(counts.func_id, 0);
+    let instructions = disassemble(&collect_function_bytecodes(&remapped).unwrap()[0].bytecode)
+        .expect("remapped zero-sentinel bytecode");
+    let call = instructions
+        .iter()
+        .find(|instruction| instruction.op.name == "CALL")
+        .unwrap();
+    assert_eq!(call.dwords[0], 0);
+    let psh = instructions
+        .iter()
+        .find(|instruction| instruction.op.name == "PshC4")
+        .unwrap();
+    assert_eq!(psh.dwords[0], 0);
+    let tail = parse_tail_tables(&remapped, module_region_end(&remapped).unwrap()).unwrap();
+    assert_eq!(tail.tables[2].count, 0);
+    assert_eq!(tail.tables[3].count, 0);
+    assert_eq!(tail.tables[5].count, 0);
+
+    let base_ptr = 0x7118;
+    let strict_base = cache_with_named_module(
+        "ExternalModule",
+        &[10],
+        Tables {
+            funcs: vec![func_row(
+                base_ptr,
+                "ZeroMappedFunction",
+                "ExternalModule",
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(0x7118, base_ptr)],
+            ..Tables::default()
+        },
+    );
+    let (strict, strict_counts) = remap_module_to_base(&mini, &strict_base)
+        .expect("strict remap must not resolve raw CALL 0 through regen T4[0]");
+    assert_eq!(strict_counts.func_id, 0);
+    let strict_instructions =
+        disassemble(&collect_function_bytecodes(&strict).unwrap()[0].bytecode).unwrap();
+    assert_eq!(
+        strict_instructions
+            .iter()
+            .find(|instruction| instruction.op.name == "CALL")
+            .unwrap()
+            .dwords[0],
+        0
+    );
+    assert_eq!(
+        strict_instructions
+            .iter()
+            .find(|instruction| instruction.op.name == "PshC4")
+            .unwrap()
+            .dwords[0],
+        0
+    );
+}
+
+#[test]
+fn sequential_guard_rejects_t1_key_in_the_t7_derived_domain() {
+    let type_id = 0x0800_7120;
+    let colliding_key = property_key(type_id, 4);
+    let mini = cache(
+        &[10],
+        Tables {
+            types: vec![type_row(colliding_key, "PropertyDomainType", MODULE, &[])],
+            type_ids: vec![id_row(type_id, colliding_key)],
+            properties: vec![property_row(type_id, 4, "CollidingProperty")],
+            ..Tables::default()
+        },
+    );
+
+    let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&mini)
+        .expect_err("T1 OldReference keys must never occupy the derived T7 key domain");
+    assert!(matches!(
+        error,
+        SpliceError::SequentialKeyCollision { table: 6, key } if key == colliding_key
+    ));
+}
+
+#[test]
+fn allow_new_synthetic_old_references_remain_eight_byte_aligned() {
+    let (mini, _) = remap_module_to_base_with_options(
+        &regen_cache(),
+        &base_cache(),
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .unwrap();
+    let tail = parse_tail_tables(&mini, module_region_end(&mini).unwrap()).unwrap();
+    for table in [0usize, 2, 4] {
+        for &key in &tail.tables[table].keys {
+            assert_eq!(
+                key & 7,
+                0,
+                "synthetic OldReference {key:#x} in T{} must preserve Win64 low3=0 alignment",
+                table + 1
+            );
+        }
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_inconsistent_property_key_fields() {
+    let base = base_cache();
+    let mut row = property_row(BASE_TYPE_ID, 4, "InconsistentProperty");
+    let inconsistent_key = property_key(BASE_TYPE_ID, 4) ^ 2;
+    row[..8].copy_from_slice(&inconsistent_key.to_le_bytes());
+    let mini = cache(
+        &[10],
+        Tables {
+            properties: vec![row],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(&base, &mini, "inconsistent T7 key");
+}
+
+#[test]
+fn sequential_guard_rejects_high_dword_function_id_alias() {
+    let base = base_cache();
+    let alias = (1i64 << 32) | i64::from(BASE_FUNC_ID);
+    let class = class_record_with_embedded_refs(0, alias);
+    let mini = cache_with_class(&[10], Tables::default(), Some(&class));
+    assert_guard_rejects_reference(&base, &mini, "high-dword embedded function-id alias");
+}
+
+#[test]
+fn strict_remap_sign_extends_positive_embedded_id_mapped_to_negative() {
+    const REGEN_ID: i32 = 0x7fff_0123;
+    const BASE_ID: i32 = 0x8000_1234u32 as i32;
+    let (base, regen) = embedded_function_id_caches(BASE_ID, REGEN_ID, i64::from(REGEN_ID));
+
+    let (mini, counts) = remap_module_to_base(&regen, &base).expect("strict embedded-id remap");
+    assert_eq!(counts.embed_func_id, 1);
+    assert!(contains_single_factory_ref(&mini, i64::from(BASE_ID)));
+    assert!(
+        !contains_single_factory_ref(&mini, i64::from(BASE_ID as u32)),
+        "a negative i32 must not be serialized as a zero-extended int64"
+    );
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("the canonically sign-extended strict mini passes admission");
+}
+
+#[test]
+fn allow_new_remap_clears_negative_high_dword_when_mapped_id_is_positive() {
+    const REGEN_ID: i32 = 0x8000_1234u32 as i32;
+    const BASE_ID: i32 = 0x7fff_0123;
+    let (base, regen) = embedded_function_id_caches(BASE_ID, REGEN_ID, i64::from(REGEN_ID));
+
+    let (mini, counts) = remap_module_to_base_with_options(
+        &regen,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new embedded-id remap");
+    assert_eq!(counts.embed_func_id, 1);
+    assert!(contains_single_factory_ref(&mini, i64::from(BASE_ID)));
+    let stale_negative_high_dword = (0xffff_ffff_0000_0000u64 | u64::from(BASE_ID as u32)) as i64;
+    assert!(
+        !contains_single_factory_ref(&mini, stale_negative_high_dword),
+        "the regen slot's negative high dword must not survive a positive mapping"
+    );
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("the canonical allow-new mini passes admission");
+}
+
+#[test]
+fn remappers_reject_noncanonical_high_dword_embedded_function_ids() {
+    const REGEN_ID: i32 = 0x1234_567;
+    const BASE_ID: i32 = 0x2345_678;
+    let malformed = (1i64 << 32) | i64::from(REGEN_ID);
+
+    for allow_new_symbols in [false, true] {
+        let (base, regen) = embedded_function_id_caches(BASE_ID, REGEN_ID, malformed);
+        let error = if allow_new_symbols {
+            remap_module_to_base_with_options(
+                &regen,
+                &base,
+                RemapOptions {
+                    allow_new_symbols: true,
+                },
+            )
+            .unwrap_err()
+        } else {
+            remap_module_to_base(&regen, &base).unwrap_err()
+        };
+        assert!(
+            matches!(
+                error,
+                RemapError::UnresolvedEffectiveReference {
+                    kind: "embedded function id",
+                    op: "Factory/BehaviorRefs",
+                    key,
+                } if key == malformed
+            ),
+            "allow_new_symbols={allow_new_symbols}: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn allow_new_rejects_identical_and_conflicting_duplicate_t1_through_t5_keys() {
+    let base = cache(&[10], Tables::default());
+    let expected_fields = [
+        "duplicate TypeReferences key",
+        "duplicate TypeIdReferenceToPointer key",
+        "duplicate FunctionReferences key",
+        "duplicate FunctionIdReferenceToPointer key",
+        "duplicate GlobalReferences key",
+    ];
+
+    for (table, expected_field) in expected_fields.into_iter().enumerate() {
+        for conflicting in [false, true] {
+            let regen = cache(&[10], duplicate_tail_key_tables(table, conflicting));
+            let error = remap_module_to_base_with_options(
+                &regen,
+                &base,
+                RemapOptions {
+                    allow_new_symbols: true,
+                },
+            )
+            .expect_err("a public allow-new remap must never emit duplicate keyed rows");
+            assert!(
+                matches!(
+                    error,
+                    RemapError::Wire(WireError::BadLen { field, .. })
+                        if field == expected_field
+                ),
+                "T{} conflicting={conflicting}: {error:?}",
+                table + 1
+            );
+        }
+    }
+}
+
+#[test]
+fn sequential_guard_accepts_zero_embedded_function_sentinel() {
+    let base = base_cache();
+    let class = class_record_with_embedded_refs(0, 0);
+    let mini = cache_with_class(&[10], Tables::default(), Some(&class));
+    let prepared = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("zero is the Factory/BehaviorRefs sentinel");
+    assert_eq!(prepared, mini);
+}
+
+#[test]
+fn sequential_guard_rejects_invalid_module_record_datatypes() {
+    let base = base_cache();
+    let cases = [
+        (
+            "identifier DataType with null pointer",
+            cache_with_function_return_datatype(0, 5),
+        ),
+        (
+            "primitive DataType with non-null pointer",
+            cache_with_function_return_datatype(BASE_TYPE_PTR, 0x52),
+        ),
+        (
+            "auto DataType with a primitive token",
+            cache_with_function_return_datatype_flags(
+                0,
+                0x52,
+                [false, false, false, false, true, false],
+            ),
+        ),
+        (
+            "DataType with token zero",
+            cache_with_function_return_datatype(0, 0),
+        ),
+    ];
+    for (case, mini) in cases {
+        assert_guard_rejects_reference(&base, &mini, case);
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_flagged_type_from_an_unknown_external_module() {
+    const PTR: i64 = 0x71a0;
+    const ID: i32 = 0x0800_71a0;
+    let base = cache(&[10], Tables::default());
+    let mini = cache(
+        &[76, ID | 0x4000_0000, 10],
+        Tables {
+            types: vec![type_row(PTR, "UnknownExternalType", "ExternalModule", &[])],
+            type_ids: vec![id_row(ID, PTR)],
+            ..Tables::default()
+        },
+    );
+
+    assert_guard_rejects_reference(
+        &base,
+        &mini,
+        "flagged TYPEID cannot claim a module absent from both base and current mini",
+    );
+    remap_module_to_base_with_options(
+        &mini,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect_err("allow-new must reject a selected T1 row from an unknown external module");
+}
+
+#[test]
+fn sequential_guard_accepts_type_modules_owned_by_the_current_mini_or_base() {
+    const PTR: i64 = 0x71a8;
+    const ID: i32 = 0x0800_71a8;
+    let tables = || Tables {
+        types: vec![type_row(PTR, "KnownExternalType", "ExternalModule", &[])],
+        type_ids: vec![id_row(ID, PTR)],
+        ..Tables::default()
+    };
+
+    let base = cache(&[10], Tables::default());
+    let current_module =
+        cache_with_named_module("ExternalModule", &[76, ID | 0x4000_0000, 10], tables());
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&current_module)
+        .expect("a T1 module may name the current mini module");
+    remap_module_to_base_with_options(
+        &current_module,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new may carry a T1 row owned by the current mini module");
+
+    let base_with_external_module = cache_with_named_module("ExternalModule", &[10], tables());
+    let different_target_module = cache(&[76, ID | 0x4000_0000, 10], tables());
+    SequentialMiniGuard::new(&base_with_external_module)
+        .unwrap()
+        .check_and_record(&different_target_module)
+        .expect("a T1 module may name a base module even when the mini targets another module");
+    remap_module_to_base_with_options(
+        &different_target_module,
+        &base_with_external_module,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new may carry a T1 row owned by a base module");
+}
+
+#[test]
+fn allow_new_seeds_target_symbols_from_inner_module_name_only() {
+    const PTR: i64 = 0x71ac;
+    const ID: i32 = 0x0800_71ac;
+    let base = cache_with_named_module("PristineBase", &[10], Tables::default());
+    let regen = cache_with_module_key_and_name(
+        "OuterAlias",
+        "InnerReal",
+        &[10],
+        Tables {
+            types: vec![type_row(PTR, "IrrelevantOuterAliasType", "OuterAlias", &[])],
+            type_ids: vec![id_row(ID, PTR)],
+            ..Tables::default()
+        },
+    );
+
+    let (mini, counts) = remap_module_to_base_with_options(
+        &regen,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("an outer TMap alias must not make its unrelated symbol row part of the target");
+    assert_eq!(counts.total(), 0);
+    let tables = parse_tail_tables(&mini, module_region_end(&mini).unwrap()).unwrap();
+    assert_eq!(
+        tables
+            .tables
+            .iter()
+            .map(|table| table.count)
+            .collect::<Vec<_>>(),
+        vec![0, 0, 0, 0, 0, 0, 0],
+        "only the inner ModuleName may seed target-module symbol retention"
+    );
+}
+
+#[test]
+fn sequential_guard_requires_modules_for_global_imported_and_t5_rows() {
+    let base = cache(&[10], Tables::default());
+    let mut global_function_code = Vec::new();
+    qw_op(61, 0x71b0, &mut global_function_code);
+    global_function_code.push(10);
+    let mut imported_function_code = Vec::new();
+    qw_op(61, 0x71b8, &mut imported_function_code);
+    imported_function_code.push(10);
+    let mut global_code = Vec::new();
+    qw_op(1, 0x71c0, &mut global_code);
+    global_code.push(10);
+    let cases = [
+        (
+            "global T3",
+            cache(
+                &global_function_code,
+                Tables {
+                    funcs: vec![func_row_flags(
+                        0x71b0,
+                        "MissingModuleGlobalFunction",
+                        "MissingGlobalModule",
+                        "",
+                        false,
+                        false,
+                        false,
+                        0,
+                        &[],
+                        0,
+                    )],
+                    func_ids: vec![id_row(0x71b0, 0x71b0)],
+                    ..Tables::default()
+                },
+            ),
+        ),
+        (
+            "imported T3",
+            cache(
+                &imported_function_code,
+                Tables {
+                    funcs: vec![func_row_flags(
+                        0x71b8,
+                        "MissingModuleImportedFunction",
+                        "MissingImportedModule",
+                        "",
+                        false,
+                        true,
+                        false,
+                        0,
+                        &[],
+                        0,
+                    )],
+                    func_ids: vec![id_row(0x71b8, 0x71b8)],
+                    ..Tables::default()
+                },
+            ),
+        ),
+        (
+            "nonempty-module T5",
+            cache(
+                &global_code,
+                Tables {
+                    globals: vec![global_row(
+                        0x71c0,
+                        "MissingModuleGlobal",
+                        "MissingGlobalModule",
+                    )],
+                    ..Tables::default()
+                },
+            ),
+        ),
+    ];
+
+    for (case, mini) in cases {
+        assert_guard_rejects_reference(&base, &mini, case);
+        let result = remap_module_to_base_with_options(
+            &mini,
+            &base,
+            RemapOptions {
+                allow_new_symbols: true,
+            },
+        );
+        assert!(
+            result.is_err(),
+            "allow-new accepted {case} from an unknown module"
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_referenced_imported_t3_with_an_empty_module() {
+    const PTR: i64 = 0x71d8;
+    const ID: i32 = 0x71d8;
+    let base = cache(&[10], Tables::default());
+    let mut code = Vec::new();
+    qw_op(61, PTR, &mut code);
+    code.push(10);
+    let mini = cache(
+        &code,
+        Tables {
+            funcs: vec![func_row_flags(
+                PTR,
+                "EmptyModuleImportedFunction",
+                "",
+                "",
+                false,
+                true,
+                false,
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(ID, PTR)],
+            ..Tables::default()
+        },
+    );
+
+    let guard_error = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect_err("an imported declaration needs exact import membership");
+    assert!(matches!(
+        guard_error,
+        SpliceError::MiniReference(RemapError::InvalidTailRow {
+            table: 2,
+            row_key: PTR,
+            kind: "declaration membership",
+            ..
+        })
+    ));
+
+    let remap_error = remap_module_to_base_with_options(
+        &mini,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect_err("allow-new must not carry an imported declaration without import membership");
+    assert!(matches!(
+        remap_error,
+        RemapError::InvalidTailRow {
+            table: 2,
+            row_key: PTR,
+            kind: "declaration membership",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn sequential_guard_does_not_treat_a_prior_mini_as_module_authority() {
+    const PTR: i64 = 0x71e0;
+    const ID: i32 = 0x0800_71e0;
+    let rows = || Tables {
+        types: vec![type_row(PTR, "PriorMiniType", "MiniA", &[])],
+        type_ids: vec![id_row(ID, PTR)],
+        ..Tables::default()
+    };
+    let mini_a = cache_with_named_module("MiniA", &[10], rows());
+    let mini_b = cache_with_named_module("MiniB", &[76, ID | 0x4000_0000, 10], rows());
+
+    let mut guard = SequentialMiniGuard::new(&cache(&[10], Tables::default())).unwrap();
+    guard
+        .check_and_record(&mini_a)
+        .expect("MiniA is authoritative for its own novel T1/T2 rows");
+    let error = guard
+        .check_and_record(&mini_b)
+        .expect_err("an exact prior-mini row is novelty history, not authority for MiniB");
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::InvalidTailRow {
+            table: 0,
+            row_key: PTR,
+            kind: "declaration membership",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn sequential_guard_rejects_leaf_t1_without_a_matching_class_or_enum() {
+    const PTR: i64 = 0x71e8;
+    const ID: i32 = 0x0800_71e8;
+    let base = cache_with_named_module("PristineBase", &[10], Tables::default());
+    let mini = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&[76, ID, 10], 0x0500_0101)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(PTR, "BogusType", "ModuleA", "Types", &[])],
+            type_ids: vec![id_row(ID, PTR)],
+            ..Tables::default()
+        },
+    );
+
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &mini,
+        0,
+        PTR,
+        "leaf T1 names no serialized class or enum",
+    );
+}
+
+#[test]
+fn sequential_guard_accepts_t1_matching_current_or_base_class_and_enum() {
+    const CLASS_PTR: i64 = 0x71f0;
+    const CLASS_ID: i32 = 0x0800_71f0;
+    const ENUM_PTR: i64 = 0x71f8;
+    const ENUM_ID: i32 = 0x0800_71f8;
+    let class = structural_class_record_full_named(
+        "OwnedClass",
+        "Types",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let enum_value = enum_record_named("OwnedEnum", "Types", 0, 0);
+    let tables = || Tables {
+        types: vec![
+            type_row_ns(CLASS_PTR, "OwnedClass", "ModuleA", "Types", &[]),
+            type_row_ns(ENUM_PTR, "OwnedEnum", "ModuleA", "Types", &[]),
+        ],
+        type_ids: vec![id_row(CLASS_ID, CLASS_PTR), id_row(ENUM_ID, ENUM_PTR)],
+        ..Tables::default()
+    };
+    let code = [76, CLASS_ID, 76, ENUM_ID, 10];
+
+    let current = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&code, 0x0500_0102)],
+        &[class.clone()],
+        &[enum_value.clone()],
+        &[],
+        tables(),
+    );
+    let pristine = cache_with_named_module("PristineBase", &[10], Tables::default());
+    SequentialMiniGuard::new(&pristine)
+        .unwrap()
+        .check_and_record(&current)
+        .expect("current class and enum declarations authorize matching leaf T1 rows");
+    remap_module_to_base_with_options(
+        &current,
+        &pristine,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new accepts current class and enum declaration membership");
+
+    let base = cache_with_module_key_name_and_records(
+        "BaseOuterA",
+        "ModuleA",
+        &[],
+        &[class],
+        &[enum_value],
+        &[],
+        Tables::default(),
+    );
+    let from_base = cache_with_module_key_name_and_records(
+        "OuterB",
+        "ModuleB",
+        &[function(&code, 0x0500_0103)],
+        &[],
+        &[],
+        &[],
+        tables(),
+    );
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&from_base)
+        .expect("base class and enum declarations authorize matching leaf T1 rows");
+    remap_module_to_base_with_options(
+        &from_base,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new accepts base class and enum declaration membership");
+}
+
+#[test]
+fn sequential_guard_rejects_wrong_namespace_t1_declaration() {
+    const WRONG_PTR: i64 = 0x7200;
+    const WRONG_ID: i32 = 0x0800_7200;
+    let class = structural_class_record_full_named(
+        "NamespaceType",
+        "Right::Namespace",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let wrong_namespace = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&[76, WRONG_ID, 10], 0x0500_0104)],
+        &[class],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(
+                WRONG_PTR,
+                "NamespaceType",
+                "ModuleA",
+                "Wrong::Namespace",
+                &[],
+            )],
+            type_ids: vec![id_row(WRONG_ID, WRONG_PTR)],
+            ..Tables::default()
+        },
+    );
+    let pristine = cache_with_named_module("PristineBase", &[10], Tables::default());
+    assert_guard_and_allow_new_reject_declaration(
+        &pristine,
+        &wrong_namespace,
+        0,
+        WRONG_PTR,
+        "T1 namespace differs from its current class declaration",
+    );
+}
+
+#[test]
+fn sequential_guard_rejects_duplicate_runtime_declarations_atomically() {
+    let base = cache_with_named_module("PristineBase", &[10], Tables::default());
+    let class = structural_class_record_full_named(
+        "DuplicateType",
+        "Duplicate::Namespace",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let enum_value = enum_record_named("DuplicateType", "Duplicate::Namespace", 0, 0);
+    let duplicate_type = cache_with_module_key_name_and_records(
+        "OuterType",
+        "ModuleType",
+        &[],
+        &[class.clone()],
+        &[enum_value],
+        &[],
+        Tables::default(),
+    );
+    let corrected_type = cache_with_module_key_name_and_records(
+        "OuterType",
+        "ModuleType",
+        &[],
+        &[class],
+        &[],
+        &[],
+        Tables::default(),
+    );
+
+    let duplicate_function = cache_with_module_key_name_and_records(
+        "OuterFunction",
+        "ModuleFunction",
+        &[function(&[10], 0x0500_0201), function(&[10], 0x0500_0202)],
+        &[],
+        &[],
+        &[],
+        Tables::default(),
+    );
+    let corrected_function = cache_with_module_key_name_and_records(
+        "OuterFunction",
+        "ModuleFunction",
+        &[function(&[10], 0x0500_0201)],
+        &[],
+        &[],
+        &[],
+        Tables::default(),
+    );
+
+    let global = global_record_named("DuplicateGlobal", "Duplicate::Namespace");
+    let duplicate_global = cache_with_module_key_name_and_records(
+        "OuterGlobal",
+        "ModuleGlobal",
+        &[],
+        &[],
+        &[],
+        &[global.clone(), global.clone()],
+        Tables::default(),
+    );
+    let corrected_global = cache_with_module_key_name_and_records(
+        "OuterGlobal",
+        "ModuleGlobal",
+        &[],
+        &[],
+        &[],
+        &[global],
+        Tables::default(),
+    );
+
+    let property = property_record_named("DuplicateProperty");
+    let duplicate_property_class = structural_class_record_full_named(
+        "PropertyOwner",
+        "",
+        &[property.clone(), property.clone()],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let corrected_property_class = structural_class_record_full_named(
+        "PropertyOwner",
+        "",
+        &[property],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let duplicate_property = cache_with_module_key_name_and_records(
+        "OuterProperty",
+        "ModuleProperty",
+        &[],
+        &[duplicate_property_class],
+        &[],
+        &[],
+        Tables::default(),
+    );
+    let corrected_property = cache_with_module_key_name_and_records(
+        "OuterProperty",
+        "ModuleProperty",
+        &[],
+        &[corrected_property_class],
+        &[],
+        &[],
+        Tables::default(),
+    );
+
+    for (field, malformed, corrected) in [
+        ("duplicate type declaration", duplicate_type, corrected_type),
+        (
+            "duplicate function declaration",
+            duplicate_function,
+            corrected_function,
+        ),
+        (
+            "duplicate global declaration",
+            duplicate_global,
+            corrected_global,
+        ),
+        (
+            "duplicate property declaration",
+            duplicate_property,
+            corrected_property,
+        ),
+    ] {
+        let mut guard = SequentialMiniGuard::new(&base).unwrap();
+        let error = guard
+            .check_and_record(&malformed)
+            .expect_err("duplicate runtime declaration must be refused");
+        assert!(
+            matches!(
+                error,
+                SpliceError::MiniReference(RemapError::Wire(WireError::BadLen {
+                    field: actual,
+                    ..
+                })) if actual == field
+            ),
+            "{field}: unexpected error: {error:?}"
+        );
+        guard
+            .check_and_record(&corrected)
+            .expect("duplicate-declaration refusal must not commit guard history");
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_prior_only_t1_declaration() {
+    const PRIOR_PTR: i64 = 0x7208;
+    const PRIOR_ID: i32 = 0x0800_7208;
+    let base = cache_with_module_key_name_and_records(
+        "BaseOuterA",
+        "ModuleA",
+        &[],
+        &[],
+        &[],
+        &[],
+        Tables::default(),
+    );
+    let prior_class = structural_class_record_full_named(
+        "PriorOnlyType",
+        "Types",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let prior = cache_with_module_key_name_and_records(
+        "PriorOuter",
+        "ModuleA",
+        &[],
+        &[prior_class],
+        &[],
+        &[],
+        Tables::default(),
+    );
+    let later = cache_with_module_key_name_and_records(
+        "OuterB",
+        "ModuleB",
+        &[function(&[76, PRIOR_ID, 10], 0x0500_0105)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(
+                PRIOR_PTR,
+                "PriorOnlyType",
+                "ModuleA",
+                "Types",
+                &[],
+            )],
+            type_ids: vec![id_row(PRIOR_ID, PRIOR_PTR)],
+            ..Tables::default()
+        },
+    );
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    guard
+        .check_and_record(&prior)
+        .expect("prior declaration carrier is valid in isolation");
+    let error = guard
+        .check_and_record(&later)
+        .expect_err("a prior mini declaration is not authority for a later T1 row");
+    assert!(
+        matches!(
+            error,
+            SpliceError::MiniReference(RemapError::InvalidTailRow {
+                table: 0,
+                row_key: PRIOR_PTR,
+                kind,
+                ..
+            }) if kind == "declaration membership"
+        ),
+        "unexpected prior-only T1 error: {error:?}"
+    );
+}
+
+#[test]
+fn sequential_guard_rejects_nonstring_t5_without_a_matching_global_declaration() {
+    const PTR: i64 = 0x7210;
+    let mut code = Vec::new();
+    qw_op(1, PTR, &mut code);
+    code.push(10);
+    let base = cache_with_named_module("PristineBase", &[10], Tables::default());
+    let mini = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&code, 0x0500_0106)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            globals: vec![global_row_ns(
+                PTR,
+                "MissingGlobal",
+                "ModuleA",
+                "Globals",
+                false,
+            )],
+            ..Tables::default()
+        },
+    );
+
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &mini,
+        4,
+        PTR,
+        "non-string T5 names no serialized global variable",
+    );
+}
+
+#[test]
+fn sequential_guard_accepts_t5_matching_current_or_base_global() {
+    const PTR: i64 = 0x7218;
+    let mut code = Vec::new();
+    qw_op(1, PTR, &mut code);
+    code.push(10);
+    let global = global_record_named("OwnedGlobal", "Globals");
+    let tables = || Tables {
+        globals: vec![global_row_ns(
+            PTR,
+            "OwnedGlobal",
+            "ModuleA",
+            "Globals",
+            false,
+        )],
+        ..Tables::default()
+    };
+
+    let pristine = cache_with_named_module("PristineBase", &[10], Tables::default());
+    let current = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&code, 0x0500_0107)],
+        &[],
+        &[],
+        &[global.clone()],
+        tables(),
+    );
+    SequentialMiniGuard::new(&pristine)
+        .unwrap()
+        .check_and_record(&current)
+        .expect("current global declaration authorizes its matching T5 row");
+    remap_module_to_base_with_options(
+        &current,
+        &pristine,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new accepts current global declaration membership");
+
+    let base = cache_with_module_key_name_and_records(
+        "BaseOuterA",
+        "ModuleA",
+        &[],
+        &[],
+        &[],
+        &[global],
+        Tables::default(),
+    );
+    let from_base = cache_with_module_key_name_and_records(
+        "OuterB",
+        "ModuleB",
+        &[function(&code, 0x0500_0108)],
+        &[],
+        &[],
+        &[],
+        tables(),
+    );
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&from_base)
+        .expect("base global declaration authorizes its matching T5 row");
+    remap_module_to_base_with_options(
+        &from_base,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new accepts base global declaration membership");
+}
+
+#[test]
+fn sequential_guard_rejects_prior_only_t5_global_declaration() {
+    const PTR: i64 = 0x7220;
+    let base = cache_with_module_key_name_and_records(
+        "BaseOuterA",
+        "ModuleA",
+        &[],
+        &[],
+        &[],
+        &[],
+        Tables::default(),
+    );
+    let prior = cache_with_module_key_name_and_records(
+        "PriorOuter",
+        "ModuleA",
+        &[],
+        &[],
+        &[],
+        &[global_record_named("PriorOnlyGlobal", "Globals")],
+        Tables::default(),
+    );
+    let mut code = Vec::new();
+    qw_op(1, PTR, &mut code);
+    code.push(10);
+    let later = cache_with_module_key_name_and_records(
+        "OuterB",
+        "ModuleB",
+        &[function(&code, 0x0500_0109)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            globals: vec![global_row_ns(
+                PTR,
+                "PriorOnlyGlobal",
+                "ModuleA",
+                "Globals",
+                false,
+            )],
+            ..Tables::default()
+        },
+    );
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    guard
+        .check_and_record(&prior)
+        .expect("prior global carrier is valid in isolation");
+    let error = guard
+        .check_and_record(&later)
+        .expect_err("a prior mini global declaration is not authority for a later T5 row");
+    assert!(
+        matches!(
+            error,
+            SpliceError::MiniReference(RemapError::InvalidTailRow {
+                table: 4,
+                row_key: PTR,
+                kind,
+                ..
+            }) if kind == "declaration membership"
+        ),
+        "unexpected prior-only T5 error: {error:?}"
+    );
+}
+
+#[test]
+fn sequential_guard_rejects_imported_t3_without_a_matching_function_import() {
+    const PTR: i64 = 0x7228;
+    const ID: i32 = 0x0500_0110;
+    let mut code = Vec::new();
+    qw_op(61, PTR, &mut code);
+    code.push(10);
+    let base = cache_with_named_module("PristineBase", &[10], Tables::default());
+    let mini = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&code, 0x0500_0111)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            funcs: vec![func_row_flags(
+                PTR,
+                "ImportedNoBinding",
+                "ModuleA",
+                "Imports",
+                false,
+                true,
+                false,
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(ID, PTR)],
+            ..Tables::default()
+        },
+    );
+
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &mini,
+        2,
+        PTR,
+        "imported T3 has a current module but no matching FunctionImport",
+    );
+}
+
+#[test]
+fn sequential_guard_rejects_empty_module_nondeclaration_t3_and_t5_rows() {
+    const FUNC_PTR: i64 = 0x7238;
+    const FUNC_ID: i32 = 0x0500_0114;
+    const GLOBAL_PTR: i64 = 0x7240;
+    let base = cache_with_named_module("PristineBase", &[10], Tables::default());
+
+    let mut call_code = Vec::new();
+    qw_op(61, FUNC_PTR, &mut call_code);
+    call_code.push(10);
+    let function_mini = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&call_code, 0x0500_0115)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            funcs: vec![func_row_flags(
+                FUNC_PTR,
+                "EngineGlobalMissing",
+                "",
+                "Globals",
+                false,
+                false,
+                false,
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(FUNC_ID, FUNC_PTR)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &function_mini,
+        2,
+        FUNC_PTR,
+        "empty-module ordinary T3 has no serialized global function declaration",
+    );
+
+    let mut global_code = Vec::new();
+    qw_op(1, GLOBAL_PTR, &mut global_code);
+    global_code.push(10);
+    let global_mini = cache_with_module_key_name_and_records(
+        "OuterB",
+        "ModuleB",
+        &[function(&global_code, 0x0500_0116)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            globals: vec![global_row_ns(
+                GLOBAL_PTR,
+                "EngineGlobalMissing",
+                "",
+                "Globals",
+                false,
+            )],
+            ..Tables::default()
+        },
+    );
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &global_mini,
+        4,
+        GLOBAL_PTR,
+        "empty-module non-string T5 has no serialized global variable declaration",
+    );
+}
+
+#[test]
+fn sequential_guard_accepts_empty_module_string_t5_and_exact_pristine_rows() {
+    const STRING_PTR: i64 = 0x7248;
+    let base = cache_with_named_module("PristineBase", &[10], Tables::default());
+    let mut string_code = Vec::new();
+    qw_op(1, STRING_PTR, &mut string_code);
+    string_code.push(10);
+    let string_mini = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&string_code, 0x0500_0117)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            globals: vec![global_row_ns(STRING_PTR, "literal value", "", "", true)],
+            ..Tables::default()
+        },
+    );
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&string_mini)
+        .expect("string T5 rows are literal values and need no declaration membership");
+    remap_module_to_base_with_options(
+        &string_mini,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new accepts an empty-module string T5 literal");
+
+    const FUNC_PTR: i64 = 0x7250;
+    const FUNC_ID: i32 = 0x0500_0118;
+    const GLOBAL_PTR: i64 = 0x7258;
+    let repeated_tables = || Tables {
+        funcs: vec![func_row_flags(
+            FUNC_PTR,
+            "PristineEngineGlobal",
+            "",
+            "Globals",
+            false,
+            false,
+            false,
+            0,
+            &[],
+            0,
+        )],
+        func_ids: vec![id_row(FUNC_ID, FUNC_PTR)],
+        globals: vec![global_row_ns(
+            GLOBAL_PTR,
+            "PristineEngineGlobal",
+            "",
+            "Globals",
+            false,
+        )],
+        ..Tables::default()
+    };
+    let base = cache_with_named_module("PristineBase", &[10], repeated_tables());
+    let mut code = Vec::new();
+    qw_op(61, FUNC_PTR, &mut code);
+    qw_op(1, GLOBAL_PTR, &mut code);
+    code.push(10);
+    let repeat = cache_with_module_key_name_and_records(
+        "OuterB",
+        "ModuleB",
+        &[function(&code, 0x0500_0119)],
+        &[],
+        &[],
+        &[],
+        repeated_tables(),
+    );
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&repeat)
+        .expect("exact pristine T3/T4/T5 repeats are grandfathered without declarations");
+    remap_module_to_base_with_options(
+        &repeat,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new resolves exact empty-module rows back to the pristine generation");
+}
+
+#[test]
+fn sequential_guard_rejects_empty_module_leaf_and_unauthorized_template_sentinel_t1() {
+    const EMPTY_PTR: i64 = 0x7260;
+    const EMPTY_ID: i32 = 0x0800_7260;
+    const SENTINEL_PTR: i64 = 0x7268;
+    const SENTINEL_ID: i32 = 0x0800_7268;
+    let base = cache_with_named_module("PristineBase", &[10], Tables::default());
+
+    let empty_leaf = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&[76, EMPTY_ID, 10], 0x0500_011a)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(
+                EMPTY_PTR,
+                "EngineTypeMissing",
+                "",
+                "Types",
+                &[],
+            )],
+            type_ids: vec![id_row(EMPTY_ID, EMPTY_PTR)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &empty_leaf,
+        0,
+        EMPTY_PTR,
+        "empty-module leaf T1 has no class or enum declaration",
+    );
+
+    let sentinel = cache_with_module_key_name_and_records(
+        "OuterB",
+        "ModuleB",
+        &[function(&[76, SENTINEL_ID, 10], 0x0500_011b)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(
+                SENTINEL_PTR,
+                "T",
+                "$__T__",
+                "TemplateParameters",
+                &[],
+            )],
+            type_ids: vec![id_row(SENTINEL_ID, SENTINEL_PTR)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &sentinel,
+        0,
+        SENTINEL_PTR,
+        "$__T__ sentinel has no exact pristine authority",
+    );
+}
+
+#[test]
+fn sequential_guard_accepts_exact_pristine_template_sentinel_t1() {
+    const PTR: i64 = 0x7270;
+    const ID: i32 = 0x0800_7270;
+    let tables = || Tables {
+        types: vec![type_row_ns(PTR, "T", "$__T__", "TemplateParameters", &[])],
+        type_ids: vec![id_row(ID, PTR)],
+        ..Tables::default()
+    };
+    let base = cache_with_named_module("PristineBase", &[10], tables());
+    let repeat = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&[76, ID, 10], 0x0500_011c)],
+        &[],
+        &[],
+        &[],
+        tables(),
+    );
+
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&repeat)
+        .expect("an exact pristine-authorized $__T__ sentinel remains valid");
+    remap_module_to_base_with_options(
+        &repeat,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new resolves an exact pristine $__T__ sentinel");
+}
+
+#[test]
+fn sequential_guard_rejects_template_instance_without_a_pristine_template_base() {
+    const FOO_PTR: i64 = 0x7278;
+    const FOO_ID: i32 = 0x0800_7278;
+    const BOGUS_PTR: i64 = 0x7280;
+    const BOGUS_ID: i32 = 0x1000_7280;
+    let foo_class = structural_class_record_full_named(
+        "Foo",
+        "Types",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let base = cache_with_module_key_name_and_records(
+        "BaseOuter",
+        "TemplateBase",
+        &[],
+        &[foo_class],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(FOO_PTR, "Foo", "TemplateBase", "Types", &[])],
+            type_ids: vec![id_row(FOO_ID, FOO_PTR)],
+            ..Tables::default()
+        },
+    );
+    let mini = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&[76, BOGUS_ID, 10], 0x0500_011d)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            types: vec![
+                type_row_ns(FOO_PTR, "Foo", "TemplateBase", "Types", &[]),
+                type_row_ns(
+                    BOGUS_PTR,
+                    "BogusTemplate",
+                    "IgnoredModule",
+                    "Templates",
+                    &[FOO_PTR],
+                ),
+            ],
+            type_ids: vec![id_row(FOO_ID, FOO_PTR), id_row(BOGUS_ID, BOGUS_PTR)],
+            ..Tables::default()
+        },
+    );
+
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &mini,
+        0,
+        BOGUS_PTR,
+        "template Name/Namespace/arity has no pristine T1 template instance",
+    );
+}
+
+#[test]
+fn sequential_guard_rejects_template_instance_with_only_wrong_arity_authority() {
+    const FOO_PTR: i64 = 0x72e8;
+    const FOO_ID: i32 = 0x0800_72e8;
+    const BASE_BOX_PTR: i64 = 0x72f0;
+    const BASE_BOX_ID: i32 = 0x1000_72f0;
+    const TWO_ARG_BOX_PTR: i64 = 0x72f8;
+    const TWO_ARG_BOX_ID: i32 = 0x1000_72f8;
+    let foo = structural_class_record_full_named(
+        "Foo",
+        "Types",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let base = cache_with_module_key_name_and_records(
+        "BaseOuter",
+        "TemplateBase",
+        &[],
+        &[foo],
+        &[],
+        &[],
+        Tables {
+            types: vec![
+                type_row_ns(FOO_PTR, "Foo", "TemplateBase", "Types", &[]),
+                type_row_ns(
+                    BASE_BOX_PTR,
+                    "Box",
+                    "IgnoredModule",
+                    "Templates",
+                    &[FOO_PTR],
+                ),
+            ],
+            type_ids: vec![id_row(FOO_ID, FOO_PTR), id_row(BASE_BOX_ID, BASE_BOX_PTR)],
+            ..Tables::default()
+        },
+    );
+    let mini = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&[76, TWO_ARG_BOX_ID, 10], 0x0500_0125)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            types: vec![
+                type_row_ns(FOO_PTR, "Foo", "TemplateBase", "Types", &[]),
+                type_row_ns(
+                    TWO_ARG_BOX_PTR,
+                    "Box",
+                    "AnotherIgnoredModule",
+                    "Templates",
+                    &[FOO_PTR, FOO_PTR],
+                ),
+            ],
+            type_ids: vec![
+                id_row(FOO_ID, FOO_PTR),
+                id_row(TWO_ARG_BOX_ID, TWO_ARG_BOX_PTR),
+            ],
+            ..Tables::default()
+        },
+    );
+
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &mini,
+        0,
+        TWO_ARG_BOX_PTR,
+        "pristine Box<T> must not authorize novel Box<T,U>",
+    );
+}
+
+#[test]
+fn sequential_guard_accepts_new_template_combination_from_pristine_template_authority() {
+    const FOO_PTR: i64 = 0x7288;
+    const FOO_ID: i32 = 0x0800_7288;
+    const BASE_BOX_PTR: i64 = 0x7290;
+    const BASE_BOX_ID: i32 = 0x1000_7290;
+    const BAR_PTR: i64 = 0x7298;
+    const BAR_ID: i32 = 0x0800_7298;
+    const NEW_BOX_PTR: i64 = 0x72a0;
+    const NEW_BOX_ID: i32 = 0x1000_72a0;
+    let foo_class = structural_class_record_full_named(
+        "Foo",
+        "Types",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let base = cache_with_module_key_name_and_records(
+        "BaseOuter",
+        "TemplateBase",
+        &[],
+        &[foo_class],
+        &[],
+        &[],
+        Tables {
+            types: vec![
+                type_row_ns(FOO_PTR, "Foo", "TemplateBase", "Types", &[]),
+                type_row_ns(
+                    BASE_BOX_PTR,
+                    "Box",
+                    "PristineIgnoredModule",
+                    "Templates",
+                    &[FOO_PTR],
+                ),
+            ],
+            type_ids: vec![id_row(FOO_ID, FOO_PTR), id_row(BASE_BOX_ID, BASE_BOX_PTR)],
+            ..Tables::default()
+        },
+    );
+    let bar_class = structural_class_record_full_named(
+        "Bar",
+        "Types",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let mini = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&[76, NEW_BOX_ID, 10], 0x0500_011e)],
+        &[bar_class],
+        &[],
+        &[],
+        Tables {
+            types: vec![
+                type_row_ns(BAR_PTR, "Bar", "ModuleA", "Types", &[]),
+                type_row_ns(
+                    NEW_BOX_PTR,
+                    "Box",
+                    "CurrentIgnoredModule",
+                    "Templates",
+                    &[BAR_PTR],
+                ),
+            ],
+            type_ids: vec![id_row(BAR_ID, BAR_PTR), id_row(NEW_BOX_ID, NEW_BOX_PTR)],
+            ..Tables::default()
+        },
+    );
+
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("pristine Box<Foo> authorizes novel Box<Bar> by Name/Namespace/arity");
+    remap_module_to_base_with_options(
+        &mini,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new accepts a template combination backed by a pristine template base");
+}
+
+#[test]
+fn sequential_guard_rejects_script_t7_name_without_a_matching_current_property() {
+    const OWNER_PTR: i64 = 0x72a8;
+    const OWNER_ID: i32 = 0x0800_72a8;
+    const OFFSET: i32 = 4;
+    let owner = structural_class_record_full_named(
+        "Owner",
+        "Types",
+        &[property_record_named("Good")],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let mini = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(&[79 | (OFFSET << 16), OWNER_ID, 10], 0x0500_011f)],
+        &[owner],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(OWNER_PTR, "Owner", "ModuleA", "Types", &[])],
+            type_ids: vec![id_row(OWNER_ID, OWNER_PTR)],
+            properties: vec![property_row(OWNER_ID, OFFSET, "Bogus")],
+            ..Tables::default()
+        },
+    );
+    let base = cache_with_named_module("PristineBase", &[10], Tables::default());
+
+    assert_guard_and_allow_new_reject_declaration(
+        &base,
+        &mini,
+        6,
+        property_key(OWNER_ID, OFFSET),
+        "script T7 name differs from the owner's direct current property",
+    );
+}
+
+#[test]
+fn sequential_guard_accepts_script_t7_matching_current_or_base_property() {
+    const CURRENT_PTR: i64 = 0x72b0;
+    const CURRENT_ID: i32 = 0x0800_72b0;
+    const BASE_PTR: i64 = 0x72b8;
+    const BASE_ID: i32 = 0x0800_72b8;
+    const OFFSET: i32 = 4;
+    let owner_class = |name: &str| {
+        structural_class_record_full_named(
+            name,
+            "Types",
+            &[property_record_named("Good")],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[0; 7],
+            &[],
+            &[],
+            None,
+        )
+    };
+
+    let current = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[function(
+            &[79 | (OFFSET << 16), CURRENT_ID, 10],
+            0x0500_0120,
+        )],
+        &[owner_class("CurrentOwner")],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(
+                CURRENT_PTR,
+                "CurrentOwner",
+                "ModuleA",
+                "Types",
+                &[],
+            )],
+            type_ids: vec![id_row(CURRENT_ID, CURRENT_PTR)],
+            properties: vec![property_row(CURRENT_ID, OFFSET, "Good")],
+            ..Tables::default()
+        },
+    );
+    let pristine = cache_with_named_module("PristineBase", &[10], Tables::default());
+    SequentialMiniGuard::new(&pristine)
+        .unwrap()
+        .check_and_record(&current)
+        .expect("a script T7 may match a direct property in the current mini");
+    remap_module_to_base_with_options(
+        &current,
+        &pristine,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new accepts a script T7 backed by a current property");
+
+    let base = cache_with_module_key_name_and_records(
+        "BaseOuter",
+        "ModuleA",
+        &[],
+        &[owner_class("BaseOwner")],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(BASE_PTR, "BaseOwner", "ModuleA", "Types", &[])],
+            type_ids: vec![id_row(BASE_ID, BASE_PTR)],
+            ..Tables::default()
+        },
+    );
+    let from_base = cache_with_module_key_name_and_records(
+        "OuterB",
+        "ModuleB",
+        &[function(&[79 | (OFFSET << 16), BASE_ID, 10], 0x0500_0121)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            properties: vec![property_row(BASE_ID, OFFSET, "Good")],
+            ..Tables::default()
+        },
+    );
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&from_base)
+        .expect("a script T7 may match a direct property in the pristine base");
+    remap_module_to_base_with_options(
+        &from_base,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("allow-new accepts a script T7 backed by a pristine property");
+}
+
+#[test]
+fn allow_new_carries_only_used_t7_for_existing_non_target_script_owner() {
+    const BASE_OWNER_PTR: i64 = 0x72ba_1000;
+    const REGEN_OWNER_PTR: i64 = 0x72ba_2000;
+    const BASE_OWNER_ID: i32 = 0x0800_72ba;
+    const REGEN_OWNER_ID: i32 = 0x0800_73ba;
+    const OFFSET: i32 = 12;
+    const OWNER_MODULE: &str = "OwnerModule";
+    const TARGET_MODULE: &str = "TargetModule";
+
+    let owner = structural_class_record_full_named(
+        "ExternalOwner",
+        "Types",
+        &[property_record_named("UsedField")],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let base = cache_with_module_key_name_and_records(
+        "OwnerOuter",
+        OWNER_MODULE,
+        &[],
+        &[owner],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(
+                BASE_OWNER_PTR,
+                "ExternalOwner",
+                OWNER_MODULE,
+                "Types",
+                &[],
+            )],
+            type_ids: vec![id_row(BASE_OWNER_ID, BASE_OWNER_PTR)],
+            ..Tables::default()
+        },
+    );
+    let regen = cache_with_module_key_name_and_records(
+        "TargetOuter",
+        TARGET_MODULE,
+        &[function(
+            &[79 | (OFFSET << 16), REGEN_OWNER_ID, 10],
+            0x0500_0190,
+        )],
+        &[],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(
+                REGEN_OWNER_PTR,
+                "ExternalOwner",
+                OWNER_MODULE,
+                "Types",
+                &[],
+            )],
+            type_ids: vec![id_row(REGEN_OWNER_ID, REGEN_OWNER_PTR)],
+            properties: vec![
+                property_row(REGEN_OWNER_ID, OFFSET, "UsedField"),
+                property_row(REGEN_OWNER_ID, OFFSET + 4, "UnreferencedField"),
+            ],
+            ..Tables::default()
+        },
+    );
+
+    let (mini, _) = remap_module_to_base_with_options(
+        &regen,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("the pristine class declaration authorizes its newly referenced property");
+    let mini_tail = module_region_end(&mini).unwrap();
+    let tables = parse_tail_tables(&mini, mini_tail).unwrap();
+    assert_eq!(
+        tables
+            .tables
+            .iter()
+            .map(|table| table.count)
+            .collect::<Vec<_>>(),
+        vec![0, 0, 0, 0, 0, 0, 1],
+        "only the concretely used property row is retained"
+    );
+
+    let composed = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .compose_add(&base, &mini)
+        .expect("the production composition path accepts the retained pristine-backed T7");
+    let refs = RefResolver::build(&composed).unwrap();
+    assert_eq!(refs.member(BASE_OWNER_ID, OFFSET), Some("UsedField"));
+    let functions = collect_function_bytecodes(&composed).unwrap();
+    let addsi = functions
+        .iter()
+        .flat_map(|function| disassemble(&function.bytecode).unwrap())
+        .find(|instruction| instruction.op.name == "ADDSi")
+        .unwrap();
+    assert_eq!(addsi.dwords[0] as i32, BASE_OWNER_ID);
+}
+
+#[test]
+fn sequential_guard_rejects_script_t7_with_only_prior_mini_property_authority() {
+    const OWNER_PTR: i64 = 0x72c0;
+    const OWNER_ID: i32 = 0x0800_72c0;
+    const OFFSET: i32 = 4;
+    let empty_owner = structural_class_record_full_named(
+        "Owner",
+        "Types",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let base = cache_with_module_key_name_and_records(
+        "BaseOuter",
+        "ModuleA",
+        &[],
+        &[empty_owner],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(OWNER_PTR, "Owner", "ModuleA", "Types", &[])],
+            type_ids: vec![id_row(OWNER_ID, OWNER_PTR)],
+            ..Tables::default()
+        },
+    );
+    let prior_owner = structural_class_record_full_named(
+        "Owner",
+        "Types",
+        &[property_record_named("PriorOnly")],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let prior = cache_with_module_key_name_and_records(
+        "PriorOuter",
+        "ModuleA",
+        &[],
+        &[prior_owner],
+        &[],
+        &[],
+        Tables::default(),
+    );
+    let later = cache_with_module_key_name_and_records(
+        "OuterB",
+        "ModuleB",
+        &[function(&[79 | (OFFSET << 16), OWNER_ID, 10], 0x0500_0122)],
+        &[],
+        &[],
+        &[],
+        Tables {
+            properties: vec![property_row(OWNER_ID, OFFSET, "PriorOnly")],
+            ..Tables::default()
+        },
+    );
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    guard
+        .check_and_record(&prior)
+        .expect("a property-bearing prior module is structurally valid in isolation");
+    let error = guard
+        .check_and_record(&later)
+        .expect_err("a prior mini property is not pristine declaration authority");
+    assert!(
+        matches!(
+            error,
+            SpliceError::MiniReference(RemapError::InvalidTailRow {
+                table: 6,
+                row_key,
+                kind,
+                ..
+            }) if row_key == property_key(OWNER_ID, OFFSET)
+                && kind == "declaration membership"
+        ),
+        "unexpected prior-only T7 error: {error:?}"
+    );
+}
+
+#[test]
+fn sequential_guard_requires_pristine_exact_t7_authority_for_native_and_template_owners() {
+    const OFFSET: i32 = 4;
+    for (name, id, function_id, tables) in [
+        (
+            "NativeOwner",
+            0x0400_72c8,
+            0x0500_0123,
+            Tables {
+                types: vec![type_row_ns(0x72c8, "NativeOwner", "", "Engine", &[])],
+                type_ids: vec![id_row(0x0400_72c8, 0x72c8)],
+                ..Tables::default()
+            },
+        ),
+        (
+            "TemplateOwner",
+            0x1000_72d0,
+            0x0500_0124,
+            Tables {
+                types: vec![
+                    type_row_ns(0x72e8, "TemplateArg", "", "Engine", &[]),
+                    type_row_ns(0x72d0, "TemplateOwner", "IgnoredModule", "Types", &[0x72e8]),
+                ],
+                type_ids: vec![id_row(0x0400_72e8, 0x72e8), id_row(0x1000_72d0, 0x72d0)],
+                ..Tables::default()
+            },
+        ),
+    ] {
+        let base = cache_with_named_module("PristineBase", &[10], tables);
+        let mini = cache_with_module_key_name_and_records(
+            name,
+            "ModuleA",
+            &[function(&[79 | (OFFSET << 16), id, 10], function_id)],
+            &[],
+            &[],
+            &[],
+            Tables {
+                properties: vec![property_row(id, OFFSET, "Good")],
+                ..Tables::default()
+            },
+        );
+        assert_guard_and_allow_new_reject_declaration(
+            &base,
+            &mini,
+            6,
+            property_key(id, OFFSET),
+            &format!("{name} T7 is novel rather than an exact pristine row"),
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_compose_edit_rejects_deleting_class_referenced_by_retained_t1() {
+    const OWNER_PTR: i64 = 0x72d8;
+    const OWNER_ID: i32 = 0x0800_72d8;
+    let owner = structural_class_record_full_named(
+        "RetainedOwner",
+        "Types",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[0; 7],
+        &[],
+        &[],
+        None,
+    );
+    let base = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[],
+        &[owner.clone()],
+        &[],
+        &[],
+        Tables {
+            types: vec![type_row_ns(
+                OWNER_PTR,
+                "RetainedOwner",
+                "ModuleA",
+                "Types",
+                &[],
+            )],
+            type_ids: vec![id_row(OWNER_ID, OWNER_PTR)],
+            ..Tables::default()
+        },
+    );
+    let deleted = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[],
+        &[],
+        &[],
+        &[],
+        Tables::default(),
+    );
+    let corrected = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[],
+        &[owner],
+        &[],
+        &[],
+        Tables::default(),
+    );
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard
+        .compose_edit(&base, &deleted, "OuterA")
+        .expect_err("the prospective output retains T1 but deletes its direct class");
+    assert!(
+        matches!(
+            error,
+            SpliceError::ComposedModule(RemapError::InvalidTailRow {
+                table: 0,
+                row_key: OWNER_PTR,
+                kind,
+                ..
+            }) if kind == "declaration membership"
+        ),
+        "unexpected retained-T1 edit error: {error:?}"
+    );
+    guard
+        .compose_edit(&base, &corrected, "OuterA")
+        .expect("failed final-output validation must not poison a corrected class retry");
+}
+
+#[test]
+fn sequential_guard_compose_edit_rejects_deleting_global_referenced_by_retained_t5() {
+    const GLOBAL_PTR: i64 = 0x72e0;
+    let global = global_record_named("RetainedGlobal", "Globals");
+    let base = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[],
+        &[],
+        &[],
+        &[global.clone()],
+        Tables {
+            globals: vec![global_row_ns(
+                GLOBAL_PTR,
+                "RetainedGlobal",
+                "ModuleA",
+                "Globals",
+                false,
+            )],
+            ..Tables::default()
+        },
+    );
+    let deleted = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[],
+        &[],
+        &[],
+        &[],
+        Tables::default(),
+    );
+    let corrected = cache_with_module_key_name_and_records(
+        "OuterA",
+        "ModuleA",
+        &[],
+        &[],
+        &[],
+        &[global],
+        Tables::default(),
+    );
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard
+        .compose_edit(&base, &deleted, "OuterA")
+        .expect_err("the prospective output retains T5 but deletes its global declaration");
+    assert!(
+        matches!(
+            error,
+            SpliceError::ComposedModule(RemapError::InvalidTailRow {
+                table: 4,
+                row_key: GLOBAL_PTR,
+                kind,
+                ..
+            }) if kind == "declaration membership"
+        ),
+        "unexpected retained-T5 edit error: {error:?}"
+    );
+    guard
+        .compose_edit(&base, &corrected, "OuterA")
+        .expect("failed final-output validation must not poison a corrected global retry");
+}
+
+#[test]
+fn sequential_guard_resolves_method_module_ownership_through_its_owner_type() {
+    const OWNER_PTR: i64 = 0x71c8;
+    const METHOD_PTR: i64 = 0x71d0;
+    let mini = cache(
+        &[10],
+        Tables {
+            types: vec![type_row(OWNER_PTR, "CurrentModuleOwner", MODULE, &[])],
+            type_ids: vec![id_row(0x0800_71c8, OWNER_PTR)],
+            funcs: vec![func_row_flags(
+                METHOD_PTR,
+                "OwnerScopedMethod",
+                "MissingButIgnoredMethodModule",
+                "Missing::ButIgnoredMethodNamespace",
+                false,
+                false,
+                true,
+                OWNER_PTR,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(0x71d0, METHOD_PTR)],
+            ..Tables::default()
+        },
+    );
+
+    SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("a method resolves through its owner type, not its ignored T3 Module field");
+}
+
+#[test]
+fn sequential_guard_rejects_new_symbol_rows_without_reverse_ids() {
+    let base = base_cache();
+    let type_mini = cache(
+        &[10],
+        Tables {
+            types: vec![type_row(0x7201, "UnmappedNewType", MODULE, &[])],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(&base, &type_mini, "T1 row without reverse T2 id");
+
+    let function_mini = cache(
+        &[10],
+        Tables {
+            funcs: vec![func_row(0x7202, "UnmappedNewFunction", MODULE, 0, &[], 0)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(&base, &function_mini, "T3 row without reverse T4 id");
+}
+
+#[test]
+fn sequential_guard_rejects_duplicate_reverse_id_aliases() {
+    let base = base_cache();
+    let type_ptr = 0x7301;
+    let type_mini = cache(
+        &[10],
+        Tables {
+            types: vec![type_row(type_ptr, "AliasedNewType", MODULE, &[])],
+            type_ids: vec![id_row(0x0800_7301, type_ptr), id_row(0x0800_7302, type_ptr)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(&base, &type_mini, "two T2 ids alias one T1 ptr");
+
+    let function_ptr = 0x7302;
+    let function_mini = cache(
+        &[10],
+        Tables {
+            funcs: vec![func_row(
+                function_ptr,
+                "AliasedNewFunction",
+                MODULE,
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(0x7301, function_ptr), id_row(0x7302, function_ptr)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(&base, &function_mini, "two T4 ids alias one T3 ptr");
+}
+
+#[test]
+fn sequential_guard_rejects_type_and_function_identity_aliases_against_base() {
+    let base = base_cache();
+    let type_alias = type_symbol_mini(0x7401, 0x0800_7401, "ExistingType", &[]);
+    let type_error = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&type_alias)
+        .unwrap_err();
+    assert!(matches!(
+        type_error,
+        SpliceError::MiniReference(RemapError::InvalidTailRow {
+            table: 0,
+            row_key: 0x7401,
+            kind: "symbol identity",
+            ref detail,
+        }) if detail.contains("0x1111")
+    ));
+
+    let function_alias = function_symbol_mini(0x7402, 0x7402, "ExistingFn", BASE_TYPE_PTR, &[]);
+    let function_error = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&function_alias)
+        .unwrap_err();
+    assert!(matches!(
+        function_error,
+        SpliceError::MiniReference(RemapError::InvalidTailRow {
+            table: 2,
+            row_key: 0x7402,
+            kind: "symbol identity",
+            ref detail,
+        }) if detail.contains("0x1222")
+    ));
+}
+
+#[test]
+fn sequential_guard_rejects_type_and_function_identity_aliases_within_one_mini() {
+    let base = cache(&[10], Tables::default());
+    let type_mini = cache(
+        &[10],
+        Tables {
+            types: vec![
+                type_row(0x7501, "RepeatedType", MODULE, &[]),
+                type_row(0x7502, "RepeatedType", MODULE, &[]),
+            ],
+            type_ids: vec![id_row(0x0800_7501, 0x7501), id_row(0x0800_7502, 0x7502)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(&base, &type_mini, "two T1 keys share one identity");
+
+    let function_mini = cache(
+        &[10],
+        Tables {
+            funcs: vec![
+                func_row(0x7503, "RepeatedFunction", MODULE, 0, &[], 0),
+                func_row(0x7504, "RepeatedFunction", MODULE, 0, &[], 0),
+            ],
+            func_ids: vec![id_row(0x7503, 0x7503), id_row(0x7504, 0x7504)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(&base, &function_mini, "two T3 keys share one identity");
+}
+
+#[test]
+fn sequential_guard_rejects_distinct_nonstring_t5_keys_with_shared_identity() {
+    let base = cache(&[10], Tables::default());
+    let mini = cache(
+        &[10],
+        Tables {
+            globals: vec![
+                global_row(0x7551, "LegitimateGlobalAlias", MODULE),
+                global_row(0x7552, "LegitimateGlobalAlias", MODULE),
+            ],
+            ..Tables::default()
+        },
+    );
+
+    assert_guard_rejects_reference(
+        &base,
+        &mini,
+        "two non-string T5 keys share one portable identity",
+    );
+}
+
+#[test]
+fn sequential_guard_distinguishes_t3_const_and_imported_decl_flags() {
+    let base = cache(&[10], Tables::default());
+    let mini = cache(
+        &[10],
+        Tables {
+            funcs: vec![
+                func_row_flags(
+                    0x7561,
+                    "FlaggedFunction",
+                    MODULE,
+                    "",
+                    false,
+                    false,
+                    false,
+                    0,
+                    &[],
+                    0,
+                ),
+                func_row_flags(
+                    0x7562,
+                    "FlaggedFunction",
+                    MODULE,
+                    "",
+                    true,
+                    false,
+                    false,
+                    0,
+                    &[],
+                    0,
+                ),
+            ],
+            func_ids: vec![id_row(0x7561, 0x7561), id_row(0x7562, 0x7562)],
+            ..Tables::default()
+        },
+    );
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("const must distinguish T3 identity");
+}
+
+#[test]
+fn sequential_guard_projects_method_module_and_namespace_out_of_t3_identity() {
+    let owner = 0x7580;
+    let base_func = 0x7588;
+    let mini_func = 0x7590;
+    let base = cache(
+        &[10],
+        Tables {
+            types: vec![type_row(owner, "ProjectedOwner", "OwnerModule", &[])],
+            type_ids: vec![id_row(0x0800_7580, owner)],
+            funcs: vec![func_row_flags(
+                base_func,
+                "ProjectedMethod",
+                "OriginalMethodModule",
+                "Original::MethodNamespace",
+                false,
+                false,
+                true,
+                owner,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(0x7588, base_func)],
+            ..Tables::default()
+        },
+    );
+    let mini = cache(
+        &[10],
+        Tables {
+            funcs: vec![func_row_flags(
+                mini_func,
+                "ProjectedMethod",
+                "DriftedMethodModule",
+                "Drifted::MethodNamespace",
+                false,
+                false,
+                true,
+                owner,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(0x7590, mini_func)],
+            ..Tables::default()
+        },
+    );
+
+    let error = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect_err("method lookup identity must ignore its own module and namespace drift");
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::InvalidTailRow {
+            table: 2,
+            kind: "symbol identity",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn sequential_guard_projects_imported_namespace_out_and_rejects_method_owner_shape() {
+    let drift_owner = 0x7598;
+    let base_func = 0x75a0;
+    let mini_func = 0x75a8;
+    let base = cache(
+        &[10],
+        Tables {
+            types: vec![type_row(
+                drift_owner,
+                "ImportedDriftOwner",
+                "OwnerModule",
+                &[],
+            )],
+            type_ids: vec![id_row(0x0800_7598, drift_owner)],
+            funcs: vec![func_row_flags(
+                base_func,
+                "ProjectedImport",
+                MODULE,
+                "Original::ImportNamespace",
+                false,
+                true,
+                false,
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(0x75a0, base_func)],
+            ..Tables::default()
+        },
+    );
+    let mini = cache(
+        &[10],
+        Tables {
+            funcs: vec![func_row_flags(
+                mini_func,
+                "ProjectedImport",
+                MODULE,
+                "Drifted::ImportNamespace",
+                false,
+                true,
+                false,
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(0x75a8, mini_func)],
+            ..Tables::default()
+        },
+    );
+
+    let error = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect_err("imported lookup identity must ignore namespace drift");
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::InvalidTailRow {
+            table: 2,
+            kind: "declaration membership",
+            ..
+        })
+    ));
+
+    for (case, is_method, owner, key) in [
+        ("imported method bit", true, 0, 0x75b0),
+        ("imported owner pointer", false, drift_owner, 0x75b8),
+    ] {
+        let malformed = cache(
+            &[10],
+            Tables {
+                funcs: vec![func_row_flags(
+                    key,
+                    "ProjectedImport",
+                    MODULE,
+                    "Drifted::ImportNamespace",
+                    false,
+                    true,
+                    is_method,
+                    owner,
+                    &[],
+                    0,
+                )],
+                func_ids: vec![id_row(key as i32, key)],
+                ..Tables::default()
+            },
+        );
+        let error = SequentialMiniGuard::new(&base)
+            .unwrap()
+            .check_and_record(&malformed)
+            .expect_err(case);
+        assert!(
+            matches!(
+                error,
+                SpliceError::MiniReference(RemapError::Wire(
+                    WireError::InvalidFunctionReference { .. }
+                ))
+            ),
+            "{case}: unexpected error: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_t3_method_owner_disagreement_both_directions() {
+    let owner = 0x7570;
+    let base = cache(
+        &[10],
+        Tables {
+            types: vec![type_row(owner, "Owner", MODULE, &[])],
+            type_ids: vec![id_row(0x0800_7570, owner)],
+            ..Tables::default()
+        },
+    );
+    for (case, is_method, owner_ptr, key) in [
+        ("non-method with owner", false, owner, 0x7571),
+        ("method without owner", true, 0, 0x7572),
+    ] {
+        let mini = cache(
+            &[10],
+            Tables {
+                funcs: vec![func_row_flags(
+                    key,
+                    "InvalidMethodShape",
+                    MODULE,
+                    "",
+                    false,
+                    false,
+                    is_method,
+                    owner_ptr,
+                    &[],
+                    0,
+                )],
+                func_ids: vec![id_row(key as i32, key)],
+                ..Tables::default()
+            },
+        );
+        assert_guard_rejects_reference(&base, &mini, case);
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_type_and_function_identity_aliases_from_prior_minis() {
+    let base = cache(&[10], Tables::default());
+
+    let mut type_guard = SequentialMiniGuard::new(&base).unwrap();
+    type_guard
+        .check_and_record(&type_symbol_mini(0x7601, 0x0800_7601, "PriorType", &[]))
+        .expect("first type identity is unique");
+    let type_error = type_guard
+        .check_and_record(&type_symbol_mini(0x7602, 0x0800_7602, "PriorType", &[]))
+        .unwrap_err();
+    assert!(matches!(type_error, SpliceError::MiniReference(_)));
+
+    let mut function_guard = SequentialMiniGuard::new(&base).unwrap();
+    function_guard
+        .check_and_record(&function_symbol_mini(
+            0x7603,
+            0x7603,
+            "PriorFunction",
+            0,
+            &[],
+        ))
+        .expect("first function identity is unique");
+    let function_error = function_guard
+        .check_and_record(&function_symbol_mini(
+            0x7604,
+            0x7604,
+            "PriorFunction",
+            0,
+            &[],
+        ))
+        .unwrap_err();
+    assert!(matches!(function_error, SpliceError::MiniReference(_)));
+}
+
+#[test]
+fn sequential_guard_grandfathers_exact_key_repeats_from_ambiguous_base() {
+    let repeated_type = type_row(0x7701, "AmbiguousType", MODULE, &[]);
+    let repeated_function = func_row(0x7703, "AmbiguousFunction", MODULE, 0, &[], 0);
+    let base = cache(
+        &[10],
+        Tables {
+            types: vec![
+                repeated_type.clone(),
+                type_row(0x7702, "AmbiguousType", MODULE, &[]),
+            ],
+            type_ids: vec![id_row(0x0800_7701, 0x7701), id_row(0x0800_7702, 0x7702)],
+            funcs: vec![
+                repeated_function.clone(),
+                func_row(0x7704, "AmbiguousFunction", MODULE, 0, &[], 0),
+            ],
+            func_ids: vec![id_row(0x7703, 0x7703), id_row(0x7704, 0x7704)],
+            ..Tables::default()
+        },
+    );
+    let mini = cache(
+        &[10],
+        Tables {
+            types: vec![repeated_type],
+            type_ids: vec![id_row(0x0800_7701, 0x7701)],
+            funcs: vec![repeated_function],
+            func_ids: vec![id_row(0x7703, 0x7703)],
+            ..Tables::default()
+        },
+    );
+
+    let prepared = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("an exact known-key repeat must not reinterpret ambiguous base identity");
+    assert_eq!(prepared, mini);
+}
+
+#[test]
+fn sequential_guard_grandfathers_exact_id_repeats_from_aliased_base_maps() {
+    let type_ptr = 0x7751;
+    let function_ptr = 0x7752;
+    let base = cache(
+        &[10],
+        Tables {
+            types: vec![type_row(type_ptr, "HistoricallyAliasedType", MODULE, &[])],
+            type_ids: vec![id_row(0x0800_7751, type_ptr), id_row(0x0800_7752, type_ptr)],
+            funcs: vec![func_row(
+                function_ptr,
+                "HistoricallyAliasedFunction",
+                MODULE,
+                0,
+                &[],
+                0,
+            )],
+            func_ids: vec![id_row(0x7751, function_ptr), id_row(0x7752, function_ptr)],
+            ..Tables::default()
+        },
+    );
+    let exact_rows_only = cache(
+        &[10],
+        Tables {
+            type_ids: vec![id_row(0x0800_7751, type_ptr)],
+            func_ids: vec![id_row(0x7751, function_ptr)],
+            ..Tables::default()
+        },
+    );
+
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&exact_rows_only)
+        .expect("exact existing T2/T4 id rows must grandfather historical base pointer aliases");
+
+    for (table, new_id, mini, witness) in [
+        (
+            1,
+            0x0800_7753,
+            cache(
+                &[10],
+                Tables {
+                    type_ids: vec![id_row(0x0800_7753, type_ptr)],
+                    ..Tables::default()
+                },
+            ),
+            "0x8007751",
+        ),
+        (
+            3,
+            0x7753,
+            cache(
+                &[10],
+                Tables {
+                    func_ids: vec![id_row(0x7753, function_ptr)],
+                    ..Tables::default()
+                },
+            ),
+            "0x7751",
+        ),
+    ] {
+        let error = SequentialMiniGuard::new(&base)
+            .unwrap()
+            .check_and_record(&mini)
+            .unwrap_err();
+        assert!(
+            matches!(
+                error,
+                SpliceError::MiniReference(RemapError::InvalidTailRow {
+                    table: actual_table,
+                    row_key,
+                    kind: "pointer-to-id mapping",
+                    ref detail,
+                }) if actual_table == table && row_key == i64::from(new_id) && detail.contains(witness)
+            ),
+            "table {table} did not report deterministic lowest prior id: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_identity_state_is_atomic_when_static_rebase_fails() {
+    let base = cache(&[10], Tables::default());
+    let bad = cache(
+        &[(60u32 | (9 << 16)) as i32, 10],
+        Tables {
+            types: vec![type_row(0x7801, "RetryIdentity", MODULE, &[])],
+            type_ids: vec![id_row(0x0800_7801, 0x7801)],
+            static_names: vec![sia("RetryStatic")],
+            ..Tables::default()
+        },
+    );
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard.check_and_record(&bad).unwrap_err();
+    assert!(matches!(error, SpliceError::StaticNameRebase(_)));
+
+    let corrected = cache(
+        &[60, 10],
+        Tables {
+            types: vec![type_row(0x7802, "RetryIdentity", MODULE, &[])],
+            type_ids: vec![id_row(0x0800_7802, 0x7802)],
+            static_names: vec![sia("RetryStatic")],
+            ..Tables::default()
+        },
+    );
+    guard
+        .check_and_record(&corrected)
+        .expect("failed rebase must not record the rejected identity under its first key");
+}
+
+#[test]
+fn sequential_guard_rejects_prior_mini_type_and_function_id_pointer_aliases() {
+    let base = cache(&[10], Tables::default());
+
+    let type_row_bytes = type_row(0x7901, "PriorMappedType", MODULE, &[]);
+    let mut type_guard = SequentialMiniGuard::new(&base).unwrap();
+    type_guard
+        .check_and_record(&cache(
+            &[10],
+            Tables {
+                types: vec![type_row_bytes.clone()],
+                type_ids: vec![id_row(0x0800_7901, 0x7901)],
+                ..Tables::default()
+            },
+        ))
+        .expect("first T2 mapping is unique");
+    let type_alias = cache(
+        &[10],
+        Tables {
+            types: vec![type_row_bytes],
+            type_ids: vec![id_row(0x0800_7902, 0x7901)],
+            ..Tables::default()
+        },
+    );
+    let type_error = type_guard.check_and_record(&type_alias).unwrap_err();
+    assert!(matches!(type_error, SpliceError::MiniReference(_)));
+
+    let function_row_bytes = func_row(0x7903, "PriorMappedFunction", MODULE, 0, &[], 0);
+    let mut function_guard = SequentialMiniGuard::new(&base).unwrap();
+    function_guard
+        .check_and_record(&cache(
+            &[10],
+            Tables {
+                funcs: vec![function_row_bytes.clone()],
+                func_ids: vec![id_row(0x7903, 0x7903)],
+                ..Tables::default()
+            },
+        ))
+        .expect("first T4 mapping is unique");
+    let function_alias = cache(
+        &[10],
+        Tables {
+            funcs: vec![function_row_bytes],
+            func_ids: vec![id_row(0x7904, 0x7903)],
+            ..Tables::default()
+        },
+    );
+    let function_error = function_guard
+        .check_and_record(&function_alias)
+        .unwrap_err();
+    assert!(matches!(function_error, SpliceError::MiniReference(_)));
+}
+
+#[test]
+fn sequential_guard_uses_base_only_type_dependencies_for_alias_identity() {
+    let dependency_ptr = 0x7a01;
+    let base = cache(
+        &[10],
+        Tables {
+            types: vec![
+                type_row(dependency_ptr, "BaseDependency", MODULE, &[]),
+                type_row(0x7a02, "DependentType", MODULE, &[dependency_ptr]),
+            ],
+            type_ids: vec![
+                id_row(0x0800_7a01, dependency_ptr),
+                id_row(0x0800_7a02, 0x7a02),
+            ],
+            funcs: vec![func_row(
+                0x7a03,
+                "DependentFunction",
+                MODULE,
+                0,
+                &[dependency_ptr],
+                0,
+            )],
+            func_ids: vec![id_row(0x7a03, 0x7a03)],
+            ..Tables::default()
+        },
+    );
+
+    let type_alias = type_symbol_mini(0x7a04, 0x0800_7a04, "DependentType", &[dependency_ptr]);
+    assert_guard_rejects_reference(
+        &base,
+        &type_alias,
+        "T1 identity must resolve an omitted base-only subtype",
+    );
+
+    let function_alias =
+        function_symbol_mini(0x7a05, 0x7a05, "DependentFunction", 0, &[dependency_ptr]);
+    assert_guard_rejects_reference(
+        &base,
+        &function_alias,
+        "T3 identity must resolve an omitted base-only parameter type",
+    );
+}
+
+#[test]
+fn sequential_guard_distinguishes_recursively_nested_type_identities() {
+    let base_foo = 0x7b01;
+    let base_inner = 0x7b02;
+    let base_outer = 0x7b03;
+    let base = cache(
+        &[10],
+        Tables {
+            types: vec![
+                type_row_ns(base_foo, "Leaf", MODULE, "Foo", &[]),
+                type_row_ns(base_inner, "Inner", "Templates", "", &[base_foo]),
+                type_row_ns(base_outer, "Outer", "Templates", "", &[base_inner]),
+            ],
+            type_ids: vec![
+                id_row(0x0800_7b01, base_foo),
+                id_row(0x0800_7b02, base_inner),
+                id_row(0x0800_7b03, base_outer),
+            ],
+            ..Tables::default()
+        },
+    );
+
+    let mini_bar = 0x7b11;
+    let mini_inner = 0x7b12;
+    let mini_outer = 0x7b13;
+    let mini = cache(
+        &[10],
+        Tables {
+            types: vec![
+                type_row_ns(mini_bar, "Leaf", MODULE, "Bar", &[]),
+                type_row_ns(mini_inner, "Inner", "Templates", "", &[mini_bar]),
+                type_row_ns(mini_outer, "Outer", "Templates", "", &[mini_inner]),
+            ],
+            type_ids: vec![
+                id_row(0x0800_7b11, mini_bar),
+                id_row(0x0800_7b12, mini_inner),
+                id_row(0x0800_7b13, mini_outer),
+            ],
+            ..Tables::default()
+        },
+    );
+
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("Outer<Inner<Bar::Leaf>> must differ from Outer<Inner<Foo::Leaf>>");
+}
+
+#[test]
+fn sequential_guard_projects_template_instance_module_out_of_t1_identity() {
+    let leaf = 0x7bb0;
+    let base_template = 0x7bb8;
+    let mini_template = 0x7bc0;
+    let base = cache(
+        &[10],
+        Tables {
+            types: vec![
+                type_row_ns(leaf, "TemplateLeaf", "LeafModule", "N", &[]),
+                type_row_ns(
+                    base_template,
+                    "ProjectedTemplate",
+                    "OriginalTemplateModule",
+                    "N",
+                    &[leaf],
+                ),
+            ],
+            type_ids: vec![
+                id_row(0x0800_7bb0, leaf),
+                id_row(0x0800_7bb8, base_template),
+            ],
+            ..Tables::default()
+        },
+    );
+    let mini = cache(
+        &[10],
+        Tables {
+            types: vec![type_row_ns(
+                mini_template,
+                "ProjectedTemplate",
+                "DriftedTemplateModule",
+                "N",
+                &[leaf],
+            )],
+            type_ids: vec![id_row(0x0800_7bc0, mini_template)],
+            ..Tables::default()
+        },
+    );
+
+    let error = SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect_err("template-instance lookup ignores the declaring module");
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::InvalidTailRow {
+            table: 0,
+            kind: "symbol identity",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn sequential_guard_rejects_noncanonical_template_sentinel_rows() {
+    let leaf = 0x7bd0;
+    for (case, key, namespace, subtypes) in [
+        ("missing sentinel namespace", 0x7bd8, "", vec![]),
+        (
+            "sentinel carrying template arguments",
+            0x7be0,
+            "SentinelNamespace",
+            vec![leaf],
+        ),
+    ] {
+        let mut types = vec![type_row_ns(key, "Sentinel", "$__T__", namespace, &subtypes)];
+        let mut type_ids = vec![id_row(0x0800_7bd8 + ((key - 0x7bd8) / 8) as i32, key)];
+        if !subtypes.is_empty() {
+            types.insert(0, type_row(leaf, "SentinelLeaf", "LeafModule", &[]));
+            type_ids.insert(0, id_row(0x0800_7bd0, leaf));
+        }
+        let mini = cache(
+            &[10],
+            Tables {
+                types,
+                type_ids,
+                ..Tables::default()
+            },
+        );
+        let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+            .unwrap()
+            .check_and_record(&mini)
+            .expect_err(case);
+        assert!(
+            matches!(
+                error,
+                SpliceError::MiniReference(RemapError::Wire(
+                    WireError::InvalidTypeReference { .. }
+                ))
+            ),
+            "{case}: unexpected error: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_recursively_resolves_base_only_nested_type_fallback() {
+    let leaf = 0x7c01;
+    let inner = 0x7c02;
+    let outer = 0x7c03;
+    let base = cache(
+        &[10],
+        Tables {
+            types: vec![
+                type_row_ns(leaf, "Leaf", "FooModule", "Foo", &[]),
+                type_row_ns(inner, "Inner", "Templates", "", &[leaf]),
+                type_row_ns(outer, "Outer", "Templates", "", &[inner]),
+            ],
+            type_ids: vec![
+                id_row(0x0800_7c01, leaf),
+                id_row(0x0800_7c02, inner),
+                id_row(0x0800_7c03, outer),
+            ],
+            ..Tables::default()
+        },
+    );
+    let alias = cache(
+        &[10],
+        Tables {
+            types: vec![type_row_ns(0x7c04, "Outer", "Templates", "", &[inner])],
+            type_ids: vec![id_row(0x0800_7c04, 0x7c04)],
+            ..Tables::default()
+        },
+    );
+    assert_guard_rejects_reference(
+        &base,
+        &alias,
+        "base-only Inner<Foo::Leaf> must contribute its recursive identity",
+    );
+}
+
+#[test]
+fn sequential_guard_rejects_cyclic_recursive_type_identity() {
+    let key = 0x7d01;
+    let mini = type_symbol_mini(key, 0x0800_7d01, "SelfCycle", &[key]);
+    let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&mini)
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::Wire(WireError::CyclicTypeReference {
+            key: actual,
+        })) if actual == key
+    ));
+}
+
+fn amplified_type_identity_tables(depth: usize, shared_parents: usize) -> Tables {
+    let mut types = Vec::new();
+    let mut type_ids = Vec::new();
+    let first_key = 0x7e00i64;
+    types.push(type_row_ns(first_key, "Leaf", "Amplifier", "N", &[]));
+    type_ids.push(id_row(0x0800_7e00, first_key));
+    let mut child = first_key;
+    for level in 1..=depth {
+        let key = first_key + level as i64;
+        types.push(type_row_ns(
+            key,
+            &format!("Pair{level}"),
+            "Amplifier",
+            "N",
+            &[child, child],
+        ));
+        type_ids.push(id_row(0x0800_7e00 + level as i32, key));
+        child = key;
+    }
+    for parent in 0..shared_parents {
+        let ordinal = depth + 1 + parent;
+        let key = first_key + ordinal as i64;
+        types.push(type_row_ns(
+            key,
+            &format!("SharedParent{parent}"),
+            "Amplifier",
+            "N",
+            &[child],
+        ));
+        type_ids.push(id_row(0x0800_7e00 + ordinal as i32, key));
+    }
+    Tables {
+        types,
+        type_ids,
+        ..Tables::default()
+    }
+}
+
+#[test]
+fn sequential_guard_rejects_per_identity_dag_amplification() {
+    let mut tables = amplified_type_identity_tables(13, 0);
+    // Keep the aggregate budget above the sum of the still-legal ancestor identities so this
+    // fixture isolates the per-identity cap reached by the exponentially amplified final row.
+    tables.static_names.push(sia(&"P".repeat(65_536)));
+    let mini = cache(&[10], tables);
+    let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&mini)
+        .unwrap_err();
+    assert!(
+        matches!(
+            error,
+            SpliceError::MiniReference(RemapError::Wire(WireError::IdentityTooLarge {
+                max: 65_536,
+                ..
+            }))
+        ),
+        "unexpected amplification refusal: {error:?}"
+    );
+}
+
+#[test]
+fn sequential_guard_rejects_aggregate_shared_child_identity_amplification() {
+    let mini = cache(&[10], amplified_type_identity_tables(7, 12));
+    let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&mini)
+        .unwrap_err();
+    assert!(
+        matches!(
+            error,
+            SpliceError::MiniReference(RemapError::Wire(WireError::IdentityBudgetExceeded {
+                max: 65_536
+            }))
+        ),
+        "unexpected aggregate amplification refusal: {error:?}"
+    );
+}
+
+#[test]
+fn sequential_guard_enforces_identity_budget_across_split_t1_and_t3_minis() {
+    const DEPTH: usize = 5;
+    const MAX_MINIS: usize = 32;
+    let child = 0x7e00 + DEPTH as i64;
+    let mut base_tables = amplified_type_identity_tables(DEPTH, 0);
+    for ordinal in 0..MAX_MINIS {
+        let key = 0x8f00 + ordinal as i64 * 8;
+        base_tables.types.push(type_row_ns(
+            key,
+            &format!("SplitBudgetType{ordinal}"),
+            "PristineIgnoredModule",
+            "N",
+            &[0x7e00],
+        ));
+        base_tables
+            .type_ids
+            .push(id_row(0x1001_0000 + ordinal as i32, key));
+    }
+    let base = cache(&[10], base_tables);
+
+    for domain in ["T1", "T3"] {
+        let mut guard = SequentialMiniGuard::new(&base).unwrap();
+        let mut accepted = 0usize;
+        let mut refused = None;
+        for ordinal in 0..MAX_MINIS {
+            let key = 0x7f00 + ordinal as i64 * 8;
+            let mini = if domain == "T1" {
+                cache(
+                    &[10],
+                    Tables {
+                        types: vec![type_row_ns(
+                            key,
+                            &format!("SplitBudgetType{ordinal}"),
+                            MODULE,
+                            "N",
+                            &[child],
+                        )],
+                        type_ids: vec![id_row(0x1002_0000 + ordinal as i32, key)],
+                        ..Tables::default()
+                    },
+                )
+            } else {
+                cache(
+                    &[10],
+                    Tables {
+                        funcs: vec![func_row(
+                            key,
+                            &format!("SplitBudgetFunction{ordinal}"),
+                            MODULE,
+                            0,
+                            &[child],
+                            0,
+                        )],
+                        func_ids: vec![id_row(0x0001_0000 + ordinal as i32, key)],
+                        ..Tables::default()
+                    },
+                )
+            };
+            match guard.check_and_record(&mini) {
+                Ok(_) => accepted += 1,
+                Err(error) => {
+                    assert!(
+                        matches!(
+                            error,
+                            SpliceError::MiniReference(RemapError::Wire(
+                                WireError::IdentityBudgetExceeded { .. }
+                            ))
+                        ),
+                        "{domain} split budget failed for another reason: {error:?}"
+                    );
+                    refused = Some(ordinal);
+                    break;
+                }
+            }
+        }
+        assert!(
+            accepted >= 2,
+            "{domain} fixture crossed before proving split state"
+        );
+        assert!(
+            refused.is_some(),
+            "{domain} accepted all {MAX_MINIS} amplified minis by resetting the budget"
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_bounds_namespace_tolerant_t1_identity_comparisons() {
+    let mut types = Vec::new();
+    let mut type_ids = Vec::new();
+    for ordinal in 0..160i32 {
+        let key = 0x8800 + i64::from(ordinal) * 8;
+        types.push(type_row_ns(
+            key,
+            "ComparisonBudgetType",
+            MODULE,
+            &format!("DistinctNamespace{ordinal:03}"),
+            &[],
+        ));
+        type_ids.push(id_row(0x0802_0000 + ordinal, key));
+    }
+    let mini = cache(
+        &[10],
+        Tables {
+            types,
+            type_ids,
+            ..Tables::default()
+        },
+    );
+
+    let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&mini)
+        .expect_err("pairwise-distinct namespaces must not permit quadratic T1 matching work");
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::Wire(
+            WireError::IdentityComparisonBudgetExceeded { .. }
+        ))
+    ));
+}
+
+#[test]
+fn sequential_guard_bounds_namespace_tolerant_t3_identity_comparisons() {
+    let mut funcs = Vec::new();
+    let mut func_ids = Vec::new();
+    for ordinal in 0..160i32 {
+        let key = 0x9800 + i64::from(ordinal) * 8;
+        funcs.push(func_row_ns(
+            key,
+            "ComparisonBudgetFunction",
+            MODULE,
+            &format!("DistinctNamespace{ordinal:03}"),
+            0,
+            &[],
+            0,
+        ));
+        func_ids.push(id_row(0x0002_0000 + ordinal, key));
+    }
+    let mini = cache(
+        &[10],
+        Tables {
+            funcs,
+            func_ids,
+            ..Tables::default()
+        },
+    );
+
+    let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&mini)
+        .expect_err("pairwise-distinct namespaces must not permit quadratic T3 matching work");
+    assert!(matches!(
+        error,
+        SpliceError::MiniReference(RemapError::Wire(
+            WireError::IdentityComparisonBudgetExceeded { .. }
+        ))
+    ));
+}
+
+#[test]
+fn allow_new_indexes_a_large_target_type_frontier_instead_of_rescanning_rows() {
+    const ROWS: i32 = 12_000;
+    let mut types = Vec::with_capacity(ROWS as usize);
+    let mut type_ids = Vec::with_capacity(ROWS as usize);
+    let mut classes = Vec::with_capacity(ROWS as usize);
+    for ordinal in 0..ROWS {
+        let ptr = 0x3000_0000 + i64::from(ordinal) * 8;
+        let id = 0x0804_0000 + ordinal;
+        let name = format!("PlannerType{ordinal:05}");
+        types.push(type_row(ptr, &name, MODULE, &[]));
+        type_ids.push(id_row(id, ptr));
+        classes.push(structural_class_record_full_named(
+            &name,
+            "",
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[0; 7],
+            &[],
+            &[],
+            None,
+        ));
+    }
+    let regen = cache_with_module_key_name_and_records(
+        "PlannerOuter",
+        MODULE,
+        &[function(&[10], 0x0500_0200)],
+        &classes,
+        &[],
+        &[],
+        Tables {
+            types,
+            type_ids,
+            ..Tables::default()
+        },
+    );
+    let base = cache_with_named_module("PlannerBase", &[10], Tables::default());
+
+    let started = std::time::Instant::now();
+    let (mini, _) = remap_module_to_base_with_options(
+        &regen,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .expect("the indexed frontier admits every independently declared target type");
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(15),
+        "12k target rows must not trigger quadratic dependency-row scans"
+    );
+    let tail = parse_tail_tables(&mini, module_region_end(&mini).unwrap()).unwrap();
+    assert_eq!(tail.tables[0].count, ROWS as u32);
+    assert_eq!(tail.tables[1].count, ROWS as u32);
+}
+
+#[test]
+fn sequential_guard_indexes_many_property_and_native_alloc_sites_once() {
+    const ROWS: i32 = 8_192;
+    const OPS: usize = 16_384;
+    const OWNER_PTR: i64 = 0x4100_0000;
+    const OWNER_ID: i32 = 0x0805_0000;
+    let mut base_types = Vec::with_capacity(ROWS as usize);
+    let mut base_type_ids = Vec::with_capacity(ROWS as usize);
+    for ordinal in 0..ROWS {
+        let ptr = 0x4000_0000 + i64::from(ordinal) * 8;
+        let id = 0x0404_0000 + ordinal;
+        base_types.push(type_row(ptr, &format!("NativeType{ordinal:05}"), "", &[]));
+        base_type_ids.push(id_row(id, ptr));
+    }
+    let native_ptr = 0x4000_0000 + i64::from(ROWS - 1) * 8;
+    // Keep the source-proportional identity budget above this deliberately row-dense synthetic
+    // base. Shipping has ample module bytes; this fixture otherwise unrealistically consists
+    // almost entirely of tail identities.
+    let base_code = vec![10; 500_000];
+    let base = cache_with_named_module(
+        "IndexedBase",
+        &base_code,
+        Tables {
+            types: base_types,
+            type_ids: base_type_ids,
+            ..Tables::default()
+        },
+    );
+    let mut properties = Vec::with_capacity(ROWS as usize);
+    for ordinal in 0..ROWS {
+        properties.push(property_row(
+            OWNER_ID,
+            ordinal * 4,
+            &format!("Field{ordinal:05}"),
+        ));
+    }
+    let member_offset = (ROWS - 1) * 4;
+    let mut code = Vec::with_capacity(OPS * 6 + 1);
+    for _ in 0..OPS {
+        code.extend([79 | (member_offset << 16), OWNER_ID]);
+        qw_op(64, native_ptr, &mut code);
+        code.push(0);
+    }
+    code.push(10);
+    let mini = cache(
+        &code,
+        Tables {
+            types: vec![type_row(OWNER_PTR, "IndexedOwner", MODULE, &[])],
+            type_ids: vec![id_row(OWNER_ID, OWNER_PTR)],
+            properties,
+            ..Tables::default()
+        },
+    );
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+
+    let started = std::time::Instant::now();
+    guard
+        .check_and_record(&mini)
+        .expect("indexed T7 membership and one native T2 summary validate all repeated sites");
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(15),
+        "repeated property/ALLOC0 sites must not rescan T7/T2 or allocate per instruction"
+    );
+}
+
+#[test]
+fn sequential_guard_bounds_late_namespace_identity_comparison_work() {
+    const ROWS: i32 = 48;
+    const COMMON_PREFIX_BYTES: usize = 12 * 1024;
+    let common = "N".repeat(COMMON_PREFIX_BYTES);
+    let mut types = Vec::new();
+    let mut type_ids = Vec::new();
+    for ordinal in 0..ROWS {
+        let key = 0xa800 + i64::from(ordinal) * 8;
+        types.push(type_row_ns(
+            key,
+            "LateNamespaceWorkType",
+            MODULE,
+            &format!("{common}{ordinal:04}"),
+            &[],
+        ));
+        type_ids.push(id_row(0x0803_0000 + ordinal, key));
+    }
+    let mini = cache(
+        &[10],
+        Tables {
+            types,
+            type_ids,
+            ..Tables::default()
+        },
+    );
+
+    let error = SequentialMiniGuard::new(&cache(&[10], Tables::default()))
+        .unwrap()
+        .check_and_record(&mini)
+        .expect_err(
+            "a below-count-budget bucket with long late-differing namespaces must have a byte-work budget",
+        );
+    assert!(
+        matches!(
+            error,
+            SpliceError::MiniReference(RemapError::Wire(
+                WireError::IdentityComparisonBudgetExceeded { .. }
+            ))
+        ),
+        "unexpected identity comparison work refusal: {error:?}"
+    );
+}
+
+fn composition_base(function_id: i32) -> Vec<u8> {
+    let mut base = cache_with_function_id(&[10], Tables::default(), function_id);
+    replace_ascii_same_len(&mut base, "EditedModule", "PristineBase");
+    base
+}
+
+fn assert_composed_structure_error(mini: &[u8], field: &'static str) {
+    let error = splice_auto(&composition_base(0x0100_0001), mini).unwrap_err();
+    assert!(
+        matches!(
+            error,
+            SpliceError::ComposedModule(RemapError::InvalidModuleStructure {
+                field: actual,
+                ..
+            }) if actual == field
+        ),
+        "expected {field} structural refusal, got {error:?}"
+    );
+}
+
+fn function_id_cache(ids: &[i32]) -> Vec<u8> {
+    let functions = ids
+        .iter()
+        .map(|&id| function(&[10], id))
+        .collect::<Vec<_>>();
+    cache_with_records(&functions, &[], &[], &[])
+}
+
+#[test]
+fn composed_cache_accepts_one_zero_but_rejects_duplicate_function_ids() {
+    let with_zero = splice_auto(&composition_base(0x0100_0001), &function_id_cache(&[0]))
+        .expect("Function.Id zero is a legal cache key when it remains unique");
+    assert_eq!(module_count(&with_zero), 2);
+
+    let duplicate_zero_error =
+        splice_auto(&composition_base(0x0100_0001), &function_id_cache(&[0, 0])).unwrap_err();
+    assert!(
+        matches!(
+            duplicate_zero_error,
+            SpliceError::ComposedModule(RemapError::Wire(WireError::BadLen {
+                field: "duplicate function declaration",
+                ..
+            }))
+        ),
+        "unexpected duplicate-zero refusal: {duplicate_zero_error:?}"
+    );
+
+    let duplicate = 0x0200_0001;
+    let duplicate_error = splice_auto(
+        &composition_base(0x0100_0001),
+        &function_id_cache(&[duplicate, duplicate]),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(
+            duplicate_error,
+            SpliceError::ComposedModule(RemapError::Wire(WireError::BadLen {
+                field: "duplicate function declaration",
+                ..
+            }))
+        ),
+        "unexpected duplicate refusal: {duplicate_error:?}"
+    );
+}
+
+#[test]
+fn composed_cache_rejects_function_id_collision_across_added_modules() {
+    let duplicate = 0x0200_0010;
+    let error = splice_auto(
+        &composition_base(duplicate),
+        &function_id_cache(&[duplicate]),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::ComposedModule(RemapError::FunctionIdCollision { id, .. })
+            if id == duplicate
+    ));
+}
+
+#[test]
+fn composed_cache_accepts_unique_negative_function_id() {
+    let combined = splice_auto(&composition_base(0x0200_0020), &function_id_cache(&[-7]))
+        .expect("negative nonzero Function.Id values are valid runtime lookup keys");
+    assert_eq!(module_count(&combined), 2);
+}
+
+#[test]
+fn replace_may_reuse_target_function_id_but_not_an_untouched_modules_id() {
+    let target_id = 0x0200_0030;
+    let untouched_id = 0x0200_0031;
+    let target = cache_with_function_id(&[10], Tables::default(), target_id);
+    let mut untouched = cache_with_function_id(&[10], Tables::default(), untouched_id);
+    replace_ascii_same_len(&mut untouched, "EditedModule", "SecondModule");
+    let base = splice_auto(&target, &untouched).expect("two unique source modules");
+
+    let replacement = cache_with_function_id(&[10], Tables::default(), target_id);
+    replace_module(&base, &replacement, MODULE)
+        .expect("replacement may retain the Function.Id owned by the removed target");
+
+    let colliding = cache_with_function_id(&[10], Tables::default(), untouched_id);
+    let error = replace_module(&base, &colliding, MODULE).unwrap_err();
+    assert!(matches!(
+        error,
+        SpliceError::ComposedModule(RemapError::FunctionIdCollision { id, .. })
+            if id == untouched_id
+    ));
+}
+
+#[test]
+fn composed_cache_scans_function_ids_at_every_runtime_record_location() {
+    let seven_refs = [0i64; 7];
+    let unique = structural_class_record_full(
+        &[],
+        &[function(&[10], 0x0250_0002)],
+        &[0],
+        &[function(&[10], 0x0250_0003)],
+        &[],
+        &seven_refs,
+        &[function(&[10], 0x0250_0004)],
+        &[2],
+        None,
+    );
+    let unique_mini = cache_with_all_records(
+        &[function(&[10], 0x0250_0001)],
+        &[unique],
+        &[],
+        &[global_init_record(&function(&[10], 0x0250_0005))],
+        &[],
+    );
+    splice_auto(&composition_base(0x0250_0000), &unique_mini)
+        .expect("unique ids across module/method/ctor/behavior/global-init records");
+
+    for location in ["method", "constructor", "behavior", "global init"] {
+        let duplicate = 0x0250_0010;
+        let method_id = if location == "method" {
+            duplicate
+        } else {
+            0x0250_0012
+        };
+        let constructor_id = if location == "constructor" {
+            duplicate
+        } else {
+            0x0250_0013
+        };
+        let behavior_id = if location == "behavior" {
+            duplicate
+        } else {
+            0x0250_0014
+        };
+        let global_id = if location == "global init" {
+            duplicate
+        } else {
+            0x0250_0015
+        };
+        let class = structural_class_record_full(
+            &[],
+            &[function(&[10], method_id)],
+            &[0],
+            &[function(&[10], constructor_id)],
+            &[],
+            &seven_refs,
+            &[function(&[10], behavior_id)],
+            &[2],
+            None,
+        );
+        let mini = cache_with_all_records(
+            &[function(&[10], duplicate)],
+            &[class],
+            &[],
+            &[global_init_record(&function(&[10], global_id))],
+            &[],
+        );
+        let error = splice_auto(&composition_base(0x0250_0000), &mini).unwrap_err();
+        assert!(
+            matches!(
+                error,
+                SpliceError::ComposedModule(RemapError::FunctionIdCollision { id, .. })
+                    if id == duplicate
+            ),
+            "{location} Function.Id was not scanned: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn loadout_rekeys_function_ids_at_every_runtime_record_location() {
+    let seven_refs = [0i64; 7];
+    let make_mini = |outer: &str, inner: &str| {
+        let class = structural_class_record_full(
+            &[],
+            &[function(&[10], 0x0260_0002)],
+            &[0],
+            &[function(&[10], 0x0260_0003)],
+            &[],
+            &seven_refs,
+            &[function(&[10], 0x0260_0004)],
+            &[2],
+            None,
+        );
+        cache_with_module_key_name_and_records(
+            outer,
+            inner,
+            &[function(&[10], 0x0260_0001)],
+            &[class],
+            &[],
+            &[global_init_record(&function(&[10], 0x0260_0005))],
+            Tables::default(),
+        )
+    };
+    let base = composition_base(0x0260_0000);
+    let first = make_mini("AllSitesA", "AllSitesA");
+    let second = make_mini("AllSitesB", "AllSitesB");
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    builder.inspect(&first).unwrap();
+    builder.inspect(&second).unwrap();
+    let plan = builder.finish().unwrap();
+    let first = remap_module_to_base_with_loadout_plan(&first, &base, &plan).unwrap();
+    let second = remap_module_to_base_with_loadout_plan(&second, &base, &plan).unwrap();
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let running = guard.compose_add(&base, &first).unwrap();
+    guard.compose_add(&running, &second).expect(
+        "free, method, constructor, behavior, and global-init Function.Id sites must all rekey",
+    );
+}
+
+#[test]
+fn composed_cache_rejects_all_paired_count_mismatches() {
+    let seven_refs = [0i64; 7];
+    let parameter_name = cache_with_records(
+        &[shaped_function(
+            0x0300_0001,
+            FunctionShape {
+                parameter_types: 1,
+                ..FunctionShape::default()
+            },
+        )],
+        &[],
+        &[],
+        &[],
+    );
+    let parameter_flag = cache_with_records(
+        &[shaped_function(
+            0x0300_0002,
+            FunctionShape {
+                parameter_types: 1,
+                parameter_names: 1,
+                parameter_defaults: 1,
+                ..FunctionShape::default()
+            },
+        )],
+        &[],
+        &[],
+        &[],
+    );
+    let parameter_default = cache_with_records(
+        &[shaped_function(
+            0x0300_0003,
+            FunctionShape {
+                parameter_types: 1,
+                parameter_names: 1,
+                parameter_flags: 1,
+                ..FunctionShape::default()
+            },
+        )],
+        &[],
+        &[],
+        &[],
+    );
+    let object_variables = cache_with_records(
+        &[shaped_function(
+            0x0300_0004,
+            FunctionShape {
+                object_types: 1,
+                ..FunctionShape::default()
+            },
+        )],
+        &[],
+        &[],
+        &[],
+    );
+    let variable_offset = cache_with_records(
+        &[shaped_function(
+            0x0300_0005,
+            FunctionShape {
+                variable_program_positions: 1,
+                variable_options: 1,
+                ..FunctionShape::default()
+            },
+        )],
+        &[],
+        &[],
+        &[],
+    );
+    let variable_option = cache_with_records(
+        &[shaped_function(
+            0x0300_0006,
+            FunctionShape {
+                variable_program_positions: 1,
+                variable_offsets: 1,
+                ..FunctionShape::default()
+            },
+        )],
+        &[],
+        &[],
+        &[],
+    );
+    let function_metadata = cache_with_records(
+        &[shaped_function(
+            0x0300_0007,
+            FunctionShape {
+                unreal_metadata: Some((1, 0)),
+                ..FunctionShape::default()
+            },
+        )],
+        &[],
+        &[],
+        &[],
+    );
+    let behavior_function = shaped_function(0x0300_0009, FunctionShape::default());
+    let class_behaviors =
+        structural_class_record(&[], &[], &[], &seven_refs, &[behavior_function], &[], None);
+    let class_behavior_counts = cache_with_records(
+        &[function(&[10], 0x0300_0008)],
+        &[class_behaviors],
+        &[],
+        &[],
+    );
+    let class_metadata =
+        structural_class_record(&[], &[], &[], &seven_refs, &[], &[], Some((1, 0)));
+    let class_metadata_counts =
+        cache_with_records(&[function(&[10], 0x0300_000a)], &[class_metadata], &[], &[]);
+    let property_metadata = structural_class_record(
+        &[property_with_metadata(1, 0)],
+        &[],
+        &[],
+        &seven_refs,
+        &[],
+        &[],
+        None,
+    );
+    let property_metadata_counts = cache_with_records(
+        &[function(&[10], 0x0300_000b)],
+        &[property_metadata],
+        &[],
+        &[],
+    );
+    let enum_counts = cache_with_records(
+        &[function(&[10], 0x0300_000c)],
+        &[],
+        &[enum_record(1, 0)],
+        &[],
+    );
+    let import_flags = cache_with_records(
+        &[function(&[10], 0x0300_000d)],
+        &[],
+        &[],
+        &[import_record(1, 0, 1)],
+    );
+    let import_defaults = cache_with_records(
+        &[function(&[10], 0x0300_000e)],
+        &[],
+        &[],
+        &[import_record(1, 1, 0)],
+    );
+
+    let cases = [
+        ("Function.Parameters", parameter_name),
+        ("Function.Parameters", parameter_flag),
+        ("Function.Parameters", parameter_default),
+        ("Function.ObjectVariables", object_variables),
+        ("Function.VariableInfo", variable_offset),
+        ("Function.VariableInfo", variable_option),
+        ("UFunction.Metadata", function_metadata),
+        ("Class.Behaviors", class_behavior_counts),
+        ("Class.Metadata", class_metadata_counts),
+        ("UProperty.Metadata", property_metadata_counts),
+        ("Enum.Entries", enum_counts),
+        ("Import.Parameters", import_flags),
+        ("Import.Parameters", import_defaults),
+    ];
+    for (field, mini) in cases {
+        assert_composed_structure_error(&mini, field);
+    }
+}
+
+#[test]
+fn composed_module_parser_rejects_oversized_local_arrays_without_allocating_them() {
+    const HUGE_COUNT: i32 = 50_000_000;
+    let cases = [
+        (
+            "ObjVariablePos",
+            0x0330_0010,
+            FunctionShape {
+                serialized_object_positions: Some(HUGE_COUNT),
+                ..FunctionShape::default()
+            },
+        ),
+        (
+            "VariableInfoProgramPos",
+            0x0330_0011,
+            FunctionShape {
+                serialized_variable_program_positions: Some(HUGE_COUNT),
+                ..FunctionShape::default()
+            },
+        ),
+    ];
+
+    for (field, function_id, shape) in cases {
+        let mini = cache_with_records(&[shaped_function(function_id, shape)], &[], &[], &[]);
+        let error = match splice_auto(&composition_base(0x0330_0001), &mini) {
+            Ok(_) => panic!("oversized {field} unexpectedly parsed"),
+            Err(error) => error,
+        };
+        assert!(
+            matches!(
+                error,
+                SpliceError::Wire(WireError::Eof { .. })
+                    | SpliceError::Wire(WireError::BadLen { .. })
+                    | SpliceError::ComposedModule(RemapError::Wire(WireError::Eof { .. }))
+                    | SpliceError::ComposedModule(RemapError::Wire(WireError::BadLen { .. }))
+            ),
+            "oversized {field}: unexpected error: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn sequential_guard_preflights_tail_count_caps_and_records_failures_atomically() {
+    const KEYED_LIMIT: u64 = 131_072;
+    const STATIC_LIMIT: u64 = 65_536;
+    const MINI_LIMIT: u64 = 256;
+    let raw_count_mini = |table: usize, count: u32| {
+        let mut mini = cache(&[10], Tables::default());
+        let tail = module_region_end(&mini).unwrap();
+        assert!(table <= 5);
+        mini[tail + table * 4..tail + table * 4 + 4].copy_from_slice(&count.to_le_bytes());
+        mini
+    };
+
+    let base = cache(&[10], Tables::default());
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    for (resource, actual, limit, mini) in [
+        (
+            "keyed row count",
+            KEYED_LIMIT + 1,
+            KEYED_LIMIT,
+            raw_count_mini(0, (KEYED_LIMIT + 1) as u32),
+        ),
+        (
+            "StaticNames count",
+            STATIC_LIMIT + 1,
+            STATIC_LIMIT,
+            raw_count_mini(5, (STATIC_LIMIT + 1) as u32),
+        ),
+    ] {
+        let error = match guard.check_and_record(&mini) {
+            Ok(_) => panic!("oversized {resource} unexpectedly passed"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            SpliceError::SequentialLimitExceeded {
+                resource: actual_resource,
+                actual: actual_value,
+                limit: actual_limit,
+            } if actual_resource == resource && actual_value == actual && actual_limit == limit
+        ));
+    }
+
+    let empty = cache(&[10], Tables::default());
+    for accepted in 0..MINI_LIMIT {
+        guard.check_and_record(&empty).unwrap_or_else(|error| {
+            panic!(
+                "failed preflight consumed usage; mini {} of {MINI_LIMIT} failed: {error:?}",
+                accepted + 1
+            )
+        });
+    }
+    let error = guard
+        .check_and_record(&empty)
+        .expect_err("mini count limit+1 must fail");
+    assert!(matches!(
+        error,
+        SpliceError::SequentialLimitExceeded {
+            resource: "mini count",
+            actual: 257,
+            limit: 256,
+        }
+    ));
+}
+
+#[test]
+fn sequential_guard_preflights_per_function_and_total_bytecode_caps_atomically() {
+    const FUNCTION_LIMIT: usize = 4 * 1024 * 1024;
+    const TOTAL_LIMIT: u64 = 16 * 1024 * 1024;
+    let base = cache(&[10], Tables::default());
+
+    let oversized_function = {
+        let code = vec![10; FUNCTION_LIMIT + 1];
+        cache(&code, Tables::default())
+    };
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard
+        .check_and_record(&oversized_function)
+        .expect_err("one function above the 4M-dword limit must fail in streaming preflight");
+    assert!(matches!(
+        error,
+        SpliceError::SequentialLimitExceeded {
+            resource: "mini function bytecode dwords",
+            actual,
+            limit: 4_194_304,
+        } if actual == 4_194_305
+    ));
+    guard
+        .check_and_record(&cache(&[10], Tables::default()))
+        .expect("a failed per-function preflight must not consume sequential guard state");
+
+    let oversized_total = {
+        // Four functions exactly at the per-function boundary prove equality is admitted far
+        // enough for the independent aggregate check to report total-limit+1.
+        let boundary = vec![10; FUNCTION_LIMIT];
+        let functions = [
+            function(&boundary, 0x0600_0001),
+            function(&boundary, 0x0600_0002),
+            function(&boundary, 0x0600_0003),
+            function(&boundary, 0x0600_0004),
+            function(&[10], 0x0600_0005),
+        ];
+        let module = module_value_with_records(&functions, &[], &[], &[], &[]);
+        cache_from_module_value(&module, Tables::default())
+    };
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = guard
+        .check_and_record(&oversized_total)
+        .expect_err("aggregate bytecode above 16M dwords must fail in streaming preflight");
+    assert!(
+        matches!(
+            error,
+            SpliceError::SequentialLimitExceeded {
+                resource: "mini total bytecode dwords",
+                actual,
+                limit: TOTAL_LIMIT,
+            } if actual == TOTAL_LIMIT + 1
+        ),
+        "unexpected aggregate bytecode error: {error:?}"
+    );
+    guard
+        .check_and_record(&cache(&[10], Tables::default()))
+        .expect("a failed aggregate preflight must not consume sequential guard state");
+}
+
+#[test]
+fn composed_cache_validates_object_variables_on_heap_mask() {
+    for (heap_mask, function_id) in [(0, 0x0340_0001), (1, 0x0340_0002)] {
+        let mini = cache_with_records(
+            &[shaped_function(
+                function_id,
+                FunctionShape {
+                    variable_space: 4,
+                    object_types: 1,
+                    object_positions: 1,
+                    object_position_values: &[4],
+                    object_heap_mask: heap_mask,
+                    stack_needed: 4,
+                    ..FunctionShape::default()
+                },
+            )],
+            &[],
+            &[],
+            &[],
+        );
+        splice_auto(&composition_base(0x0340_0000), &mini)
+            .unwrap_or_else(|error| panic!("heap mask {heap_mask} must be valid: {error:?}"));
+    }
+
+    for (heap_mask, function_id) in [(-1, 0x0340_0003), (2, 0x0340_0004)] {
+        let mini = cache_with_records(
+            &[shaped_function(
+                function_id,
+                FunctionShape {
+                    variable_space: 4,
+                    object_types: 1,
+                    object_positions: 1,
+                    object_position_values: &[4],
+                    object_heap_mask: heap_mask,
+                    stack_needed: 4,
+                    ..FunctionShape::default()
+                },
+            )],
+            &[],
+            &[],
+            &[],
+        );
+        assert_composed_structure_error(&mini, "Function.ObjVariablesOnHeap");
+    }
+}
+
+#[test]
+fn composed_cache_validates_variable_space_object_positions_and_stack_needed() {
+    for (case, function_id, shape) in [
+        (
+            "empty zero-sized frame",
+            0x0340_0005,
+            FunctionShape::default(),
+        ),
+        (
+            "object at the lower frame bound",
+            0x0340_0006,
+            FunctionShape {
+                variable_space: 4,
+                object_types: 1,
+                object_positions: 1,
+                object_position_values: &[1],
+                object_heap_mask: 1,
+                stack_needed: 4,
+                ..FunctionShape::default()
+            },
+        ),
+    ] {
+        let mini = cache_with_records(&[shaped_function(function_id, shape)], &[], &[], &[]);
+        splice_auto(&composition_base(0x0340_0000), &mini)
+            .unwrap_or_else(|error| panic!("{case} must be valid: {error:?}"));
+    }
+
+    let invalid = [
+        (
+            "negative VariableSpace",
+            "Function.VariableSpace",
+            0x0340_0007,
+            FunctionShape {
+                variable_space: -1,
+                ..FunctionShape::default()
+            },
+        ),
+        (
+            "zero object position",
+            "Function.ObjectVariables",
+            0x0340_0008,
+            FunctionShape {
+                variable_space: 4,
+                object_types: 1,
+                object_positions: 1,
+                object_position_values: &[0],
+                stack_needed: 4,
+                ..FunctionShape::default()
+            },
+        ),
+        (
+            "object position beyond VariableSpace",
+            "Function.ObjectVariables",
+            0x0340_0009,
+            FunctionShape {
+                variable_space: 4,
+                object_types: 1,
+                object_positions: 1,
+                object_position_values: &[5],
+                stack_needed: 4,
+                ..FunctionShape::default()
+            },
+        ),
+        (
+            "StackNeeded below VariableSpace",
+            "Function.StackNeeded",
+            0x0340_000a,
+            FunctionShape {
+                variable_space: 4,
+                stack_needed: 3,
+                ..FunctionShape::default()
+            },
+        ),
+    ];
+    for (case, field, function_id, shape) in invalid {
+        let mini = cache_with_records(&[shaped_function(function_id, shape)], &[], &[], &[]);
+        let error = splice_auto(&composition_base(0x0340_0000), &mini).unwrap_err();
+        assert!(
+            matches!(
+                error,
+                SpliceError::ComposedModule(RemapError::InvalidModuleStructure {
+                    field: actual,
+                    ..
+                }) if actual == field
+            ),
+            "{case}: expected {field}, got {error:?}"
+        );
+    }
+}
+
+#[test]
+fn composed_cache_validates_variable_info_state_machine() {
+    const OBJ_UNINIT: i32 = 0;
+    const OBJ_INIT: i32 = 1;
+    const BLOCK_BEGIN: i32 = 2;
+    const BLOCK_END: i32 = 3;
+
+    let balanced = cache_with_records(
+        &[shaped_function(
+            0x0340_0010,
+            FunctionShape {
+                variable_space: 4,
+                object_types: 1,
+                object_positions: 1,
+                object_position_values: &[4],
+                variable_program_positions: 4,
+                variable_program_values: &[0, 0, 0, 1],
+                variable_offsets: 4,
+                variable_offset_values: &[0, 4, 4, 0],
+                variable_options: 4,
+                variable_option_values: &[BLOCK_BEGIN, OBJ_INIT, OBJ_UNINIT, BLOCK_END],
+                stack_needed: 4,
+                ..FunctionShape::default()
+            },
+        )],
+        &[],
+        &[],
+        &[],
+    );
+    splice_auto(&composition_base(0x0340_0000), &balanced)
+        .expect("balanced block and matching object INIT/UNINIT offsets are valid");
+
+    let invalid = [
+        (
+            "option 4",
+            0x0340_0011,
+            FunctionShape {
+                variable_space: 4,
+                object_types: 1,
+                object_positions: 1,
+                object_position_values: &[4],
+                variable_program_positions: 1,
+                variable_program_values: &[0],
+                variable_offsets: 1,
+                variable_offset_values: &[4],
+                variable_options: 1,
+                variable_option_values: &[4],
+                stack_needed: 4,
+                ..FunctionShape::default()
+            },
+        ),
+        (
+            "UNINIT missing from object offsets",
+            0x0340_0012,
+            FunctionShape {
+                variable_space: 4,
+                object_types: 1,
+                object_positions: 1,
+                object_position_values: &[4],
+                variable_program_positions: 1,
+                variable_program_values: &[0],
+                variable_offsets: 1,
+                variable_offset_values: &[8],
+                variable_options: 1,
+                variable_option_values: &[OBJ_UNINIT],
+                stack_needed: 4,
+                ..FunctionShape::default()
+            },
+        ),
+        (
+            "INIT with empty object offsets",
+            0x0340_0013,
+            FunctionShape {
+                variable_space: 4,
+                variable_program_positions: 1,
+                variable_program_values: &[0],
+                variable_offsets: 1,
+                variable_offset_values: &[4],
+                variable_options: 1,
+                variable_option_values: &[OBJ_INIT],
+                stack_needed: 4,
+                ..FunctionShape::default()
+            },
+        ),
+        (
+            "lone BLOCK_END",
+            0x0340_0014,
+            FunctionShape {
+                variable_program_positions: 1,
+                variable_program_values: &[0],
+                variable_offsets: 1,
+                variable_offset_values: &[0],
+                variable_options: 1,
+                variable_option_values: &[BLOCK_END],
+                ..FunctionShape::default()
+            },
+        ),
+        (
+            "unsorted ProgramPos",
+            0x0340_0015,
+            FunctionShape {
+                variable_program_positions: 2,
+                variable_program_values: &[1, 0],
+                variable_offsets: 2,
+                variable_offset_values: &[0, 0],
+                variable_options: 2,
+                variable_option_values: &[BLOCK_BEGIN, BLOCK_END],
+                ..FunctionShape::default()
+            },
+        ),
+    ];
+    for (case, function_id, shape) in invalid {
+        let mini = cache_with_records(&[shaped_function(function_id, shape)], &[], &[], &[]);
+        let error = splice_auto(&composition_base(0x0340_0000), &mini).unwrap_err();
+        assert!(
+            matches!(
+                error,
+                SpliceError::ComposedModule(RemapError::InvalidModuleStructure {
+                    field: "Function.VariableInfo",
+                    ..
+                })
+            ),
+            "{case}: unexpected error: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn composed_cache_validates_behavior_function_type_tags() {
+    let seven_refs = [0i64; 7];
+    for (behavior_type, function_id, should_pass) in
+        [(2, 0x0340_0021, true), (0, 0x0340_0022, false)]
+    {
+        let behavior = shaped_function(function_id + 1, FunctionShape::default());
+        let class = structural_class_record(
+            &[],
+            &[],
+            &[],
+            &seven_refs,
+            &[behavior],
+            &[behavior_type],
+            None,
+        );
+        let mini = cache_with_records(&[function(&[10], function_id)], &[class], &[], &[]);
+        if should_pass {
+            splice_auto(&composition_base(0x0340_0000), &mini)
+                .expect("BehaviorFunctionTypes tag 2 is canonical");
+        } else {
+            assert_composed_structure_error(&mini, "Class.BehaviorFunctionTypes");
+        }
+    }
+
+    let two_behaviors = structural_class_record(
+        &[],
+        &[],
+        &[],
+        &seven_refs,
+        &[
+            shaped_function(0x0340_0024, FunctionShape::default()),
+            shaped_function(0x0340_0025, FunctionShape::default()),
+        ],
+        &[2, 2],
+        None,
+    );
+    let mini = cache_with_records(&[function(&[10], 0x0340_0023)], &[two_behaviors], &[], &[]);
+    assert_composed_structure_error(&mini, "Class.BehaviorFunctions");
+}
+
+#[test]
+fn composed_cache_accepts_complete_structural_positive_matrix() {
+    let shape = FunctionShape {
+        parameter_types: 1,
+        parameter_names: 1,
+        parameter_flags: 1,
+        parameter_defaults: 1,
+        variable_space: 4,
+        object_types: 1,
+        object_positions: 1,
+        object_position_values: &[4],
+        variable_program_positions: 1,
+        variable_program_values: &[0],
+        variable_offsets: 1,
+        variable_offset_values: &[4],
+        variable_options: 1,
+        variable_option_values: &[1],
+        stack_needed: 4,
+        unreal_metadata: Some((1, 1)),
+        ..FunctionShape::default()
+    };
+    let behavior_function = shaped_function(0x0350_0003, FunctionShape::default());
+    let class = structural_class_record_full(
+        &[property_with_metadata(1, 1)],
+        &[
+            shaped_function(0x0350_0001, FunctionShape::default()),
+            shaped_function(0x0350_0002, FunctionShape::default()),
+        ],
+        &[0, 1, -1],
+        &[
+            shaped_function(0x0350_0004, FunctionShape::default()),
+            shaped_function(0x0350_0005, FunctionShape::default()),
+        ],
+        &[0],
+        &[0; 7],
+        &[behavior_function],
+        &[2],
+        Some((1, 1)),
+    );
+    let global = global_init_record(&shaped_function(0x0350_0006, FunctionShape::default()));
+    let mini = cache_with_all_records(
+        &[shaped_function(0, shape)],
+        &[class],
+        &[enum_record(1, 1)],
+        &[global],
+        &[import_record(1, 1, 1)],
+    );
+
+    let combined = splice_auto(&composition_base(0x0350_0007), &mini).expect(
+        "equal paired arrays, canonical BehaviorRefs, sparse MethodTable and unequal ctor/factory counts are valid",
+    );
+    assert_eq!(module_count(&combined), 2);
+}
+
+#[test]
+fn composed_cache_rejects_noncanonical_behavior_ref_count() {
+    let class = structural_class_record(&[], &[], &[], &[0; 6], &[], &[], None);
+    let mini = cache_with_records(&[function(&[10], 0x0400_0001)], &[class], &[], &[]);
+    assert_composed_structure_error(&mini, "Class.BehaviorRefs");
+}
+
+#[test]
+fn composed_cache_rejects_oob_and_duplicate_method_table_indices() {
+    let seven_refs = [0i64; 7];
+    let methods = [function(&[10], 0x0400_0011), function(&[10], 0x0400_0012)];
+    for method_table in [vec![2], vec![0, 0]] {
+        let class =
+            structural_class_record(&[], &methods, &method_table, &seven_refs, &[], &[], None);
+        let mini = cache_with_records(&[function(&[10], 0x0400_0010)], &[class], &[], &[]);
+        assert_composed_structure_error(&mini, "Class.MethodTable");
+    }
+}
+
+#[test]
+fn strict_remap_stamps_target_guid_and_passes_the_sequential_guard() {
+    let mut base = base_cache();
+    base[..16].copy_from_slice(&[0x33; 16]);
+    let mut regen = regen_existing_flagged_typeid_cache();
+    regen[..16].copy_from_slice(&[0x44; 16]);
+
+    let (mini, _) = remap_module_to_base(&regen, &base).unwrap();
+    assert_eq!(&mini[..16], &base[..16]);
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("strict remapped refs all resolve through the target base");
+}
+
+#[test]
+fn allow_new_remap_stamps_target_guid_and_passes_the_sequential_guard() {
+    let mut base = base_cache();
+    base[..16].copy_from_slice(&[0x55; 16]);
+    let mut regen = regen_cache();
+    regen[..16].copy_from_slice(&[0x66; 16]);
+
+    let (mini, _) = remap_module_to_base_with_options(
+        &regen,
+        &base,
+        RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .unwrap();
+    assert_eq!(&mini[..16], &base[..16]);
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&mini)
+        .expect("allow-new rows and operands resolve through the effective base-plus-mini tables");
+}
+
+#[test]
+fn extracted_referenceless_mini_from_the_same_base_passes() {
+    let base = base_cache();
+    let extracted = extract_module(&base, MODULE).unwrap();
+    SequentialMiniGuard::new(&base)
+        .unwrap()
+        .check_and_record(&extracted)
+        .expect("same-generation extraction carries complete effective reference tables");
 }
 
 #[test]
@@ -387,9 +6777,37 @@ fn sequential_guard_rejects_collisions_in_every_keyed_tail_table() {
     for table in [0usize, 1, 2, 3, 4, 6] {
         let base = cache(&[10], Tables::default());
         let mut guard = SequentialMiniGuard::new(&base).unwrap();
-        guard
-            .check_and_record(&keyed_mini(table, 0x55, "First"))
-            .unwrap();
+        let first = keyed_mini(table, 0x55, "First");
+        let first = if table == 6 {
+            let owner = structural_class_record_full_named(
+                "PropertyOwner",
+                "",
+                &[property_record_named("First")],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[0; 7],
+                &[],
+                &[],
+                None,
+            );
+            let functions = [function(&[10], DEFAULT_MODULE_FUNCTION_ID)];
+            let module =
+                module_value_with_name_and_records(MODULE, &functions, &[owner], &[], &[], &[]);
+            cache_from_module_value(
+                &module,
+                Tables {
+                    types: vec![type_row(0x3055, "PropertyOwner", MODULE, &[])],
+                    type_ids: vec![id_row(0x55, 0x3055)],
+                    properties: vec![property_row(0x55, 4, "First")],
+                    ..Tables::default()
+                },
+            )
+        } else {
+            first
+        };
+        guard.check_and_record(&first).unwrap();
         let err = guard
             .check_and_record(&keyed_mini_with_value_delta(table, 0x55, "Second", 1))
             .unwrap_err();
@@ -413,7 +6831,35 @@ fn sequential_guard_accepts_exact_duplicate_symbol_rows() {
     let base = cache(&[10], Tables::default());
     for table in [0usize, 1, 2, 3, 4, 6] {
         let mut guard = SequentialMiniGuard::new(&base).unwrap();
-        let mini = keyed_mini(table, 0x66, "SharedSymbol");
+        let mini = if table == 6 {
+            let owner = structural_class_record_full_named(
+                "PropertyOwner",
+                "",
+                &[property_record_named("SharedSymbol")],
+                &[],
+                &[],
+                &[],
+                &[],
+                &[0; 7],
+                &[],
+                &[],
+                None,
+            );
+            let functions = [function(&[10], DEFAULT_MODULE_FUNCTION_ID)];
+            let module =
+                module_value_with_name_and_records(MODULE, &functions, &[owner], &[], &[], &[]);
+            cache_from_module_value(
+                &module,
+                Tables {
+                    types: vec![type_row(0x3066, "PropertyOwner", MODULE, &[])],
+                    type_ids: vec![id_row(0x66, 0x3066)],
+                    properties: vec![property_row(0x66, 4, "SharedSymbol")],
+                    ..Tables::default()
+                },
+            )
+        } else {
+            keyed_mini(table, 0x66, "SharedSymbol")
+        };
         guard.check_and_record(&mini).unwrap();
         guard
             .check_and_record(&mini)
@@ -438,6 +6884,139 @@ fn sequential_guard_rejects_cross_table_oldreference_reuse() {
             key: 0x71
         }
     ));
+}
+
+#[test]
+fn compose_add_rejects_running_bytes_from_another_guard_history() {
+    const KEY: i64 = 0xb100;
+    let base = composition_base(0x0500_0001);
+    let mini_a = cache_with_module_key_name_and_function_id(
+        "MiniA",
+        "MiniA",
+        &[10],
+        Tables {
+            types: vec![type_row(KEY, "RunningType", "MiniA", &[])],
+            type_ids: vec![id_row(0x0800_b100, KEY)],
+            ..Tables::default()
+        },
+        0x0500_0002,
+    );
+    let mut call_b = Vec::new();
+    qw_op(61, KEY, &mut call_b);
+    call_b.push(10);
+    let mini_b = cache_with_module_key_name_and_function_id(
+        "MiniB",
+        "MiniB",
+        &call_b,
+        Tables {
+            funcs: vec![func_row(KEY, "RunningFunction", "MiniB", 0, &[], 0)],
+            func_ids: vec![id_row(0x0000_b100, KEY)],
+            ..Tables::default()
+        },
+        0x0500_0003,
+    );
+
+    let mut guard_a = SequentialMiniGuard::new(&base).unwrap();
+    let running_a = guard_a
+        .compose_add(&base, &mini_a)
+        .expect("Guard A may append MiniA to the pristine base");
+
+    let mut fresh_guard = SequentialMiniGuard::new(&base).unwrap();
+    let error = fresh_guard
+        .compose_add(&running_a, &mini_b)
+        .expect_err("a fresh guard must not stage MiniB against running bytes containing MiniA");
+    assert!(
+        matches!(error, SpliceError::RunningStateMismatch),
+        "expected an exact running-state mismatch before staging, got {error:?}"
+    );
+
+    fresh_guard
+        .compose_add(&base, &mini_b)
+        .expect("running-state mismatch must leave fresh guard history uncommitted");
+}
+
+#[test]
+fn compose_add_rejects_after_check_and_record_invalidates_running_state() {
+    let base = composition_base(0x0500_0005);
+    let mini_a = cache_with_module_key_name_and_function_id(
+        "CheckedA",
+        "CheckedA",
+        &[10],
+        Tables::default(),
+        0x0500_0006,
+    );
+    let mini_b = cache_with_module_key_name_and_function_id(
+        "ComposedB",
+        "ComposedB",
+        &[10],
+        Tables::default(),
+        0x0500_0007,
+    );
+    let corrected = cache_with_module_key_name_and_function_id(
+        "CheckedRetry",
+        "CheckedRetry",
+        &[10],
+        Tables::default(),
+        0x0500_0008,
+    );
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    guard
+        .check_and_record(&mini_a)
+        .expect("history-only validation of A succeeds");
+    let error = guard
+        .compose_add(&base, &mini_b)
+        .expect_err("compose_add cannot reconstruct running bytes after check_and_record(A)");
+    assert!(matches!(error, SpliceError::RunningStateMismatch));
+    guard.check_and_record(&corrected).expect(
+        "running-state mismatch occurs before staging and cannot poison validation history",
+    );
+}
+
+#[test]
+fn splice_and_guard_reject_duplicate_inner_module_names_atomically() {
+    let base = cache_with_module_key_name_and_function_id(
+        "OuterA",
+        "InnerX",
+        &[10],
+        Tables::default(),
+        0x0500_0011,
+    );
+    let colliding = cache_with_module_key_name_and_function_id(
+        "OuterB",
+        "InnerX",
+        &[10],
+        Tables::default(),
+        0x0500_0012,
+    );
+    let corrected = cache_with_module_key_name_and_function_id(
+        "OuterB",
+        "InnerY",
+        &[10],
+        Tables::default(),
+        0x0500_0012,
+    );
+
+    let splice_error = splice(&base, &colliding)
+        .expect_err("distinct outer keys must not hide a duplicate inner ModuleName");
+    assert!(matches!(
+        splice_error,
+        SpliceError::InnerNameCollision(ref name) if name == "InnerX"
+    ));
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let compose_error = guard
+        .compose_add(&base, &colliding)
+        .expect_err("compose_add must reject the same duplicate inner ModuleName");
+    assert!(matches!(
+        compose_error,
+        SpliceError::InnerNameCollision(ref name) if name == "InnerX"
+    ));
+
+    let composed = guard
+        .compose_add(&base, &corrected)
+        .expect("inner-name collision must not commit staged guard history");
+    assert_eq!(module_names(&composed).unwrap(), vec!["OuterA", "OuterB"]);
 }
 
 fn static_mini_str(name: &str, raw_index: u16) -> Vec<u8> {
@@ -513,6 +7092,7 @@ fn sequential_guard_state_is_atomic_when_static_rebase_fails() {
         &[(60u32 | (9 << 16)) as i32, 10], // no mini-local T6 row can satisfy index 9
         Tables {
             types: vec![type_row(0x7777, "RetryType", MODULE, &[])],
+            type_ids: vec![id_row(0x7777, 0x7777)],
             static_names: vec![sia("RetryName")],
             ..Tables::default()
         },
@@ -528,6 +7108,7 @@ fn sequential_guard_state_is_atomic_when_static_rebase_fails() {
         &[(60u32 | (2 << 16)) as i32, 10],
         Tables {
             types: vec![type_row(0x7777, "RetryType", MODULE, &[])],
+            type_ids: vec![id_row(0x7777, 0x7777)],
             static_names: vec![sia("RetryName")],
             ..Tables::default()
         },
@@ -556,10 +7137,10 @@ fn two_class_bearing_allow_new_minis_get_identity_stable_disjoint_keys_and_compo
     // All three caches deliberately reuse the same raw pointer/id values. Only portable symbol
     // identity differs, mirroring independent game-compiler runs that each allocate first-free
     // ids for their own additive class module.
-    let mut base = base_cache();
+    let mut base = base_cache_with_function_id(0x1100_0001);
     replace_ascii_same_len(&mut base, "EditedModule", "PristineBase");
-    let regen_a = regen_cache();
-    let mut regen_b = regen_cache();
+    let regen_a = regen_cache_with_function_id(0x1100_0002);
+    let mut regen_b = regen_cache_with_function_id(0x1100_0003);
     replace_ascii_same_len(&mut regen_b, "EditedModule", "SecondModule");
 
     let raw_a = parse_tail_tables(&regen_a, module_region_end(&regen_a).unwrap()).unwrap();
@@ -595,10 +7176,8 @@ fn two_class_bearing_allow_new_minis_get_identity_stable_disjoint_keys_and_compo
     }
 
     let mut guard = SequentialMiniGuard::new(&base).unwrap();
-    let prepared_a = guard.check_and_record(&mini_a).unwrap();
-    let prepared_b = guard.check_and_record(&mini_b).unwrap();
-    let after_a = splice_auto(&base, &prepared_a).unwrap();
-    let combined = splice_auto(&after_a, &prepared_b).unwrap();
+    let after_a = guard.compose_add(&base, &mini_a).unwrap();
+    let combined = guard.compose_add(&after_a, &mini_b).unwrap();
     assert_eq!(
         module_names(&combined).unwrap(),
         vec!["PristineBase", "EditedModule", "SecondModule"]
@@ -637,14 +7216,14 @@ fn strict_remap_maps_typeid_core_and_preserves_handle_flags() {
 }
 
 #[test]
-fn flagged_typeid_alone_declares_and_carries_external_new_type() {
+fn flagged_typeid_alone_declares_and_carries_current_module_new_type() {
     const PTR: i64 = 0x7777;
     const ID: i32 = 0x0800_7777;
     let base = cache(&[10], Tables::default());
     let regen = cache(
         &[76, ID | 0x4000_0000, 10],
         Tables {
-            types: vec![type_row(PTR, "ExternalNewType", "ExternalModule", &[])],
+            types: vec![type_row(PTR, "ExternalNewType", MODULE, &[])],
             type_ids: vec![id_row(ID, PTR)],
             ..Tables::default()
         },
@@ -729,38 +7308,93 @@ fn allow_new_reuses_unique_gap_a_rows_and_only_carries_probe_classes() {
     qw_op(75, PROBE_CHOICE_PTR, &mut code); // OBJTYPE: genuinely new probe choice
     qw_op(61, REGEN_TOPIC_FUNC_PTR, &mut code); // CALLSYS: namespace-drifted method
     code.push(10); // RET
-    let regen = cache(
-        &code,
-        Tables {
-            types: vec![
-                // The emitter flattened the namespace blocks for these existing semantic rows.
-                type_row(REGEN_QUEST_PTR, "UG1RQuest", MODULE, &[]),
-                type_row(REGEN_TOPIC_PTR, "UTopic", MODULE, &[]),
-                type_row(PROBE_QUEST_PTR, "UQuest_GORE_PROBE_HOMER_MINI", MODULE, &[]),
-                type_row(
-                    PROBE_CHOICE_PTR,
-                    "UChoiceGOREProbeHomerMiniQuest",
-                    MODULE,
-                    &[],
-                ),
-            ],
-            type_ids: vec![
-                id_row(REGEN_QUEST_ID, REGEN_QUEST_PTR),
-                id_row(REGEN_TOPIC_ID, REGEN_TOPIC_PTR),
-                id_row(PROBE_QUEST_ID, PROBE_QUEST_PTR),
-                id_row(PROBE_CHOICE_ID, PROBE_CHOICE_PTR),
-            ],
-            funcs: vec![func_row(
-                REGEN_TOPIC_FUNC_PTR,
-                "CanUse",
+    let regen_tables = Tables {
+        types: vec![
+            // The emitter flattened the namespace blocks for these existing semantic rows.
+            type_row(REGEN_QUEST_PTR, "UG1RQuest", MODULE, &[]),
+            type_row(REGEN_TOPIC_PTR, "UTopic", MODULE, &[]),
+            type_row(PROBE_QUEST_PTR, "UQuest_GORE_PROBE_HOMER_MINI", MODULE, &[]),
+            type_row(
+                PROBE_CHOICE_PTR,
+                "UChoiceGOREProbeHomerMiniQuest",
                 MODULE,
-                REGEN_TOPIC_PTR,
                 &[],
-                0,
-            )],
-            ..Tables::default()
-        },
-    );
+            ),
+        ],
+        type_ids: vec![
+            id_row(REGEN_QUEST_ID, REGEN_QUEST_PTR),
+            id_row(REGEN_TOPIC_ID, REGEN_TOPIC_PTR),
+            id_row(PROBE_QUEST_ID, PROBE_QUEST_PTR),
+            id_row(PROBE_CHOICE_ID, PROBE_CHOICE_PTR),
+        ],
+        funcs: vec![func_row(
+            REGEN_TOPIC_FUNC_PTR,
+            "CanUse",
+            MODULE,
+            REGEN_TOPIC_PTR,
+            &[],
+            0,
+        )],
+        ..Tables::default()
+    };
+    let classes = [
+        structural_class_record_full_named(
+            "UG1RQuest",
+            "G1R::UG1RQuest",
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[0; 7],
+            &[],
+            &[],
+            None,
+        ),
+        structural_class_record_full_named(
+            "UTopic",
+            "G1R::UTopic",
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[0; 7],
+            &[],
+            &[],
+            None,
+        ),
+        structural_class_record_full_named(
+            "UQuest_GORE_PROBE_HOMER_MINI",
+            "",
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[0; 7],
+            &[],
+            &[],
+            None,
+        ),
+        structural_class_record_full_named(
+            "UChoiceGOREProbeHomerMiniQuest",
+            "",
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[0; 7],
+            &[],
+            &[],
+            None,
+        ),
+    ];
+    let functions = [function(&code, DEFAULT_MODULE_FUNCTION_ID)];
+    let regen_module =
+        module_value_with_name_and_records(MODULE, &functions, &classes, &[], &[], &[]);
+    let regen = cache_from_module_value(&regen_module, regen_tables);
 
     let (mini, _) = remap_module_to_base_with_options(
         &regen,
@@ -898,7 +7532,10 @@ fn allow_new_carries_minimal_rows_rekeys_collisions_and_replaces_cleanly() {
         counts.total() >= 8,
         "all typed refs should be processed: {counts:?}"
     );
-    assert_eq!(counts.embed_type_ptr, 2, "DerivedFrom + ShadowType");
+    assert_eq!(
+        counts.embed_type_ptr, 4,
+        "DerivedFrom + ShadowType + NewFn parameter/return declarations"
+    );
     assert_eq!(counts.embed_func_id, 4, "FactoryRefs + BehaviorRefs");
     let mini_tail = module_region_end(&mini).unwrap();
     let mini_tables = parse_tail_tables(&mini, mini_tail).unwrap();
@@ -988,7 +7625,7 @@ fn allow_new_carries_minimal_rows_rekeys_collisions_and_replaces_cleanly() {
     let module_bytes = &replaced[0x18..tail];
     let contains = |needle: &[u8]| module_bytes.windows(needle.len()).any(|w| w == needle);
     let mut type_ref_sequence = 2i32.to_le_bytes().to_vec(); // MethodTable count
-    type_ref_sequence.extend_from_slice(&7i32.to_le_bytes());
+    type_ref_sequence.extend_from_slice(&(-1i32).to_le_bytes());
     type_ref_sequence.extend_from_slice(&(-1i32).to_le_bytes());
     type_ref_sequence.extend_from_slice(&BASE_TYPE_PTR.to_le_bytes()); // DerivedFrom
     type_ref_sequence.extend_from_slice(&objtype.to_le_bytes()); // ShadowType
@@ -999,11 +7636,18 @@ fn allow_new_carries_minimal_rows_rekeys_collisions_and_replaces_cleanly() {
     let mut function_ref_sequence = 2i32.to_le_bytes().to_vec();
     function_ref_sequence.extend_from_slice(&(BASE_FUNC_ID as i64).to_le_bytes());
     function_ref_sequence.extend_from_slice(&(call_id as i64).to_le_bytes());
-    let occurrences = module_bytes
+    let factory_occurrences = module_bytes
         .windows(function_ref_sequence.len())
         .filter(|w| *w == function_ref_sequence)
         .count();
-    assert_eq!(occurrences, 2, "FactoryRefs and BehaviorRefs both remapped");
+    assert_eq!(factory_occurrences, 1, "FactoryRefs remapped");
+    let mut behavior_ref_sequence = 7i32.to_le_bytes().to_vec();
+    behavior_ref_sequence.extend_from_slice(&(BASE_FUNC_ID as i64).to_le_bytes());
+    behavior_ref_sequence.extend_from_slice(&(call_id as i64).to_le_bytes());
+    assert!(
+        contains(&behavior_ref_sequence),
+        "BehaviorRefs retain their canonical count and remap their function ids"
+    );
 
     let global = instrs
         .iter()
@@ -1076,13 +7720,10 @@ fn real_viper_and_asghan_allow_new_regens_compose_when_fixtures_are_available() 
         .map(|(_, _, path)| std::fs::read(path).expect("read promoted fixture mini"))
         .collect();
     let mut fixture_guard = SequentialMiniGuard::new(&base).unwrap();
-    let fixture_first = fixture_guard.check_and_record(&fixture_minis[0]).unwrap();
-    let fixture_second = fixture_guard.check_and_record(&fixture_minis[1]).unwrap();
-    let fixture_combined = splice_auto(
-        &splice_auto(&base, &fixture_first).unwrap(),
-        &fixture_second,
-    )
-    .unwrap();
+    let fixture_after_first = fixture_guard.compose_add(&base, &fixture_minis[0]).unwrap();
+    let fixture_combined = fixture_guard
+        .compose_add(&fixture_after_first, &fixture_minis[1])
+        .unwrap();
     let fixture_names = module_names(&fixture_combined).unwrap();
     for (module, _, _) in &fixtures {
         assert!(
@@ -1111,10 +7752,11 @@ fn real_viper_and_asghan_allow_new_regens_compose_when_fixtures_are_available() 
     }
 
     // This exact boundary previously failed first at T2 id 134244321 and then at T4 id 294413.
+    // Exercise the production composition path so every prospective output also passes the final
+    // pristine-aware T1/T3/T5/T7 declaration closure before the guard commits either mini.
     let mut guard = SequentialMiniGuard::new(&base).unwrap();
-    let first = guard.check_and_record(&minis[0]).unwrap();
-    let second = guard.check_and_record(&minis[1]).unwrap();
-    let combined = splice_auto(&splice_auto(&base, &first).unwrap(), &second).unwrap();
+    let after_first = guard.compose_add(&base, &minis[0]).unwrap();
+    let combined = guard.compose_add(&after_first, &minis[1]).unwrap();
     let names = module_names(&combined).unwrap();
     for (module, _, _) in fixtures {
         assert!(names.iter().any(|name| name == module), "missing {module}");
@@ -1167,4 +7809,6 @@ fn real_cache_tail_tables_roundtrip_when_configured() {
         bytes[tail..],
         "raw table rows round-trip byte-for-byte"
     );
+    SequentialMiniGuard::new(&bytes)
+        .expect("real Shipping cache identities must fit the composed 4x/256 MiB guard budget");
 }

--- a/crates/gore-as/tests/splice_test.rs
+++ b/crates/gore-as/tests/splice_test.rs
@@ -1,6 +1,9 @@
-use gore_as::cache::splice::{replace_module, splice, splice_auto, splice_case_a, SpliceError};
+use gore_as::cache::splice::{
+    extract_module, replace_module, splice, splice_auto, splice_case_a,
+    validate_standalone_script_cache, SequentialMiniGuard, SpliceError,
+};
 use gore_as::cache::tables::parse_tail_tables;
-use gore_as::cache::walk_modules::{module_count, module_names, module_region_end};
+use gore_as::cache::walk_modules::{module_count, module_names, module_ranges, module_region_end};
 
 const SAMPLES: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -13,6 +16,256 @@ fn read_sample(name: &str) -> Option<Vec<u8>> {
 
 const MINI: &str = "PrecompiledScript.minimal-1fn.Cache"; // 1 fn, empty tail
 const RICH: &str = "PrecompiledScript.richtest.Cache"; // class-bearing, non-empty tail
+
+fn fstring(value: &str) -> Vec<u8> {
+    let mut out = ((value.len() + 1) as i32).to_le_bytes().to_vec();
+    out.extend_from_slice(value.as_bytes());
+    out.push(0);
+    out
+}
+
+fn sia(value: &str) -> Vec<u8> {
+    if value.is_empty() {
+        return 0i32.to_le_bytes().to_vec();
+    }
+    let mut out = (value.len() as i32).to_le_bytes().to_vec();
+    out.extend_from_slice(value.as_bytes());
+    out.push(0);
+    out
+}
+
+fn empty_module_entry(outer_name: &str, inner_name: &str) -> Vec<u8> {
+    let mut out = fstring(outer_name);
+    out.extend_from_slice(&sia(inner_name));
+    out.extend_from_slice(&[0; 5 * 4]); // functions/classes/enums/globals/imports
+    out.extend_from_slice(&0i64.to_le_bytes()); // CodeHash
+    out.extend_from_slice(&0u32.to_le_bytes()); // ImportedModules
+    out.extend_from_slice(&sia("")); // StaticsClassName
+    out.extend_from_slice(&0u32.to_le_bytes()); // DeclaredEvents
+    out.extend_from_slice(&0u32.to_le_bytes()); // DeclaredDelegates
+    out.extend_from_slice(&sia("")); // ScriptRelativeFilename
+    out.extend_from_slice(&0u32.to_le_bytes()); // PostInitFunctions
+    out
+}
+
+fn empty_modules_cache(modules: &[(&str, &str)]) -> Vec<u8> {
+    let mut out = [0x11; 16].to_vec();
+    out.extend_from_slice(&gore_as::cache::header::CACHE_MAGIC.to_le_bytes());
+    out.extend_from_slice(&(modules.len() as u32).to_le_bytes());
+    for &(outer_name, inner_name) in modules {
+        out.extend_from_slice(&empty_module_entry(outer_name, inner_name));
+    }
+    out.extend_from_slice(&[0; 7 * 4]); // empty tail tables
+    out
+}
+
+fn empty_module_cache(module: &str) -> Vec<u8> {
+    empty_modules_cache(&[(module, module)])
+}
+
+fn standalone_cache_with_tail_keys(rows: &[(usize, i64)]) -> Vec<u8> {
+    let mut cache = empty_module_cache("FullReplacement");
+    cache.truncate(cache.len() - 7 * 4);
+    for table in 0..7 {
+        let keys = rows
+            .iter()
+            .filter_map(|&(candidate, key)| (candidate == table).then_some(key))
+            .collect::<Vec<_>>();
+        cache.extend_from_slice(&(keys.len() as i32).to_le_bytes());
+        for key in keys {
+            match table {
+                0 => {
+                    cache.extend_from_slice(&key.to_le_bytes());
+                    cache.extend_from_slice(&sia("Type"));
+                    cache.extend_from_slice(&sia("FullReplacement"));
+                    cache.extend_from_slice(&sia(""));
+                    cache.extend_from_slice(&0i32.to_le_bytes());
+                }
+                1 | 3 => {
+                    cache.extend_from_slice(&(key as i32).to_le_bytes());
+                    cache.extend_from_slice(&0x4000i64.to_le_bytes());
+                }
+                2 => {
+                    cache.extend_from_slice(&key.to_le_bytes());
+                    cache.extend_from_slice(&sia("Function"));
+                    cache.extend_from_slice(&sia("FullReplacement"));
+                    cache.extend_from_slice(&sia(""));
+                    cache.extend_from_slice(&[0; 3 * 4]);
+                    cache.extend_from_slice(&0i64.to_le_bytes());
+                    cache.extend_from_slice(&0i32.to_le_bytes());
+                    cache.extend_from_slice(&[0; 36]);
+                }
+                4 => {
+                    cache.extend_from_slice(&key.to_le_bytes());
+                    cache.extend_from_slice(&sia("Global"));
+                    cache.extend_from_slice(&sia("FullReplacement"));
+                    cache.extend_from_slice(&sia(""));
+                    cache.extend_from_slice(&0i32.to_le_bytes());
+                }
+                5 => unreachable!("StaticNames is intentionally not keyed"),
+                6 => {
+                    cache.extend_from_slice(&key.to_le_bytes());
+                    cache.extend_from_slice(&sia("Property"));
+                    cache.extend_from_slice(&0i32.to_le_bytes());
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+    cache
+}
+
+#[test]
+fn impossible_module_count_is_refused_before_capacity_allocation() {
+    let mut malformed = [0x11; 16].to_vec();
+    malformed.extend_from_slice(&gore_as::cache::header::CACHE_MAGIC.to_le_bytes());
+    malformed.extend_from_slice(&u32::MAX.to_le_bytes());
+    let mini = empty_module_cache("Mini");
+
+    assert!(module_region_end(&malformed).is_err());
+    assert!(module_names(&malformed).is_err());
+    assert!(module_ranges(&malformed).is_err());
+    assert!(extract_module(&malformed, "Missing").is_err());
+    assert!(splice(&malformed, &mini).is_err());
+    assert!(replace_module(&malformed, &mini, "Missing").is_err());
+}
+
+#[test]
+fn sequential_guard_rejects_bad_cache_magic_without_poisoning_retry() {
+    let base = empty_module_cache("Base");
+    let mut bad_base = base.clone();
+    bad_base[0x10..0x14].copy_from_slice(&0xdead_beefu32.to_le_bytes());
+    assert!(matches!(
+        SequentialMiniGuard::new(&bad_base),
+        Err(SpliceError::Header(_))
+    ));
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let good_mini = empty_module_cache("Mini");
+    let mut bad_mini = good_mini.clone();
+    bad_mini[0x10..0x14].copy_from_slice(&0xdead_beefu32.to_le_bytes());
+    assert!(matches!(
+        guard.compose_add(&base, &bad_mini),
+        Err(SpliceError::Header(_))
+    ));
+    guard
+        .compose_add(&base, &good_mini)
+        .expect("a bad-magic refusal must not commit guard history");
+}
+
+#[test]
+fn standalone_script_cache_validation_is_structural_guid_agnostic_and_non_mutating() {
+    let mut cache = empty_module_cache("FullReplacement");
+    cache[..16].copy_from_slice(&[0xa5; 16]);
+    let original = cache.clone();
+
+    validate_standalone_script_cache(&cache)
+        .expect("a complete replacement owns its GUID and valid wire container");
+    assert_eq!(
+        cache, original,
+        "structural validation must not rewrite bytes"
+    );
+}
+
+#[test]
+fn standalone_script_cache_validation_rejects_bad_container_shapes() {
+    let short = vec![0u8; gore_as::cache::header::CacheHeader::SIZE - 1];
+    assert!(matches!(
+        validate_standalone_script_cache(&short),
+        Err(SpliceError::Header(_))
+    ));
+
+    let mut wrong_magic = empty_module_cache("FullReplacement");
+    wrong_magic[0x10..0x14].copy_from_slice(&0xdead_beefu32.to_le_bytes());
+    assert!(matches!(
+        validate_standalone_script_cache(&wrong_magic),
+        Err(SpliceError::Header(_))
+    ));
+
+    let mut truncated = empty_module_cache("FullReplacement");
+    truncated.pop();
+    assert!(matches!(
+        validate_standalone_script_cache(&truncated),
+        Err(SpliceError::Wire(_))
+    ));
+
+    let mut impossible_count = empty_module_cache("FullReplacement");
+    impossible_count[0x14..0x18].copy_from_slice(&u32::MAX.to_le_bytes());
+    assert!(matches!(
+        validate_standalone_script_cache(&impossible_count),
+        Err(SpliceError::Wire(_))
+    ));
+
+    let mut trailing = empty_module_cache("FullReplacement");
+    trailing.push(0);
+    assert!(matches!(
+        validate_standalone_script_cache(&trailing),
+        Err(SpliceError::Wire(_))
+    ));
+
+    let duplicate_key = empty_modules_cache(&[("Dup", "InnerA"), ("Dup", "InnerB")]);
+    assert!(matches!(
+        validate_standalone_script_cache(&duplicate_key),
+        Err(SpliceError::ModuleKeyCollision(ref name)) if name == "Dup"
+    ));
+}
+
+#[test]
+fn standalone_script_cache_validation_rejects_tail_map_key_collisions() {
+    for table in [0usize, 1, 2, 3, 4, 6] {
+        let error = validate_standalone_script_cache(&standalone_cache_with_tail_keys(&[
+            (table, 0x41),
+            (table, 0x41),
+        ]))
+        .expect_err("duplicate TMap keys are malformed in a standalone cache too");
+        assert!(
+            matches!(error, SpliceError::KeyCollision { table: got, key: 0x41 } if got == table),
+            "unexpected table-{table} error: {error:?}"
+        );
+    }
+
+    for table in [2usize, 4, 6] {
+        let error = validate_standalone_script_cache(&standalone_cache_with_tail_keys(&[
+            (0, 0x52),
+            (table, 0x52),
+        ]))
+        .expect_err("T1/T3/T5/T7 share one runtime key domain");
+        assert!(
+            matches!(error, SpliceError::KeyCollision { table: got, key: 0x52 } if got == table),
+            "unexpected shared-domain table-{table} error: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn duplicate_outer_module_keys_are_rejected_before_ambiguous_composition() {
+    let malformed = empty_modules_cache(&[("Dup", "InnerA"), ("Dup", "InnerB")]);
+    let mini = empty_module_cache("Added");
+
+    let guard_error = SequentialMiniGuard::new(&malformed)
+        .expect_err("Unreal's Modules TMap cannot represent duplicate outer keys");
+    assert!(
+        matches!(guard_error, SpliceError::InnerNameCollision(ref name) if name == "Dup"),
+        "unexpected guard error: {guard_error:?}"
+    );
+
+    let splice_error = splice(&malformed, &mini)
+        .expect_err("a low-level splice must not publish a duplicate-key Modules TMap");
+    assert!(
+        matches!(splice_error, SpliceError::InnerNameCollision(ref name) if name == "Dup"),
+        "unexpected splice error: {splice_error:?}"
+    );
+
+    let replace_error = replace_module(&malformed, &mini, "Dup")
+        .expect_err("replace must not silently choose the first duplicate target key");
+    assert!(
+        matches!(replace_error, SpliceError::AmbiguousTarget(ref name) if name == "Dup"),
+        "unexpected replace error: {replace_error:?}"
+    );
+
+    let corrected = empty_modules_cache(&[("OuterA", "InnerA"), ("OuterB", "InnerB")]);
+    SequentialMiniGuard::new(&corrected).expect("distinct outer and inner names remain valid");
+}
 
 #[test]
 fn splices_primitive_module_into_base() {

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -22,8 +22,8 @@ pub use dialog::DialogTopicSpec;
 
 pub type Files = BTreeMap<String, Vec<u8>>;
 
-// Bundle-side voice inputs are untrusted. Check the file length before allocating and retain a
-// bounded-reader check for files that grow after metadata is read. Keep this manifest limit in
+// Externally supplied voice inputs are not yet validated. Check the file length before allocating
+// and retain a bounded-reader check for files that grow after metadata is read. Keep this limit in
 // sync with the manager importer; Ogg payloads use gore-vo's public/default processing limit.
 const MAX_VOICE_MANIFEST_BYTES: u64 = 16 * 1024 * 1024;
 /// Hard deployment/build-wide cap for simultaneously resident source Ogg payloads. Rewritten ZIP
@@ -34,6 +34,7 @@ const MAX_BUNDLE_MANIFEST_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_DEPLOY_RECORD_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_AUDIO_WAV_BYTES: u64 = 512 * 1024 * 1024;
 const MAX_SCRIPT_MINI_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_SCRIPT_MINI_TOTAL_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 const MAX_TEXTURE_IMAGE_BYTES: u64 = 256 * 1024 * 1024;
 /// A loose game file is opaque bytes we never decode, so the cap only has to keep one bundle
 /// payload from exhausting the disk it is staged on. Nothing about the format is assumed.
@@ -2766,6 +2767,35 @@ pub(crate) fn read_safe_bundle_file(
     read_regular_file_limited(&canonical, label, max_bytes)
 }
 
+fn read_bundle_script_mini_phase(
+    bundle_root: &Path,
+    rel: &Path,
+    phase: &'static str,
+    used: &mut u64,
+) -> Result<Vec<u8>> {
+    let remaining = MAX_SCRIPT_MINI_TOTAL_BYTES
+        .checked_sub(*used)
+        .ok_or_else(|| {
+            ModError::Other(format!(
+                "{phase} already exceeds the {MAX_SCRIPT_MINI_TOTAL_BYTES}-byte cumulative limit"
+            ))
+        })?;
+    let mini = read_safe_bundle_file(
+        bundle_root,
+        rel,
+        phase,
+        MAX_SCRIPT_MINI_BYTES.min(remaining),
+    )?;
+    charge_script_phase_bytes(
+        phase,
+        used,
+        u64::try_from(mini.len()).unwrap_or(u64::MAX),
+        MAX_SCRIPT_MINI_BYTES,
+        MAX_SCRIPT_MINI_TOTAL_BYTES,
+    )?;
+    Ok(mini)
+}
+
 fn resolve_safe_bundle_file(bundle_root: &Path, rel: &Path, label: &str) -> Result<(PathBuf, u64)> {
     let rel_text = rel.to_string_lossy();
     if !is_safe_rel_path(&rel_text) {
@@ -3311,6 +3341,7 @@ fn update_content_hash(hash: &mut u64, bytes: &[u8]) {
 
 /// Hash a file with a fixed-size buffer. Voice archives can be many GiB, so drift checks must not
 /// materialize the live ZIP merely to compare it with the hash persisted in the deploy record.
+#[cfg(test)]
 fn content_hash_file(path: &Path) -> std::io::Result<String> {
     let mut remaining = u64::MAX;
     content_hash_file_bounded(path, &mut remaining)
@@ -3495,11 +3526,7 @@ pub(crate) fn tree_fingerprint_bounded(
     remaining_bytes: &mut u64,
     remaining_entries: &mut u64,
 ) -> Result<String> {
-    tree_fingerprint_with_prefix_bounded(
-        root,
-        None,
-        Some((remaining_bytes, remaining_entries)),
-    )
+    tree_fingerprint_with_prefix_bounded(root, None, Some((remaining_bytes, remaining_entries)))
 }
 
 fn tree_fingerprint_with_prefix(root: &Path, prefix: Option<&str>) -> Result<String> {
@@ -3983,9 +4010,10 @@ thread_local! {
 #[cfg(test)]
 fn probe_install_state(install_root: &Path) -> gore_as::compile::InstallCompileStateProbe {
     let running = STATED_GAME_PROCESS.with(|stated| stated.get());
-    gore_as::compile::probe_install_compile_state_with_stated_game_process(install_root, move || {
-        Ok(running)
-    })
+    gore_as::compile::probe_install_compile_state_with_stated_game_process(
+        install_root,
+        move || Ok(running),
+    )
 }
 
 /// States, for the rest of this test, that the game is running. Restores the previous answer on
@@ -4129,7 +4157,180 @@ struct PlannedIdentity {
 struct DiskWrite {
     live: PathBuf,
     candidate: tempfile::TempPath,
+    len: u64,
     hash: String,
+}
+
+impl DiskWrite {
+    /// Bind a disk-backed candidate to the exact length and SHA-256 that planning accepted. The
+    /// publication path rechecks this identity on its same-directory staged copy immediately before
+    /// promotion, so a mutable tempfile can never make the record describe different live bytes.
+    fn seal(live: PathBuf, candidate: tempfile::TempPath) -> Result<Self> {
+        let metadata = std::fs::symlink_metadata(&candidate).map_err(io(&format!(
+            "reading disk-backed candidate metadata for {}",
+            live.display()
+        )))?;
+        if metadata_is_link(&metadata) || !metadata.is_file() {
+            return Err(ModError::Other(format!(
+                "disk-backed candidate is not a regular non-link file for {}",
+                live.display()
+            )));
+        }
+        let len = metadata.len();
+        let hash = sha256_file(&candidate).map_err(|error| {
+            ModError::Other(format!(
+                "hashing disk-backed candidate for {}: {error}",
+                live.display()
+            ))
+        })?;
+        let after = std::fs::symlink_metadata(&candidate).map_err(io(&format!(
+            "re-reading disk-backed candidate metadata for {}",
+            live.display()
+        )))?;
+        if metadata_is_link(&after) || !after.is_file() || after.len() != len {
+            return Err(ModError::Other(format!(
+                "disk-backed candidate changed while being sealed for {}",
+                live.display()
+            )));
+        }
+        Ok(Self {
+            live,
+            candidate,
+            len,
+            hash,
+        })
+    }
+}
+
+/// One canonical mini retained between loadout planning and guarded composition. The random
+/// tempfile owns cleanup on every early return; length plus SHA-256 bind the exact generated bytes
+/// across the reopen needed after the large planning context has been dropped.
+#[derive(Debug)]
+pub(crate) struct SealedScriptMini {
+    candidate: tempfile::TempPath,
+    len: u64,
+    sha256: [u8; 32],
+}
+
+fn charge_script_phase_bytes(
+    phase: &'static str,
+    used: &mut u64,
+    added: u64,
+    max_file_bytes: u64,
+    max_total_bytes: u64,
+) -> Result<()> {
+    if added > max_file_bytes {
+        return Err(ModError::Other(format!(
+            "{phase} exceeds the {max_file_bytes}-byte per-mini limit: {added} bytes"
+        )));
+    }
+    let actual = used
+        .checked_add(added)
+        .ok_or_else(|| ModError::Other(format!("{phase} cumulative byte count overflowed")))?;
+    if actual > max_total_bytes {
+        return Err(ModError::Other(format!(
+            "{phase} exceeds the {max_total_bytes}-byte cumulative limit: {actual} bytes"
+        )));
+    }
+    *used = actual;
+    Ok(())
+}
+
+/// Persist one canonicalized mini without retaining its bytes in memory. `used` is a phase-local
+/// disk-output budget, deliberately separate from both source-read passes.
+pub(crate) fn seal_script_mini(
+    bytes: Vec<u8>,
+    max_file_bytes: u64,
+    used: &mut u64,
+    max_total_bytes: u64,
+) -> Result<SealedScriptMini> {
+    let len = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    charge_script_phase_bytes(
+        "canonical script mini output",
+        used,
+        len,
+        max_file_bytes,
+        max_total_bytes,
+    )?;
+    let sha256 = Sha256::digest(&bytes).into();
+    let mut candidate = tempfile::Builder::new()
+        .prefix(".gore-script-canonical-")
+        .tempfile()
+        .map_err(io("creating canonical script mini candidate"))?;
+    candidate
+        .write_all(&bytes)
+        .map_err(io("writing canonical script mini candidate"))?;
+    candidate
+        .as_file()
+        .sync_all()
+        .map_err(io("syncing canonical script mini candidate"))?;
+    Ok(SealedScriptMini {
+        candidate: candidate.into_temp_path(),
+        len,
+        sha256,
+    })
+}
+
+/// Reopen and verify a canonical mini after the loadout plan has been dropped. Allocation is based
+/// only on the previously sealed length, and the same verified `Vec` is passed to the guard.
+pub(crate) fn read_sealed_script_mini(
+    sealed: &SealedScriptMini,
+    max_file_bytes: u64,
+    used: &mut u64,
+    max_total_bytes: u64,
+) -> Result<Vec<u8>> {
+    if sealed.len > max_file_bytes {
+        return Err(ModError::Other(format!(
+            "canonical script mini exceeds the {max_file_bytes}-byte per-mini read limit: {} bytes",
+            sealed.len
+        )));
+    }
+    let projected = used.checked_add(sealed.len).ok_or_else(|| {
+        ModError::Other("canonical script mini read cumulative byte count overflowed".into())
+    })?;
+    if projected > max_total_bytes {
+        return Err(ModError::Other(format!(
+            "canonical script mini reads exceed the {max_total_bytes}-byte cumulative limit: {projected} bytes"
+        )));
+    }
+    let capacity = usize::try_from(sealed.len).map_err(|_| {
+        ModError::Other(format!(
+            "canonical script mini is too large for this platform: {} bytes",
+            sealed.len
+        ))
+    })?;
+    let file = std::fs::File::open(&sealed.candidate).map_err(io(&format!(
+        "opening canonical script mini candidate {}",
+        sealed.candidate.display()
+    )))?;
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(capacity).map_err(|error| {
+        ModError::Other(format!(
+            "canonical script mini cannot be buffered for guarded composition ({} bytes): {error}",
+            sealed.len
+        ))
+    })?;
+    file.take(sealed.len.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(io(&format!(
+            "reading canonical script mini candidate {}",
+            sealed.candidate.display()
+        )))?;
+    let observed = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    if observed != sealed.len {
+        return Err(ModError::Other(format!(
+            "canonical script mini candidate changed length: expected {}, read {observed}",
+            sealed.len
+        )));
+    }
+    let observed_sha256: [u8; 32] = Sha256::digest(&bytes).into();
+    if observed_sha256 != sealed.sha256 {
+        return Err(ModError::Other(
+            "canonical script mini candidate changed after planning".into(),
+        ));
+    }
+    *used = projected;
+    Ok(bytes)
 }
 
 impl DeployPlan {
@@ -4494,18 +4695,10 @@ pub(crate) fn prepare_voice_archive_writes(
         let (candidate, _) = archive
             .rewrite_edits_to_temp(archive_edits)
             .map_err(|e| ModError::Voice(format!("{}: {e}", live.display())))?;
-        let hash = content_hash_file(&candidate).map_err(io(&format!(
-            "hashing voice candidate for {}",
-            live.display()
-        )))?;
         if drifted {
             plan.refresh_baks.push(live.clone());
         }
-        plan.file_writes.push(DiskWrite {
-            live,
-            candidate,
-            hash,
-        });
+        plan.file_writes.push(DiskWrite::seal(live, candidate)?);
     }
     Ok(())
 }
@@ -5691,6 +5884,23 @@ fn prepare(
     gp: &GamePaths,
     prev: Option<&DeployRecord>,
 ) -> Result<DeployPlan> {
+    // Every AngelScript component materializes the same shipping ScriptCache. Reject a second one
+    // before opening either component's manifest or building any plan/temp state; otherwise each
+    // component would receive a fresh copy of the per-loadout resource envelope before the generic
+    // duplicate-destination gate rejects the finished deploy plan.
+    if manifest
+        .components
+        .iter()
+        .filter(|component| matches!(component, Component::AngelScriptPatch { .. }))
+        .take(2)
+        .count()
+        > 1
+    {
+        return Err(ModError::Other(format!(
+            "duplicate deploy target: {}",
+            gp.script_cache.display()
+        )));
+    }
     let mut plan = DeployPlan::default();
     let mut voice = PendingVoiceEdits::new();
     let mut voice_order = 0usize;
@@ -5699,7 +5909,7 @@ fn prepare(
     for (comp_idx, comp) in manifest.components.iter().enumerate() {
         match comp {
             Component::Ue4ssLua { name, path, .. } => {
-                // The manifest may come from an untrusted bundle: reject names/paths that could
+                // The manifest is externally supplied: reject names/paths that could
                 // escape the bundle source or the UE4SS Mods directory.
                 if !is_safe_mod_name(name) || !is_safe_rel_path(path) {
                     return Err(ModError::Other(format!(
@@ -5923,6 +6133,9 @@ fn prepare(
                         e.op, e.module
                     )));
                 }
+                if let Some(e) = entries.iter().find(|e| !is_safe_rel_path(&e.mini)) {
+                    return Err(ModError::Other(format!("unsafe mini path: {:?}", e.mini)));
+                }
                 let cache_path = gp.script_cache.clone();
                 if !cache_path.exists() {
                     return Err(ModError::Other(format!(
@@ -5935,40 +6148,93 @@ fn prepare(
                 if drifted {
                     plan.refresh_baks.push(cache_path.clone());
                 }
+                // Pass 1 inventories portable novel identities without retaining any mini bytes.
+                // The immutable union, rather than package/loadout order, determines every finite-
+                // domain pointer and engine-ID assignment.
+                let mut inspect_bytes = 0u64;
+                let mut loadout_builder =
+                    gore_as::cache::splice::LoadoutScriptIdPlanBuilder::new(&pristine)
+                        .map_err(|err| ModError::Other(format!("prepare script ID plan: {err}")))?;
+                for e in &entries {
+                    let mini = read_bundle_script_mini_phase(
+                        bundle_dir,
+                        Path::new(&e.mini),
+                        "script mini-cache inspection",
+                        &mut inspect_bytes,
+                    )?;
+                    loadout_builder.inspect(&mini).map_err(|err| {
+                        ModError::Other(format!("inspect script mini {}: {err}", e.module))
+                    })?;
+                }
+                let loadout_plan = loadout_builder
+                    .finish()
+                    .map_err(|err| ModError::Other(format!("finish script ID plan: {err}")))?;
+
+                // Pass 2 rereads the exact inspected source bytes. The core plan SHA-binds that
+                // reopen, then each canonical result is sealed in a private tempfile so the large
+                // plan/base context can be released before the guard builds its own base indexes.
+                let mut rewrite_source_bytes = 0u64;
+                let mut canonical_output_bytes = 0u64;
+                let mut canonical_minis = Vec::new();
+                canonical_minis
+                    .try_reserve_exact(entries.len())
+                    .map_err(|error| {
+                        ModError::Other(format!(
+                            "cannot reserve canonical script mini candidates: {error}"
+                        ))
+                    })?;
+                for e in &entries {
+                    let mini = read_bundle_script_mini_phase(
+                        bundle_dir,
+                        Path::new(&e.mini),
+                        "script mini-cache canonicalization",
+                        &mut rewrite_source_bytes,
+                    )?;
+                    let canonical = gore_as::cache::splice::remap_module_to_base_with_loadout_plan(
+                        &mini,
+                        &pristine,
+                        &loadout_plan,
+                    )
+                    .map_err(|err| {
+                        ModError::Other(format!("canonicalize script mini {}: {err}", e.module))
+                    })?;
+                    canonical_minis.push(seal_script_mini(
+                        canonical,
+                        MAX_SCRIPT_MINI_BYTES,
+                        &mut canonical_output_bytes,
+                        MAX_SCRIPT_MINI_TOTAL_BYTES,
+                    )?);
+                }
+                drop(loadout_plan);
+
+                // Pass 3 verifies each generated tempfile's length and SHA-256, then composes that
+                // exact Vec. Consuming the candidates releases their disk footprint incrementally.
                 let mut script_merge_guard =
                     gore_as::cache::splice::SequentialMiniGuard::new(&pristine).map_err(|err| {
                         ModError::Other(format!("prepare script composition: {err}"))
                     })?;
                 let mut running = pristine;
-                for e in &entries {
-                    if !is_safe_rel_path(&e.mini) {
-                        return Err(ModError::Other(format!("unsafe mini path: {:?}", e.mini)));
-                    }
-                    let mini = read_safe_bundle_file(
-                        bundle_dir,
-                        Path::new(&e.mini),
-                        "script mini-cache",
+                let mut canonical_read_bytes = 0u64;
+                for (e, sealed) in entries.iter().zip(canonical_minis) {
+                    let mini = read_sealed_script_mini(
+                        &sealed,
                         MAX_SCRIPT_MINI_BYTES,
+                        &mut canonical_read_bytes,
+                        MAX_SCRIPT_MINI_TOTAL_BYTES,
                     )?;
-                    if e.op != "add" && e.op != "edit" {
-                        return Err(ModError::Other(format!(
-                            "invalid script op {:?} for module {:?}",
-                            e.op, e.module
-                        )));
-                    }
-                    let prepared = script_merge_guard
-                        .check_and_record(&mini)
-                        .map_err(|err| ModError::Other(format!("compose {}: {err}", e.module)))?;
                     running = match e.op.as_str() {
-                        "add" => gore_as::cache::splice::splice_auto(&running, &prepared).map_err(
-                            |err| ModError::Other(format!("splice {}: {err}", e.module)),
-                        )?,
-                        "edit" => {
-                            gore_as::cache::splice::replace_module(&running, &prepared, &e.module)
+                        "add" => {
+                            script_merge_guard
+                                .compose_add(&running, &mini)
                                 .map_err(|err| {
-                                ModError::Other(format!("replace {}: {err}", e.module))
-                            })?
+                                    ModError::Other(format!("splice {}: {err}", e.module))
+                                })?
                         }
+                        "edit" => script_merge_guard
+                            .compose_edit(&running, &mini, &e.module)
+                            .map_err(|err| {
+                                ModError::Other(format!("replace {}: {err}", e.module))
+                            })?,
                         other => {
                             return Err(ModError::Other(format!(
                                 "invalid script op {other:?} for module {:?}",
@@ -6029,8 +6295,8 @@ fn prepare_file_component(
         MAX_BUNDLE_MANIFEST_BYTES,
     )?)?;
     for (game_path, payload_rel) in &map {
-        // The manifest may come from an untrusted bundle: re-ask the authoring-time question here
-        // rather than trusting that whoever wrote the bundle asked it.
+        // The manifest is externally supplied: re-ask the authoring-time question here because
+        // authoring-time validation is not a deployment-time proof.
         validate_loose_game_path(game_path)?;
         if !is_safe_rel_path(payload_rel) {
             return Err(ModError::Other(format!(
@@ -6068,17 +6334,13 @@ fn prepare_file_component(
         if select_pristine_source(&live, prev)?.drifted {
             plan.refresh_baks.push(live.clone());
         }
-        let (candidate, hash) = snapshot_bundle_payload(
+        let candidate = snapshot_bundle_payload(
             bundle_dir,
             payload_rel,
             "loose file payload",
             MAX_LOOSE_FILE_BYTES,
         )?;
-        plan.file_writes.push(DiskWrite {
-            live,
-            candidate,
-            hash,
-        });
+        plan.file_writes.push(DiskWrite::seal(live, candidate)?);
     }
     Ok(())
 }
@@ -6104,7 +6366,7 @@ fn snapshot_bundle_payload(
     rel: &str,
     label: &str,
     max_bytes: u64,
-) -> Result<(tempfile::TempPath, String)> {
+) -> Result<tempfile::TempPath> {
     let (canonical, len) = resolve_safe_bundle_file(bundle_dir, Path::new(rel), label)?;
     if len > max_bytes {
         return Err(ModError::Other(format!(
@@ -6133,9 +6395,7 @@ fn snapshot_bundle_payload(
         .as_file()
         .sync_all()
         .map_err(io(&format!("syncing {label} candidate")))?;
-    let candidate = candidate.into_temp_path();
-    let hash = content_hash_file(&candidate).map_err(io(&format!("hashing {label} candidate")))?;
-    Ok((candidate, hash))
+    Ok(candidate.into_temp_path())
 }
 
 /// Prepare ONE texture component: cook each PNG in the patch dir at `path` (bundle-relative)
@@ -6365,7 +6625,7 @@ fn prepare_pak_file_component(
                 None,
             );
             for (game_path, payload_rel) in &map {
-                // The manifest may come from an untrusted bundle: ask the same authoring question
+                // The manifest is externally supplied: ask the same authoring question
                 // the `files` section asks, against the same allowlist. One allowlist, one answer
                 // to "may a bundle claim this destination" — the mechanism does not widen it.
                 validate_loose_game_path(game_path)?;
@@ -6792,8 +7052,17 @@ fn apply_writes(plan: &DeployPlan, undo: &mut Undo) -> Result<()> {
                     write.live.display()
                 ))
             })?;
+        let (staged, parent) = stage_atomic_publish_copy(
+            &write.candidate,
+            &write.live,
+            Some((write.len, write.hash.as_str())),
+        )?;
+        publish_atomic_temp(staged, &write.live)?;
+        // Only a completed atomic promote turns the prepared identity into a published identity.
+        // In particular, a staged length/SHA failure must leave Undo at `None` so rollback and the
+        // recovery record never describe intended bytes as if they had reached the live path.
         file_undo.published_hash = Some(write.hash.clone());
-        atomic_publish_copy(&write.candidate, &write.live)?;
+        sync_parent_directory(&parent)?;
     }
     Ok(())
 }
@@ -7243,6 +7512,28 @@ fn same_path(a: &Path, b: &str) -> bool {
 /// and `retire_leftovers` — recognize logically-identical paths regardless of prefix/case.
 fn same_path_s(a: &str, b: &str) -> bool {
     same_path(Path::new(a), b)
+}
+
+/// Stable ordinal case-insensitive identity for a single Windows filename. Windows compares UTF-16
+/// units without expanding them, so map only a BMP scalar whose Unicode uppercase is exactly one
+/// BMP scalar. This keeps `ß` distinct from `SS` and supplementary-plane letters distinct from
+/// their Unicode uppercase, while Greek final sigma (`ς`) and sigma (`σ`) still share `Σ`.
+pub(crate) fn windows_file_name_key(value: &str) -> String {
+    let mut key = String::with_capacity(value.len());
+    for scalar in value.chars() {
+        if scalar.len_utf16() != 1 {
+            key.push(scalar);
+            continue;
+        }
+        let mut uppercase = scalar.to_uppercase();
+        let first = uppercase.next().unwrap_or(scalar);
+        key.push(if uppercase.next().is_none() && first.len_utf16() == 1 {
+            first
+        } else {
+            scalar
+        });
+    }
+    key
 }
 
 fn path_exists_no_follow(path: &Path) -> bool {
@@ -9083,13 +9374,31 @@ fn atomic_copy(source: &Path, destination: &Path) -> Result<()> {
             destination.display()
         )));
     }
-    atomic_publish_copy(source, destination)
+    atomic_publish_copy(source, destination, None)
 }
 
 /// Publish a disk-backed candidate to `destination` with fixed memory use. The source may live on
 /// another volume: it is first streamed into a verified unique sibling of the destination, then
 /// durably atomically promoted using the same platform-specific path as [`atomic_write`].
-fn atomic_publish_copy(source: &Path, destination: &Path) -> Result<()> {
+#[cfg(test)]
+fn atomic_publish_copy(
+    source: &Path,
+    destination: &Path,
+    expected: Option<(u64, &str)>,
+) -> Result<()> {
+    let (temp, parent) = stage_atomic_publish_copy(source, destination, expected)?;
+    publish_atomic_temp(temp, destination)?;
+    sync_parent_directory(&parent)
+}
+
+/// Stream one source into a same-directory sibling and authenticate that sibling immediately
+/// before its caller promotes it. Keeping promotion separate lets transactional callers mark Undo
+/// as published only after the atomic rename has actually succeeded.
+fn stage_atomic_publish_copy(
+    source: &Path,
+    destination: &Path,
+    expected: Option<(u64, &str)>,
+) -> Result<(tempfile::NamedTempFile, PathBuf)> {
     #[cfg(test)]
     if take_injected_atomic_write_failure(destination) {
         return Err(ModError::Other(format!(
@@ -9104,8 +9413,27 @@ fn atomic_publish_copy(source: &Path, destination: &Path) -> Result<()> {
         ))
     })?;
     let temp = verified_temp_copy_in(source, parent, ".gore-copy-stage-")?;
-    publish_atomic_temp(temp, destination)?;
-    sync_parent_directory(parent)
+    if let Some((expected_len, expected_hash)) = expected {
+        let staged_len = temp
+            .as_file()
+            .metadata()
+            .map_err(io("reading staged disk-write metadata"))?
+            .len();
+        if staged_len != expected_len {
+            return Err(ModError::Other(format!(
+                "disk-backed candidate length changed after planning for {}: expected {expected_len}, staged {staged_len}",
+                destination.display()
+            )));
+        }
+        let staged_hash = sha256_file(temp.path())?;
+        if staged_hash != expected_hash {
+            return Err(ModError::Other(format!(
+                "disk-backed candidate SHA-256 changed after planning for {}: expected {expected_hash}, staged {staged_hash}",
+                destination.display()
+            )));
+        }
+    }
+    Ok((temp, parent.to_path_buf()))
 }
 
 #[cfg(test)]
@@ -12687,10 +13015,11 @@ mod tests {
         let backup = bak_path(&live);
         assert_eq!(std::fs::read(&backup).unwrap(), pristine_zip);
         assert_eq!(first_record.deployed_hashes.len(), 1);
+        let live_hash = sha256_file(&live).unwrap();
         assert!(first_record
             .deployed_hashes
             .values()
-            .any(|hash| hash == &content_hash(&std::fs::read(&live).unwrap())));
+            .any(|hash| hash == &live_hash));
 
         // A missing archive is a hard prepare error. It must leave the active deployment and its
         // record byte-for-byte intact rather than silently producing a partial voice patch.
@@ -12790,6 +13119,383 @@ mod tests {
         assert_eq!(std::fs::read(&live).unwrap(), before_live);
         assert_eq!(std::fs::read(&backup).unwrap(), before_backup);
         assert!(!record_path(&game).exists());
+    }
+
+    fn test_script_cache_with_guid(module: &str, guid: [u8; 16]) -> Vec<u8> {
+        fn sia(value: &str) -> Vec<u8> {
+            if value.is_empty() {
+                return 0i32.to_le_bytes().to_vec();
+            }
+            let mut out = (value.len() as i32).to_le_bytes().to_vec();
+            out.extend_from_slice(value.as_bytes());
+            out.push(0);
+            out
+        }
+
+        fn fstring(value: &str) -> Vec<u8> {
+            let mut out = ((value.len() + 1) as i32).to_le_bytes().to_vec();
+            out.extend_from_slice(value.as_bytes());
+            out.push(0);
+            out
+        }
+
+        let mut out = guid.to_vec();
+        out.extend_from_slice(&gore_as::cache::header::CACHE_MAGIC.to_le_bytes());
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring(module));
+        out.extend_from_slice(&sia(module));
+        out.extend_from_slice(&[0u8; 5 * 4]); // functions/classes/enums/globals/imports
+        out.extend_from_slice(&0i64.to_le_bytes()); // code hash
+        out.extend_from_slice(&0i32.to_le_bytes()); // imported modules
+        out.extend_from_slice(&sia("")); // statics class
+        out.extend_from_slice(&[0u8; 2 * 4]); // events/delegates
+        out.extend_from_slice(&sia("")); // source path
+        out.extend_from_slice(&0i32.to_le_bytes()); // post-init functions
+        out.extend_from_slice(&[0u8; 7 * 4]); // empty global tail tables
+        out
+    }
+
+    fn test_script_cache_with_type(
+        module: &str,
+        guid: [u8; 16],
+        type_name: &str,
+        provisional_ptr: i64,
+        provisional_type_id: i32,
+    ) -> Vec<u8> {
+        fn sia(value: &str) -> Vec<u8> {
+            if value.is_empty() {
+                return 0i32.to_le_bytes().to_vec();
+            }
+            let mut out = (value.len() as i32).to_le_bytes().to_vec();
+            out.extend_from_slice(value.as_bytes());
+            out.push(0);
+            out
+        }
+
+        fn fstring(value: &str) -> Vec<u8> {
+            let mut out = ((value.len() + 1) as i32).to_le_bytes().to_vec();
+            out.extend_from_slice(value.as_bytes());
+            out.push(0);
+            out
+        }
+
+        let mut out = guid.to_vec();
+        out.extend_from_slice(&gore_as::cache::header::CACHE_MAGIC.to_le_bytes());
+        out.extend_from_slice(&1u32.to_le_bytes());
+        out.extend_from_slice(&fstring(module));
+        out.extend_from_slice(&sia(module));
+        out.extend_from_slice(&0i32.to_le_bytes()); // functions
+        out.extend_from_slice(&1i32.to_le_bytes()); // classes
+        out.extend_from_slice(&sia(type_name));
+        out.extend_from_slice(&sia("")); // namespace
+        out.extend_from_slice(&[0u8; 3 * 4]); // flags/properties/methods
+        out.extend_from_slice(&0i32.to_le_bytes()); // method table
+        out.extend_from_slice(&0i64.to_le_bytes()); // derived from
+        out.extend_from_slice(&0i64.to_le_bytes()); // shadow type
+        out.extend_from_slice(&[0u8; 2 * 4]); // constructors/factories
+        out.extend_from_slice(&7i32.to_le_bytes()); // fixed behavior slots
+        out.extend_from_slice(&[0u8; 7 * 8]);
+        out.extend_from_slice(&[0u8; 3 * 4]); // behavior funcs/types + no Unreal tail
+        out.extend_from_slice(&[0u8; 3 * 4]); // enums/globals/imports
+        out.extend_from_slice(&0i64.to_le_bytes()); // code hash
+        out.extend_from_slice(&0i32.to_le_bytes()); // imported modules
+        out.extend_from_slice(&sia("")); // statics class
+        out.extend_from_slice(&[0u8; 2 * 4]); // events/delegates
+        out.extend_from_slice(&sia("")); // source path
+        out.extend_from_slice(&0i32.to_le_bytes()); // post-init functions
+
+        out.extend_from_slice(&1u32.to_le_bytes()); // T1
+        out.extend_from_slice(&provisional_ptr.to_le_bytes());
+        out.extend_from_slice(&sia(type_name));
+        out.extend_from_slice(&sia(module));
+        out.extend_from_slice(&sia("")); // namespace
+        out.extend_from_slice(&0u32.to_le_bytes()); // subtypes
+        out.extend_from_slice(&1u32.to_le_bytes()); // T2
+        out.extend_from_slice(&provisional_type_id.to_le_bytes());
+        out.extend_from_slice(&provisional_ptr.to_le_bytes());
+        out.extend_from_slice(&[0u8; 5 * 4]); // T3..T7
+        out
+    }
+
+    fn test_type_id_assignments(bytes: &[u8]) -> BTreeMap<String, i32> {
+        use gore_as::cache::tables::parse_tail_tables;
+        use gore_as::cache::walk_modules::module_region_end;
+        use gore_as::cache::wire::Cursor;
+
+        let tail = parse_tail_tables(bytes, module_region_end(bytes).unwrap()).unwrap();
+        let type_names: BTreeMap<i64, String> = tail.tables[0]
+            .entry_starts
+            .iter()
+            .map(|&start| {
+                let mut cursor = Cursor::at(bytes, start);
+                let ptr = cursor.read_i64().unwrap();
+                let name = cursor.read_sia().unwrap();
+                (name, ptr)
+            })
+            .map(|(name, ptr)| (ptr, name))
+            .collect();
+        tail.tables[1]
+            .entry_starts
+            .iter()
+            .filter_map(|&start| {
+                let mut cursor = Cursor::at(bytes, start);
+                let id = cursor.read_i32().unwrap();
+                let ptr = cursor.read_i64().unwrap();
+                type_names.get(&ptr).cloned().map(|name| (name, id))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn direct_script_prepare_canonicalizes_colliding_minis_independently_of_order() {
+        fn run(reverse: bool) -> BTreeMap<String, i32> {
+            let dir = tempfile::tempdir().unwrap();
+            let game = dir.path().join("game");
+            let script_dir = game.join("G1R/Script");
+            std::fs::create_dir_all(&script_dir).unwrap();
+            let live = script_dir.join("PrecompiledScript_Shipping.Cache");
+            let guid = [0x31; 16];
+            std::fs::write(&live, test_script_cache_with_guid("_gore_base", guid)).unwrap();
+
+            let bundle = dir.path().join("bundle");
+            std::fs::create_dir_all(bundle.join("scripts")).unwrap();
+            const COLLIDING_TYPE_ID: i32 = 0x0B3F_6760;
+            std::fs::write(
+                bundle.join("scripts/a.cache"),
+                test_script_cache_with_type(
+                    "_gore_collision_14",
+                    guid,
+                    "CollisionType1901",
+                    0x6000_0000_4455_0001,
+                    COLLIDING_TYPE_ID,
+                ),
+            )
+            .unwrap();
+            std::fs::write(
+                bundle.join("scripts/b.cache"),
+                test_script_cache_with_type(
+                    "_gore_collision_7",
+                    guid,
+                    "CollisionType2149",
+                    0x6000_0000_4455_0002,
+                    COLLIDING_TYPE_ID,
+                ),
+            )
+            .unwrap();
+            let mut entries = vec![
+                ScriptEntry {
+                    op: "add".into(),
+                    module: "_gore_collision_14".into(),
+                    mini: "scripts/a.cache".into(),
+                },
+                ScriptEntry {
+                    op: "add".into(),
+                    module: "_gore_collision_7".into(),
+                    mini: "scripts/b.cache".into(),
+                },
+            ];
+            if reverse {
+                entries.reverse();
+            }
+            std::fs::write(
+                bundle.join("scripts/manifest.json"),
+                serde_json::to_vec(&entries).unwrap(),
+            )
+            .unwrap();
+            let manifest = ModManifest {
+                format: 1,
+                mod_meta: ModMeta {
+                    name: "CanonicalScriptLoadout".into(),
+                    version: "1".into(),
+                    author: "offline-test".into(),
+                },
+                components: vec![Component::AngelScriptPatch {
+                    path: "scripts".into(),
+                }],
+            };
+
+            let plan = prepare(&bundle, &manifest, &resolve_game_paths(&game), None).unwrap();
+            let (_, output) = plan
+                .writes
+                .iter()
+                .find(|(path, _)| path == &live)
+                .expect("direct prepare emits the composed script cache");
+            let module_names = gore_as::cache::walk_modules::module_names(output).unwrap();
+            let expected = if reverse {
+                vec!["_gore_base", "_gore_collision_7", "_gore_collision_14"]
+            } else {
+                vec!["_gore_base", "_gore_collision_14", "_gore_collision_7"]
+            };
+            assert_eq!(module_names, expected);
+            let assignments = test_type_id_assignments(output);
+            assert_ne!(
+                assignments["CollisionType1901"], assignments["CollisionType2149"],
+                "colliding provisional T2 IDs need distinct final assignments"
+            );
+            assignments
+        }
+
+        assert_eq!(
+            run(false),
+            run(true),
+            "direct bundle order must not change portable-identity assignments"
+        );
+    }
+
+    #[test]
+    fn sealed_script_mini_rejects_same_length_temp_mutation_and_cleans_up() {
+        let original = b"canonical mini bytes".to_vec();
+        let mut output_bytes = 0u64;
+        let sealed = seal_script_mini(original, 1024, &mut output_bytes, 1024).unwrap();
+        assert_eq!(output_bytes, sealed.len);
+        let path = sealed.candidate.to_path_buf();
+        std::fs::write(&path, b"tampered!!mini bytes").unwrap();
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), sealed.len);
+
+        let mut read_bytes = 0u64;
+        let error = read_sealed_script_mini(&sealed, 1024, &mut read_bytes, 1024)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("changed after planning"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(read_bytes, 0, "a rejected reopen must not commit budget");
+        drop(sealed);
+        assert!(!path.exists(), "TempPath drop must remove the candidate");
+    }
+
+    #[test]
+    fn script_phase_budgets_are_independent_and_checked_before_temp_io() {
+        let mut inspect_bytes = 0u64;
+        let mut rewrite_bytes = 0u64;
+        charge_script_phase_bytes("inspect", &mut inspect_bytes, 4, 4, 4).unwrap();
+        charge_script_phase_bytes("rewrite", &mut rewrite_bytes, 4, 4, 4).unwrap();
+        assert_eq!((inspect_bytes, rewrite_bytes), (4, 4));
+
+        let error = charge_script_phase_bytes("rewrite", &mut rewrite_bytes, 1, 4, 4)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("cumulative limit"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(rewrite_bytes, 4, "failed charge must not change its phase");
+
+        let mut output_bytes = 0u64;
+        let error = seal_script_mini(vec![0; 5], 4, &mut output_bytes, 4)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("per-mini limit"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            output_bytes, 0,
+            "oversized output must fail before tempfile I/O"
+        );
+    }
+
+    #[test]
+    fn deploy_rejects_a_script_mini_from_another_cache_before_game_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let game = dir.path().join("game");
+        let script_dir = game.join("G1R/Script");
+        std::fs::create_dir_all(&script_dir).unwrap();
+        let live = script_dir.join("PrecompiledScript_Shipping.Cache");
+        let base = test_script_cache_with_guid("_gore_base", [0x11; 16]);
+        std::fs::write(&live, &base).unwrap();
+
+        let bundle = dir.path().join("bundle");
+        std::fs::create_dir_all(bundle.join("scripts")).unwrap();
+        let mini_rel = "scripts/0_Stale.cache";
+        std::fs::write(
+            bundle.join(mini_rel),
+            test_script_cache_with_guid("Stale", [0x22; 16]),
+        )
+        .unwrap();
+        std::fs::write(
+            bundle.join("scripts/manifest.json"),
+            serde_json::to_vec(&vec![ScriptEntry {
+                op: "add".into(),
+                module: "Stale".into(),
+                mini: mini_rel.into(),
+            }])
+            .unwrap(),
+        )
+        .unwrap();
+        let manifest = ModManifest {
+            format: 1,
+            mod_meta: ModMeta {
+                name: "StaleScriptMini".into(),
+                version: "1".into(),
+                author: "offline-test".into(),
+            },
+            components: vec![Component::AngelScriptPatch {
+                path: "scripts".into(),
+            }],
+        };
+        std::fs::write(
+            bundle.join("gore-mod.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        let before_tree = tree_fingerprint(&game).unwrap();
+
+        let error = deploy(&bundle, &game).unwrap_err().to_string();
+        assert!(
+            error.contains("does not match target base GUID")
+                && error.contains("remap the module against this exact game cache"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(std::fs::read(&live).unwrap(), base);
+        assert!(!bak_path(&live).exists());
+        assert!(!record_path(&game).exists());
+        assert!(!game.join(".gore-install-mutation.lock").exists());
+        assert_eq!(tree_fingerprint(&game).unwrap(), before_tree);
+    }
+
+    /// Multiple AngelScript components share one ScriptCache destination and must be rejected
+    /// before either component payload is opened or any per-loadout planning work begins.
+    #[test]
+    fn prepare_rejects_multiple_script_components_before_payload_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = dir.path().join("bundle");
+        std::fs::create_dir_all(&bundle).unwrap();
+        let game = dir.path().join("game");
+        let gp = resolve_game_paths(&game);
+        let manifest = ModManifest {
+            format: 1,
+            mod_meta: ModMeta {
+                name: "DuplicateScripts".into(),
+                version: "1".into(),
+                author: "offline-test".into(),
+            },
+            components: vec![
+                Component::AngelScriptPatch {
+                    path: "missing-first".into(),
+                },
+                Component::AngelScriptPatch {
+                    path: "missing-second".into(),
+                },
+            ],
+        };
+
+        let error = prepare(&bundle, &manifest, &gp, None)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            error.contains("duplicate deploy target:")
+                && error.contains(&gp.script_cache.display().to_string()),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !error.contains("script manifest"),
+            "component payload was opened before duplicate rejection: {error}"
+        );
+        assert!(!bundle.join("missing-first").exists());
+        assert!(!bundle.join("missing-second").exists());
     }
 
     /// prepare() must reject a manifest whose op is neither add nor edit, naming the module.
@@ -13882,6 +14588,84 @@ mod tests {
             }
         }
         prepare_target_identities(plan, Some(&prior)).unwrap();
+    }
+
+    #[test]
+    fn commit_rejects_same_length_disk_candidate_mutation_without_game_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let game = dir.path().join("game");
+        let live = game.join("G1R/Content/mutable.bin");
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"pristine").unwrap();
+
+        let mut candidate = ::tempfile::NamedTempFile::new().unwrap();
+        candidate.write_all(b"prepared").unwrap();
+        candidate.as_file().sync_all().unwrap();
+        let write = DiskWrite::seal(live.clone(), candidate.into_temp_path()).unwrap();
+        let candidate_path = write.candidate.to_path_buf();
+        assert_eq!(std::fs::metadata(&candidate_path).unwrap().len(), write.len);
+        assert!(write.hash.starts_with("sha256:"));
+
+        // Same length defeats size-only validation; only the prepared SHA-256 can catch this.
+        std::fs::write(&candidate_path, b"tampered").unwrap();
+        assert_eq!(std::fs::metadata(&candidate_path).unwrap().len(), write.len);
+        let plan = DeployPlan {
+            file_writes: vec![write],
+            ..Default::default()
+        };
+
+        let mut apply_undo = Undo::default();
+        apply_undo.files.push(LiveFileUndo {
+            live: live.clone(),
+            snapshot: verified_temp_copy(&live, ".gore-test-undo-")
+                .unwrap()
+                .into_temp_path(),
+            published_hash: None,
+            backup: None,
+        });
+        let direct_error = apply_writes(&plan, &mut apply_undo)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            direct_error.contains("disk-backed candidate SHA-256 changed after planning"),
+            "unexpected error: {direct_error}"
+        );
+        assert_eq!(
+            apply_undo.files[0].published_hash, None,
+            "a failed staged verification must not claim intended bytes were published"
+        );
+        assert_eq!(std::fs::read(&live).unwrap(), b"pristine");
+        drop(apply_undo);
+
+        let error = commit_plan(
+            &resolve_game_paths(&game),
+            &game,
+            plan,
+            DeployRecord {
+                owner: "manager".into(),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("disk-backed candidate SHA-256 changed after planning"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(std::fs::read(&live).unwrap(), b"pristine");
+        assert!(
+            !bak_path(&live).exists(),
+            "failed commit must remove its backup"
+        );
+        assert!(
+            !record_path(&game).exists(),
+            "failed commit must restore the absent prior record"
+        );
+        assert!(
+            !candidate_path.exists(),
+            "the rejected prepared candidate remains TempPath-owned"
+        );
     }
 
     fn ue4ss_transaction_dirs(root: &Path) -> Vec<PathBuf> {
@@ -15656,6 +16440,24 @@ mod tests {
             "unexpected error: {error}"
         );
         assert!(original.exists());
+    }
+
+    #[test]
+    fn windows_filename_identity_collapses_unicode_case_aliases() {
+        assert_eq!(
+            windows_file_name_key("Voice\u{03c2}.bank"),
+            windows_file_name_key("voice\u{03c3}.BANK")
+        );
+        assert_ne!(
+            windows_file_name_key("Voiceß.bank"),
+            windows_file_name_key("VoiceSS.bank"),
+            "Windows ordinal comparison must not apply Unicode multi-scalar expansions"
+        );
+        assert_ne!(
+            windows_file_name_key("Voice\u{10428}.bank"),
+            windows_file_name_key("Voice\u{10400}.bank"),
+            "Windows ordinal comparison must not case-fold UTF-16 surrogate pairs"
+        );
     }
 
     #[cfg(windows)]

--- a/crates/gore-mod/src/mgr/analyze.rs
+++ b/crates/gore-mod/src/mgr/analyze.rs
@@ -3,8 +3,10 @@
 //! [`analyze`] folds the enabled mods' component footprints into per-namespace buckets and
 //! reports every target claimed by two or more distinct mods. Opaque UE4SS components retain
 //! their known targets and also produce a conservative unknown-footprint advisory when another
-//! relevant UE4SS mod is enabled. It never touches the filesystem — everything comes from
-//! library metadata plus the loadout — so callers can re-run it on every reorder/toggle.
+//! relevant UE4SS mod is enabled. Compatible raw-base + patch layering is likewise an advisory,
+//! because neither participant wins the composed file. It never touches the filesystem —
+//! everything comes from library metadata plus the loadout — so callers can re-run it on every
+//! reorder/toggle.
 //!
 //! Ordering contract: [`Conflict::mods`] follows loadout (mount) order. For `Soft`/`Hard`
 //! conflicts the LAST id is the later-wins winner; `Info` advisories intentionally have no winner.
@@ -23,7 +25,7 @@ pub struct Conflict {
     pub kind: ConflictKind,
     pub target: String,
     /// Involved library mod ids in loadout order. The LAST one wins for `Soft`/`Hard`; `Info`
-    /// advisories describe uncertainty and have no winner.
+    /// advisories have no winner.
     pub mods: Vec<String>,
     pub severity: Severity,
 }
@@ -47,7 +49,8 @@ pub enum ConflictKind {
     ScriptModule,
     /// Voice ZIP member edit, target `"<archive>|<member path>"` (case-insensitive later-wins).
     VoiceArchive,
-    /// Wholesale live-file replacement (`"lcache"` / `"bank:<name>"` / `"script_cache"`).
+    /// Wholesale live-file replacement, including its base+patch composition advisory
+    /// (`"lcache"` / `"bank:<name>"` / `"script_cache"`).
     RawFile,
     /// One game-root-relative file claimed by two mods, target = that path (case-insensitive,
     /// forward slashes). Both routes to it live here: an in-place `files` replacement, and a pak
@@ -63,14 +66,16 @@ pub enum Severity {
     Soft,
     /// The earlier mod's whole component is clobbered or the two cannot coexist.
     Hard,
-    /// Advisory about an unknown footprint, not a proven later-wins clash.
+    /// Advisory without a later-wins winner (for example an unknown footprint or compatible
+    /// raw-base + patch composition).
     Info,
 }
 
 /// Report every target claimed by two or more distinct enabled mods, plus an `Info` advisory when
-/// an opaque UE4SS footprint can interact with another relevant UE4SS mod. `mods` is the library
-/// in any order; only loadout entries with `enabled == true` participate, in loadout order (which
-/// also orders [`Conflict::mods`]). Output is sorted by `(kind, target)` with mod ids deduped.
+/// an opaque UE4SS footprint can interact with another relevant UE4SS mod or when a raw base and a
+/// compatible patch compose without either mod winning the whole file. `mods` is the library in
+/// any order; only loadout entries with `enabled == true` participate, in loadout order (which also
+/// orders [`Conflict::mods`]). Output is sorted by `(kind, target)` with mod ids deduped.
 pub fn analyze(mods: &[&ModEntryMeta], loadout: &Loadout) -> Vec<Conflict> {
     let enabled = enabled_in_order(mods, loadout);
     let mut buckets: BTreeMap<(ConflictKind, String), (Severity, Vec<String>)> = BTreeMap::new();
@@ -78,6 +83,10 @@ pub fn analyze(mods: &[&ModEntryMeta], loadout: &Loadout) -> Vec<Conflict> {
     // not of either claimant: `note`'s take-the-worse rule cannot express "these two are only soft
     // because both arrive through the pak filesystem".
     let mut loose: BTreeMap<String, LooseClaims> = BTreeMap::new();
+    // Audio bank identity follows Windows filename semantics, while sample identity stays exact.
+    // Keep it separate from generic buckets so the displayed target can retain the last claimant's
+    // real spelling instead of exposing the normalized key.
+    let mut audio: BTreeMap<(String, Option<String>), AudioClaims> = BTreeMap::new();
 
     for m in &enabled {
         for c in &m.components {
@@ -95,13 +104,10 @@ pub fn analyze(mods: &[&ModEntryMeta], loadout: &Loadout) -> Vec<Conflict> {
                 }
                 ComponentInfo::AudioPatch { targets, .. } => {
                     for t in targets {
-                        note(
-                            &mut buckets,
-                            ConflictKind::Audio,
-                            t.clone(),
-                            Severity::Soft,
-                            &m.id,
-                        );
+                        audio
+                            .entry(audio_target_identity(t))
+                            .or_default()
+                            .claim(t, &m.id);
                     }
                 }
                 // Texture patches and foreign triplets both mount cooked packages, so their
@@ -188,37 +194,68 @@ pub fn analyze(mods: &[&ModEntryMeta], loadout: &Loadout) -> Vec<Conflict> {
             buckets.insert((ConflictKind::LooseFile, target), (severity, claims.ids));
         }
     }
+    for (_identity, claims) in audio {
+        if claims.ids.len() >= 2 {
+            buckets.insert(
+                (ConflictKind::Audio, claims.target),
+                (Severity::Soft, claims.ids),
+            );
+        }
+    }
 
-    // Raw-file keys: a wholesale replacement clashes with other raw files of the same key AND
-    // with any other mod patching that same live file (a raw .lcache steamrolls a loc patch even
-    // though no second raw file exists). Patch-only overlaps stay in their own namespaces above,
-    // and a mod combining a raw file with its own patches does not conflict with itself.
-    let mut raw_targets: Vec<RawTarget> = Vec::new();
+    // Raw-file keys have two distinct relations which must not be collapsed into one winner chain:
+    // raw-vs-raw is a whole-base replacement where the later raw wins, while raw-vs-patch is
+    // compatible composition — apply always lays every loc/audio/script patch over the winning raw
+    // base, independent of their relative loadout positions. Emit a Hard row containing only raw
+    // claimants and a separate Info advisory for cross-mod base+patch composition. Patch-only
+    // overlaps stay in their own namespaces above, and one mod composing its own base and patch is
+    // not a conflict.
+    // Windows resolves bank names case-insensitively. Key by that file identity, but retain the
+    // actual spelling from the last raw claimant so the Hard winner row describes its target.
+    let mut raw_targets: BTreeMap<String, RawTarget> = BTreeMap::new();
     for m in &enabled {
         for c in &m.components {
             if let ComponentInfo::RawFile { target_file, .. } = c {
-                if !raw_targets.contains(target_file) {
-                    raw_targets.push(target_file.clone());
-                }
+                raw_targets.insert(raw_identity(target_file), target_file.clone());
             }
         }
     }
-    for rt in &raw_targets {
-        let members: Vec<&str> = enabled
+    let mut raw_conflicts = Vec::new();
+    for rt in raw_targets.values() {
+        let raw_members: Vec<String> = enabled
             .iter()
-            .filter(|m| touches_raw(m, rt))
-            .map(|m| m.id.as_str())
+            .filter(|m| replaces_raw(m, rt))
+            .map(|m| m.id.clone())
             .collect();
-        if members.len() >= 2 {
-            for id in members {
-                note(
-                    &mut buckets,
-                    ConflictKind::RawFile,
-                    raw_key(rt),
-                    Severity::Hard,
-                    id,
-                );
-            }
+        if raw_members.len() >= 2 {
+            raw_conflicts.push(Conflict {
+                kind: ConflictKind::RawFile,
+                target: raw_key(rt),
+                mods: raw_members.clone(),
+                severity: Severity::Hard,
+            });
+        }
+
+        let patch_members: Vec<String> = enabled
+            .iter()
+            .filter(|m| patches_raw(m, rt))
+            .map(|m| m.id.clone())
+            .collect();
+        let has_cross_mod_composition = raw_members
+            .iter()
+            .any(|raw_id| patch_members.iter().any(|patch_id| patch_id != raw_id));
+        if has_cross_mod_composition {
+            let members = enabled
+                .iter()
+                .filter(|m| replaces_raw(m, rt) || patches_raw(m, rt))
+                .map(|m| m.id.clone())
+                .collect();
+            raw_conflicts.push(Conflict {
+                kind: ConflictKind::RawFile,
+                target: raw_key(rt),
+                mods: members,
+                severity: Severity::Info,
+            });
         }
     }
 
@@ -254,7 +291,7 @@ pub fn analyze(mods: &[&ModEntryMeta], loadout: &Loadout) -> Vec<Conflict> {
         }
     }
 
-    buckets
+    let mut conflicts: Vec<Conflict> = buckets
         .into_iter()
         .filter(|(_, (severity, ids))| ids.len() >= 2 || *severity == Severity::Info)
         .map(|((kind, target), (severity, mods))| Conflict {
@@ -263,7 +300,18 @@ pub fn analyze(mods: &[&ModEntryMeta], loadout: &Loadout) -> Vec<Conflict> {
             mods,
             severity,
         })
-        .collect()
+        .collect();
+    conflicts.extend(raw_conflicts);
+    conflicts.sort_by(|left, right| {
+        left.kind
+            .cmp(&right.kind)
+            .then_with(|| left.target.cmp(&right.target))
+            // One target may have both a proven raw-vs-raw winner and a no-winner composition
+            // advisory. Keep the actionable row first and make equal-target order explicit.
+            .then_with(|| rank(right.severity).cmp(&rank(left.severity)))
+            .then_with(|| left.mods.cmp(&right.mods))
+    });
+    conflicts
 }
 
 /// Every mod claiming one game-root-relative file, and by which route each of them claims it.
@@ -276,6 +324,23 @@ struct LooseClaims {
     /// Claimant ids in loadout order, first-seen, deduped. A mod reaching this path by BOTH routes
     /// appears once here and in both route lists.
     ids: Vec<String>,
+}
+
+#[derive(Default)]
+struct AudioClaims {
+    /// Most recently encountered effective spelling of `bank|sample`.
+    target: String,
+    /// Distinct claimant ids in loadout order.
+    ids: Vec<String>,
+}
+
+impl AudioClaims {
+    fn claim(&mut self, target: &str, id: &str) {
+        self.target = target.to_string();
+        if !self.ids.iter().any(|existing| existing == id) {
+            self.ids.push(id.to_string());
+        }
+    }
 }
 
 impl LooseClaims {
@@ -387,16 +452,44 @@ fn raw_key(t: &RawTarget) -> String {
     }
 }
 
-/// Does `m` touch the live file `raw` replaces — either replacing it itself, or patching it
-/// (loc patch ↔ lcache, audio patch of the same bank ↔ that bank, AS patch ↔ script cache)?
-fn touches_raw(m: &ModEntryMeta, raw: &RawTarget) -> bool {
+/// Audio collision identity: Windows-case-insensitive bank filename plus the unchanged sample.
+/// A malformed legacy target without `|` retains its former exact-string behavior.
+fn audio_target_identity(target: &str) -> (String, Option<String>) {
+    match target.split_once('|') {
+        Some((bank, sample)) => (crate::windows_file_name_key(bank), Some(sample.to_string())),
+        None => (target.to_string(), None),
+    }
+}
+
+/// Case-insensitive Windows file identity used to join raw-bank claimants and audio patches.
+fn raw_identity(t: &RawTarget) -> String {
+    match t {
+        RawTarget::Lcache => "lcache".into(),
+        RawTarget::Bank { name } => format!("bank:{}", crate::windows_file_name_key(name)),
+        RawTarget::ScriptCache => "script_cache".into(),
+    }
+}
+
+fn replaces_raw(m: &ModEntryMeta, raw: &RawTarget) -> bool {
+    m.components.iter().any(|component| {
+        matches!(component, ComponentInfo::RawFile { target_file, .. }
+            if raw_identity(target_file) == raw_identity(raw))
+    })
+}
+
+/// Does `m` patch the live file whose base `raw` replaces (loc ↔ lcache, audio of the same bank ↔
+/// that bank, AngelScript ↔ script cache)?
+fn patches_raw(m: &ModEntryMeta, raw: &RawTarget) -> bool {
     m.components.iter().any(|c| match (c, raw) {
-        (ComponentInfo::RawFile { target_file, .. }, _) => target_file == raw,
         (ComponentInfo::LocPatch { .. }, RawTarget::Lcache) => true,
         (ComponentInfo::AngelScriptPatch { .. }, RawTarget::ScriptCache) => true,
         (ComponentInfo::AudioPatch { targets, .. }, RawTarget::Bank { name }) => {
-            let prefix = format!("{name}|");
-            targets.iter().any(|t| t.starts_with(&prefix))
+            let folded_name = crate::windows_file_name_key(name);
+            targets.iter().any(|target| {
+                target.split_once('|').is_some_and(|(bank, _sample)| {
+                    crate::windows_file_name_key(bank) == folded_name
+                })
+            })
         }
         _ => false,
     })
@@ -685,16 +778,81 @@ mod tests {
     #[test]
     fn audio_overlap() {
         let a = meta("mod-a", vec![audio(&["SFX.bank|whoosh", "SFX.bank|clang"])]);
-        let b = meta("mod-b", vec![audio(&["SFX.bank|whoosh"])]);
-        let out = analyze(&[&a, &b], &loadout_of(&[("mod-a", true), ("mod-b", true)]));
-        assert_eq!(
-            out,
-            vec![conflict(
-                ConflictKind::Audio,
+        let b = meta("mod-b", vec![audio(&["sfx.BANK|whoosh"])]);
+        for (entries, expected_mods, expected_target) in [
+            (
+                [("mod-a", true), ("mod-b", true)],
+                ["mod-a", "mod-b"],
+                "sfx.BANK|whoosh",
+            ),
+            (
+                [("mod-b", true), ("mod-a", true)],
+                ["mod-b", "mod-a"],
                 "SFX.bank|whoosh",
-                &["mod-a", "mod-b"],
-                Severity::Soft
-            )]
+            ),
+        ] {
+            assert_eq!(
+                analyze(&[&a, &b], &loadout_of(&entries)),
+                vec![conflict(
+                    ConflictKind::Audio,
+                    expected_target,
+                    &expected_mods,
+                    Severity::Soft
+                )]
+            );
+        }
+
+        let sample_case_variant = meta("mod-c", vec![audio(&["sfx.BANK|WHOOSH"])]);
+        assert!(
+            analyze(
+                &[&a, &sample_case_variant],
+                &loadout_of(&[("mod-a", true), ("mod-c", true)])
+            )
+            .is_empty(),
+            "sample identity must retain its existing case-sensitive semantics"
+        );
+    }
+
+    #[test]
+    fn bank_identity_does_not_expand_sharp_s_into_ss() {
+        let sharp_audio = meta("audio-sharp", vec![audio(&["Voiceß.bank|shout"])]);
+        let ss_audio = meta("audio-ss", vec![audio(&["VoiceSS.bank|shout"])]);
+        assert!(
+            analyze(
+                &[&sharp_audio, &ss_audio],
+                &loadout_of(&[("audio-sharp", true), ("audio-ss", true)])
+            )
+            .is_empty(),
+            "distinct audio banks must not be reported as one patch target"
+        );
+
+        let sharp_raw = meta(
+            "raw-sharp",
+            vec![raw(RawTarget::Bank {
+                name: "Voiceß.bank".into(),
+            })],
+        );
+        let ss_raw = meta(
+            "raw-ss",
+            vec![raw(RawTarget::Bank {
+                name: "VoiceSS.bank".into(),
+            })],
+        );
+        assert!(
+            analyze(
+                &[&sharp_raw, &ss_raw],
+                &loadout_of(&[("raw-sharp", true), ("raw-ss", true)])
+            )
+            .is_empty(),
+            "distinct raw banks must not be reported as later-wins replacements"
+        );
+        assert!(
+            analyze(
+                &[&sharp_raw, &ss_audio],
+                &loadout_of(&[("raw-sharp", true), ("audio-ss", true)])
+            )
+            .is_empty(),
+            "a raw bank must compose only with audio patches for the same Windows filename"
         );
     }
 
@@ -768,21 +926,47 @@ mod tests {
         );
     }
 
-    /// A wholesale .lcache replacement clobbers ANY other mod's loc patch — hard conflict even
-    /// though no second raw file is present.
+    /// Raw replacements are bases, and compatible patches always compose on top regardless of
+    /// which participant is later. Cover every raw-backed patch family in both loadout orders.
     #[test]
-    fn rawfile_lcache_vs_loc_patch_hard() {
-        let a = meta("mod-a", vec![raw(RawTarget::Lcache)]);
-        let b = meta("mod-b", vec![loc(&["itfo_cheese|german"])]);
-        let out = analyze(&[&a, &b], &loadout_of(&[("mod-a", true), ("mod-b", true)]));
-        assert_eq!(
-            out,
-            vec![conflict(
-                ConflictKind::RawFile,
-                "lcache",
-                &["mod-a", "mod-b"],
-                Severity::Hard
-            )]
+    fn rawfile_patch_pairs_are_no_winner_composition_advisories() {
+        fn assert_pair(raw_target: RawTarget, patch: ComponentInfo, target: &str) {
+            let raw_mod = meta("mod-raw", vec![raw(raw_target)]);
+            let patch_mod = meta("mod-patch", vec![patch]);
+            for (entries, expected_mods) in [
+                (
+                    [("mod-raw", true), ("mod-patch", true)],
+                    ["mod-raw", "mod-patch"],
+                ),
+                (
+                    [("mod-patch", true), ("mod-raw", true)],
+                    ["mod-patch", "mod-raw"],
+                ),
+            ] {
+                assert_eq!(
+                    analyze(&[&raw_mod, &patch_mod], &loadout_of(&entries)),
+                    vec![conflict(
+                        ConflictKind::RawFile,
+                        target,
+                        &expected_mods,
+                        Severity::Info,
+                    )]
+                );
+            }
+        }
+
+        assert_pair(RawTarget::Lcache, loc(&["itfo_cheese|german"]), "lcache");
+        assert_pair(
+            RawTarget::Bank {
+                name: "SFX.bank".into(),
+            },
+            audio(&["sfx.BANK|whoosh"]),
+            "bank:SFX.bank",
+        );
+        assert_pair(
+            RawTarget::ScriptCache,
+            as_patch(&["CombatTweaks"]),
+            "script_cache",
         );
     }
 
@@ -790,50 +974,105 @@ mod tests {
     fn rawfile_vs_rawfile_hard() {
         let a = meta("mod-a", vec![raw(RawTarget::Lcache)]);
         let b = meta("mod-b", vec![raw(RawTarget::Lcache)]);
-        let out = analyze(&[&a, &b], &loadout_of(&[("mod-a", true), ("mod-b", true)]));
-        assert_eq!(
-            out,
-            vec![conflict(
-                ConflictKind::RawFile,
-                "lcache",
-                &["mod-a", "mod-b"],
-                Severity::Hard
-            )]
-        );
+        for (entries, expected_mods) in [
+            ([("mod-a", true), ("mod-b", true)], ["mod-a", "mod-b"]),
+            ([("mod-b", true), ("mod-a", true)], ["mod-b", "mod-a"]),
+        ] {
+            assert_eq!(
+                analyze(&[&a, &b], &loadout_of(&entries)),
+                vec![conflict(
+                    ConflictKind::RawFile,
+                    "lcache",
+                    &expected_mods,
+                    Severity::Hard,
+                )]
+            );
+        }
     }
 
-    /// A raw bank replacement only clashes with audio patches of the SAME bank (targets with a
-    /// `"<name>|"` prefix), not with patches of other banks.
     #[test]
-    fn rawfile_bank_only_conflicts_same_bank_name() {
+    fn rawfile_bank_case_variants_share_windows_identity_and_keep_winner_spelling() {
+        let a = meta(
+            "mod-a",
+            vec![raw(RawTarget::Bank {
+                name: "Voice.bank".into(),
+            })],
+        );
+        let b = meta(
+            "mod-b",
+            vec![raw(RawTarget::Bank {
+                name: "voice.BANK".into(),
+            })],
+        );
+
+        for (entries, expected_mods, expected_target) in [
+            (
+                [("mod-a", true), ("mod-b", true)],
+                ["mod-a", "mod-b"],
+                "bank:voice.BANK",
+            ),
+            (
+                [("mod-b", true), ("mod-a", true)],
+                ["mod-b", "mod-a"],
+                "bank:Voice.bank",
+            ),
+        ] {
+            assert_eq!(
+                analyze(&[&a, &b], &loadout_of(&entries)),
+                vec![conflict(
+                    ConflictKind::RawFile,
+                    expected_target,
+                    &expected_mods,
+                    Severity::Hard,
+                )]
+            );
+        }
+    }
+
+    /// A raw bank only composes with audio patches of the SAME bank (`"<name>|"` prefix).
+    #[test]
+    fn rawfile_bank_ignores_other_bank_patch() {
         let rawm = meta(
             "mod-raw",
             vec![raw(RawTarget::Bank {
                 name: "SFX.bank".into(),
             })],
         );
-        let hit = meta("mod-hit", vec![audio(&["SFX.bank|whoosh"])]);
         let miss = meta("mod-miss", vec![audio(&["Music.bank|theme"])]);
-
-        let out = analyze(
-            &[&rawm, &hit],
-            &loadout_of(&[("mod-raw", true), ("mod-hit", true)]),
-        );
-        assert_eq!(
-            out,
-            vec![conflict(
-                ConflictKind::RawFile,
-                "bank:SFX.bank",
-                &["mod-raw", "mod-hit"],
-                Severity::Hard
-            )]
-        );
 
         let out = analyze(
             &[&rawm, &miss],
             &loadout_of(&[("mod-raw", true), ("mod-miss", true)]),
         );
         assert!(out.is_empty(), "different bank must not conflict: {out:?}");
+    }
+
+    #[test]
+    fn rawfile_raw_winner_stays_separate_from_patch_advisory() {
+        let raw_a = meta("raw-a", vec![raw(RawTarget::Lcache)]);
+        let patch = meta("patch", vec![loc(&["itfo_cheese|german"])]);
+        let raw_b = meta("raw-b", vec![raw(RawTarget::Lcache)]);
+
+        assert_eq!(
+            analyze(
+                &[&raw_a, &patch, &raw_b],
+                &loadout_of(&[("raw-a", true), ("patch", true), ("raw-b", true)]),
+            ),
+            vec![
+                conflict(
+                    ConflictKind::RawFile,
+                    "lcache",
+                    &["raw-a", "raw-b"],
+                    Severity::Hard,
+                ),
+                conflict(
+                    ConflictKind::RawFile,
+                    "lcache",
+                    &["raw-a", "patch", "raw-b"],
+                    Severity::Info,
+                ),
+            ]
+        );
     }
 
     /// Two UE4SS mods sharing a script `name` must NOT conflict: apply deploys each to its own
@@ -970,6 +1209,12 @@ mod tests {
                     "lcache",
                     &["mod-a", "mod-b"],
                     Severity::Hard
+                ),
+                conflict(
+                    ConflictKind::RawFile,
+                    "lcache",
+                    &["mod-a", "mod-b"],
+                    Severity::Info
                 ),
                 // The shared-name `lua("SharedDir", …)` on both mods yields NO conflict (distinct
                 // deploy dirs), so it does not appear here.

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -30,7 +30,7 @@
 //! Voice ZIP edits are independent of rawfiles: they merge case-insensitively per archive/member,
 //! then rewrite each archive once from its own pristine/prior-backup base.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
@@ -395,11 +395,13 @@ fn snapshot_raw_payload(
 }
 
 /// Keep the last script entry for each exact manifest module target while preserving the original
-/// order of all winners. `analyze` uses the authored target string as `ScriptModule` identity, so
-/// this intentionally does not case-fold names or infer identity from the mini-cache contents.
+/// order of all winners. The returned set records winning edits whose target was introduced by an
+/// earlier, now-shadowed add; composition may retry those winners as adds if the effective base does
+/// not already contain the target. `analyze` uses the authored target string as `ScriptModule`
+/// identity, so this intentionally does not case-fold names or infer identity from mini contents.
 fn retain_last_script_target_winners(
     scripts: Vec<(String, String, PendingPayload)>,
-) -> crate::Result<Vec<(String, String, PendingPayload)>> {
+) -> crate::Result<(Vec<(String, String, PendingPayload)>, BTreeSet<String>)> {
     let mut last_by_target = BTreeMap::<String, usize>::new();
     for (index, (_, module, _)) in scripts.iter().enumerate() {
         last_by_target.insert(module.clone(), index);
@@ -411,12 +413,19 @@ fn retain_last_script_target_winners(
         .map_err(|error| {
             ModError::Other(format!("cannot reserve winning script entries: {error}"))
         })?;
+    let mut prior_add_targets = BTreeSet::new();
+    let mut winner_edits_after_add = BTreeSet::new();
     for (index, script) in scripts.into_iter().enumerate() {
         if last_by_target.get(&script.1) == Some(&index) {
+            if script.0 == "edit" && prior_add_targets.contains(&script.1) {
+                winner_edits_after_add.insert(script.1.clone());
+            }
             winners.push(script);
+        } else if script.0 == "add" {
+            prior_add_targets.insert(script.1.clone());
         }
     }
-    Ok(winners)
+    Ok((winners, winner_edits_after_add))
 }
 
 fn validate_standalone_script_candidate(
@@ -1356,7 +1365,8 @@ fn apply_loadout_with_limits(
         // Conflict analysis and the UI promise exact-target later-wins semantics. Reduce before
         // inventory, canonicalization, and composition so a shadowed mini cannot still collide in
         // the global ID plan or attempt a duplicate module splice.
-        scripts = retain_last_script_target_winners(scripts)?;
+        let (winning_scripts, winner_edits_after_add) = retain_last_script_target_winners(scripts)?;
+        scripts = winning_scripts;
         let (base, drifted) =
             match rawfile_sources.remove(&raw_target_identity(&RawTarget::ScriptCache)) {
                 Some((_target, source)) => (
@@ -1438,6 +1448,9 @@ fn apply_loadout_with_limits(
                 "add" => merge_guard
                     .compose_add(&acc, &mini)
                     .map_err(|e| ModError::Other(format!("splice {module}: {e}")))?,
+                "edit" if winner_edits_after_add.contains(module) => merge_guard
+                    .compose_edit_or_add(&acc, &mini, module)
+                    .map_err(|e| ModError::Other(format!("replace or splice {module}: {e}")))?,
                 "edit" => merge_guard
                     .compose_edit(&acc, &mini, module)
                     .map_err(|e| ModError::Other(format!("replace {module}: {e}")))?,
@@ -4998,6 +5011,69 @@ mod tests {
 
         run(false);
         run(true);
+    }
+
+    #[test]
+    fn apply_scripts_edit_after_shadowed_add_uses_only_the_winner() {
+        for target_exists_in_base in [false, true] {
+            let g = FakeGame::new();
+            let base_modules: &[&str] = if target_exists_in_base {
+                &["_gore_base", "_gore_shared"]
+            } else {
+                &["_gore_base"]
+            };
+            fs::write(g.script_cache(), build_script_cache(base_modules)).unwrap();
+
+            let shadowed = build_script_cache_with_static_name_and_keys(
+                "_gore_shared",
+                "ShadowedAdd",
+                "ShadowedType",
+                41,
+                41,
+                0x0801_0041,
+            );
+            let winner = build_script_cache_with_static_name_and_keys(
+                "_gore_shared",
+                "WinningEdit",
+                "WinningType",
+                42,
+                42,
+                0x0801_0042,
+            );
+            let add = g.add_script_mod(
+                "script-prerequisite-add",
+                "Prerequisite Add",
+                "add",
+                "_gore_shared",
+                &shadowed,
+            );
+            let edit = g.add_script_mod(
+                "script-winning-edit",
+                "Winning Edit",
+                "edit",
+                "_gore_shared",
+                &winner,
+            );
+
+            apply_loadout(&g.root, &g.lib, &loadout(&[(&add, true), (&edit, true)]))
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "same-target add -> edit failed (target_exists_in_base={target_exists_in_base}): {error}"
+                    )
+                });
+
+            let live = fs::read(g.script_cache()).unwrap();
+            assert_eq!(
+                gore_as::cache::walk_modules::module_names(&live).unwrap(),
+                vec!["_gore_base", "_gore_shared"]
+            );
+            let refs = gore_as::cache::refs::RefResolver::build(&live).unwrap();
+            assert_eq!(refs.static_name(0), Some("WinningEdit"));
+            assert_eq!(refs.static_name(1), None);
+            let assignments = script_assignments(&live);
+            assert!(assignments.type_ids.contains_key("WinningType"));
+            assert!(!assignments.type_ids.contains_key("ShadowedType"));
+        }
     }
 
     /// A standalone `RawFile{ScriptCache}` is structurally validated from its private candidate,

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -134,6 +134,43 @@ struct PendingRaw {
     rel: PathBuf,
 }
 
+/// Windows live-file identity for the three raw targets. Bank filenames are case-insensitive, but
+/// the map value retains the actual winning path instead of ever publishing this folded key.
+fn raw_target_identity(target: &RawTarget) -> String {
+    match target {
+        RawTarget::Lcache => "lcache".into(),
+        RawTarget::Bank { name } => format!("bank:{}", crate::windows_file_name_key(name)),
+        RawTarget::ScriptCache => "script_cache".into(),
+    }
+}
+
+/// Resolve a bank spelling to the existing on-disk entry. This keeps case-insensitive Windows
+/// semantics in cross-platform tests and preserves the real path spelling for records/backups.
+fn resolve_bank_target_path(desktop: &Path, name: &str) -> crate::Result<PathBuf> {
+    let exact = desktop.join(name);
+    if exact.is_file() {
+        return Ok(exact);
+    }
+    let folded = crate::windows_file_name_key(name);
+    let mut matched = None;
+    for entry in std::fs::read_dir(desktop).map_err(crate::io(&format!(
+        "reading FMOD bank directory {}",
+        desktop.display()
+    )))? {
+        let entry = entry.map_err(crate::io("reading FMOD bank entry"))?;
+        if crate::windows_file_name_key(&entry.file_name().to_string_lossy()) != folded {
+            continue;
+        }
+        if matched.is_some() {
+            return Err(ModError::Other(format!(
+                "multiple FMOD banks differ only by case for {name:?}"
+            )));
+        }
+        matched = Some(entry.path());
+    }
+    Ok(matched.unwrap_or(exact))
+}
+
 #[derive(Debug, Clone)]
 struct PendingAdditive {
     entry: LibraryEntry,
@@ -331,6 +368,7 @@ fn read_raw_for_patch(
 
 fn snapshot_raw_payload(
     source: &PendingRaw,
+    max_payload_bytes: u64,
     limits: ApplyLimits,
     budget: &mut ApplyBudget,
 ) -> crate::Result<(tempfile::TempPath, u64)> {
@@ -342,7 +380,10 @@ fn snapshot_raw_payload(
     let (candidate, len) = source.entry.snapshot_payload_bounded(
         &source.rel,
         "raw-file payload",
-        limits.max_raw_file_bytes.min(remaining),
+        limits
+            .max_raw_file_bytes
+            .min(max_payload_bytes)
+            .min(remaining),
     )?;
     charge_bytes(
         "manager raw files",
@@ -351,6 +392,83 @@ fn snapshot_raw_payload(
         limits.max_raw_total_bytes,
     )?;
     Ok((candidate, len))
+}
+
+/// Keep the last script entry for each exact manifest module target while preserving the original
+/// order of all winners. `analyze` uses the authored target string as `ScriptModule` identity, so
+/// this intentionally does not case-fold names or infer identity from the mini-cache contents.
+fn retain_last_script_target_winners(
+    scripts: Vec<(String, String, PendingPayload)>,
+) -> crate::Result<Vec<(String, String, PendingPayload)>> {
+    let mut last_by_target = BTreeMap::<String, usize>::new();
+    for (index, (_, module, _)) in scripts.iter().enumerate() {
+        last_by_target.insert(module.clone(), index);
+    }
+
+    let mut winners = Vec::new();
+    winners
+        .try_reserve_exact(last_by_target.len())
+        .map_err(|error| {
+            ModError::Other(format!("cannot reserve winning script entries: {error}"))
+        })?;
+    for (index, script) in scripts.into_iter().enumerate() {
+        if last_by_target.get(&script.1) == Some(&index) {
+            winners.push(script);
+        }
+    }
+    Ok(winners)
+}
+
+fn validate_standalone_script_candidate(
+    candidate: &Path,
+    expected_len: u64,
+    limit: u64,
+) -> crate::Result<()> {
+    use std::io::Read as _;
+
+    if expected_len > limit {
+        return Err(ModError::Other(format!(
+            "standalone script-cache replacement exceeds the {limit} byte validation limit: {expected_len}"
+        )));
+    }
+    let capacity = usize::try_from(expected_len).map_err(|_| {
+        ModError::Other(format!(
+            "standalone script-cache candidate is too large for this platform: {expected_len} bytes"
+        ))
+    })?;
+    let file = std::fs::File::open(candidate).map_err(crate::io(&format!(
+        "opening standalone script-cache candidate {}",
+        candidate.display()
+    )))?;
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(capacity).map_err(|error| {
+        ModError::Other(format!(
+            "standalone script-cache candidate cannot be buffered for validation ({expected_len} bytes): {error}"
+        ))
+    })?;
+    file.take(limit.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(crate::io(&format!(
+            "reading standalone script-cache candidate {}",
+            candidate.display()
+        )))?;
+    let observed = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    if observed > limit {
+        return Err(ModError::Other(format!(
+            "standalone script-cache replacement exceeds the {limit} byte validation limit: {observed}"
+        )));
+    }
+    if observed != expected_len {
+        return Err(ModError::Other(format!(
+            "standalone script-cache candidate changed while validating: expected {expected_len} bytes, read {observed}"
+        )));
+    }
+    gore_as::cache::splice::validate_standalone_script_cache(&bytes)
+        .map_err(|error| ModError::Other(format!("validate standalone script cache: {error}")))?;
+    // Publication retains the original disk-backed candidate. Release the bounded validation copy
+    // before hashing or adding that candidate to the deploy plan.
+    drop(bytes);
+    Ok(())
 }
 
 fn snapshot_loose_payload(
@@ -435,7 +553,6 @@ fn stage_generated_output(
         len,
         limits.max_generated_total_bytes,
     )?;
-    let hash = crate::content_hash(&bytes);
     let mut candidate = tempfile::Builder::new()
         .prefix(".gore-manager-generated-")
         .tempfile()
@@ -448,11 +565,8 @@ fn stage_generated_output(
         .as_file()
         .sync_all()
         .map_err(crate::io("syncing generated-output candidate"))?;
-    plan.file_writes.push(crate::DiskWrite {
-        live,
-        candidate: candidate.into_temp_path(),
-        hash,
-    });
+    plan.file_writes
+        .push(crate::DiskWrite::seal(live, candidate.into_temp_path())?);
     Ok(())
 }
 
@@ -613,7 +727,7 @@ fn apply_loadout_with_limits(
         /// Folded language -> (most recent spelling, text).
         values: BTreeMap<String, (String, String)>,
     }
-    let mut rawfile_sources: BTreeMap<PathBuf, PendingRaw> = BTreeMap::new();
+    let mut rawfile_sources: BTreeMap<String, (PathBuf, PendingRaw)> = BTreeMap::new();
     // Keyed by the CASE-FOLDED destination, so loadout order gives later-wins before the plan is
     // built. This is not cosmetic: `first_duplicate_dst` rejects a plan with two writes to one
     // path, and it *resolves* those paths — so on Windows two mods spelling one file differently
@@ -623,7 +737,10 @@ fn apply_loadout_with_limits(
     // recorded.
     let mut loose_files: BTreeMap<String, (PathBuf, PendingPayload)> = BTreeMap::new();
     let mut loc: BTreeMap<String, PendingLoc> = BTreeMap::new();
+    // Bank identity is Windows-case-insensitive; sample identity deliberately remains exact. The
+    // companion map retains the last effective bank spelling for the one generated output path.
     let mut audio: BTreeMap<(String, String), PendingPayload> = BTreeMap::new();
+    let mut audio_bank_spellings: BTreeMap<String, String> = BTreeMap::new();
     let mut scripts: Vec<(String, String, PendingPayload)> = Vec::new();
     let mut voice = crate::PendingVoiceEdits::new();
     let mut voice_order = 0usize;
@@ -750,7 +867,7 @@ fn apply_loadout_with_limits(
                             {
                                 return Err(ModError::Other(format!("unsafe bank name: {name:?}")));
                             }
-                            gp.fmod_desktop.join(name)
+                            resolve_bank_target_path(&gp.fmod_desktop, name)?
                         }
                         RawTarget::ScriptCache => gp.script_cache.clone(),
                     };
@@ -772,11 +889,14 @@ fn apply_loadout_with_limits(
                     // reference for now: patched targets are bounded-read once when decoded;
                     // unpatched whole-file replacements become disk-backed snapshots below.
                     rawfile_sources.insert(
-                        target,
-                        PendingRaw {
-                            entry: l.library_entry.clone(),
-                            rel: PathBuf::from(rel),
-                        },
+                        raw_target_identity(target_file),
+                        (
+                            target,
+                            PendingRaw {
+                                entry: l.library_entry.clone(),
+                                rel: PathBuf::from(rel),
+                            },
+                        ),
                     );
                 }
                 ComponentInfo::LocPatch { rel, .. } => {
@@ -857,10 +977,14 @@ fn apply_loadout_with_limits(
                         {
                             return Err(ModError::Other(format!("unsafe bank name: {bank:?}")));
                         }
+                        let bank_key = crate::windows_file_name_key(&bank);
+                        if !samples.is_empty() {
+                            audio_bank_spellings.insert(bank_key.clone(), bank.clone());
+                        }
                         for (sample, wav_rel) in samples {
                             validate_payload_rel(&wav_rel, "WAV", limits)?;
                             audio.insert(
-                                (bank.clone(), sample),
+                                (bank_key.clone(), sample),
                                 PendingPayload {
                                     entry: l.library_entry.clone(),
                                     rel: PathBuf::from(wav_rel),
@@ -1075,15 +1199,16 @@ fn apply_loadout_with_limits(
     // else the pristine .lcache.
     if !loc.is_empty() {
         if let Some(lcache) = gp.lcache.clone() {
-            let (base, drifted) = match rawfile_sources.remove(&lcache) {
-                Some(source) => {
-                    let drifted = crate::select_pristine_source(&lcache, prior)?.drifted;
-                    (read_raw_for_patch(&source, limits, &mut budget)?, drifted)
-                }
-                // Read pristine from the PRIOR deployment's backup (via `prev`) — the live file is
-                // still the prior-modded one until the deferred undeploy below.
-                None => read_pristine_for_patch(&lcache, prior, limits, &mut budget)?,
-            };
+            let (base, drifted) =
+                match rawfile_sources.remove(&raw_target_identity(&RawTarget::Lcache)) {
+                    Some((_target, source)) => {
+                        let drifted = crate::select_pristine_source(&lcache, prior)?.drifted;
+                        (read_raw_for_patch(&source, limits, &mut budget)?, drifted)
+                    }
+                    // Read pristine from the PRIOR deployment's backup (via `prev`) — the live file is
+                    // still the prior-modded one until the deferred undeploy below.
+                    None => read_pristine_for_patch(&lcache, prior, limits, &mut budget)?,
+                };
             let mut lc = gore_loc::loc::Lcache::decode(&base)?;
             let declared: BTreeMap<String, String> = lc
                 .languages()
@@ -1161,16 +1286,28 @@ fn apply_loadout_with_limits(
         let fmod_key = crate::resolve_fmod_key(&gp);
         // Group (bank,sample)→wav into bank→[(sample,wav)].
         let mut by_bank: BTreeMap<String, Vec<(String, PendingPayload)>> = BTreeMap::new();
-        for ((bank, sample), wav) in &audio {
+        for ((bank_key, sample), wav) in &audio {
             by_bank
-                .entry(bank.clone())
+                .entry(bank_key.clone())
                 .or_default()
                 .push((sample.clone(), wav.clone()));
         }
-        for (bank, samples) in by_bank {
-            let bank_path = gp.fmod_desktop.join(&bank);
-            let (base, drifted) = match rawfile_sources.remove(&bank_path) {
-                Some(source) => {
+        for (bank_key, samples) in by_bank {
+            let bank = audio_bank_spellings.get(&bank_key).ok_or_else(|| {
+                ModError::Other(format!(
+                    "audio bank spelling was not retained for identity {bank_key:?}"
+                ))
+            })?;
+            let raw_target = RawTarget::Bank { name: bank.clone() };
+            let raw_source = rawfile_sources.remove(&raw_target_identity(&raw_target));
+            // A raw winner already resolved the real on-disk spelling while collecting bases.
+            // Otherwise resolve the audio manifest's spelling against the same Windows identity.
+            let bank_path = match &raw_source {
+                Some((target, _)) => target.clone(),
+                None => resolve_bank_target_path(&gp.fmod_desktop, bank)?,
+            };
+            let (base, drifted) = match raw_source {
+                Some((_target, source)) => {
                     let drifted = crate::select_pristine_source(&bank_path, prior)?.drifted;
                     (read_raw_for_patch(&source, limits, &mut budget)?, drifted)
                 }
@@ -1208,22 +1345,31 @@ fn apply_loadout_with_limits(
 
     // scripts → fold add/edit onto the script-cache base (rawfile override or pristine cache).
     if !scripts.is_empty() {
-        let (base, drifted) = match rawfile_sources.remove(&gp.script_cache) {
-            Some(source) => (
-                read_raw_for_patch(&source, limits, &mut budget)?,
-                crate::select_pristine_source(&gp.script_cache, prior)?.drifted,
-            ),
-            None => read_pristine_for_patch(&gp.script_cache, prior, limits, &mut budget)?,
-        };
-        let mut merge_guard = gore_as::cache::splice::SequentialMiniGuard::new(&base)
+        if let Some((op, module, _)) = scripts
+            .iter()
+            .find(|(op, _, _)| op != "add" && op != "edit")
+        {
+            return Err(ModError::Other(format!(
+                "invalid script op {op:?} for module {module:?}"
+            )));
+        }
+        // Conflict analysis and the UI promise exact-target later-wins semantics. Reduce before
+        // inventory, canonicalization, and composition so a shadowed mini cannot still collide in
+        // the global ID plan or attempt a duplicate module splice.
+        scripts = retain_last_script_target_winners(scripts)?;
+        let (base, drifted) =
+            match rawfile_sources.remove(&raw_target_identity(&RawTarget::ScriptCache)) {
+                Some((_target, source)) => (
+                    read_raw_for_patch(&source, limits, &mut budget)?,
+                    crate::select_pristine_source(&gp.script_cache, prior)?.drifted,
+                ),
+                None => read_pristine_for_patch(&gp.script_cache, prior, limits, &mut budget)?,
+            };
+        // Pass 1 inventories the complete loadout while retaining only one source mini at a time.
+        // Canonical assignments therefore depend on the portable-identity union, never mod order.
+        let mut loadout_builder = gore_as::cache::splice::LoadoutScriptIdPlanBuilder::new(&base)
             .map_err(|e| ModError::Other(format!("prepare script composition: {e}")))?;
-        let mut acc = base;
-        for (op, module, mini_payload) in &scripts {
-            if op != "add" && op != "edit" {
-                return Err(ModError::Other(format!(
-                    "invalid script op {op:?} for module {module:?}"
-                )));
-            }
+        for (_, module, mini_payload) in &scripts {
             let mini = read_pending_payload(
                 mini_payload,
                 "script mini-cache payloads",
@@ -1231,13 +1377,69 @@ fn apply_loadout_with_limits(
                 &mut budget.mini_bytes,
                 limits.max_mini_total_bytes,
             )?;
-            let prepared = merge_guard
-                .check_and_record(&mini)
-                .map_err(|e| ModError::Other(format!("compose {module}: {e}")))?;
+            loadout_builder
+                .inspect(&mini)
+                .map_err(|e| ModError::Other(format!("inspect script mini {module}: {e}")))?;
+        }
+        let loadout_plan = loadout_builder
+            .finish()
+            .map_err(|e| ModError::Other(format!("finish script ID plan: {e}")))?;
+
+        // Pass 2 rereads the SHA-bound source minis and immediately seals each canonical result on
+        // private disk. Separate phase budgets preserve the existing 4-GiB logical source envelope
+        // while bounding the additional I/O and temporary footprint to the same amount.
+        let mut rewrite_source_bytes = 0u64;
+        let mut canonical_output_bytes = 0u64;
+        let mut canonical_minis = Vec::new();
+        canonical_minis
+            .try_reserve_exact(scripts.len())
+            .map_err(|error| {
+                ModError::Other(format!(
+                    "cannot reserve canonical script mini candidates: {error}"
+                ))
+            })?;
+        for (_, module, mini_payload) in &scripts {
+            let mini = read_pending_payload(
+                mini_payload,
+                "script mini-cache canonicalization",
+                limits.max_mini_bytes,
+                &mut rewrite_source_bytes,
+                limits.max_mini_total_bytes,
+            )?;
+            let canonical = gore_as::cache::splice::remap_module_to_base_with_loadout_plan(
+                &mini,
+                &base,
+                &loadout_plan,
+            )
+            .map_err(|e| ModError::Other(format!("canonicalize script mini {module}: {e}")))?;
+            canonical_minis.push(crate::seal_script_mini(
+                canonical,
+                limits.max_mini_bytes,
+                &mut canonical_output_bytes,
+                limits.max_mini_total_bytes,
+            )?);
+        }
+        drop(loadout_plan);
+
+        // Pass 3 builds the guard only after the plan's large base context is gone. Reopen, verify,
+        // and compose each tempfile in loadout order; consuming it cleans disk incrementally.
+        let mut merge_guard = gore_as::cache::splice::SequentialMiniGuard::new(&base)
+            .map_err(|e| ModError::Other(format!("prepare script composition: {e}")))?;
+        let mut acc = base;
+        let mut canonical_read_bytes = 0u64;
+        for ((op, module, _), sealed) in scripts.iter().zip(canonical_minis) {
+            let mini = crate::read_sealed_script_mini(
+                &sealed,
+                limits.max_mini_bytes,
+                &mut canonical_read_bytes,
+                limits.max_mini_total_bytes,
+            )?;
             acc = match op.as_str() {
-                "add" => gore_as::cache::splice::splice_auto(&acc, &prepared)
+                "add" => merge_guard
+                    .compose_add(&acc, &mini)
                     .map_err(|e| ModError::Other(format!("splice {module}: {e}")))?,
-                "edit" => gore_as::cache::splice::replace_module(&acc, &prepared, module)
+                "edit" => merge_guard
+                    .compose_edit(&acc, &mini, module)
                     .map_err(|e| ModError::Other(format!("replace {module}: {e}")))?,
                 other => {
                     return Err(ModError::Other(format!(
@@ -1254,24 +1456,29 @@ fn apply_loadout_with_limits(
     }
 
     // Any rawfile whose target was NOT further patched remains a whole-file replacement. Snapshot
-    // it to a verified private temp and publish through DeployPlan's disk-backed write path: even an
-    // 8-GiB raw bank/cache never becomes an archive-sized `Vec`, and an apply error drops every
-    // candidate before the game is touched.
-    for (target, source) in rawfile_sources {
+    // it to a verified private temp and publish through DeployPlan's disk-backed write path. A
+    // standalone script cache is the one content-aware raw target: validate the exact private
+    // candidate within the in-memory patch-base envelope, then release that validation copy before
+    // the original candidate is published. Any error still drops every candidate before the game
+    // is touched.
+    for (_identity, (target, source)) in rawfile_sources {
         let drifted = crate::select_pristine_source(&target, prior)?.drifted;
-        let (candidate, _len) = snapshot_raw_payload(&source, limits, &mut budget)?;
-        let hash = crate::content_hash_file(&candidate).map_err(crate::io(&format!(
-            "hashing raw-file candidate for {}",
-            target.display()
-        )))?;
+        // Script caches are decoded for structural validation, so enforce the in-memory ceiling at
+        // the opened-file metadata gate instead of first copying up to the generic 8-GiB raw limit.
+        let snapshot_limit = if target == gp.script_cache {
+            limits.max_patch_base_bytes
+        } else {
+            limits.max_raw_file_bytes
+        };
+        let (candidate, len) = snapshot_raw_payload(&source, snapshot_limit, limits, &mut budget)?;
+        if target == gp.script_cache {
+            validate_standalone_script_candidate(&candidate, len, limits.max_patch_base_bytes)?;
+        }
         if drifted {
             plan.refresh_baks.push(target.clone());
         }
-        plan.file_writes.push(crate::DiskWrite {
-            live: target,
-            candidate,
-            hash,
-        });
+        plan.file_writes
+            .push(crate::DiskWrite::seal(target, candidate)?);
     }
 
     // Loose files have no patch layer to fold onto them: the winning payload IS the final content.
@@ -1281,18 +1488,11 @@ fn apply_loadout_with_limits(
     for (_folded, (target, source)) in loose_files {
         let drifted = crate::select_pristine_source(&target, prior)?.drifted;
         let candidate = snapshot_loose_payload(&source, limits, &mut budget)?;
-        let hash = crate::content_hash_file(&candidate).map_err(crate::io(&format!(
-            "hashing loose-file candidate for {}",
-            target.display()
-        )))?;
         if drifted {
             plan.refresh_baks.push(target.clone());
         }
-        plan.file_writes.push(crate::DiskWrite {
-            live: target,
-            candidate,
-            hash,
-        });
+        plan.file_writes
+            .push(crate::DiskWrite::seal(target, candidate)?);
     }
 
     crate::prepare_voice_archive_writes(&voice, &gp, prior, &mut plan)?;
@@ -1726,26 +1926,116 @@ mod tests {
     /// One-module allow-new-shaped cache with `STR 0`, private T1â€“T7 rows, and deterministic
     /// synthetic pointer/id keys. This exercises manager composition beyond the original empty
     /// T1â€“T5/T7 fixture that missed real class-module collisions.
-    fn build_script_cache_with_static_name(module: &str, name: &str, seed: i32) -> Vec<u8> {
+    fn probe_data_type(token: i32) -> Vec<u8> {
+        let mut out = vec![0u8; 24]; // six serialized bool words
+        out.extend_from_slice(&0i64.to_le_bytes()); // primitive TypeInfo
+        out.extend_from_slice(&token.to_le_bytes());
+        out
+    }
+
+    fn probe_function(name: &str, bytecode: &[i32], id: i32) -> Vec<u8> {
+        let mut out = as_sia(name);
+        out.extend_from_slice(&as_sia("")); // namespace
+        out.extend_from_slice(&probe_data_type(0x52)); // void return
+        out.extend_from_slice(&0i32.to_le_bytes()); // parameter types
+        out.extend_from_slice(&0i32.to_le_bytes()); // parameter names
+        out.extend_from_slice(&0i32.to_le_bytes()); // parameter flags
+        out.extend_from_slice(&0i32.to_le_bytes()); // parameter defaults
+        out.extend_from_slice(&0i32.to_le_bytes()); // traits (non-const)
+        out.extend_from_slice(&(bytecode.len() as i32).to_le_bytes());
+        for &word in bytecode {
+            out.extend_from_slice(&word.to_le_bytes());
+        }
+        out.extend_from_slice(&0i32.to_le_bytes()); // bytecode references
+        out.extend_from_slice(&0i32.to_le_bytes()); // variable space
+        out.extend_from_slice(&0i32.to_le_bytes()); // object variable types
+        out.extend_from_slice(&0i32.to_le_bytes()); // object variable positions
+        out.extend_from_slice(&0i32.to_le_bytes()); // object variables on heap
+        out.extend_from_slice(&0i32.to_le_bytes()); // variable info program positions
+        out.extend_from_slice(&0i32.to_le_bytes()); // variable info offsets
+        out.extend_from_slice(&0i32.to_le_bytes()); // variable info options
+        out.extend_from_slice(&0i32.to_le_bytes()); // stack needed
+        out.extend_from_slice(&id.to_le_bytes());
+        out.extend_from_slice(&0i32.to_le_bytes()); // declared at
+        out.extend_from_slice(&0i32.to_le_bytes()); // line numbers
+        out.extend_from_slice(&0i32.to_le_bytes()); // not a UFunction
+        out
+    }
+
+    fn probe_property(name: &str) -> Vec<u8> {
+        let mut out = as_sia(name);
+        out.extend_from_slice(&probe_data_type(0x44)); // int
+        out.extend_from_slice(&0i32.to_le_bytes()); // not private
+        out.extend_from_slice(&0i32.to_le_bytes()); // not protected
+        out.extend_from_slice(&0i32.to_le_bytes()); // no Unreal property tail
+        out
+    }
+
+    fn probe_class(type_name: &str, method_name: &str, property_name: &str, id: i32) -> Vec<u8> {
+        let mut out = as_sia(type_name);
+        out.extend_from_slice(&as_sia("")); // namespace
+        out.extend_from_slice(&0i32.to_le_bytes()); // flags
+        out.extend_from_slice(&1i32.to_le_bytes()); // properties
+        out.extend_from_slice(&probe_property(property_name));
+        out.extend_from_slice(&1i32.to_le_bytes()); // methods
+        out.extend_from_slice(&probe_function(method_name, &[10], id)); // RET
+        out.extend_from_slice(&1i32.to_le_bytes()); // method table
+        out.extend_from_slice(&0i32.to_le_bytes()); // Methods[0]
+        out.extend_from_slice(&0i64.to_le_bytes()); // derived from
+        out.extend_from_slice(&0i64.to_le_bytes()); // shadow type
+        out.extend_from_slice(&0i32.to_le_bytes()); // constructors
+        out.extend_from_slice(&0i32.to_le_bytes()); // factory refs
+        out.extend_from_slice(&7i32.to_le_bytes()); // fixed behavior slots 0..6
+        out.extend_from_slice(&[0u8; 7 * 8]);
+        out.extend_from_slice(&0i32.to_le_bytes()); // behavior functions
+        out.extend_from_slice(&0i32.to_le_bytes()); // behavior function types
+        out.extend_from_slice(&0i32.to_le_bytes()); // no Unreal class tail
+        out
+    }
+
+    fn probe_global(name: &str) -> Vec<u8> {
+        let mut out = as_sia(name);
+        out.extend_from_slice(&as_sia("")); // namespace
+        out.extend_from_slice(&probe_data_type(0x44)); // int
+        out.extend_from_slice(&1i32.to_le_bytes()); // default initialized
+        out
+    }
+
+    fn build_script_cache_with_static_name_and_keys(
+        module: &str,
+        name: &str,
+        type_name: &str,
+        identity_seed: i32,
+        key_seed: i32,
+        type_id: i32,
+    ) -> Vec<u8> {
         use gore_as::cache::header::CACHE_MAGIC;
+        let method_name = format!("ProbeFunc{identity_seed}");
+        let property_name = format!("ProbeField{identity_seed}");
+        let global_name = format!("ProbeGlobal{identity_seed}");
+
         let mut out = vec![0u8; 16];
         out.extend_from_slice(&CACHE_MAGIC.to_le_bytes());
         out.extend_from_slice(&1u32.to_le_bytes());
         out.extend_from_slice(&as_fstring(module));
         out.extend_from_slice(&as_sia(module));
         out.extend_from_slice(&1i32.to_le_bytes()); // functions
-        out.extend_from_slice(&as_sia("StaticNameProbe"));
-        out.extend_from_slice(&as_sia("")); // namespace
-        out.extend_from_slice(&[0u8; 24]); // return DataType flags
-        out.extend_from_slice(&0i64.to_le_bytes()); // primitive TypeInfo
-        out.extend_from_slice(&0x40i32.to_le_bytes()); // void token
-        out.extend_from_slice(&[0u8; 5 * 4]); // params/names/flags/defaults/traits
-        out.extend_from_slice(&2i32.to_le_bytes()); // bytecode dwords
-        out.extend_from_slice(&60i32.to_le_bytes()); // STR StaticNames[0]
-        out.extend_from_slice(&10i32.to_le_bytes()); // RET
-        out.extend_from_slice(&[0u8; 12 * 4]); // function tail through line numbers
-        out.extend_from_slice(&0i32.to_le_bytes()); // not a UFunction
-        out.extend_from_slice(&[0u8; 4 * 4]); // classes/enums/globals/imports
+        out.extend_from_slice(&probe_function(
+            "StaticNameProbe",
+            &[60, 10], // STR StaticNames[0], RET
+            0x1200_0000i32 + key_seed,
+        ));
+        out.extend_from_slice(&1i32.to_le_bytes()); // classes
+        out.extend_from_slice(&probe_class(
+            &type_name,
+            &method_name,
+            &property_name,
+            0x1300_0000i32 + key_seed,
+        ));
+        out.extend_from_slice(&0i32.to_le_bytes()); // enums
+        out.extend_from_slice(&1i32.to_le_bytes()); // globals
+        out.extend_from_slice(&probe_global(&global_name));
+        out.extend_from_slice(&0i32.to_le_bytes()); // imports
         out.extend_from_slice(&0i64.to_le_bytes()); // code hash
         out.extend_from_slice(&0i32.to_le_bytes()); // imported modules
         out.extend_from_slice(&as_sia("")); // statics class
@@ -1753,16 +2043,14 @@ mod tests {
         out.extend_from_slice(&as_sia("")); // relative filename
         out.extend_from_slice(&0i32.to_le_bytes()); // post-init functions
 
-        let type_ptr = 0x6000_0000_1000_0000i64 + i64::from(seed);
-        let func_ptr = 0x6000_0000_2000_0000i64 + i64::from(seed);
-        let global_ptr = 0x6000_0000_3000_0000i64 + i64::from(seed);
-        let type_id = 0x0801_0000i32 + seed;
-        let func_id = 1_000_000i32 + seed;
-        let type_name = format!("ProbeType{seed}");
+        let type_ptr = 0x6000_0000_1000_0000i64 + i64::from(key_seed);
+        let func_ptr = 0x6000_0000_2000_0000i64 + i64::from(key_seed);
+        let global_ptr = 0x6000_0000_3000_0000i64 + i64::from(key_seed);
+        let func_id = 1_000_000i32 + key_seed;
 
         out.extend_from_slice(&1u32.to_le_bytes()); // T1 type
         out.extend_from_slice(&type_ptr.to_le_bytes());
-        out.extend_from_slice(&as_sia(&type_name));
+        out.extend_from_slice(&as_sia(type_name));
         out.extend_from_slice(&as_sia(module));
         out.extend_from_slice(&as_sia(""));
         out.extend_from_slice(&0u32.to_le_bytes()); // no subtypes
@@ -1773,15 +2061,17 @@ mod tests {
 
         out.extend_from_slice(&1u32.to_le_bytes()); // T3 function
         out.extend_from_slice(&func_ptr.to_le_bytes());
-        out.extend_from_slice(&as_sia(&format!("ProbeFunc{seed}")));
+        out.extend_from_slice(&as_sia(&method_name));
         out.extend_from_slice(&as_sia(module));
         out.extend_from_slice(&as_sia(""));
-        out.extend_from_slice(&[0u8; 3 * 4]); // const/imported/method
+        out.extend_from_slice(&0i32.to_le_bytes()); // not const
+        out.extend_from_slice(&0i32.to_le_bytes()); // not imported
+        out.extend_from_slice(&1i32.to_le_bytes()); // method: concrete owner below
         out.extend_from_slice(&type_ptr.to_le_bytes()); // owner
         out.extend_from_slice(&0u32.to_le_bytes()); // no params
         out.extend_from_slice(&[0u8; 24]); // void return DataType flags
         out.extend_from_slice(&0i64.to_le_bytes());
-        out.extend_from_slice(&0x40i32.to_le_bytes());
+        out.extend_from_slice(&0x52i32.to_le_bytes());
 
         out.extend_from_slice(&1u32.to_le_bytes()); // T4 function id -> ptr
         out.extend_from_slice(&func_id.to_le_bytes());
@@ -1789,7 +2079,7 @@ mod tests {
 
         out.extend_from_slice(&1u32.to_le_bytes()); // T5 global
         out.extend_from_slice(&global_ptr.to_le_bytes());
-        out.extend_from_slice(&as_sia(&format!("ProbeGlobal{seed}")));
+        out.extend_from_slice(&as_sia(&global_name));
         out.extend_from_slice(&as_sia(module));
         out.extend_from_slice(&as_sia(""));
         out.extend_from_slice(&0i32.to_le_bytes()); // not a string
@@ -1800,9 +2090,70 @@ mod tests {
         out.extend_from_slice(&1u32.to_le_bytes()); // T7 property
         let property_key = (i64::from(type_id) << 1) | (4i64 << 33) | 1;
         out.extend_from_slice(&property_key.to_le_bytes());
-        out.extend_from_slice(&as_sia(&format!("ProbeField{seed}")));
+        out.extend_from_slice(&as_sia(&property_name));
         out.extend_from_slice(&type_id.to_le_bytes());
         out
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct ScriptAssignments {
+        pointers: BTreeMap<String, i64>,
+        type_ids: BTreeMap<String, i32>,
+        function_ids: BTreeMap<String, i32>,
+    }
+
+    fn script_assignments(bytes: &[u8]) -> ScriptAssignments {
+        use gore_as::cache::tables::parse_tail_tables;
+        use gore_as::cache::walk_modules::module_region_end;
+        use gore_as::cache::wire::Cursor;
+
+        let tail = parse_tail_tables(bytes, module_region_end(bytes).unwrap()).unwrap();
+        let mut type_names = BTreeMap::new();
+        let mut function_names = BTreeMap::new();
+        let mut pointers = BTreeMap::new();
+        for &start in &tail.tables[0].entry_starts {
+            let mut cursor = Cursor::at(bytes, start);
+            let ptr = cursor.read_i64().unwrap();
+            let name = cursor.read_sia().unwrap();
+            type_names.insert(ptr, name.clone());
+            pointers.insert(format!("T1:{name}"), ptr);
+        }
+        for &start in &tail.tables[2].entry_starts {
+            let mut cursor = Cursor::at(bytes, start);
+            let ptr = cursor.read_i64().unwrap();
+            let name = cursor.read_sia().unwrap();
+            function_names.insert(ptr, name.clone());
+            pointers.insert(format!("T3:{name}"), ptr);
+        }
+        for &start in &tail.tables[4].entry_starts {
+            let mut cursor = Cursor::at(bytes, start);
+            let ptr = cursor.read_i64().unwrap();
+            let name = cursor.read_sia().unwrap();
+            pointers.insert(format!("T5:{name}"), ptr);
+        }
+        let mut type_ids = BTreeMap::new();
+        for &start in &tail.tables[1].entry_starts {
+            let mut cursor = Cursor::at(bytes, start);
+            let id = cursor.read_i32().unwrap();
+            let ptr = cursor.read_i64().unwrap();
+            if let Some(name) = type_names.get(&ptr) {
+                type_ids.insert(name.clone(), id);
+            }
+        }
+        let mut function_ids = BTreeMap::new();
+        for &start in &tail.tables[3].entry_starts {
+            let mut cursor = Cursor::at(bytes, start);
+            let id = cursor.read_i32().unwrap();
+            let ptr = cursor.read_i64().unwrap();
+            if let Some(name) = function_names.get(&ptr) {
+                function_ids.insert(name.clone(), id);
+            }
+        }
+        ScriptAssignments {
+            pointers,
+            type_ids,
+            function_ids,
+        }
     }
 
     // ── fake game tree ──────────────────────────────────────────────────────────────────────────
@@ -2142,6 +2493,10 @@ mod tests {
             !crate::record_path(&game.root).exists(),
             "failed plan construction must not create a deploy record"
         );
+        assert!(
+            !game.root.join(".gore-install-mutation.lock").exists(),
+            "failed plan construction must not acquire the durable install mutation lock"
+        );
     }
 
     #[test]
@@ -2266,22 +2621,24 @@ mod tests {
 
         let aggregate_game = FakeGame::new();
         let pristine_loc = fs::read(aggregate_game.lcache()).unwrap();
-        let pristine_script = b"game".to_vec();
+        let pristine_script = build_script_cache(&["_gore_pristine"]);
         fs::write(aggregate_game.script_cache(), &pristine_script).unwrap();
         let loc = aggregate_game.add_rawfile_mod("raw-loc", "RawLoc", RawTarget::Lcache, b"1234");
+        let raw_script = build_script_cache(&["_complete_replacement"]);
+        let raw_script_len = u64::try_from(raw_script.len()).unwrap();
         let script = aggregate_game.add_rawfile_mod(
             "raw-script",
             "RawScript",
             RawTarget::ScriptCache,
-            b"5678",
+            &raw_script,
         );
         let error = apply_loadout_with_limits(
             &aggregate_game.root,
             &aggregate_game.lib,
             &loadout(&[(&loc, true), (&script, true)]),
             ApplyLimits {
-                max_raw_file_bytes: 4,
-                max_raw_total_bytes: 7,
+                max_raw_file_bytes: raw_script_len,
+                max_raw_total_bytes: raw_script_len + 3,
                 ..DEFAULT_APPLY_LIMITS
             },
             false,
@@ -3978,49 +4335,262 @@ mod tests {
         assert_ne!(got, orig, "injected sample must differ from the original");
     }
 
+    #[test]
+    fn apply_audio_bank_case_variants_share_one_output_and_last_patch_wins() {
+        fn run(reverse: bool) {
+            let g = FakeGame::new();
+            let key = gore_fmod::GOTHIC_STUDIO_KEY;
+            let live = g.bank("Voice.bank");
+            fs::write(&live, build_pristine_bank("shout", 44100, &[0i16; 64], key)).unwrap();
+
+            let pcm_a: Vec<i16> = (0..40).map(|i| (1000 + i * 20) as i16).collect();
+            let pcm_b: Vec<i16> = (0..52).map(|i| (8000 - i * 30) as i16).collect();
+            let a = g.add_audio_mod(
+                "audio-a",
+                "AudioA",
+                "Voice.bank",
+                "shout",
+                &gore_fmod::wav_pcm16(44100, 1, &pcm_a),
+            );
+            let b = g.add_audio_mod(
+                "audio-b",
+                "AudioB",
+                "voice.BANK",
+                "shout",
+                &gore_fmod::wav_pcm16(44100, 1, &pcm_b),
+            );
+            let (entries, expected) = if reverse {
+                ([(b.as_str(), true), (a.as_str(), true)], pcm_a.as_slice())
+            } else {
+                ([(a.as_str(), true), (b.as_str(), true)], pcm_b.as_slice())
+            };
+
+            let report = apply_loadout(&g.root, &g.lib, &loadout(&entries)).unwrap();
+            assert!(
+                report.warnings.is_empty(),
+                "warnings: {:?}",
+                report.warnings
+            );
+            assert_eq!(
+                decode_last_fsb5_pcm(&fs::read(&live).unwrap(), key),
+                expected,
+                "the last patch of one case-insensitive bank/sample target must win"
+            );
+
+            let record = crate::read_record(&g.root).unwrap().unwrap().record;
+            assert_eq!(record.backups.len(), 1, "one live bank must be backed up");
+            assert_eq!(
+                record.deployed_hashes.len(),
+                1,
+                "case aliases must materialize one live output"
+            );
+            let bank_names: Vec<String> = fs::read_dir(live.parent().unwrap())
+                .unwrap()
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .filter(|name| name.to_lowercase().ends_with(".bank"))
+                .collect();
+            let expected_name = if cfg!(windows) && !reverse {
+                "voice.BANK"
+            } else {
+                "Voice.bank"
+            };
+            assert_eq!(bank_names, vec![expected_name]);
+        }
+
+        run(false);
+        run(true);
+    }
+
+    #[test]
+    fn apply_audio_bank_identity_does_not_expand_sharp_s_into_ss() {
+        fn run(reverse: bool) {
+            let g = FakeGame::new();
+            let key = gore_fmod::GOTHIC_STUDIO_KEY;
+            let sharp_live = g.bank("Voiceß.bank");
+            let ss_live = g.bank("VoiceSS.bank");
+            fs::write(
+                &sharp_live,
+                build_pristine_bank("shout", 44100, &[0i16; 32], key),
+            )
+            .unwrap();
+            fs::write(
+                &ss_live,
+                build_pristine_bank("shout", 44100, &[0i16; 32], key),
+            )
+            .unwrap();
+
+            let sharp_pcm: Vec<i16> = (0..40).map(|i| (1000 + i * 20) as i16).collect();
+            let ss_pcm: Vec<i16> = (0..52).map(|i| (8000 - i * 30) as i16).collect();
+            let sharp = g.add_audio_mod(
+                "audio-sharp",
+                "AudioSharp",
+                "Voiceß.bank",
+                "shout",
+                &gore_fmod::wav_pcm16(44100, 1, &sharp_pcm),
+            );
+            let ss = g.add_audio_mod(
+                "audio-ss",
+                "AudioSs",
+                "VoiceSS.bank",
+                "shout",
+                &gore_fmod::wav_pcm16(44100, 1, &ss_pcm),
+            );
+            let entries = if reverse {
+                [(ss.as_str(), true), (sharp.as_str(), true)]
+            } else {
+                [(sharp.as_str(), true), (ss.as_str(), true)]
+            };
+
+            let report = apply_loadout(&g.root, &g.lib, &loadout(&entries)).unwrap();
+            assert!(
+                report.warnings.is_empty(),
+                "warnings: {:?}",
+                report.warnings
+            );
+            assert_eq!(
+                decode_last_fsb5_pcm(&fs::read(&sharp_live).unwrap(), key),
+                sharp_pcm,
+                "the sharp-s bank must retain its own patch"
+            );
+            assert_eq!(
+                decode_last_fsb5_pcm(&fs::read(&ss_live).unwrap(), key),
+                ss_pcm,
+                "the SS bank must retain its own patch"
+            );
+
+            let record = crate::read_record(&g.root).unwrap().unwrap().record;
+            assert_eq!(record.backups.len(), 2, "both distinct banks need backups");
+            assert_eq!(
+                record.deployed_hashes.len(),
+                2,
+                "both distinct banks must materialize their own output"
+            );
+        }
+
+        run(false);
+        run(true);
+    }
+
     /// A `RawFile{Bank}` supplies the whole bank BASE; an AudioPatch then injects on top of it —
-    /// mirroring the loc rawfile-then-patch layering for audio. The base bank's sample starts as
-    /// one pattern; the final live bank must carry the patch's pattern.
+    /// mirroring the loc rawfile-then-patch layering for audio. Match the two bank spellings using
+    /// Windows identity and prove composition is independent of their relative loadout order.
     #[test]
     fn apply_audio_rawfile_bank_is_base_then_patched() {
-        let g = FakeGame::new();
-        let key = gore_fmod::GOTHIC_STUDIO_KEY;
-        // Live pristine bank (pattern P0). The rawfile base will OVERRIDE this with pattern P1.
-        fs::write(
-            g.bank("Voice.bank"),
-            build_pristine_bank("shout", 44100, &[0i16; 64], key),
-        )
-        .unwrap();
-        let base_pat: Vec<i16> = (0..64).map(|i| (i * 100) as i16).collect();
-        let raw_bank = build_pristine_bank("shout", 44100, &base_pat, key);
-        let raw = g.add_rawfile_mod(
-            "mod-rawbank",
-            "RawBank",
-            RawTarget::Bank {
-                name: "Voice.bank".into(),
-            },
-            &raw_bank,
-        );
-        // Patch injects pattern P2 on top of the rawfile base.
-        let patch_pat: Vec<i16> = (0..48).map(|i| (7000 - i * 100) as i16).collect();
-        let wav = gore_fmod::wav_pcm16(44100, 1, &patch_pat);
-        let patch = g.add_audio_mod("mod-audiopatch", "AudioPatch", "Voice.bank", "shout", &wav);
+        fn run(patch_first: bool) {
+            let g = FakeGame::new();
+            let key = gore_fmod::GOTHIC_STUDIO_KEY;
+            // Live pristine bank (pattern P0). The rawfile base overrides it with pattern P1.
+            fs::write(
+                g.bank("Voice.bank"),
+                build_pristine_bank("shout", 44100, &[0i16; 64], key),
+            )
+            .unwrap();
+            let base_pat: Vec<i16> = (0..64).map(|i| (i * 100) as i16).collect();
+            let raw_bank = build_pristine_bank("shout", 44100, &base_pat, key);
+            let raw = g.add_rawfile_mod(
+                "mod-rawbank",
+                "RawBank",
+                RawTarget::Bank {
+                    name: "Voice.bank".into(),
+                },
+                &raw_bank,
+            );
+            // Deliberately use different casing: it is the same bank on the target Windows host.
+            let patch_pat: Vec<i16> = (0..48).map(|i| (7000 - i * 100) as i16).collect();
+            let wav = gore_fmod::wav_pcm16(44100, 1, &patch_pat);
+            let patch =
+                g.add_audio_mod("mod-audiopatch", "AudioPatch", "voice.BANK", "shout", &wav);
+            let entries = if patch_first {
+                [(patch.as_str(), true), (raw.as_str(), true)]
+            } else {
+                [(raw.as_str(), true), (patch.as_str(), true)]
+            };
 
-        // Raw first (base), patch second (on top).
-        let report =
-            apply_loadout(&g.root, &g.lib, &loadout(&[(&raw, true), (&patch, true)])).unwrap();
-        assert!(
-            report.warnings.is_empty(),
-            "warnings: {:?}",
-            report.warnings
-        );
+            let report = apply_loadout(&g.root, &g.lib, &loadout(&entries)).unwrap();
+            assert!(
+                report.warnings.is_empty(),
+                "warnings: {:?}",
+                report.warnings
+            );
 
-        let got = decode_last_fsb5_pcm(&fs::read(g.bank("Voice.bank")).unwrap(), key);
-        assert_eq!(
-            got, patch_pat,
-            "patch pattern must win over the rawfile base"
-        );
-        assert_ne!(got, base_pat, "must not be the un-patched rawfile base");
+            let live = fs::read(g.bank("Voice.bank")).unwrap();
+            let got = decode_last_fsb5_pcm(&live, key);
+            assert_eq!(
+                got, patch_pat,
+                "patch pattern must win over the rawfile base"
+            );
+            // The original sub-bank remains embedded after injection. Its PCM proves the raw bank,
+            // not the game's zero-filled pristine bank, supplied the composed base.
+            let view = gore_fmod::read_bank(&live, key).unwrap();
+            let (block, fsb) = &view.sub_banks[0];
+            let wav = gore_fmod::extract_wav(block, fsb, 0).unwrap();
+            let (_, _, base_pcm) = gore_fmod::read_wav_pcm16(&wav).unwrap();
+            assert_eq!(base_pcm, base_pat, "raw winner must supply the base");
+        }
+
+        run(false);
+        run(true);
+    }
+
+    #[test]
+    fn apply_raw_banks_casefold_last_wins_in_both_orders() {
+        fn run(reverse: bool) {
+            let g = FakeGame::new();
+            let key = gore_fmod::GOTHIC_STUDIO_KEY;
+            let live = g.bank("Voice.bank");
+            fs::write(&live, build_pristine_bank("shout", 44100, &[0i16; 16], key)).unwrap();
+
+            let bytes_a = build_pristine_bank("shout", 44100, &[111i16; 24], key);
+            let bytes_b = build_pristine_bank("shout", 44100, &[222i16; 32], key);
+            let a = g.add_rawfile_mod(
+                "raw-a",
+                "RawA",
+                RawTarget::Bank {
+                    name: "Voice.bank".into(),
+                },
+                &bytes_a,
+            );
+            let b = g.add_rawfile_mod(
+                "raw-b",
+                "RawB",
+                RawTarget::Bank {
+                    name: "voice.BANK".into(),
+                },
+                &bytes_b,
+            );
+            let (entries, expected) = if reverse {
+                ([(b.as_str(), true), (a.as_str(), true)], &bytes_a)
+            } else {
+                ([(a.as_str(), true), (b.as_str(), true)], &bytes_b)
+            };
+
+            let report = apply_loadout(&g.root, &g.lib, &loadout(&entries)).unwrap();
+            assert!(
+                report.warnings.is_empty(),
+                "warnings: {:?}",
+                report.warnings
+            );
+            assert_eq!(fs::read(&live).unwrap().as_slice(), expected.as_slice());
+
+            let bank_names: Vec<String> = fs::read_dir(live.parent().unwrap())
+                .unwrap()
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .filter(|name| name.to_lowercase().ends_with(".bank"))
+                .collect();
+            // Windows keeps the last winner's spelling for this one case-insensitive file. Unix
+            // test hosts resolve back to the single existing entry to emulate that identity.
+            let expected_name = if cfg!(windows) && !reverse {
+                "voice.BANK"
+            } else {
+                "Voice.bank"
+            };
+            assert_eq!(bank_names, vec![expected_name]);
+        }
+
+        run(false);
+        run(true);
     }
 
     // ── SCRIPTS materialization ─────────────────────────────────────────────────────────────────
@@ -4067,6 +4637,156 @@ mod tests {
         );
     }
 
+    #[test]
+    fn apply_rejects_stale_script_minis_regardless_of_mod_origin() {
+        for (kind, id) in [
+            (ModKind::Goremod, "gore-script-mini"),
+            (ModKind::ForeignMixed, "external-script-mini"),
+        ] {
+            let g = FakeGame::new();
+            let mut base = build_script_cache(&["_gore_base"]);
+            base[..16].copy_from_slice(&[0x11; 16]);
+            fs::write(g.script_cache(), &base).unwrap();
+
+            let mut mini = build_script_cache(&["_gore_added"]);
+            mini[..16].copy_from_slice(&[0x22; 16]);
+            let script = g.add_script_mod(id, "StaleScriptMini", "add", "_gore_added", &mini);
+            let sidecar = g.lib.join(&script).join(META_FILE);
+            let mut meta: ModEntryMeta =
+                serde_json::from_slice(&fs::read(&sidecar).unwrap()).unwrap();
+            meta.kind = kind;
+            fs::write(&sidecar, serde_json::to_vec_pretty(&meta).unwrap()).unwrap();
+            let before_tree = crate::tree_fingerprint(&g.root).unwrap();
+
+            let error = apply_loadout(&g.root, &g.lib, &loadout(&[(&script, true)]))
+                .unwrap_err()
+                .to_string();
+            assert!(
+                error.contains("does not match target base GUID")
+                    && error.contains("remap the module against this exact game cache"),
+                "{kind:?} must use the same script validation; unexpected error: {error}"
+            );
+            assert_no_apply_artifacts(&g, &g.script_cache(), &base);
+            assert_eq!(
+                crate::tree_fingerprint(&g.root).unwrap(),
+                before_tree,
+                "refused {kind:?} script composition must leave the game tree byte-identical"
+            );
+        }
+    }
+
+    #[test]
+    fn script_overlay_validates_an_external_raw_replacement_before_mutation() {
+        let g = FakeGame::new();
+        let base = build_script_cache(&["_gore_base"]);
+        fs::write(g.script_cache(), &base).unwrap();
+
+        let raw = g.add_rawfile_mod(
+            "external-raw-script",
+            "ExternalRawScript",
+            RawTarget::ScriptCache,
+            b"not a script cache",
+        );
+        let raw_sidecar = g.lib.join(&raw).join(META_FILE);
+        let mut raw_meta: ModEntryMeta =
+            serde_json::from_slice(&fs::read(&raw_sidecar).unwrap()).unwrap();
+        raw_meta.kind = ModKind::ForeignRawfile;
+        fs::write(&raw_sidecar, serde_json::to_vec_pretty(&raw_meta).unwrap()).unwrap();
+
+        let mini = build_script_cache(&["_gore_added"]);
+        let patch = g.add_script_mod(
+            "script-overlay",
+            "ScriptOverlay",
+            "add",
+            "_gore_added",
+            &mini,
+        );
+        let before_tree = crate::tree_fingerprint(&g.root).unwrap();
+
+        let error = apply_loadout(&g.root, &g.lib, &loadout(&[(&raw, true), (&patch, true)]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("prepare script composition"),
+            "unexpected error: {error}"
+        );
+        assert_no_apply_artifacts(&g, &g.script_cache(), &base);
+        assert_eq!(
+            crate::tree_fingerprint(&g.root).unwrap(),
+            before_tree,
+            "an invalid external raw base must be refused before the game changes"
+        );
+    }
+
+    #[test]
+    fn script_overlay_uses_complete_raw_replacement_as_its_base_in_both_orders() {
+        use gore_as::cache::walk_modules::{module_count, module_names};
+
+        fn run(reverse: bool) {
+            let g = FakeGame::new();
+
+            let mut pristine = build_script_cache(&["_installed_pristine"]);
+            pristine[..16].copy_from_slice(&[0x11; 16]);
+            fs::write(g.script_cache(), &pristine).unwrap();
+
+            // A complete replacement owns its GUID. The mini was built against that replacement,
+            // not against the installed cache, so it carries the replacement's exact GUID.
+            let raw_guid = [0xa5; 16];
+            let mut raw_cache = build_script_cache(&["_raw_base"]);
+            raw_cache[..16].copy_from_slice(&raw_guid);
+            let raw = g.add_rawfile_mod(
+                "raw-script-base",
+                "RawScriptBase",
+                RawTarget::ScriptCache,
+                &raw_cache,
+            );
+
+            let mut mini = build_script_cache(&["_raw_patch"]);
+            mini[..16].copy_from_slice(&raw_guid);
+            let patch = g.add_script_mod(
+                "raw-bound-script-patch",
+                "RawBoundScriptPatch",
+                "add",
+                "_raw_patch",
+                &mini,
+            );
+
+            let entries = if reverse {
+                [(patch.as_str(), true), (raw.as_str(), true)]
+            } else {
+                [(raw.as_str(), true), (patch.as_str(), true)]
+            };
+            let report = match apply_loadout(&g.root, &g.lib, &loadout(&entries)) {
+                Ok(report) => report,
+                Err(error) => {
+                    assert_no_apply_artifacts(&g, &g.script_cache(), &pristine);
+                    panic!("valid raw-bound script composition failed: {error}");
+                }
+            };
+            assert!(
+                report.warnings.is_empty(),
+                "warnings: {:?}",
+                report.warnings
+            );
+
+            let live = fs::read(g.script_cache()).unwrap();
+            assert_eq!(
+                &live[..16],
+                &raw_guid,
+                "the raw base must own the output GUID"
+            );
+            assert_eq!(module_count(&live), 2);
+            assert_eq!(
+                module_names(&live).unwrap(),
+                vec!["_raw_base".to_string(), "_raw_patch".to_string()],
+                "the complete raw base and its bound patch must compose regardless of loadout order"
+            );
+        }
+
+        run(false);
+        run(true);
+    }
+
     /// The script `edit` op materializes a `replace_module`: a 2-module base has one module swapped
     /// in place (count unchanged), and the LIVE cache re-walks with the replacement present and the
     /// old module gone.
@@ -4108,70 +4828,302 @@ mod tests {
 
     #[test]
     fn apply_scripts_composes_two_independent_allow_new_minis() {
-        let g = FakeGame::new();
-        let base = build_script_cache(&["_gore_base"]);
-        fs::write(g.script_cache(), &base).unwrap();
-        let mini_a = build_script_cache_with_static_name("_gore_a", "FirstName", 1);
-        let mini_b = build_script_cache_with_static_name("_gore_b", "SecondName", 2);
-        let a = g.add_script_mod("mod-as-a", "AsA", "add", "_gore_a", &mini_a);
-        let b = g.add_script_mod("mod-as-b", "AsB", "add", "_gore_b", &mini_b);
+        fn run(reverse: bool) -> ScriptAssignments {
+            let g = FakeGame::new();
+            let base = build_script_cache(&["_gore_base"]);
+            fs::write(g.script_cache(), &base).unwrap();
+            // These two real production-domain ScriptObject identities have the same masked FNV
+            // start, 0x0B3F6760. Independently prepared minis therefore carry the same T2 ID even
+            // though their other provisional keys differ. The old sequential path rejected the
+            // second T2/T7 row; the loadout plan must allocate both identities together.
+            const COLLIDING_TYPE_ID: i32 = 0x0B3F_6760;
+            let mini_a = build_script_cache_with_static_name_and_keys(
+                "_gore_collision_14",
+                "FirstName",
+                "CollisionType1901",
+                1,
+                1,
+                COLLIDING_TYPE_ID,
+            );
+            let mini_b = build_script_cache_with_static_name_and_keys(
+                "_gore_collision_7",
+                "SecondName",
+                "CollisionType2149",
+                2,
+                2,
+                COLLIDING_TYPE_ID,
+            );
+            let a = g.add_script_mod("mod-as-a", "AsA", "add", "_gore_collision_14", &mini_a);
+            let b = g.add_script_mod("mod-as-b", "AsB", "add", "_gore_collision_7", &mini_b);
+            let ordered = if reverse {
+                loadout(&[(&b, true), (&a, true)])
+            } else {
+                loadout(&[(&a, true), (&b, true)])
+            };
 
-        let report = apply_loadout(&g.root, &g.lib, &loadout(&[(&a, true), (&b, true)])).unwrap();
-        assert!(
-            report.warnings.is_empty(),
-            "warnings: {:?}",
-            report.warnings
+            let report = apply_loadout(&g.root, &g.lib, &ordered).unwrap();
+            assert!(
+                report.warnings.is_empty(),
+                "warnings: {:?}",
+                report.warnings
+            );
+
+            let live = fs::read(g.script_cache()).unwrap();
+            let names = gore_as::cache::walk_modules::module_names(&live).unwrap();
+            let expected_names = if reverse {
+                vec!["_gore_base", "_gore_collision_7", "_gore_collision_14"]
+            } else {
+                vec!["_gore_base", "_gore_collision_14", "_gore_collision_7"]
+            };
+            assert_eq!(names, expected_names);
+            let refs = gore_as::cache::refs::RefResolver::build(&live).unwrap();
+            let expected_static = if reverse {
+                ["SecondName", "FirstName"]
+            } else {
+                ["FirstName", "SecondName"]
+            };
+            assert_eq!(refs.static_name(0), Some(expected_static[0]));
+            assert_eq!(refs.static_name(1), Some(expected_static[1]));
+
+            let assignments = script_assignments(&live);
+            let type_1 = assignments.type_ids["CollisionType1901"];
+            let type_2 = assignments.type_ids["CollisionType2149"];
+            assert_ne!(type_1, type_2);
+            assert_eq!(refs.type_by_id(type_1), Some("CollisionType1901"));
+            assert_eq!(refs.type_by_id(type_2), Some("CollisionType2149"));
+            let func_1 = assignments.function_ids["ProbeFunc1"];
+            let func_2 = assignments.function_ids["ProbeFunc2"];
+            assert_ne!(func_1, func_2);
+            assert_eq!(refs.func_by_id(func_1), Some("ProbeFunc1"));
+            assert_eq!(refs.func_by_id(func_2), Some("ProbeFunc2"));
+            assert_eq!(refs.member(type_1, 4), Some("ProbeField1"));
+            assert_eq!(refs.member(type_2, 4), Some("ProbeField2"));
+            let functions =
+                gore_as::cache::walk_modules::collect_function_bytecodes(&live).unwrap();
+            let indices: Vec<u16> = functions
+                .iter()
+                .filter_map(|function| {
+                    gore_as::cache::disasm::disassemble(&function.bytecode)
+                        .unwrap()
+                        .into_iter()
+                        .find(|ins| ins.op.name == "STR")
+                        .map(|instruction| instruction.words[0])
+                })
+                .collect();
+            assert_eq!(indices, vec![0, 1], "later mini operand must be rebased");
+            assignments
+        }
+
+        let forward = run(false);
+        let reverse = run(true);
+        assert_eq!(
+            forward, reverse,
+            "portable identities must keep the same canonical pointer/ID assignment under loadout reorder"
         );
-
-        let live = fs::read(g.script_cache()).unwrap();
-        let names = gore_as::cache::walk_modules::module_names(&live).unwrap();
-        assert_eq!(names, vec!["_gore_base", "_gore_a", "_gore_b"]);
-        let refs = gore_as::cache::refs::RefResolver::build(&live).unwrap();
-        assert_eq!(refs.static_name(0), Some("FirstName"));
-        assert_eq!(refs.static_name(1), Some("SecondName"));
-        assert_eq!(refs.type_by_id(0x0801_0001), Some("ProbeType1"));
-        assert_eq!(refs.type_by_id(0x0801_0002), Some("ProbeType2"));
-        assert_eq!(refs.func_by_id(1_000_001), Some("ProbeFunc1"));
-        assert_eq!(refs.func_by_id(1_000_002), Some("ProbeFunc2"));
-        assert_eq!(refs.member(0x0801_0001, 4), Some("ProbeField1"));
-        assert_eq!(refs.member(0x0801_0002, 4), Some("ProbeField2"));
-        let functions = gore_as::cache::walk_modules::collect_function_bytecodes(&live).unwrap();
-        let indices: Vec<u16> = functions
-            .iter()
-            .map(|function| {
-                gore_as::cache::disasm::disassemble(&function.bytecode)
-                    .unwrap()
-                    .into_iter()
-                    .find(|ins| ins.op.name == "STR")
-                    .unwrap()
-                    .words[0]
-            })
-            .collect();
-        assert_eq!(indices, vec![0, 1], "later mini operand must be rebased");
     }
 
-    /// The script-cache arm's rawfile path: a `RawFile{ScriptCache}` with arbitrary bytes and NO
-    /// script patches is written to the live cache VERBATIM (base with no overlay). This exercises
-    /// the deterministic orchestration of the script-cache target without needing real gore-as
-    /// bytes — the whole-file replacement that a script rawfile performs.
+    #[test]
+    fn apply_scripts_same_target_keeps_later_winner_and_independent_target() {
+        fn run(reverse: bool) {
+            let g = FakeGame::new();
+            let base = build_script_cache(&["_gore_base"]);
+            fs::write(g.script_cache(), &base).unwrap();
+
+            // Both contenders claim the exact same manifest target and carry that same module name.
+            // Their private symbols make it observable which mini actually reached composition.
+            let mini_a = build_script_cache_with_static_name_and_keys(
+                "_gore_shared",
+                "SharedFromA",
+                "SharedTypeA",
+                31,
+                31,
+                0x0801_0031,
+            );
+            let mini_b = build_script_cache_with_static_name_and_keys(
+                "_gore_shared",
+                "SharedFromB",
+                "SharedTypeB",
+                32,
+                32,
+                0x0801_0032,
+            );
+            let independent_mini = build_script_cache_with_static_name_and_keys(
+                "_gore_independent",
+                "IndependentName",
+                "IndependentType",
+                33,
+                33,
+                0x0801_0033,
+            );
+            let a = g.add_script_mod("script-a", "Script A", "add", "_gore_shared", &mini_a);
+            let independent = g.add_script_mod(
+                "script-independent",
+                "Independent",
+                "add",
+                "_gore_independent",
+                &independent_mini,
+            );
+            let b = g.add_script_mod("script-b", "Script B", "add", "_gore_shared", &mini_b);
+            let ordered = if reverse {
+                loadout(&[(&b, true), (&independent, true), (&a, true)])
+            } else {
+                loadout(&[(&a, true), (&independent, true), (&b, true)])
+            };
+
+            apply_loadout(&g.root, &g.lib, &ordered).unwrap();
+
+            let live = fs::read(g.script_cache()).unwrap();
+            assert_eq!(
+                gore_as::cache::walk_modules::module_names(&live).unwrap(),
+                vec!["_gore_base", "_gore_independent", "_gore_shared"]
+            );
+            let refs = gore_as::cache::refs::RefResolver::build(&live).unwrap();
+            let (winner_name, winner_type, loser_type) = if reverse {
+                ("SharedFromA", "SharedTypeA", "SharedTypeB")
+            } else {
+                ("SharedFromB", "SharedTypeB", "SharedTypeA")
+            };
+            assert_eq!(refs.static_name(0), Some("IndependentName"));
+            assert_eq!(refs.static_name(1), Some(winner_name));
+            assert_eq!(refs.static_name(2), None, "only two minis may be composed");
+
+            let assignments = script_assignments(&live);
+            assert!(assignments.type_ids.contains_key("IndependentType"));
+            assert!(assignments.type_ids.contains_key(winner_type));
+            assert!(
+                !assignments.type_ids.contains_key(loser_type),
+                "the earlier entry for one exact module target must not reach planning or compose"
+            );
+        }
+
+        run(false);
+        run(true);
+    }
+
+    /// A standalone `RawFile{ScriptCache}` is structurally validated from its private candidate,
+    /// then that same candidate is published VERBATIM. Its GUID belongs to the complete replacement
+    /// and deliberately need not match the installed cache. Origin never changes this policy.
     #[test]
     fn apply_scripts_rawfile_written_verbatim() {
-        let g = FakeGame::new();
-        // A live pristine cache that must be fully replaced by the rawfile.
-        fs::write(g.script_cache(), b"PRISTINE-CACHE-BYTES").unwrap();
-        let raw = b"\x00\x01\x02RAW-SCRIPT-CACHE\xff\xfe".to_vec();
-        let a = g.add_rawfile_mod("mod-rawsc", "RawSc", RawTarget::ScriptCache, &raw);
+        for (kind, id, guid) in [
+            (ModKind::Goremod, "gore-raw-script", 0xa5),
+            (ModKind::ForeignRawfile, "foreign-raw-script", 0x5a),
+        ] {
+            let g = FakeGame::new();
+            let pristine = build_script_cache(&["_gore_pristine"]);
+            fs::write(g.script_cache(), &pristine).unwrap();
 
-        let report = apply_loadout(&g.root, &g.lib, &loadout(&[(&a, true)])).unwrap();
-        assert!(
-            report.warnings.is_empty(),
-            "warnings: {:?}",
-            report.warnings
+            let mut raw = build_script_cache(&["_complete_replacement"]);
+            raw[..16].copy_from_slice(&[guid; 16]);
+            assert_ne!(&raw[..16], &pristine[..16]);
+            let entry = g.add_rawfile_mod(id, "RawSc", RawTarget::ScriptCache, &raw);
+            let sidecar = g.lib.join(&entry).join(META_FILE);
+            let mut meta: ModEntryMeta =
+                serde_json::from_slice(&fs::read(&sidecar).unwrap()).unwrap();
+            meta.kind = kind;
+            fs::write(&sidecar, serde_json::to_vec_pretty(&meta).unwrap()).unwrap();
+
+            let report = apply_loadout(&g.root, &g.lib, &loadout(&[(&entry, true)])).unwrap();
+            assert!(
+                report.warnings.is_empty(),
+                "{kind:?} warnings: {:?}",
+                report.warnings
+            );
+            assert_eq!(
+                fs::read(g.script_cache()).unwrap(),
+                raw,
+                "{kind:?} full ScriptCache replacement must remain byte-identical"
+            );
+        }
+    }
+
+    #[test]
+    fn standalone_script_rawfiles_reject_bad_containers_before_mutation() {
+        let valid = build_script_cache(&["_complete_replacement"]);
+        let short = vec![0u8; gore_as::cache::header::CacheHeader::SIZE - 1];
+        let mut wrong_magic = valid.clone();
+        wrong_magic[0x10..0x14].copy_from_slice(&0xdead_beefu32.to_le_bytes());
+        let mut truncated = valid.clone();
+        truncated.pop();
+        let mut impossible_count = valid.clone();
+        impossible_count[0x14..0x18].copy_from_slice(&u32::MAX.to_le_bytes());
+        let duplicate_module_key = build_script_cache(&["DuplicateModule", "DuplicateModule"]);
+
+        for (case, malformed) in [
+            ("short", short),
+            ("wrong-magic", wrong_magic),
+            ("truncated", truncated),
+            ("impossible-count", impossible_count),
+            ("duplicate-module-key", duplicate_module_key),
+        ] {
+            for (kind, origin) in [
+                (ModKind::Goremod, "gore"),
+                (ModKind::ForeignRawfile, "foreign"),
+            ] {
+                let g = FakeGame::new();
+                let pristine = build_script_cache(&["_gore_pristine"]);
+                fs::write(g.script_cache(), &pristine).unwrap();
+                let id = format!("{origin}-{case}");
+                let entry = g.add_rawfile_mod(
+                    &id,
+                    "MalformedScriptCache",
+                    RawTarget::ScriptCache,
+                    &malformed,
+                );
+                let sidecar = g.lib.join(&entry).join(META_FILE);
+                let mut meta: ModEntryMeta =
+                    serde_json::from_slice(&fs::read(&sidecar).unwrap()).unwrap();
+                meta.kind = kind;
+                fs::write(&sidecar, serde_json::to_vec_pretty(&meta).unwrap()).unwrap();
+
+                let error = apply_loadout(&g.root, &g.lib, &loadout(&[(&entry, true)]))
+                    .unwrap_err()
+                    .to_string();
+                assert!(
+                    error.contains("validate standalone script cache"),
+                    "{kind:?}/{case} unexpected error: {error}"
+                );
+                assert_no_apply_artifacts(&g, &g.script_cache(), &pristine);
+            }
+        }
+    }
+
+    #[test]
+    fn standalone_script_rawfile_uses_patch_base_limit_before_snapshot() {
+        let g = FakeGame::new();
+        let pristine = build_script_cache(&["_gore_pristine"]);
+        fs::write(g.script_cache(), &pristine).unwrap();
+        let raw = build_script_cache(&["_complete_replacement"]);
+        let entry = g.add_rawfile_mod(
+            "bounded-raw-script",
+            "BoundedRawScript",
+            RawTarget::ScriptCache,
+            &raw,
         );
+        let limit = u64::try_from(raw.len() - 1).unwrap();
+        let before_tree = crate::tree_fingerprint(&g.root).unwrap();
+
+        let error = apply_loadout_with_limits(
+            &g.root,
+            &g.lib,
+            &loadout(&[(&entry, true)]),
+            ApplyLimits {
+                max_patch_base_bytes: limit,
+                ..DEFAULT_APPLY_LIMITS
+            },
+            false,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains(&format!("raw-file payload exceeds the {limit} byte limit")),
+            "unexpected error: {error}"
+        );
+        assert_no_apply_artifacts(&g, &g.script_cache(), &pristine);
         assert_eq!(
-            fs::read(g.script_cache()).unwrap(),
-            raw,
-            "rawfile ScriptCache must be written verbatim as the live cache"
+            crate::tree_fingerprint(&g.root).unwrap(),
+            before_tree,
+            "the opened-file size gate must reject before snapshotting or game mutation"
         );
     }
 

--- a/crates/gore-mod/src/mgr/preflight.rs
+++ b/crates/gore-mod/src/mgr/preflight.rs
@@ -718,16 +718,14 @@ fn inspect_loadout_with_budgets(
                     .components
                     .iter()
                     .any(|component| matches!(component, ComponentInfo::Ue4ssLua { .. }));
+                // Component metadata is only a bounded projection. A malformed, legacy, or
+                // partially inspected sidecar may omit `targets`, but Apply will still read and
+                // compose the script manifest. Every enabled script component therefore requires
+                // the shipping cache; never let an empty advisory target list weaken preflight.
                 requires_script_cache |= meta
                     .components
                     .iter()
-                    .any(|component| {
-                        matches!(
-                            component,
-                            ComponentInfo::AngelScriptPatch { targets, .. }
-                                if !targets.is_empty()
-                        )
-                    });
+                    .any(|component| matches!(component, ComponentInfo::AngelScriptPatch { .. }));
             }
             Err(error) => match error {
                 EvidenceFailure::Problem(message) => {
@@ -2233,7 +2231,7 @@ mod tests {
         write_enabled_loadout(&loadout, &["deferred"]);
 
         let inspected = inspect_loadout(&library, &loadout);
-        assert!(!inspected.requires_script_cache);
+        assert!(inspected.requires_script_cache);
         let check = inspected.check;
         assert_eq!(check.state, PreflightStateV1::Ok);
         assert_eq!(check.code, "loadout_metadata_ready");
@@ -2246,7 +2244,7 @@ mod tests {
     }
 
     #[test]
-    fn script_cache_is_required_only_for_declared_script_edits() {
+    fn every_script_component_requires_the_shipping_cache() {
         let install = install_fixture();
         let library = install.path().join("library");
         fs::create_dir(&library).unwrap();
@@ -2279,8 +2277,13 @@ mod tests {
             )
         };
         let empty = inspect();
-        assert_eq!(empty.checks[1].code, "install_recognized");
-        assert_eq!(empty.checks[3].action, "review_apply");
+        assert_eq!(empty.checks[1].code, "install_incomplete");
+        assert_eq!(empty.checks[1].action, "verify_game_files");
+        assert!(empty.checks[1]
+            .items
+            .iter()
+            .any(|item| item.ends_with("PrecompiledScript_Shipping.Cache")));
+        assert_eq!(empty.checks[3].action, "verify_game_files");
 
         write_library_meta(
             &library,

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -12,7 +12,6 @@ use gore_as::cache::default_evidence::{
 };
 use gore_as::cache::header::CacheHeader;
 use gore_as::cache::scan::scan_strings;
-use gore_as::cache::splice::splice_auto;
 use gore_as::cache::walk_modules::{module_count, module_region_end};
 
 #[derive(Subcommand)]
@@ -224,19 +223,24 @@ pub enum AsCmd {
         )]
         diagnostics_inject_delay_ms: u64,
     },
-    /// Replace an existing module (by name) in a base cache with a mini-cache's module.
+    /// Replace an existing module using a mini-cache bound to this exact base generation.
     Replace {
+        /// Base cache (e.g. PrecompiledScript_Shipping.Cache).
         base: PathBuf,
+        /// Base-bound mini-cache from `compile-module` or `extract-remap`; raw generator output
+        /// has a fresh GUID and is refused until it is remapped to this exact base.
         mini: PathBuf,
+        /// Existing outer Modules TMap key to replace.
         target: String,
         #[arg(short, long)]
         out: PathBuf,
     },
-    /// Splice a primitive-only mini-cache module into a base cache.
+    /// Splice a base-bound mini-cache module into a base cache.
     Splice {
         /// Base cache (e.g. PrecompiledScript_Shipping.Cache).
         base: PathBuf,
-        /// Mini-cache from -as-generate-precompiled-data (one primitive-only module).
+        /// Base-bound mini-cache from `compile-module` or `extract-remap`; raw generator output
+        /// has a fresh GUID and is refused until it is remapped to this exact base.
         mini: PathBuf,
         /// Output path for the spliced cache.
         #[arg(short, long)]
@@ -2290,7 +2294,10 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             let base_b = read_module_cache(&base)?;
             let mini_b = read_module_cache(&mini)?;
             let n = module_count(&base_b);
-            let res = gore_as::cache::splice::replace_module(&base_b, &mini_b, &target)
+            let mut guard = gore_as::cache::splice::SequentialMiniGuard::new(&base_b)
+                .context("validating replace base")?;
+            let res = guard
+                .compose_edit(&base_b, &mini_b, &target)
                 .context("replace")?;
             std::fs::write(&out, &res).with_context(|| format!("writing {}", out.display()))?;
             println!(
@@ -2306,7 +2313,9 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             let base_b = read_module_cache(&base)?;
             let mini_b = read_module_cache(&mini)?;
             let before = module_count(&base_b);
-            let spliced = splice_auto(&base_b, &mini_b).context("splicing")?;
+            let mut guard = gore_as::cache::splice::SequentialMiniGuard::new(&base_b)
+                .context("validating splice base")?;
+            let spliced = guard.compose_add(&base_b, &mini_b).context("splicing")?;
             std::fs::write(&out, &spliced).with_context(|| format!("writing {}", out.display()))?;
             println!(
                 "spliced: {} modules -> {} ; {} -> {} bytes ; wrote {}",

--- a/crates/gore/tests/integration/as_cache_test.rs
+++ b/crates/gore/tests/integration/as_cache_test.rs
@@ -11,6 +11,13 @@ fn fixture_path() -> String {
     .to_string()
 }
 
+fn minimal_cache_header(guid: [u8; 16], module_count: u32) -> Vec<u8> {
+    let mut bytes = guid.to_vec();
+    bytes.extend_from_slice(&gore_as::cache::header::CACHE_MAGIC.to_le_bytes());
+    bytes.extend_from_slice(&module_count.to_le_bytes());
+    bytes
+}
+
 fn expected_default_evidence(cache: &[u8]) -> (&'static str, &'static str, &'static str) {
     match format!("{:x}", Sha256::digest(cache)).as_str() {
         "1018f1cfe6b99a650eecb33afb96752d691d2088ead27808971b812f04ecb4c2" => (
@@ -113,6 +120,51 @@ fn every_module_cache_subcommand_rejects_a_file_that_is_not_a_module_cache() {
         !outdir_path.exists(),
         "emit-all must refuse before it creates an output tree"
     );
+}
+
+#[test]
+fn splice_and_replace_refuse_a_mini_from_another_cache_before_writing_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let base_path = dir.path().join("base.Cache");
+    let mini_path = dir.path().join("foreign-mini.Cache");
+    let out_path = dir.path().join("never-written.Cache");
+
+    let mut base = minimal_cache_header([0x11; 16], 0);
+    base.extend_from_slice(&[0u8; 28]); // seven empty tail tables
+    std::fs::write(&base_path, base).unwrap();
+    // The GUID mismatch is checked before the declared module body is parsed.
+    std::fs::write(&mini_path, minimal_cache_header([0x22; 16], 1)).unwrap();
+
+    for args in [
+        vec![
+            "as",
+            "splice",
+            base_path.to_str().unwrap(),
+            mini_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+        ],
+        vec![
+            "as",
+            "replace",
+            base_path.to_str().unwrap(),
+            mini_path.to_str().unwrap(),
+            "SomeModule",
+            "-o",
+            out_path.to_str().unwrap(),
+        ],
+    ] {
+        Command::cargo_bin("gore")
+            .unwrap()
+            .args(args)
+            .assert()
+            .failure()
+            .stderr(contains("does not match target base GUID"));
+        assert!(
+            !out_path.exists(),
+            "a foreign mini must be refused before the output path is created"
+        );
+    }
 }
 
 #[test]

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -172,12 +172,42 @@ gore as splice        vanilla.Cache mini.Cache -o modded.Cache
 gore as extract regen.Cache <Module> -o mini.Cache
 ```
 
+`replace` and `splice` accept only a mini-cache already bound to the exact base
+generation by `compile-module` or `extract-remap`. Raw
+`-as-generate-precompiled-data` output carries a fresh GUID and is refused; remap
+it against the intended pristine base first.
+
 `--allow-new-symbols` is deliberately opt-in. Existing references are still
 mapped back to the vanilla cache; only rows for classes, functions, and names
 that do not exist there are retained, with collision checks before deployment.
 Mod Studio defaults it **on** for a new module and **off** for an edit; an
 existing-module edit can enable it explicitly when it intentionally adds a class
 or function.
+
+The remapped mini-cache is bound to the exact target cache GUID. Apply checks
+that binding again and validates every executable reference and retained symbol
+dependency against the effective base-plus-mini tables before it creates a game
+backup, deploy record, or mutation lock. A mini built for an older game cache is
+therefore refused rather than spliced. After a game update, compile or remap the
+module again against the new pristine `PrecompiledScript_Shipping.Cache`; do not
+reuse the previous mini-cache or copy its old GUID.
+
+These checks depend only on the cache contents, never on where the mod came
+from. A GORE bundle, a community download, and a manually prepared package all
+follow the same path and receive no origin-based exception.
+
+A whole-cache replacement without additional script patches is validated as a
+complete cache and then copied byte-for-byte. Its GUID belongs to that complete
+replacement and does not have to match the currently installed cache. If other
+script patches are layered on top, the replacement becomes their effective base
+and the normal GUID and dependency checks apply before deployment.
+
+Mod Manager plans all enabled script patches together before changing the game,
+so internal number collisions between otherwise independent mods do not depend
+on load order. Patches for different modules are combined. If several entries
+target the same module, the later loadout entry is the displayed and deployed
+winner. A complete raw cache is a base rather than a winner over compatible
+module patches; those patches are applied on top of it in either order.
 
 The `-o` form of `compile` leaves the install exactly as it was, so the live
 `PrecompiledScript_Shipping.Cache` is still the pristine cache these commands

--- a/docs/reference/game-updates.md
+++ b/docs/reference/game-updates.md
@@ -32,6 +32,13 @@ Three identities travel together and all three are sealed:
 | `G1R\Script\PrecompiledScript_Shipping.Cache` | the AngelScript module cache, carrying a GUID in its first 16 bytes |
 | `G1R\Script\Binds.Cache` | the native binding table: class → `/Script/` path, and field → type |
 
+Deployable AngelScript mini-caches are exact-generation artifacts too. GORE
+stamps the target cache GUID during remap and, before any installation mutation,
+requires the mini GUID to equal the effective base cache and resolves its
+bytecode and retained table dependencies against that base. A game update that
+changes the cache therefore invalidates old minis even when their module names
+still exist; rebuild or remap them against the new pristine cache.
+
 A fourth input is sealed but **not shipped by Steam**: the `.usmap` reflection
 dump under `G1R\Binaries\Win64\ue4ss\`. UE4SS generates it on your machine. Its
 filename carries the engine build (`G1R-5.4.3-<build>-<hash>.usmap`), so a stale


### PR DESCRIPTION
## Summary

- plan all enabled AngelScript patches together so independent modules compose deterministically, with later same-module entries winning
- allow a complete ScriptCache replacement to act as the base for compatible module patches
- validate, bound, seal, and re-check script inputs before any game mutation; preserve atomic rollback and publication identity
- make raw-base layering and Windows bank conflict identity consistent in analysis and apply
- document generation binding and the uniform handling of all external mod sources

## Validation

- exact Windows CI entry point: `python test.py all`
- Mod Studio: `flutter analyze` + 2,364 tests (1 intentional skip)
- Mod Manager: `flutter analyze` + 249 tests
- docs, plugin, release contracts: 57 tests plus link/plugin/workflow checks
- WSL: complete `gore-as` and `gore-mod` suites
- installed Shipping cache: tail roundtrip and 164,607/164,607 functions disassembled cleanly
- independent final code, scope, Manager, and AngelScript reviews: clean

No game files were modified and the game was not launched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> gore-as changes affect untrusted cache parsing and fingerprinting on the script-cache mutation path; Manager changes are mostly UI semantics and test coverage with limited production logic churn.
> 
> **Overview**
> **Mod Manager** documents that informational conflict advisories—including compatible **raw-base + patch** composition—never get a loadout “winner,” and adds tests so **info** `raw_file` rows stay separate from **hard** rows on the same target (hard still shows a winner). FFI/library tests now cover **`file_patch`**, **`pak_file_patch`**, and **`voice_archive_patch`** component decoding.
> 
> **gore-as** adds allocation-light **preflight** (module work, tail row counts) before cloning caches or building reference indexes/resolvers, and runs it consistently on default fingerprint and tag-map paths. **Bytecode disassembly** preflights instruction count and projected heap before allocating. **GlobalReference.Name** is decoded as UTF-8 only when `bIsString` is set (after reading name/module/namespace on the wire), with matching validation in NPC archetype preflight and `RefResolver`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adbfc38bdf94b0cb7c1641ba8f55fec4a38f2552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->