### PR TITLE
fix(gore-as): remap prepared static names

### DIFF
--- a/crates/gore-as/src/cache/remap.rs
+++ b/crates/gore-as/src/cache/remap.rs
@@ -8055,6 +8055,53 @@ fn plan_static_names(
     Ok(())
 }
 
+/// Prepared minis already encode their private StaticNames rows as absolute indices immediately
+/// after the pristine pool. The loadout-wide second pass must therefore resolve
+/// `base.static_names.len() + local_row`, not reinterpret that absolute operand as a local row in
+/// the mini's compact T6 table.
+fn plan_prepared_static_names(
+    plan: &mut NewSymbolPlan,
+    prepared: &TailMetadata,
+    base: &TailMetadata,
+) -> Result<(), RemapError> {
+    let base_len = base.static_names.len() as i64;
+    let base_by_name: HashMap<&str, i64> = base
+        .static_names
+        .iter()
+        .map(|row| (row.name.as_str(), row.index as i64))
+        .collect();
+    let prepared_by_source: HashMap<i64, &StaticRowMeta> = prepared
+        .static_names
+        .iter()
+        .map(|row| (base_len + row.index as i64, row))
+        .collect();
+    let mut new_by_name: HashMap<String, i64> = HashMap::new();
+    let mut used: Vec<i64> = plan.used_static_indices.iter().copied().collect();
+    used.sort_unstable();
+    for raw in used {
+        if raw >= 0 && raw < base_len {
+            plan.static_indices.insert(raw, raw);
+            continue;
+        }
+        let row = prepared_by_source
+            .get(&raw)
+            .copied()
+            .ok_or(RemapError::MissingStaticName(raw))?;
+        let final_index = if let Some(&base_index) = base_by_name.get(row.name.as_str()) {
+            base_index
+        } else if let Some(&selected) = new_by_name.get(&row.name) {
+            selected
+        } else {
+            let index = base_len + plan.selected_static_rows.len() as i64;
+            plan.selected_static_rows.push(row.index);
+            new_by_name.insert(row.name.clone(), index);
+            index
+        };
+        plan.static_indices.insert(raw, final_index);
+    }
+    Ok(())
+}
+
 fn property_key(type_id: i32, member_offset: i32) -> i64 {
     ((type_id as i64) << 1) | ((member_offset as i64) << 33) | 1
 }
@@ -8599,6 +8646,7 @@ fn finish_new_symbol_remap(
     pristine_header: &[u8],
     base: &AllowNewBaseContext,
     analyzed: AnalyzedNewSymbolMini,
+    prepared_static_names: bool,
 ) -> Result<(Vec<u8>, RemapCounts), RemapError> {
     let AnalyzedNewSymbolMini {
         regen,
@@ -8610,7 +8658,11 @@ fn finish_new_symbol_remap(
         mut comparison_budget,
     } = analyzed;
 
-    plan_static_names(&mut plan, &meta, &base.meta)?;
+    if prepared_static_names {
+        plan_prepared_static_names(&mut plan, &meta, &base.meta)?;
+    } else {
+        plan_static_names(&mut plan, &meta, &base.meta)?;
+    }
     plan_properties(&mut plan, &meta, &base.meta, &targets, &regen, &base.syms)?;
     let selected_property_indices: HashSet<usize> = plan
         .selected_properties
@@ -8968,7 +9020,13 @@ pub(super) fn remap_module_to_base_with_loadout_plan(
         &analyzed.spans,
         loadout,
     )?;
-    finish_new_symbol_remap(extracted_mini, &loadout.pristine_header, base, analyzed)
+    finish_new_symbol_remap(
+        extracted_mini,
+        &loadout.pristine_header,
+        base,
+        analyzed,
+        true,
+    )
 }
 
 fn remap_module_allow_new(
@@ -8991,7 +9049,7 @@ fn remap_module_allow_new(
         &analyzed.regen,
         &base_context.syms,
     )?;
-    finish_new_symbol_remap(extracted_mini, base, &base_context, analyzed)
+    finish_new_symbol_remap(extracted_mini, base, &base_context, analyzed, false)
 }
 
 /// Public entry: rewrite `extracted_mini`'s module bytecode refs to `base`'s keys, returning a

--- a/crates/gore-as/src/cache/remap_loadout_plan_tests.rs
+++ b/crates/gore-as/src/cache/remap_loadout_plan_tests.rs
@@ -1563,6 +1563,128 @@ fn prepared_base_only_func_id_preserves_factory_ref_and_static_name() {
 }
 
 #[test]
+fn loadout_second_pass_accepts_prepared_absolute_static_name_index() {
+    const BASE_FUNC_PTR: i64 = 0xc110;
+    const BASE_FUNC_ID: i32 = 130;
+    const MINI_FUNC_PTR: i64 = 0xc220;
+    const MINI_FUNC_ID: i32 = 131;
+    let base = cache(
+        "Pristine",
+        &[function_record("__STATIC_NAME", &[], BASE_FUNC_ID)],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(
+                BASE_FUNC_PTR,
+                "__STATIC_NAME",
+                "Pristine",
+                &[],
+            )],
+            func_ids: vec![id_row(BASE_FUNC_ID, BASE_FUNC_PTR)],
+            static_names: vec![sia("BaseName0"), sia("BaseName1")],
+            ..TailRows::default()
+        },
+    );
+    // A compile-module artifact has already been remapped against `base`: its first compact T6
+    // row is addressed at the absolute index immediately after the two pristine rows.
+    let prepared = cache(
+        "PreparedStaticConsumer",
+        &[function_record_with_code(
+            "UsesPreparedStaticName",
+            &[],
+            MINI_FUNC_ID,
+            &[2, 2, 9, BASE_FUNC_ID, 10],
+        )],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(
+                MINI_FUNC_PTR,
+                "UsesPreparedStaticName",
+                "PreparedStaticConsumer",
+                &[],
+            )],
+            func_ids: vec![id_row(MINI_FUNC_ID, MINI_FUNC_PTR)],
+            static_names: vec![sia("PreparedName")],
+            ..TailRows::default()
+        },
+    );
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    builder.inspect(&prepared).unwrap();
+    let plan = builder.finish().unwrap();
+    let output = remap_module_to_base_with_loadout_plan(&prepared, &base, &plan)
+        .unwrap()
+        .0;
+
+    let meta = TailMetadata::build(&output).unwrap();
+    assert_eq!(meta.static_names.len(), 1);
+    assert_eq!(meta.static_names[0].name, "PreparedName");
+    let spans = collect_module_spans(&output).unwrap();
+    assert_eq!(spans.code.len(), 1);
+    let span = &spans.code[0];
+    let code: Vec<i32> = (0..span.count)
+        .map(|index| {
+            let offset = span.data_off + index * 4;
+            i32::from_le_bytes(output[offset..offset + 4].try_into().unwrap())
+        })
+        .collect();
+    assert_eq!(code, [2, 2, 9, BASE_FUNC_ID, 10]);
+}
+
+#[test]
+fn loadout_second_pass_rejects_missing_prepared_static_name_row() {
+    const BASE_FUNC_PTR: i64 = 0xd110;
+    const BASE_FUNC_ID: i32 = 140;
+    const MINI_FUNC_PTR: i64 = 0xd220;
+    const MINI_FUNC_ID: i32 = 141;
+    let base = cache(
+        "Pristine",
+        &[function_record("__STATIC_NAME", &[], BASE_FUNC_ID)],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(
+                BASE_FUNC_PTR,
+                "__STATIC_NAME",
+                "Pristine",
+                &[],
+            )],
+            func_ids: vec![id_row(BASE_FUNC_ID, BASE_FUNC_PTR)],
+            static_names: vec![sia("BaseName")],
+            ..TailRows::default()
+        },
+    );
+    let malformed = cache(
+        "MalformedStaticConsumer",
+        &[function_record_with_code(
+            "UsesMissingStaticName",
+            &[],
+            MINI_FUNC_ID,
+            &[2, 2, 9, BASE_FUNC_ID, 10],
+        )],
+        &[],
+        TailRows {
+            funcs: vec![function_tail_row(
+                MINI_FUNC_PTR,
+                "UsesMissingStaticName",
+                "MalformedStaticConsumer",
+                &[],
+            )],
+            func_ids: vec![id_row(MINI_FUNC_ID, MINI_FUNC_PTR)],
+            // Its sole row lives at prepared absolute index 1, not the referenced gap at 2.
+            static_names: vec![sia("OnlyPreparedName")],
+            ..TailRows::default()
+        },
+    );
+
+    let mut builder = LoadoutScriptIdPlanBuilder::new(&base).unwrap();
+    builder.inspect(&malformed).unwrap();
+    let plan = builder.finish().unwrap();
+    assert!(matches!(
+        remap_module_to_base_with_loadout_plan(&malformed, &base, &plan),
+        Err(RemapError::MissingStaticName(2))
+    ));
+}
+
+#[test]
 fn successor_allocator_wraps_and_reports_small_domain_exhaustion() {
     let mut allocator = SuccessorAllocator::new(1, 3, [2, 3]);
     assert_eq!(allocator.allocate_from(2), Some(1));


### PR DESCRIPTION
## Summary

- distinguish raw and prepared StaticNames operand spaces during the loadout-wide remap
- preserve pristine indices and resolve private prepared rows as `base_count + local_row`
- reject missing prepared rows without weakening the raw compile/extract path

## Validation

- `cargo test -p gore-as loadout_second_pass_ -- --nocapture` (2 passed)
- full `cargo test -p gore-as` (323 passed, 13 ignored, integrations passed)
- real Shipping-cache Manager composition completed after the fix
- live Viper dialog rendered `[Gore probe] UI fixture`; UE4SS logged `RENDER_PASS exact_count=1`
- independent read-only diff review: clean

The real installation was restored afterward to its byte-exact four-mod baseline; no test package remains deployed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cache remap planning for loadout composition; wrong static-name resolution could break composed modules, but the change is scoped behind the loadout path with explicit error handling and tests.
> 
> **Overview**
> Fixes **StaticNames** remapping when a module has already been prepared against a pristine base and bytecode operands use **absolute** indices (`pristine_count + local_row`) rather than indices into the mini’s compact T6 table.
> 
> `finish_new_symbol_remap` takes a `prepared_static_names` flag: the **loadout plan** path uses new `plan_prepared_static_names`, which keeps pristine indices unchanged and maps private prepared rows via `base.static_names.len() + local_row`; the **raw** `remap_module_allow_new` path still uses `plan_static_names`.
> 
> Tests cover a successful loadout second pass with a prepared absolute index and `RemapError::MissingStaticName` when the referenced prepared row is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6393c7975a8dc3b5625c907f34dad44dfc61b686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->