### PR TITLE
feat(manager): align CLI, MCP, and docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "gore",
-  "description": "GORE, the modding toolkit for Gothic 1 Remake: the MCP server that exposes every gore CLI command, and the workflow knowledge that goes with it.",
+  "description": "GORE for Gothic 1 Remake: author mods and safely run the complete Mod Manager lifecycle through the CLI-backed MCP server and workflow skill.",
   "owner": {
     "name": "Daniel Hoer",
     "url": "https://github.com/dh0er"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "gore",
-      "description": "Mod Gothic 1 Remake from your assistant: textures, localized text, dialog, audio, voice-over, item values and AngelScript, built into one bundle and deployed as a unit.",
+      "description": "Author Gothic 1 Remake mods or safely import, enable, order, analyze, preflight, apply, check status, recover, remove and reset GORE or external mods.",
       "source": "./plugins/gore",
       "category": "development"
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,15 +5,15 @@
     "name": "Daniel Hoer"
   },
   "metadata": {
-    "description": "GORE, the modding toolkit for Gothic 1 Remake: the MCP server that exposes every gore CLI command, and the workflow knowledge that goes with it.",
-    "version": "0.2.0",
+    "description": "GORE for Gothic 1 Remake: author mods and safely run the complete Mod Manager lifecycle through the CLI-backed MCP server and workflow skill.",
+    "version": "0.3.0",
     "pluginRoot": "plugins"
   },
   "plugins": [
     {
       "name": "gore",
       "source": "gore",
-      "description": "Mod Gothic 1 Remake from your assistant: textures, localized text, dialog, audio, voice-over, item values and AngelScript, built into one bundle and deployed as a unit."
+      "description": "Author Gothic 1 Remake mods or safely import, enable, order, analyze, preflight, apply, check status, recover, remove and reset GORE or external mods."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@
 | **[gore-lua](lua/README.md)** | Small Lua helper library that ships into the game, for hand-written UE4SS mods. | 🚧 Work in progress |
 | **[Assistant plugin](plugins/gore/README.md)** | The MCP server and the modding skill, installed into Claude Code, Codex or Cursor in one step. | ⚗️ Experimental use |
 
-The Flutter GUIs reuse the exact same Rust crates as the CLI through a
-`dart:ffi` bridge — the CLI is always the most complete surface.
+The Flutter GUIs reuse the same Rust engine as the CLI through a `dart:ffi`
+bridge. The CLI is the expert and automation surface; the GUIs package those
+contracts into guided workflows instead of maintaining a second engine.
 
 ## 📊 Status
 
@@ -29,7 +30,7 @@ The Flutter GUIs reuse the exact same Rust crates as the CLI through a
 | [Textures](docs/guide/textures.md) | Full | Replace textures | A few, like the mouse cursors, are stored somewhere this cannot reach |
 | [DataAssets](docs/guide/dataassets.md) | Partly | Edit cooked game data | Only assets the engine describes natively; Blueprint ones are refused |
 | [Scripts](docs/guide/scripts.md) | Partly | Read the game's script code, change it, add your own | Reverse-engineered and lossy — recompiled code is not always identical |
-| [Mods & load order](docs/guide/bundles.md) | Full | Ship all of the above as one mod, run many together, and install mods that GORE did not build — plain zips, pak files, UE4SS mod folders | Nobody else's mod has been through it: the one end-to-end test used a file GORE made itself |
+| [Mods & load order](docs/guide/bundles.md) | Full | Ship all of the above as one mod, run many together, and install mods that GORE did not build — plain zips, pak files, UE4SS mod folders | Four Nexus mods have run through one real-install campaign; third-party AngelScript and three-way script conflicts remain unqualified |
 
 GORE will not edit your saves — that is the
 [Save Editor](apps/save-editor/README.md) — and everything above was seen by one
@@ -140,7 +141,7 @@ Everything lives in [`docs/`](docs/README.md).
 | 🖼️ [Textures](docs/guide/textures.md) · 📦 [DataAssets](docs/guide/dataassets.md) | Additive UE5 IoStore Zen triplets |
 | 📜 [Scripts](docs/guide/scripts.md) | Decompile, recompile, and splice the AngelScript cache |
 | 📦 [Bundling & deploying](docs/guide/bundles.md) | One spec → one mod that deploys as a unit |
-| 🧩 [Running many mods](docs/guide/mod-manager.md) | `gore mgr`: library, load order, conflicts |
+| 🧩 [Running many mods](docs/guide/mod-manager.md) | `gore mgr`: library, load order, conflict evidence, preflight/recovery, Apply and Reset |
 | ⌨️ [CLI reference](docs/guide/cli-reference.md) | Every command, subcommand, and flag |
 | 🤖 [AI assistants](docs/guide/mcp.md) | Install the plugin, or wire the MCP server up by hand; what gets confirmed with you |
 | 🖥️ [Mod Studio](docs/guide/mod-studio.md) | The no-code GUI: NPCs, quests, voice, project backups |

--- a/apps/mod-manager/CHANGELOG.md
+++ b/apps/mod-manager/CHANGELOG.md
@@ -8,9 +8,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.1.0] - Unreleased
 
-- First Early Alpha release candidate. Publication remains blocked on the
-  clean-machine and real-install acceptance passes.
-- Mod library, load order, conflict detection, and declarative Apply/Undeploy.
+- First Early Alpha release candidate. The real-install workflow has completed
+  one acceptance campaign; publication remains blocked on clean-Windows
+  portable, installer, recovery, Reset, and uninstall acceptance and explicit
+  release authorization.
+- Complete Manager lifecycle: import, inspect, enable, disable, reorder, remove,
+  analyze, declarative Apply, deployment status, confirmed abandoned-operation
+  recovery, Studio takeover, and Reset/Undeploy.
+- Bounded import for GORE bundles and supported foreign zips/folders, loose
+  `_P.pak`, IoStore `.utoc`/`.ucas` pairs with optional same-stem `.pak`, UE4SS
+  Lua folders, mixed packages, and raw `.lcache`, `.bank`, and
+  `PrecompiledScript*.Cache` replacements. `.7z`/`.rar`, multipart or incomplete
+  IoStore, unknown, unsafe, and corrupt inputs fail without a partial import.
+- Stable verified source/content identity keeps moved or unchanged reimports on
+  one entry, updates changed input in place, and refuses ambiguous identity.
+- Full-loadout deployment for item overrides, localization, audio, voice,
+  textures, cooked assets, loose files, packed files, AngelScript, and dialog
+  topics, with owned backups, drift/status evidence, and fail-closed recovery.
+- Conflict and footprint reporting distinguishes Exact, Partial, Advisory, and
+  Opaque knowledge instead of presenting an empty result as proof of safety.
+  Voice archives and loose/packed-file claims are covered; opaque UE4SS and
+  undeclared script targets remain visibly qualified.
+- Numeric Unreal container priorities now follow the displayed order. A
+  real-install campaign with Nexus mods #244, #512, #269, and Attack Input V4
+  verified both #244/#512 order directions, new-game and existing-save loading,
+  enable/disable/reorder/Reset, and byte-exact restoration of the captured
+  loadout with no temporary campaign residue.
+- Fixed prepared-mini AngelScript StaticNames remapping. A GORE-authored Viper
+  probe using the PR #91 Core DLL rendered `[Gore probe] UI fixture` and logged
+  `ARMED`, `CHOICE_PASS`, and `RENDER_PASS` with `exact_count=1`. This does not
+  qualify a third-party AngelScript mod or a three-way script conflict. #269 was
+  disabled for that probe after its separate off-game-thread UE4SS Lua crash.
+- Actionable first-run diagnosis, compact localized mutation errors, intended
+  winners/load-order direction, deployment ownership details, and truthful
+  recovery guidance are available in the GUI.
 - Windows installer with WinSparkle update checks; the portable zip remains
   self-contained and updater-free.
 - Documented that uninstalling removes the app and its normal

--- a/apps/mod-manager/README.md
+++ b/apps/mod-manager/README.md
@@ -21,21 +21,30 @@ portable builds are deliberately updater-free.
 
 - **Import** into a local library: built mod-bundle folders/zips (with a root
   `gore-mod.json`), foreign mod zips/folders, loose `_P.pak` files, IoStore
-  triplets (`.utoc`/`.ucas`/`.pak`), UE4SS Lua mod folders, and raw game-file
-  replacements.
+  pairs (`.utoc`/`.ucas`, with an optional same-stem `.pak`), UE4SS Lua mod
+  folders, and raw `.lcache`, `.bank`, or `PrecompiledScript*.Cache` game-file
+  replacements. Extract `.7z` and `.rar` downloads first. Multipart or
+  incomplete IoStore sets and unknown, unsafe, or corrupt inputs are refused
+  without publishing a partial library entry or changing the loadout.
 - **Enable/disable**, **remove**, and **drag to reorder** mods in the load order
   (later wins). Removing a library entry updates the target loadout; if that
   mod is already deployed, choose **Apply** afterwards to update the game.
-- **Detect recognized conflicts** across mods — localization, audio,
-  texture/asset, item overrides (CDO), scripts, and raw-file replacements — and
-  show intended winners. Each component is marked Exact, Partial, Advisory, or
-  Opaque so incomplete target knowledge stays visible; these grades do not
-  claim the game's runtime priority is proven.
+- **Detect recognized conflicts** across mods — localization, audio, voice
+  archives, texture/asset containers, item overrides (CDO), scripts, loose and
+  packed game-file claims, and raw-file replacements — and show intended
+  winners. Loose-file versus packed-file precedence is advisory, and an opaque
+  UE4SS component cannot produce a complete target inventory. Each component
+  is marked Exact, Partial, Advisory, or Opaque so incomplete knowledge stays
+  visible; these grades do not claim the game's runtime priority is proven.
 - **Apply** declaratively: full-recompute the modded state from a pristine base
-  and deploy the whole enabled set (backups first), or **undeploy all** to
-  restore.
+  and deploy the whole enabled set (backups first), or use the normal
+  **Reset/Undeploy** action to restore a validated Manager-owned deployment. A
+  Mod Studio deployment is preserved unless you explicitly choose and confirm
+  the separate **Take over** workflow below.
 - **Recover an interrupted Manager change** after confirmation when the native
-  setup check can identify a clearly abandoned Manager operation. Active
+  setup check can identify a clearly abandoned Manager operation. The app binds
+  its action to that exact report; the equivalent expert route is `gore mgr
+  preflight` followed by `gore mgr recover --expected-guard-id <TOKEN>`. Active
   changes stay on the wait path. Script-build recovery and recovery data that
   GORE cannot identify stay in recovery help. Do not delete the installation
   lock by hand; check the status again before using Undeploy.
@@ -46,6 +55,32 @@ portable builds are deliberately updater-free.
   cleanup action.
 - **Take over** a Mod Studio test-deploy so both tools do not fight over the
   install.
+
+## Real-install evidence
+
+On 2026-08-18 one packaged real-install campaign exercised four genuine Nexus
+mods: Main Menu Replacer — Remake (#244), Mainmenu Sleeper Enhanced (#512),
+Gothic UI Reposition (#269), and Attack Input V4. Numeric container priorities
+were observed in both order directions: `#244 -> #512` showed the Sleeper /
+Gothic-II menu, while `#512 -> #244` showed the red Remake artwork. A new game
+and an existing save loaded, and the tested enable, disable, reorder, Apply, and
+Reset paths behaved as expected.
+
+The same campaign rendered the GORE-authored Viper choice `[Gore probe] UI
+fixture`; `UE4SS.log` recorded `ARMED`, `CHOICE_PASS`, and `RENDER_PASS` with
+`exact_count=1`. That is live AngelScript composition evidence, but not evidence
+for a third-party AngelScript mod or a three-way script conflict: this probe used
+the PR #91-fixed app-local Core DLL. #269 was disabled for the probe after an
+earlier crash was isolated to its own UE4SS Lua loop calling `FindAllOf` off the
+game thread; no GORE or AngelScript frame was present. No save was written by
+the probe.
+
+After testing, the captured loadout was restored byte-for-byte, all temporary
+campaign entries and game-tree payloads were removed, the original signed Core
+DLL was restored, and the original four-mod deployment reported in sync. This
+is one person and one Windows installation. Clean-Windows portable, installer,
+recovery, Reset, and uninstall acceptance remains open, so 0.1.0 is not yet a
+published release.
 
 ## What it can not do
 

--- a/crates/gore-as/FORMAT.md
+++ b/crates/gore-as/FORMAT.md
@@ -48,6 +48,22 @@ extract-remap --allow-new-symbols can retain and rekey the minimal rows needed
 by a newly authored class/function-bearing module; the default remains strict
 and rejects unresolved new symbols.
 
+### StaticNames indices in raw and prepared minis
+
+The compact T6 table does not have one index convention at every stage. A raw
+extracted mini addresses its private StaticNames rows by local table index. A
+mini already prepared against a pristine base instead encodes a private row as
+the absolute operand `pristine_static_count + compact_row`; operands below the
+pristine count still refer directly to pristine rows.
+
+The loadout-wide second remap pass therefore preserves valid pristine operands
+and resolves each prepared absolute private operand through the mini's compact
+T6 row. It may then reuse a same-named pristine or already selected row, or
+append the row to the composed pool. It must not reinterpret that absolute
+operand as a local row. An operand in the prepared private range without the
+corresponding compact row fails closed with `MissingStaticName`; the raw
+extract/remap path keeps the local-index rule.
+
 ## Semantic-oracle slot normalization
 
 `gore as bytediff --norm-slots` keeps N2 opt-in and fail-closed. Its cheap path
@@ -74,7 +90,8 @@ difference.
 
 - The complete 7,305-module tree parses through the final tail-table byte.
 - Extract/remap/splice round-trips are covered by synthetic and real-cache
-  tests, including independently composed class-bearing mini-caches.
+  tests, including independently composed class-bearing mini-caches and
+  prepared absolute StaticNames operands with a missing-row refusal.
 - The corrected emitted tree compiles with the game compiler into a structurally
   complete cache; an intentional unknown symbol produces normal
   file:line:column error output and publishes no cache.

--- a/crates/gore-mcp/src/argv.rs
+++ b/crates/gore-mcp/src/argv.rs
@@ -1973,6 +1973,25 @@ mod tests {
     }
 
     #[test]
+    fn manager_recovery_forces_noninteractive_confirmation_and_json() {
+        assert_eq!(
+            argv_of(
+                "gore_mgr",
+                "recover",
+                json!({ "expected_guard_id": "guard-1" }),
+            ),
+            vec![
+                "mgr",
+                "recover",
+                "--expected-guard-id",
+                "guard-1",
+                "--yes",
+                "--json",
+            ]
+        );
+    }
+
+    #[test]
     fn positionals_are_ordered_and_separated_from_flags() {
         assert_eq!(
             argv_of(

--- a/crates/gore-mcp/src/capabilities.rs
+++ b/crates/gore-mcp/src/capabilities.rs
@@ -144,9 +144,10 @@ pub fn instructions(opts: &Options, policy: Policy) -> String {
 /// already been wrong once — it still listed `mod build`, `stubs`, `audio extract` and `as emit-all`
 /// after those four learned to check their destination and ask only when something is in the way.
 ///
-/// The bar is deliberately narrow: `Class::Mutate` and worse, which is the tier that asks no matter
-/// what it is handed. Commands that ask only about an occupied destination are covered by the
-/// sentence above this list, and naming them here would tell a model to avoid calls that are free.
+/// The bar is deliberately narrow: protected Manager-state writes, installation mutations, and
+/// destructive operations, which ask no matter what they are handed. Commands that ask only about
+/// an occupied destination are covered by the sentence above this list, and naming them here would
+/// tell a model to avoid calls that are free.
 ///
 /// `GameLaunch` is excluded because the line below this one is about exactly those, by name.
 fn always_gated() -> Vec<String> {
@@ -154,7 +155,10 @@ fn always_gated() -> Vec<String> {
         .iter()
         .flat_map(|group| group.commands.iter().map(move |command| (group, command)))
         .filter(|(_, command)| {
-            matches!(command.safety.base, Class::Mutate | Class::Destructive)
+            matches!(
+                command.safety.base,
+                Class::ManagerWrite | Class::Mutate | Class::Destructive
+            )
         })
         .map(|(group, command)| match group.shape {
             GroupShape::Nested => format!("{} {}", group.cli, command.sub),
@@ -237,7 +241,7 @@ TOOLS
   gore_texture   Textures in the IoStore containers: list, extract, replace, pack, deploy.
   gore_asset     Cooked DataAssets: receipt-sealed, byte-exact edits.
   gore_mod       Build one unified mod bundle and deploy or undeploy it as a single unit.
-  gore_mgr       Run several mods at once: library, load order, conflict report, composed apply.
+  gore_mgr       Manage a loadout end to end: import, order, preflight, recover, apply, status, reset.
   gore_as        AngelScript cache: inspect, decompile, patch defaults, recompile modules.
 
 Each of the last fourteen wraps a family of subcommands. Choose one with `subcommand` and put its

--- a/crates/gore-mcp/src/schema.rs
+++ b/crates/gore-mcp/src/schema.rs
@@ -318,4 +318,40 @@ mod tests {
         assert!(note.contains("`out`"));
         assert!(note.contains("--allow-write"));
     }
+
+    #[test]
+    fn manager_import_is_a_protected_state_write_not_an_install_mutation() {
+        let command = spec::group("gore_mgr").unwrap().command("import").unwrap();
+        let note = safety_note(&command.safety);
+
+        assert_eq!(note, "WRITES MANAGER STATE — needs --allow-write");
+        assert!(!note.contains("INSTALL"), "{note}");
+
+        let description = tool("gore_mgr")["description"].as_str().unwrap().to_string();
+        let import = description
+            .split_once("\nimport —")
+            .and_then(|(_, tail)| tail.split_once("\nlist —").map(|(section, _)| section))
+            .expect("rendered import section");
+        assert!(import.contains(&format!("[{note}]")), "{import}");
+    }
+
+    #[test]
+    fn authoritative_manager_reads_disclose_ungated_reconciliation() {
+        let manager = spec::group("gore_mgr").unwrap();
+        for sub in ["list", "analyze", "status"] {
+            let command = manager.command(sub).unwrap();
+            assert_eq!(safety_note(&command.safety), "may reconcile Manager state", "{sub}");
+            assert!(!command.safety.requirements(&serde_json::Map::new()).write, "{sub}");
+        }
+    }
+
+    #[test]
+    fn reversible_manager_edits_are_accurately_labeled_but_ungated() {
+        let manager = spec::group("gore_mgr").unwrap();
+        for sub in ["enable", "disable", "order"] {
+            let command = manager.command(sub).unwrap();
+            assert_eq!(safety_note(&command.safety), "updates Manager loadout", "{sub}");
+            assert!(!command.safety.requirements(&serde_json::Map::new()).write, "{sub}");
+        }
+    }
 }

--- a/crates/gore-mcp/src/spec/groups/deploy.rs
+++ b/crates/gore-mcp/src/spec/groups/deploy.rs
@@ -2,7 +2,7 @@
 //!
 //! This is where most of the commands that reach into the game installation live. Everything that
 //! only *produces* a mod is [`Safety::write`]; everything that *installs* one is
-//! [`Safety::mutate`], and `mgr reset` — which undeploys everything — is
+//! [`Safety::mutate`], and `mgr reset` — which removes only a Manager-owned deployment — is
 //! [`Safety::destructive`].
 //!
 //! Every `summary` and `help` string is copied verbatim from the corresponding clap doc comment.
@@ -579,20 +579,32 @@ const MGR_GAME_ARGS: &[ArgSpec] = &[GAME, LIBRARY, LOADOUT];
 
 const MGR_RESET_ARGS: &[ArgSpec] = &[GAME];
 
+const MGR_RECOVER_ARGS: &[ArgSpec] = &[
+    GAME,
+    ArgSpec::new(
+        "expected_guard_id",
+        Long("expected-guard-id"),
+        Str,
+        "Exact opaque action token reported by `mgr preflight`",
+        true,
+    ),
+];
+
 const MGR_COMMANDS: &[CommandSpec] = &[
     CommandSpec::new(
         "import",
         "Import a mod (folder, .zip, or single game file) into the library",
         MGR_IMPORT_ARGS,
-        // Re-importing the same source under the same name derives the same id, and activation moves
-        // the existing library entry aside before `cleanup()` deletes its payload for good -- so an
-        // import can be the only thing standing between the user and an older mod version.
-        Safety::mutate(),
+        // A verified source/content/entry-id match may update an existing Manager entry. The
+        // crash-safe publication either leaves an unchanged import alone or promotes the new tree
+        // and cleans the previous payload before returning. It never touches the game installation.
+        Safety::manager_write(),
         T_NORMAL,
     )
     .gated_because(
-        "supersedes the library entry of the same name, and the version it replaces is deleted \
-         for good the next time the loadout is applied",
+        "can replace a verified source, content, or entry-id match in the Manager library; changed \
+         content is cleaned up during crash-safe publication, while an unchanged re-import is a \
+         no-op",
     )
     .guide("mod-manager"),
     CommandSpec::new(
@@ -604,14 +616,14 @@ const MGR_COMMANDS: &[CommandSpec] = &[
         // it either renames the backup back into place or calls `transaction.cleanup()`, which
         // discards the superseded entry for good. It stays ungated — refusing to *list* a library
         // would be absurd — but nothing may advertise it as read-only when it can delete.
-        Safety::write(),
+        Safety::manager_reconcile(),
         T_FAST,
     )
     .guide("mod-manager"),
     // Deletes the imported mod from the library, then rewrites the loadout without it. Nothing
     // here is created, and nothing puts it back: the user has to re-import from wherever the mod
     // originally came from, which they may no longer have. `enable`, `disable` and `order` stay
-    // plain writes because each is undone by its own inverse; this one is not.
+    // ungated Manager edits because each is undone by its own inverse; this one is not.
     CommandSpec::new(
         "remove",
         "Remove a mod from the library (and drop it from the loadout)",
@@ -628,7 +640,7 @@ const MGR_COMMANDS: &[CommandSpec] = &[
         "enable",
         "Enable a loadout entry (it will deploy on the next apply)",
         MGR_ID_ARGS,
-        Safety::write(),
+        Safety::manager_edit(),
         T_FAST,
     )
     .guide("mod-manager"),
@@ -636,7 +648,7 @@ const MGR_COMMANDS: &[CommandSpec] = &[
         "disable",
         "Disable a loadout entry (it will not deploy)",
         MGR_ID_ARGS,
-        Safety::write(),
+        Safety::manager_edit(),
         T_FAST,
     )
     .guide("mod-manager"),
@@ -644,7 +656,7 @@ const MGR_COMMANDS: &[CommandSpec] = &[
         "order",
         "Move a loadout entry to a new position (0 = mounts first, loses conflicts)",
         MGR_ORDER_ARGS,
-        Safety::write(),
+        Safety::manager_edit(),
         T_FAST,
     )
     .guide("mod-manager"),
@@ -657,8 +669,33 @@ const MGR_COMMANDS: &[CommandSpec] = &[
         // it either renames the backup back into place or calls `transaction.cleanup()`, which
         // discards the superseded entry for good. It stays ungated — refusing to *list* a library
         // would be absurd — but nothing may advertise it as read-only when it can delete.
-        Safety::write(),
+        Safety::manager_reconcile(),
         T_NORMAL,
+    )
+    .guide("mod-manager"),
+    CommandSpec::new(
+        "preflight",
+        "Inspect Manager readiness and recovery evidence without changing anything",
+        MGR_GAME_ARGS,
+        Safety::read(),
+        T_NORMAL,
+    )
+    .json(JsonSupport::Stdout)
+    .guide("mod-manager"),
+    CommandSpec::new(
+        "recover",
+        "Recover one exact abandoned Manager mutation selected by its preflight token",
+        MGR_RECOVER_ARGS,
+        Safety::mutate(),
+        T_LONG,
+    )
+    .json(JsonSupport::Stdout)
+    // The CLI asks y/N by default. MCP stdin carries JSON-RPC and cannot answer that prompt, so the
+    // server's own consent gate stands in for it and the child receives the explicit confirmation.
+    .forced(&["--yes"])
+    .gated_because(
+        "repairs the exact abandoned Manager installation change selected by the preflight token \
+         and may restore its recorded pristine state or preserve a change that already completed",
     )
     .guide("mod-manager"),
     CommandSpec::new(
@@ -677,22 +714,26 @@ const MGR_COMMANDS: &[CommandSpec] = &[
         "status",
         "Show whether the game is in sync with the target loadout",
         MGR_GAME_ARGS,
-        Safety::read(),
+        // Status opens the authoritative Store snapshot. Like list/analyze, that may persist a
+        // valid loadout reconciliation, so clients must not advertise the call as read-only. It is
+        // intentionally ungated: the repair only canonicalizes Manager-owned state.
+        Safety::manager_reconcile(),
         T_NORMAL,
     )
+    .json(JsonSupport::Stdout)
     .guide("mod-manager"),
-    // Undeploys everything and restores the pristine installation. The only command in the whole
-    // table classified as destructive rather than merely mutating.
+    // Removes only a Manager-owned deployment and restores its pristine base. A Studio deployment
+    // is refused and preserved, including if ownership changes during the operation.
     CommandSpec::new(
         "reset",
-        "Undeploy everything the manager has active (restore pristine)",
+        "Undeploy the active Manager deployment (never removes a Studio deploy)",
         MGR_RESET_ARGS,
         Safety::destructive(),
         T_LONG,
     )
     .gated_because(
-        "undeploys every mod the manager has active and restores the pristine installation, so \
-         nothing this manager deployed is left in the game",
+        "undeploys the active Manager deployment and restores its pristine base while refusing to \
+         remove a Studio deployment",
     )
     .guide("mod-manager"),
 ];
@@ -701,8 +742,9 @@ pub const MGR: GroupSpec = GroupSpec {
     tool: "gore_mgr",
     title: "gore mgr",
     cli: "mgr",
-    summary: "Run several mods at once: import them into a library, order them, check for \
-              conflicts, and apply the whole loadout as one composed deployment.",
+    summary: "Run several mods at once: import and order them, inspect readiness, conflicts, and \
+              status, recover an interrupted Manager change, and apply or reset the whole loadout \
+              as one composed deployment.",
     shape: GroupShape::Nested,
     commands: MGR_COMMANDS,
 };
@@ -717,27 +759,45 @@ mod tests {
         assert_eq!(TEXTURE.commands.len(), 8);
         assert_eq!(ASSET.commands.len(), 4);
         assert_eq!(MOD.commands.len(), 3);
-        assert_eq!(MGR.commands.len(), 10);
+        assert_eq!(MGR.commands.len(), 12);
     }
 
     #[test]
-    fn no_manager_command_that_can_recover_a_transaction_claims_to_be_read_only() {
-        // `mgr list` and `mgr analyze` print and nothing else — but both go through
-        // `import::list`, which recovers an interrupted replacement before listing and may discard
-        // the superseded entry. Some clients auto-approve read-only tools; this must not be one.
-        for sub in ["list", "analyze"] {
+    fn manager_reads_that_may_reconcile_state_are_not_advertised_as_read_only() {
+        // `mgr list` and `mgr analyze` may finish an interrupted library replacement. All three
+        // open the authoritative Store snapshot, which may persist a valid loadout reconciliation.
+        // Some clients auto-approve read-only tools; these must not claim that annotation.
+        for sub in ["list", "analyze", "status"] {
             let command = MGR.command(sub).expect("exists");
             assert_ne!(
                 command.safety.worst_case(),
                 Class::Read,
-                "`mgr {sub}` recovers interrupted imports and cannot be advertised as read-only"
+                "`mgr {sub}` may reconcile Manager state and cannot be advertised as read-only"
             );
-            // Still ungated: refusing to list a library would be worse than the problem.
+            // Still ungated: canonical Store reconciliation is part of taking an authoritative
+            // Manager snapshot, not a user-requested install or library mutation.
             assert!(!command.safety.worst_case().needs_write_permission());
         }
 
-        // `status` is genuinely read-only — it does not go through `import::list`.
-        assert_eq!(MGR.command("status").expect("exists").safety.worst_case(), Class::Read);
+        let preflight = MGR.command("preflight").expect("exists");
+        assert_eq!(preflight.safety.worst_case(), Class::Read);
+        assert_eq!(preflight.json, JsonSupport::Stdout);
+    }
+
+    #[test]
+    fn manager_recovery_is_token_bound_gated_and_noninteractive_over_mcp() {
+        let recover = MGR.command("recover").expect("exists");
+        assert_eq!(recover.safety.worst_case(), Class::Mutate);
+        assert!(recover.safety.worst_case().needs_write_permission());
+        assert_eq!(recover.json, JsonSupport::Stdout);
+        assert_eq!(recover.forced_argv, ["--yes"]);
+        assert!(recover.arg("expected_guard_id").is_some());
+
+        let reset = MGR.command("reset").expect("exists");
+        assert!(
+            reset.gated_because.is_some_and(|reason| reason.contains("Studio deployment")),
+            "reset consent must disclose its Manager-only ownership boundary"
+        );
     }
 
     #[test]
@@ -755,11 +815,11 @@ mod tests {
 
     #[test]
     fn exactly_the_installing_and_deleting_commands_need_allow_write() {
-        // The two `deploy`/`undeploy` pairs are texture and mod; `apply` and `reset` are the
-        // manager's install-wide operations. The rest are here because they overwrite or delete
-        // paths this layer cannot check: `remove` destroys library content, `import` replaces it
-        // when the same mod is imported twice, and `texture replace` rewrites cooked files under a
-        // mount-mapped path. `texture index` is here only in its `out`-less form, where it
+        // The two `deploy`/`undeploy` pairs are texture and mod; `recover`, `apply`, and `reset` are
+        // the manager's install-wide operations. The rest are here because they overwrite or
+        // delete paths this layer cannot check: `remove` destroys library content, `import` may
+        // replace a verified source/content/entry-id match, and `texture replace` rewrites cooked
+        // files under a mount-mapped path. `texture index` is here only in its `out`-less form, where it
         // publishes into the shared data directory and prunes the other cached generations;
         // `worst_case` reports that shape.
         //
@@ -776,7 +836,7 @@ mod tests {
             gated,
             vec![
                 "replace", "deploy", "index", "undeploy", "deploy", "undeploy",
-                "import", "remove", "apply", "reset"
+                "import", "remove", "recover", "apply", "reset"
             ]
         );
 

--- a/crates/gore-mcp/src/spec/mod.rs
+++ b/crates/gore-mcp/src/spec/mod.rs
@@ -131,6 +131,12 @@ pub enum Class {
     Read,
     /// Creates new files. Never touches the game installation or an existing input.
     Write,
+    /// Opens the Mod Manager Store and may persist its automatic reconciliation. Ungated.
+    ManagerReconcile,
+    /// Intentionally updates reversible Mod Manager loadout state. Ungated.
+    ManagerEdit,
+    /// Rewrites the protected Mod Manager library/loadout state without touching the game install.
+    ManagerWrite,
     /// Modifies the game installation, or rewrites an existing file in place.
     Mutate,
     /// Undoes or discards work wholesale.
@@ -142,7 +148,7 @@ pub enum Class {
 impl Class {
     /// Whether `--allow-write` is needed.
     pub fn needs_write_permission(&self) -> bool {
-        matches!(self, Class::Mutate | Class::Destructive)
+        matches!(self, Class::ManagerWrite | Class::Mutate | Class::Destructive)
     }
 
     /// Whether `--allow-game-launch` is needed.
@@ -154,6 +160,9 @@ impl Class {
         match self {
             Class::Read => "read-only",
             Class::Write => "writes new files",
+            Class::ManagerReconcile => "may reconcile Manager state",
+            Class::ManagerEdit => "updates Manager loadout",
+            Class::ManagerWrite => "WRITES MANAGER STATE — needs --allow-write",
             Class::Mutate => "MODIFIES THE INSTALL — needs --allow-write",
             Class::Destructive => "DESTRUCTIVE — needs --allow-write",
             // Both flags, not one: `requirements` marks every GameLaunch command as a write too,
@@ -310,6 +319,15 @@ impl Safety {
     pub const fn write() -> Self {
         Self::of(Class::Write)
     }
+    pub const fn manager_reconcile() -> Self {
+        Self::of(Class::ManagerReconcile)
+    }
+    pub const fn manager_edit() -> Self {
+        Self::of(Class::ManagerEdit)
+    }
+    pub const fn manager_write() -> Self {
+        Self::of(Class::ManagerWrite)
+    }
     pub const fn mutate() -> Self {
         Self::of(Class::Mutate)
     }
@@ -406,7 +424,10 @@ impl Safety {
             self.in_place_without.is_some_and(|escape| !args.contains_key(escape));
         Requirements {
             write: rewrites_in_place
-                || matches!(self.base, Class::Mutate | Class::Destructive | Class::GameLaunch),
+                || matches!(
+                    self.base,
+                    Class::ManagerWrite | Class::Mutate | Class::Destructive | Class::GameLaunch
+                ),
             game_launch: matches!(self.base, Class::GameLaunch),
             rewrites_in_place,
         }
@@ -462,11 +483,11 @@ pub struct CommandSpec {
     pub guide: Option<&'static str>,
     /// Why *this* command needs a person to agree, completing "`gore <path>` …".
     ///
-    /// Required of every [`Class::Mutate`] and [`Class::Destructive`] command, and checked by a
-    /// test in this module. One sentence used to answer for all of them — "changes the game
-    /// installation or the shared catalogs the tools read" — and for several it was simply untrue:
-    /// `audio extract` aimed at a temp directory changes neither, and an assistant that had read
-    /// the arguments had to contradict its own server in front of the user.
+    /// Required of every [`Class::ManagerWrite`], [`Class::Mutate`], and [`Class::Destructive`]
+    /// command, and checked by a test in this module. One sentence used to answer for all of them —
+    /// "changes the game installation or the shared catalogs the tools read" — and for several it
+    /// was simply untrue: `audio extract` aimed at a temp directory changes neither, and an
+    /// assistant that had read the arguments had to contradict its own server in front of the user.
     ///
     /// The true reason was never missing, only unpublished: it is the comment above each of these
     /// entries, explaining what the command overwrites and why the gate cannot preflight it. This
@@ -622,7 +643,7 @@ impl GroupSpec {
 
 /// Wall-clock caps. Three tiers rather than a number per command: the distinction that matters is
 /// "prints something", "rewrites some files" and "walks the entire game", and inventing a precise
-/// budget for each of 82 commands would be false precision.
+/// budget for each of 87 commands would be false precision.
 pub const T_FAST: u64 = 60;
 pub const T_NORMAL: u64 = 300;
 pub const T_LONG: u64 = 1800;
@@ -662,7 +683,7 @@ pub const GROUPS: &[GroupSpec] = &[
 ///
 /// A literal, not a computed value: it is a claim about the CLI, and the integration test compares
 /// it against what clap actually exposes. Changing it should be a deliberate act.
-pub const EXPECTED_LEAF_COUNT: usize = 85;
+pub const EXPECTED_LEAF_COUNT: usize = 87;
 
 pub fn group(tool: &str) -> Option<&'static GroupSpec> {
     GROUPS.iter().find(|group| group.tool == tool)
@@ -932,8 +953,16 @@ mod tests {
         // The same fact is stated in three places — this label, the instructions primer, and the
         // refusal message — and it has now been wrong in each of them once. A command that needs
         // write permission must say so wherever it says anything.
-        for class in [Class::Read, Class::Write, Class::Mutate, Class::Destructive, Class::GameLaunch]
-        {
+        for class in [
+            Class::Read,
+            Class::Write,
+            Class::ManagerReconcile,
+            Class::ManagerEdit,
+            Class::ManagerWrite,
+            Class::Mutate,
+            Class::Destructive,
+            Class::GameLaunch,
+        ] {
             let label = class.label();
             assert_eq!(
                 label.contains("--allow-write"),
@@ -1224,7 +1253,10 @@ mod tests {
         // is wrong is worse than a gate that is strict.
         for group in GROUPS {
             for command in group.commands {
-                if matches!(command.safety.base, Class::Mutate | Class::Destructive) {
+                if matches!(
+                    command.safety.base,
+                    Class::ManagerWrite | Class::Mutate | Class::Destructive
+                ) {
                     assert!(
                         command.gated_because.is_some(),
                         "`gore {} {}` is gated outright but states no reason. Add \

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -12906,6 +12906,22 @@ pub fn recover_manager_install(
 /// Undo the active gore-mod deployment at `game_root`: restore every backup and remove the
 /// UE4SS mod. No-op if nothing is deployed.
 pub fn undeploy(game_root: &Path) -> Result<Option<DeployRecord>> {
+    undeploy_with_owner_policy(game_root, false)
+}
+
+/// Undo only an active Manager-owned deployment at `game_root`.
+///
+/// A Studio-owned deployment is refused before install ownership is acquired. The deploy record
+/// is then re-read under that ownership and must still match byte-for-byte, so a concurrent
+/// Manager-to-Studio owner change is also refused without touching either deployment.
+pub fn undeploy_manager(game_root: &Path) -> Result<Option<DeployRecord>> {
+    undeploy_with_owner_policy(game_root, true)
+}
+
+fn undeploy_with_owner_policy(
+    game_root: &Path,
+    manager_only: bool,
+) -> Result<Option<DeployRecord>> {
     // Match deploy's absolutization so the record file is found regardless of the caller's cwd.
     let game_root = abs_root(game_root);
     // Preserve the established no-op behavior without creating a lock file. A present record is
@@ -12915,6 +12931,12 @@ pub fn undeploy(game_root: &Path) -> Result<Option<DeployRecord>> {
         return Ok(None);
     };
     let manager = initial.record.owner == "manager";
+    if manager_only && !manager {
+        return Err(ModError::Other(format!(
+            "STUDIO_DEPLOY_ACTIVE:{}",
+            initial.record.mod_name
+        )));
+    }
     let owner = if manager {
         "gore-mod:manager-undeploy"
     } else {
@@ -18000,6 +18022,64 @@ mod tests {
     #[test]
     fn undeploy_refuses_studio_record_replaced_by_manager_before_lock() {
         assert_undeploy_record_owner_swap_is_refused("", "manager");
+    }
+
+    #[test]
+    fn manager_only_undeploy_preserves_a_studio_deploy() {
+        let dir = tempfile::tempdir().unwrap();
+        let game = dir.path().join("game");
+        std::fs::create_dir_all(&game).unwrap();
+        let record = DeployRecord {
+            mod_name: "StudioMod".into(),
+            ..Default::default()
+        };
+        let bytes = serde_json::to_vec_pretty(&record).unwrap();
+        let path = record_path(&game);
+        std::fs::write(&path, &bytes).unwrap();
+
+        let error = undeploy_manager(&game).unwrap_err().to_string();
+
+        assert_eq!(error, "STUDIO_DEPLOY_ACTIVE:StudioMod");
+        assert_eq!(std::fs::read(&path).unwrap(), bytes);
+        assert!(!game.join(".gore-install-mutation.lock").exists());
+    }
+
+    #[test]
+    fn manager_only_undeploy_refuses_a_manager_to_studio_owner_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let game = dir.path().join("game");
+        let mods = game.join("G1R/Content/Paks/~mods");
+        std::fs::create_dir_all(&mods).unwrap();
+        let manager_live = mods.join("manager_P.pak");
+        let studio_live = mods.join("studio_P.pak");
+        std::fs::write(&manager_live, b"manager").unwrap();
+        std::fs::write(&studio_live, b"studio").unwrap();
+        let record_for = |name: &str, owner: &str, live: &Path| DeployRecord {
+            mod_name: name.into(),
+            owner: owner.into(),
+            managed_paks: vec![live.display().to_string()],
+            deployed_hashes: BTreeMap::from([(
+                live.display().to_string(),
+                sha256_file(live).unwrap(),
+            )]),
+            ..Default::default()
+        };
+        let path = record_path(&game);
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&record_for("Manager", "manager", &manager_live)).unwrap(),
+        )
+        .unwrap();
+        let studio_bytes =
+            serde_json::to_vec_pretty(&record_for("Studio", "", &studio_live)).unwrap();
+        replace_record_before_undeploy_acquire(&path, &studio_bytes);
+
+        let error = undeploy_manager(&game).unwrap_err().to_string();
+
+        assert!(error.contains("UNDEPLOY_BASIS_CHANGED"), "got: {error}");
+        assert_eq!(std::fs::read(&manager_live).unwrap(), b"manager");
+        assert_eq!(std::fs::read(&studio_live).unwrap(), b"studio");
+        assert_eq!(std::fs::read(&path).unwrap(), studio_bytes);
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -1570,6 +1570,12 @@ pub fn undeploy_all(game_root: &Path) -> crate::Result<bool> {
     Ok(crate::undeploy(game_root)?.is_some())
 }
 
+/// Undeploy only a Manager-owned deployment. A Studio deploy is preserved and refused, including
+/// if the deploy owner changes while this operation waits for install ownership.
+pub fn undeploy_manager_only(game_root: &Path) -> crate::Result<bool> {
+    Ok(crate::undeploy_manager(game_root)?.is_some())
+}
+
 // ── naming helpers ────────────────────────────────────────────────────────────────────────────
 
 /// `<root>/G1R/Content/Paks/~mods` — where manager paks/triplets mount.

--- a/crates/gore/CHANGELOG.md
+++ b/crates/gore/CHANGELOG.md
@@ -10,17 +10,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 First release. Command-line toolkit for modding Gothic 1 Remake.
 
-- `mod` and `mgr` — build a bundle from one spec, deploy or undeploy it, and run
-  several mods together with a conflict report.
+- `mod` — build and transactionally deploy one bundle containing item
+  overrides, localization, audio, voice, textures/assets, loose or packed
+  files, AngelScript, and dialog topics.
+- `mgr` — keep a verified library and ordered loadout; import supported GORE and
+  foreign mods; enable, disable, reorder, remove, analyze, Apply, inspect status,
+  recover an abandoned Manager operation, and Reset through the shared Manager
+  engine. Import accepts zip/folder packages, loose `_P.pak`, IoStore pairs with
+  an optional same-stem `.pak`, UE4SS Lua folders, and known raw game files;
+  unsupported or malformed inputs fail without partial publication.
+- `mgr preflight` exposes the bounded read-only setup/recovery report;
+  `mgr recover` requires the exact current abandoned-operation token and either
+  interactive confirmation or `--yes`; `status --json` returns the full native
+  report. Reset is Manager-only and refuses a Studio deployment, Remove points
+  to the required next Apply, and zero-row Analyze output keeps coverage gaps
+  visible as "no recognized conflicts" rather than claiming conflict freedom.
 - `loc`, `audio`, `voice`, `texture`, `asset`, `as` — edit localized text, FMOD
   banks, voice-over archives, IoStore textures, cooked DataAssets and the
   AngelScript cache.
 - `location-catalog` and `location` — build the named-location catalog, and look
   a waypoint or spot name up in it offline.
-- `mcp serve` — all 82 commands over the Model Context Protocol, with every
-  installation change confirmed first.
+- `mcp serve` — all 87 commands over the Model Context Protocol, with protected
+  installation, Manager-library, deletion, and in-place-rewrite operations
+  confirmed first.
 - `guide` — the manual, built into the binary and rendered to one HTML file.
 - Commands whose evidence is audited against a specific game build say which
   build you have and which ones were audited, instead of quietly doing less.
 - `as qualify` derives everything a new game build needs to be audited, and
   refuses rather than guessing when the evidence does not hold together.
+- Prepared AngelScript mini-caches now resolve their absolute private
+  StaticNames operands during loadout composition while raw minis retain their
+  local-index convention; missing prepared rows fail closed.
+- A 2026-08-18 real-install Manager campaign ran Nexus mods #244, #512, #269,
+  and Attack Input V4, verified both numeric #244/#512 order directions, loaded
+  a new game and an existing save, exercised enable/disable/reorder/Reset, and
+  restored the captured loadout byte-for-byte. Its live Viper AngelScript proof
+  was a GORE-authored fixture using the PR #91 Core DLL, not a third-party or
+  three-way script qualification. Clean-Windows package acceptance remains open.

--- a/crates/gore/src/cmd/doctor.rs
+++ b/crates/gore/src/cmd/doctor.rs
@@ -1196,10 +1196,10 @@ fn install_recovery_fix_for(
              not stop it or delete lock files"
         }
         ManagerInstallRecoveryReadiness::AbandonedManager { .. } => {
-            "open the Mod Manager app for this installation and choose Recover. The app verifies \
-             the exact interrupted Manager operation before changing anything; the CLI does not \
-             currently perform this recovery. Do not delete lock files; run reset/undeploy only \
-             after recovery"
+            "run 'gore mgr preflight' for this installation, then pass its exact current token to \
+             'gore mgr recover --expected-guard-id <TOKEN>' and confirm; or open the Mod Manager \
+             app and choose Recover. Both routes recheck the exact interrupted Manager operation. \
+             Do not delete lock files; run reset/undeploy only after recovery"
         }
         ManagerInstallRecoveryReadiness::CompileOrAmbiguous => {
             "this belongs to script-build recovery or cannot be attributed safely. Leave the \
@@ -3313,8 +3313,9 @@ mod tests {
             },
             true,
         );
+        assert!(abandoned.contains("gore mgr preflight"), "{abandoned}");
+        assert!(abandoned.contains("gore mgr recover"), "{abandoned}");
         assert!(abandoned.contains("choose Recover"), "{abandoned}");
-        assert!(abandoned.contains("CLI does not currently"), "{abandoned}");
         assert!(abandoned.contains("only after recovery"), "{abandoned}");
         assert!(!abandoned.contains("opaque-test-token"), "{abandoned}");
 

--- a/crates/gore/src/cmd/mgr.rs
+++ b/crates/gore/src/cmd/mgr.rs
@@ -10,17 +10,19 @@
 
 use anyhow::{Context, Result};
 use clap::Subcommand;
+use std::io::Write as _;
 use std::path::PathBuf;
 
 use gore_mod::mgr::{
     self,
     analyze::{Conflict, Severity},
-    apply::undeploy_all,
+    apply::undeploy_manager_only,
     import,
+    model::FootprintCoverage,
     status::ManagerStatus,
     store::StoreSnapshot,
 };
-use gore_mod::ManagerInstallRecoveryReadiness;
+use gore_mod::{ManagerInstallRecoveryOutcome, ManagerInstallRecoveryReadiness};
 
 #[derive(Subcommand)]
 pub enum MgrAction {
@@ -87,6 +89,34 @@ pub enum MgrAction {
         #[arg(long)]
         loadout: Option<PathBuf>,
     },
+    /// Inspect Manager readiness and recovery evidence without changing anything
+    Preflight {
+        /// Game root (the folder containing G1R/)
+        #[arg(long)]
+        game: Option<PathBuf>,
+        #[arg(long)]
+        library: Option<PathBuf>,
+        #[arg(long)]
+        loadout: Option<PathBuf>,
+        /// Emit the stable native preflight response as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Recover one exact abandoned Manager mutation selected by its preflight token
+    Recover {
+        /// Game root (the folder containing G1R/)
+        #[arg(long)]
+        game: Option<PathBuf>,
+        /// Exact opaque action token reported by `mgr preflight`
+        #[arg(long)]
+        expected_guard_id: String,
+        /// Confirm recovery without the interactive y/N prompt
+        #[arg(long)]
+        yes: bool,
+        /// Emit the stable native recovery response as JSON (requires --yes)
+        #[arg(long, requires = "yes")]
+        json: bool,
+    },
     /// Compose the enabled loadout into one deployment against the game
     Apply {
         /// Game root (the folder containing G1R/)
@@ -106,8 +136,11 @@ pub enum MgrAction {
         library: Option<PathBuf>,
         #[arg(long)]
         loadout: Option<PathBuf>,
+        /// Emit the full native status report, including bounded owned-path evidence, as JSON
+        #[arg(long)]
+        json: bool,
     },
-    /// Undeploy everything the manager has active (restore pristine)
+    /// Undeploy the active Manager deployment (never removes a Studio deploy)
     Reset {
         /// Game root (the folder containing G1R/)
         #[arg(long)]
@@ -223,6 +256,11 @@ pub fn run(action: MgrAction) -> Result<()> {
                 })?;
 
             println!("removed {id}: {removed}");
+            if removed {
+                println!(
+                    "library and loadout updated; run 'gore mgr apply' to update any deployed game"
+                );
+            }
             Ok(())
         }
 
@@ -280,13 +318,49 @@ pub fn run(action: MgrAction) -> Result<()> {
             let conflicts = store.analyze();
 
             if conflicts.is_empty() {
-                println!("no conflicts");
+                println!("no recognized conflicts");
             } else {
                 for c in &conflicts {
                     println!("{}", format_conflict(c));
                 }
             }
+            if let Some(warning) = coverage_warning(&store) {
+                println!("warning: {warning}");
+            }
             Ok(())
+        }
+
+        MgrAction::Preflight {
+            game,
+            library,
+            loadout,
+            json,
+        } => {
+            let game = gore_loc::config::game_root(game)?;
+            let (lib, ld_path) = store_paths(library, loadout)?;
+            let report = mgr::preflight::preflight_v1(&game, &lib, &ld_path);
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "ok": true,
+                        "preflight": report,
+                    }))?
+                );
+            } else {
+                print_preflight(&report);
+            }
+            Ok(())
+        }
+
+        MgrAction::Recover {
+            game,
+            expected_guard_id,
+            yes,
+            json,
+        } => {
+            let game = gore_loc::config::game_root(game)?;
+            recover_selected_manager_install(&game, &expected_guard_id, yes, json)
         }
 
         MgrAction::Apply {
@@ -334,18 +408,42 @@ pub fn run(action: MgrAction) -> Result<()> {
             game,
             library,
             loadout,
+            json,
         } => {
             let game = gore_loc::config::game_root(game)?;
             let (lib, ld_path) = store_paths(library, loadout)?;
             let store = StoreSnapshot::open(&lib, &ld_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-            let st = store.status(&game).map_err(|e| anyhow::anyhow!("{e}"))?;
-            println!("{}", describe_status(&game, &st));
+            let report = store
+                .status_report(&game)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "ok": true,
+                        "status": report,
+                    }))?
+                );
+            } else {
+                println!("{}", describe_status(&game, &report.status));
+            }
             Ok(())
         }
 
         MgrAction::Reset { game } => {
             let game = gore_loc::config::game_root(game)?;
-            let removed = undeploy_all(&game).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let removed = match undeploy_manager_only(&game) {
+                Ok(removed) => removed,
+                Err(error) => {
+                    let message = error.to_string();
+                    if let Some(name) = message.strip_prefix("STUDIO_DEPLOY_ACTIVE:") {
+                        anyhow::bail!(
+                            "refusing: a studio deploy is active ({name}) — undeploy it from Mod Studio"
+                        );
+                    }
+                    return Err(anyhow::anyhow!(message)).context("resetting manager deployment");
+                }
+            };
             if removed {
                 println!("reset: undeployed the active manager deployment");
             } else {
@@ -354,6 +452,183 @@ pub fn run(action: MgrAction) -> Result<()> {
             Ok(())
         }
     }
+}
+
+fn print_preflight(report: &mgr::preflight::ManagerPreflightV1) {
+    for check in &report.checks {
+        println!(
+            "{:?}: {:?} code={} action={} — {}",
+            check.id, check.state, check.code, check.action, check.detail
+        );
+        if let Some(token) = &check.action_token {
+            println!("  recovery token: {token}");
+        }
+        for item in &check.items {
+            println!("  {item}");
+        }
+    }
+}
+
+fn validate_recovery_selection(
+    readiness: &ManagerInstallRecoveryReadiness,
+    expected_guard_id: &str,
+) -> Result<()> {
+    match readiness {
+        ManagerInstallRecoveryReadiness::AbandonedManager { guard_id }
+            if guard_id == expected_guard_id =>
+        {
+            Ok(())
+        }
+        ManagerInstallRecoveryReadiness::AbandonedManager { .. } => anyhow::bail!(
+            "recovery selection changed; run 'gore mgr preflight' again and use its exact token"
+        ),
+        ManagerInstallRecoveryReadiness::Missing => {
+            anyhow::bail!("no abandoned Manager mutation is available for recovery")
+        }
+        ManagerInstallRecoveryReadiness::Active => anyhow::bail!(
+            "recovery blocked: a GORE installation change is active; wait for it to finish"
+        ),
+        ManagerInstallRecoveryReadiness::CompileOrAmbiguous => anyhow::bail!(
+            "recovery blocked: script-build recovery or an unclear lock owner requires recovery help"
+        ),
+        ManagerInstallRecoveryReadiness::Invalid => anyhow::bail!(
+            "recovery blocked: GORE could not inspect the installation lock safely"
+        ),
+    }
+}
+
+fn recover_selected_manager_install(
+    game_root: &std::path::Path,
+    expected_guard_id: &str,
+    yes: bool,
+    json: bool,
+) -> Result<()> {
+    if expected_guard_id.is_empty() {
+        anyhow::bail!("--expected-guard-id must not be empty");
+    }
+    if expected_guard_id.len() > 512 {
+        anyhow::bail!("--expected-guard-id exceeds its 512-byte limit");
+    }
+
+    let readiness = gore_mod::probe_manager_install_recovery(game_root);
+    validate_recovery_selection(&readiness, expected_guard_id)?;
+
+    if !yes {
+        println!("Recover this exact abandoned Manager installation change?");
+        println!("  game: {}", game_root.display());
+        println!("  recovery token: {expected_guard_id}");
+        println!(
+            "Recovery may restore the recorded pristine state or preserve a change that already completed."
+        );
+        print!("Proceed? [y/N] ");
+        std::io::stdout()
+            .flush()
+            .context("flushing recovery prompt")?;
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .context("reading recovery confirmation")?;
+        if !answer.trim().eq_ignore_ascii_case("y") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    let outcome = gore_mod::recover_manager_install(game_root, expected_guard_id)
+        .map_err(|error| anyhow::anyhow!("{error}"))
+        .context("recovering the selected Manager installation change")?;
+    let completed = recovery_outcome_completed(outcome);
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": completed,
+                "outcome": outcome,
+            }))?
+        );
+    } else if completed {
+        println!("{}", describe_recovery_outcome(outcome));
+    }
+    if completed {
+        Ok(())
+    } else {
+        anyhow::bail!(describe_recovery_outcome(outcome))
+    }
+}
+
+fn recovery_outcome_completed(outcome: ManagerInstallRecoveryOutcome) -> bool {
+    matches!(
+        outcome,
+        ManagerInstallRecoveryOutcome::AlreadyClean
+            | ManagerInstallRecoveryOutcome::PreMutationLockCleared
+            | ManagerInstallRecoveryOutcome::RecoveredToPristine
+            | ManagerInstallRecoveryOutcome::CompletedApplyPreserved
+            | ManagerInstallRecoveryOutcome::CompletedUndeployConfirmed
+    )
+}
+
+fn describe_recovery_outcome(outcome: ManagerInstallRecoveryOutcome) -> &'static str {
+    match outcome {
+        ManagerInstallRecoveryOutcome::AlreadyClean => {
+            "recovery: the selected installation change is already clean"
+        }
+        ManagerInstallRecoveryOutcome::Busy => {
+            "recovery not performed: another installation change became active"
+        }
+        ManagerInstallRecoveryOutcome::PreMutationLockCleared => {
+            "recovery complete: the abandoned pre-mutation lock was cleared"
+        }
+        ManagerInstallRecoveryOutcome::RecoveredToPristine => {
+            "recovery complete: the installation was restored to its recorded pristine state"
+        }
+        ManagerInstallRecoveryOutcome::CompletedApplyPreserved => {
+            "recovery complete: the already-completed Manager apply was preserved"
+        }
+        ManagerInstallRecoveryOutcome::CompletedUndeployConfirmed => {
+            "recovery complete: the already-completed Manager reset was confirmed"
+        }
+        ManagerInstallRecoveryOutcome::CompileRecoveryRequired => {
+            "recovery not performed: script-build recovery is required"
+        }
+        ManagerInstallRecoveryOutcome::InspectionFailed => {
+            "recovery not performed: the installation could not be inspected safely"
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct CoverageGaps {
+    partial: usize,
+    advisory: usize,
+    opaque: usize,
+}
+
+fn coverage_gaps(store: &StoreSnapshot) -> CoverageGaps {
+    let mut gaps = CoverageGaps::default();
+    for selected in store.loadout().entries.iter().filter(|entry| entry.enabled) {
+        let Some(meta) = store.mods().iter().find(|meta| meta.id == selected.id) else {
+            continue;
+        };
+        for component in &meta.components {
+            match component.footprint_coverage() {
+                FootprintCoverage::Exact => {}
+                FootprintCoverage::Partial => gaps.partial += 1,
+                FootprintCoverage::Advisory => gaps.advisory += 1,
+                FootprintCoverage::Opaque => gaps.opaque += 1,
+            }
+        }
+    }
+    gaps
+}
+
+fn coverage_warning(store: &StoreSnapshot) -> Option<String> {
+    let gaps = coverage_gaps(store);
+    (gaps != CoverageGaps::default()).then(|| {
+        format!(
+            "conflict analysis is incomplete for enabled components (partial={}, advisory={}, opaque={})",
+            gaps.partial, gaps.advisory, gaps.opaque
+        )
+    })
 }
 
 fn format_conflict(conflict: &Conflict) -> String {
@@ -446,9 +721,9 @@ fn describe_recovery_status(readiness: &ManagerInstallRecoveryReadiness) -> Stri
                 .to_string()
         }
         ManagerInstallRecoveryReadiness::AbandonedManager { .. } => {
-            "recovery required: an interrupted Manager change was abandoned (open the Mod Manager \
-             app and choose Recover; the CLI does not currently perform this recovery; do not \
-             delete lock files; run reset/undeploy only after recovery)"
+            "recovery required: an interrupted Manager change was abandoned (run 'gore mgr \
+             preflight' to obtain its exact token, then 'gore mgr recover --expected-guard-id \
+             <TOKEN>'; do not delete lock files or run reset before recovery)"
                 .to_string()
         }
         ManagerInstallRecoveryReadiness::CompileOrAmbiguous => {
@@ -530,9 +805,9 @@ mod tests {
             describe_recovery_status(&ManagerInstallRecoveryReadiness::AbandonedManager {
                 guard_id: "opaque-test-token".into(),
             });
-        assert!(abandoned.contains("choose Recover"), "{abandoned}");
-        assert!(abandoned.contains("CLI does not currently"), "{abandoned}");
-        assert!(abandoned.contains("only after recovery"), "{abandoned}");
+        assert!(abandoned.contains("gore mgr preflight"), "{abandoned}");
+        assert!(abandoned.contains("gore mgr recover"), "{abandoned}");
+        assert!(abandoned.contains("exact token"), "{abandoned}");
         assert!(!abandoned.contains("opaque-test-token"), "{abandoned}");
 
         let compile =
@@ -543,6 +818,26 @@ mod tests {
         let invalid = describe_recovery_status(&ManagerInstallRecoveryReadiness::Invalid);
         assert!(invalid.contains("could not inspect"), "{invalid}");
         assert!(invalid.contains("do not delete lock files"), "{invalid}");
+    }
+
+    #[test]
+    fn only_completed_recovery_outcomes_are_cli_successes() {
+        for outcome in [
+            ManagerInstallRecoveryOutcome::AlreadyClean,
+            ManagerInstallRecoveryOutcome::PreMutationLockCleared,
+            ManagerInstallRecoveryOutcome::RecoveredToPristine,
+            ManagerInstallRecoveryOutcome::CompletedApplyPreserved,
+            ManagerInstallRecoveryOutcome::CompletedUndeployConfirmed,
+        ] {
+            assert!(recovery_outcome_completed(outcome), "{outcome:?}");
+        }
+        for outcome in [
+            ManagerInstallRecoveryOutcome::Busy,
+            ManagerInstallRecoveryOutcome::CompileRecoveryRequired,
+            ManagerInstallRecoveryOutcome::InspectionFailed,
+        ] {
+            assert!(!recovery_outcome_completed(outcome), "{outcome:?}");
+        }
     }
 
     #[test]
@@ -587,5 +882,41 @@ mod tests {
         std::fs::remove_file(&lock).unwrap();
 
         assert_eq!(describe_status(game, &nothing), "nothing deployed");
+    }
+
+    #[test]
+    fn recovery_selection_accepts_only_the_exact_abandoned_manager_token() {
+        assert!(validate_recovery_selection(
+            &ManagerInstallRecoveryReadiness::AbandonedManager {
+                guard_id: "selected-token".into(),
+            },
+            "selected-token",
+        )
+        .is_ok());
+
+        let changed = validate_recovery_selection(
+            &ManagerInstallRecoveryReadiness::AbandonedManager {
+                guard_id: "new-token".into(),
+            },
+            "selected-token",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(changed.contains("selection changed"), "{changed}");
+
+        for (readiness, expected) in [
+            (ManagerInstallRecoveryReadiness::Missing, "no abandoned"),
+            (ManagerInstallRecoveryReadiness::Active, "active"),
+            (
+                ManagerInstallRecoveryReadiness::CompileOrAmbiguous,
+                "script-build recovery",
+            ),
+            (ManagerInstallRecoveryReadiness::Invalid, "inspect"),
+        ] {
+            let error = validate_recovery_selection(&readiness, "selected-token")
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains(expected), "got {error:?}");
+        }
     }
 }

--- a/crates/gore/src/main.rs
+++ b/crates/gore/src/main.rs
@@ -199,7 +199,7 @@ enum Commands {
         #[command(subcommand)]
         action: cmd::texture::TextureAction,
     },
-    /// Multi-mod manager: library + loadout + conflicts + composed deploy
+    /// Multi-mod manager: library, loadout, readiness/recovery, apply, status and reset
     Mgr {
         #[command(subcommand)]
         action: cmd::mgr::MgrAction,

--- a/crates/gore/tests/integration/mgr.rs
+++ b/crates/gore/tests/integration/mgr.rs
@@ -315,7 +315,7 @@ fn mgr_import_list_enable_disable_order_analyze_status_reset() {
         ])
         .assert()
         .success()
-        .stdout(predicates::str::contains("no conflicts"));
+        .stdout(predicates::str::contains("no recognized conflicts"));
 
     // order: move id_b to position 0; the reported order lists it first.
     Command::cargo_bin("gore")
@@ -337,7 +337,7 @@ fn mgr_import_list_enable_disable_order_analyze_status_reset() {
 
     // status on an empty game tree: nothing was ever deployed here.
     let game = tmp.path().join("game");
-    std::fs::create_dir_all(&game).unwrap();
+    std::fs::create_dir_all(game.join("G1R")).unwrap();
     Command::cargo_bin("gore")
         .unwrap()
         .args([
@@ -353,6 +353,28 @@ fn mgr_import_list_enable_disable_order_analyze_status_reset() {
         .assert()
         .success()
         .stdout(predicates::str::contains("nothing deployed"));
+
+    let status_json = Command::cargo_bin("gore")
+        .unwrap()
+        .args([
+            "mgr",
+            "status",
+            "--game",
+            game.to_str().unwrap(),
+            "--library",
+            lib.to_str().unwrap(),
+            "--loadout",
+            loadout.to_str().unwrap(),
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let status_json: serde_json::Value = serde_json::from_slice(&status_json).unwrap();
+    assert_eq!(status_json["ok"], true);
+    assert_eq!(status_json["status"]["state"], "nothing_deployed");
 
     // reset on a game that has nothing deployed runs clean and says so.
     Command::cargo_bin("gore")
@@ -376,7 +398,8 @@ fn mgr_import_list_enable_disable_order_analyze_status_reset() {
         ])
         .assert()
         .success()
-        .stdout(predicates::str::contains("true"));
+        .stdout(predicates::str::contains("true"))
+        .stdout(predicates::str::contains("gore mgr apply"));
     assert!(!lib.join(&id_a).exists(), "removed entry dir must be gone");
 
     Command::cargo_bin("gore")
@@ -415,6 +438,209 @@ fn mgr_enable_unknown_id_errors() {
         .assert()
         .failure()
         .stderr(predicates::str::contains("does-not-exist"));
+}
+
+#[test]
+fn mgr_preflight_selects_and_recovers_only_the_exact_abandoned_manager_token() {
+    use gore_as::compile::InstallMutationGuard;
+
+    let tmp = TempDir::new().unwrap();
+    let game = tmp.path().join("game");
+    let library = tmp.path().join("library");
+    let loadout = tmp.path().join("loadout.json");
+    std::fs::create_dir_all(game.join("G1R")).unwrap();
+    let lock = game.join(".gore-install-mutation.lock");
+    let guard = InstallMutationGuard::acquire(&game, "gore-mod:manager-apply").unwrap();
+    let guard_id = guard.guard_id().to_owned();
+    guard.preserve_for_manual_recovery();
+
+    let output = Command::cargo_bin("gore")
+        .unwrap()
+        .args([
+            "mgr",
+            "preflight",
+            "--game",
+            game.to_str().unwrap(),
+            "--library",
+            library.to_str().unwrap(),
+            "--loadout",
+            loadout.to_str().unwrap(),
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let document: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(document["ok"], true);
+    assert_eq!(document["preflight"]["format"], 1);
+    let install_mutation = document["preflight"]["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "install_mutation")
+        .unwrap();
+    assert_eq!(
+        install_mutation["code"],
+        "manager_mutation_recovery_required"
+    );
+    assert_eq!(install_mutation["action_token"], guard_id);
+
+    Command::cargo_bin("gore")
+        .unwrap()
+        .args([
+            "mgr",
+            "recover",
+            "--game",
+            game.to_str().unwrap(),
+            "--expected-guard-id",
+            "different-valid-token",
+            "--yes",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("selection changed"));
+    assert!(lock.exists(), "a mismatched token must preserve the lock");
+
+    Command::cargo_bin("gore")
+        .unwrap()
+        .args([
+            "mgr",
+            "recover",
+            "--game",
+            game.to_str().unwrap(),
+            "--expected-guard-id",
+            &guard_id,
+        ])
+        .write_stdin("n\n")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Proceed? [y/N]"))
+        .stdout(predicates::str::contains("Aborted."));
+    assert!(
+        lock.exists(),
+        "declining confirmation must preserve the lock"
+    );
+
+    let output = Command::cargo_bin("gore")
+        .unwrap()
+        .args([
+            "mgr",
+            "recover",
+            "--game",
+            game.to_str().unwrap(),
+            "--expected-guard-id",
+            &guard_id,
+            "--yes",
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let document: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(
+        document,
+        serde_json::json!({"ok": true, "outcome": "pre_mutation_lock_cleared"})
+    );
+    assert!(!lock.exists());
+}
+
+#[test]
+fn mgr_recover_refuses_an_active_install_mutation_without_takeover() {
+    use gore_as::compile::InstallMutationGuard;
+
+    let tmp = TempDir::new().unwrap();
+    let game = tmp.path().join("game");
+    std::fs::create_dir_all(game.join("G1R")).unwrap();
+    let guard = InstallMutationGuard::acquire(&game, "gore-mod:manager-apply").unwrap();
+    let guard_id = guard.guard_id().to_owned();
+    let lock = guard.path().to_path_buf();
+
+    Command::cargo_bin("gore")
+        .unwrap()
+        .args([
+            "mgr",
+            "recover",
+            "--game",
+            game.to_str().unwrap(),
+            "--expected-guard-id",
+            &guard_id,
+            "--yes",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("installation change is active"));
+    assert!(lock.exists());
+    drop(guard);
+    assert!(!lock.exists());
+}
+
+#[test]
+fn mgr_reset_refuses_and_preserves_a_studio_deploy_record() {
+    let tmp = TempDir::new().unwrap();
+    let game = tmp.path().join("game");
+    std::fs::create_dir_all(game.join("G1R")).unwrap();
+    let record = gore_mod::DeployRecord {
+        mod_name: "StudioFixture".into(),
+        ..Default::default()
+    };
+    let bytes = serde_json::to_vec_pretty(&record).unwrap();
+    let record_path = gore_mod::deploy_record_path(&game);
+    std::fs::write(&record_path, &bytes).unwrap();
+
+    Command::cargo_bin("gore")
+        .unwrap()
+        .args(["mgr", "reset", "--game", game.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("studio deploy is active"));
+
+    assert_eq!(std::fs::read(&record_path).unwrap(), bytes);
+    assert!(!game.join(".gore-install-mutation.lock").exists());
+}
+
+#[test]
+fn mgr_analyze_discloses_opaque_coverage_instead_of_claiming_no_conflicts() {
+    let tmp = TempDir::new().unwrap();
+    let library = tmp.path().join("library");
+    let loadout = tmp.path().join("loadout.json");
+    let pak = tmp.path().join("opaque_P.pak");
+    std::fs::write(&pak, b"not an indexable pak").unwrap();
+    let id = import(&library, &loadout, &pak);
+
+    Command::cargo_bin("gore")
+        .unwrap()
+        .args([
+            "mgr",
+            "enable",
+            &id,
+            "--library",
+            library.to_str().unwrap(),
+            "--loadout",
+            loadout.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("gore")
+        .unwrap()
+        .args([
+            "mgr",
+            "analyze",
+            "--library",
+            library.to_str().unwrap(),
+            "--loadout",
+            loadout.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("no recognized conflicts"))
+        .stdout(predicates::str::contains("conflict analysis is incomplete"))
+        .stdout(predicates::str::contains("opaque=1"))
+        .stdout(predicates::str::contains("no conflicts").not());
 }
 
 /// Real CLI path for format-2 additive file mods: build -> manager import/loadout -> analyze ->

--- a/docs/development.md
+++ b/docs/development.md
@@ -178,8 +178,9 @@ gore/
 | [`gore-oodle`](../crates/gore-oodle) | Rust lib | Oodle/Kraken codec (pure Rust; no proprietary `oo2core` DLL). |
 | [`gore-as`](../crates/gore-as) | Rust lib | AngelScript precompiled-cache decoder/emitter/decompiler/splicer. |
 
-The Flutter GUIs reuse the exact same Rust crates as the CLI through the
-`dart:ffi` bridge, so the CLI is always the most complete surface.
+The Flutter GUIs reuse the same Rust engine as the CLI through the `dart:ffi`
+bridge. The CLI remains the expert and automation surface; the apps present
+shared contracts as guided workflows rather than maintaining another engine.
 
 ## Versioning
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -36,7 +36,7 @@ Everything you need to mod Gothic 1 Remake with GORE. Start with
 | Page | What it covers |
 |---|---|
 | [Bundling & deploying](bundles.md) | One spec → one mod that deploys and undeploys as a unit |
-| [Running many mods](mod-manager.md) | `gore mgr`: library, load order, conflicts, composed apply |
+| [Running many mods](mod-manager.md) | `gore mgr`: library, load order, conflict evidence, preflight/recovery, Apply and Reset |
 
 ## Also
 

--- a/docs/guide/bundles.md
+++ b/docs/guide/bundles.md
@@ -1,8 +1,9 @@
 # Bundling & deploying
 
-A **bundle** combines every domain — item overrides, localized text, audio,
-voice archives, textures, scripts, and dialog topics — into one mod that
-deploys and undeploys as a unit. This is the same engine
+A **bundle** combines every deployable domain — item overrides, localized text,
+audio, voice archives, textures/assets, loose or packed files, scripts, and
+dialog topics — into one mod that deploys and undeploys as a unit. This is the
+same engine
 [Mod Studio](../../apps/mod-studio/README.md) drives.
 
 ## The build spec
@@ -121,10 +122,12 @@ What deploy does per domain:
 
 The offline half is routine and re-checked on every test run against a temporary
 game root: a deploy writes the files it names, and an undeploy restores the
-backups and deletes the containers it owns. Whether that survives contact with
-the game was checked once, by hand, on 2026-08-07 — Gothic 1 Remake at Steam
-BuildID 24539464, `gore` built from commit `90940340`, with each mod's effect
-picked so it could not be misread, and a person looking or listening.
+backups and deletes the containers it owns. That boundary was first checked by
+hand on 2026-08-07 — Gothic 1 Remake at Steam BuildID 24539464, `gore` built
+from commit `90940340`, with each mod's effect picked so it could not be
+misread, and a person looking or listening. A later Manager campaign added
+genuine third-party, numeric-container-order, and live composed-script evidence
+described [below](#running-several-mods-at-once).
 
 One bundle carrying `overrides`, `loc_edits` and a `texture` deployed as a unit
 and took effect in a single launch. The main-menu logo was magenta, the edited
@@ -292,13 +295,20 @@ and conflict detection, use [`gore mgr`](mod-manager.md) or the
 [Mod Manager](../../apps/mod-manager/README.md) app, which consume the same
 bundles.
 
-That side was exercised on the same install, on the same day: two bundles
-editing one localization id, `gore mgr analyze` naming the winner, and the game
-showing the mod it named — then the reverse after a reorder. The details are in
-[the manager's evidence boundary](mod-manager.md#evidence-boundary). It goes
-exactly one conflict kind deep: a soft localization clash between two bundles.
-Texture-versus-texture container precedence, script splices and three-way
-conflicts were never checked against a running game.
+That side now has two manual evidence points on the same maintainer's install.
+The 2026-08-07 run checked a soft localization clash in both directions. The
+2026-08-18 run used genuine Nexus mods #244, #512, #269, and Attack Input V4;
+numeric #244/#512 container priority matched the displayed order in both
+directions, a new game and an existing save loaded, and the tested
+enable/disable/reorder/Reset paths behaved as expected. A GORE-authored Viper
+AngelScript fixture also composed and rendered with `ARMED`, `CHOICE_PASS`, and
+`RENDER_PASS` plus `exact_count=1`.
+
+The details and restoration boundary are in
+[the manager's evidence boundary](mod-manager.md#evidence-boundary). The script
+probe used the PR #91-fixed app-local Core DLL and was not a third-party
+AngelScript mod; no three-way script conflict was checked. #269 was disabled
+for that probe after a separate off-game-thread crash in its own UE4SS Lua loop.
 
 ## Other helpers
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -20,7 +20,7 @@ gore --version
 | `find` | — | Search the bundled catalogs and the effect register: class names, ids, categories, display names, and what an id does in game. | [find](find.md) |
 | `gen` | — | Compile `overrides.toml` → a UE4SS Lua override mod. | [items](items.md) |
 | `mod` | `build` · `deploy` · `undeploy` | Build/deploy/undeploy a unified bundle. | [bundles](bundles.md) |
-| `mgr` | `import` · `list` · `remove` · `enable` · `disable` · `order` · `analyze` · `apply` · `status` · `reset` | Multi-mod manager: library, load order, conflicts, composed deploy. | [mod-manager](mod-manager.md) |
+| `mgr` | `import` · `list` · `remove` · `enable` · `disable` · `order` · `analyze` · `preflight` · `recover` · `apply` · `status` · `reset` | Multi-mod manager: library, load order, readiness/recovery, conflicts, composed deployment, status and Reset. | [mod-manager](mod-manager.md) |
 | `loc` | `extract` · `status` · `export` · `import` | Read/edit localized text & dialogs in the encrypted `.lcache`. | [text-and-dialogs](text-and-dialogs.md) |
 | `audio` | `list` · `extract` · `replace` · `restore` · `export-patch` · `apply-patch` | Read/replace FMOD `.bank` audio (PCM injection, `*.gore-bak`). | [audio](audio.md) |
 | `voice` | `list` (`index`) · `match-line` · `extract` · `add` · `replace` · `apply-manifest` (`apply`) | Index/extract/copy-on-write edit voice-over ZIP archives. | [voice](voice.md) |
@@ -153,18 +153,28 @@ and failing would bury the line explaining what was not searched.
 
 ## `mgr`
 
-All subcommands except `reset` accept `--library <DIR>` and `--loadout <FILE>`.
+All subcommands except `reset` and `recover` accept `--library <DIR>` and
+`--loadout <FILE>`. Supply either both overrides or neither; a lone override is
+refused rather than being paired with unrelated default Manager state.
 
 | Subcommand | Arguments |
 |---|---|
 | `import <PATH>` | source folder / `.zip` / game file |
 | `list` | — |
-| `remove <ID>` | library entry id |
+| `remove <ID>` | library entry id; updates the target loadout only, so Apply afterwards if it was deployed |
 | `enable <ID>` / `disable <ID>` | library entry id |
 | `order <ID> <POS>` | `POS` is 0-based; 0 mounts first and loses conflicts |
 | `analyze` | — |
-| `apply` / `status` | `--game <GAME>` |
-| `reset` | `--game <GAME>` |
+| `preflight` | `--game <GAME>` · `--json`; read-only fixed setup/recovery checks |
+| `recover` | `--game <GAME>` · `--expected-guard-id <TOKEN>` · `--yes` · `--json` (`--json` requires `--yes`) |
+| `apply` | `--game <GAME>` |
+| `status` | `--game <GAME>` · `--json` |
+| `reset` | `--game <GAME>`; Manager-owned deployment only, refuses Studio ownership |
+
+`recover` accepts only the exact current abandoned-Manager `action_token`
+reported by `preflight`; it re-probes before mutation. See
+[Running many mods](mod-manager.md#interrupted-manager-changes) for the consent,
+JSON, and refusal contract.
 
 ## `loc`
 

--- a/docs/guide/dialog-authoring.md
+++ b/docs/guide/dialog-authoring.md
@@ -18,9 +18,10 @@ of that page, not a second claim.
 
 | | |
 |---|---|
-| **Shown in game** | An authored topic rendered in a real conversation on Gothic 1 Remake **1.0.3**: caption independently confirmed, `RENDER_PASS`, the same object and exact class once each in both observed arrays. `gore mod undeploy` then restored the 123,394,250-byte shipping cache to its recorded SHA-256, with 92 of 93 saves byte-identical. |
+| **Shown in game** | An authored topic rendered in a real conversation on Gothic 1 Remake **1.0.3**: caption independently confirmed, `RENDER_PASS`, the same object and exact class once each in both observed arrays. That historical version-1 proof restored the 123,394,250-byte shipping cache to its recorded SHA-256, with 92 of 93 saves byte-identical. On 2026-08-18, runtime version 3 also rendered `[Gore probe] UI fixture` on BuildID 24539464 and logged `ARMED`, `CHOICE_PASS`, and `RENDER_PASS` with `exact_count=1`; no topic was selected and no save was written. |
+| **Current-proof boundary** | The version-3 probe was GORE-authored and used the PR #91-fixed app-local Core DLL. Postflight restored the captured four-mod baseline loadout byte-for-byte and removed the temporary fixture. It does not qualify a third-party AngelScript mod or a three-way script conflict. |
 | **Not certified by that proof** | Selecting the topic. Authored knowledge or quest changes. **Recorded voice on an authored topic.** Save effects on the selection side. |
-| **Not qualified at all** | Steam build `24340829`. Runtime version 3 — it has a frozen offline candidate for `24169431`, which never completed the same clean visual requalification. |
+| **Not qualified at all** | Steam build `24340829`, the exact frozen runtime-version-3 artifact for older build `24169431`, and game/UE4SS combinations other than the separately recorded proofs. |
 | **Unproven** | Automatic discovery: that every class in a new module reaches an already constructed `ConversationTopicSet`. |
 
 One consequence worth stating plainly, because it spans two guide pages:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -125,8 +125,10 @@ What each check reads — and therefore what it can and cannot prove — is in t
 | edit your saved progress | [Save Editor](../../apps/save-editor/README.md) |
 | hand-write custom Lua behavior | [gore-lua](../../lua/README.md) |
 
-The Flutter GUIs call the exact same Rust crates as the CLI through a
-`dart:ffi` bridge. The CLI is always the most complete surface.
+The Flutter GUIs call the same Rust engine as the CLI through a `dart:ffi`
+bridge. Use the CLI for expert and automated workflows; use a GUI when its
+guided presentation is more useful. They share contracts and state rather than
+maintaining separate implementations.
 
 ## How each domain becomes a mod
 

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -7,7 +7,7 @@ check a load order for conflicts.
 
 Every tool call runs a real `gore` subcommand as a child process and returns its
 output, with the exact command line shown first — whatever the agent did, you can
-re-run it in a shell yourself. All 82 leaf commands are reachable, and this guide
+re-run it in a shell yourself. All 87 leaf commands are reachable, and this guide
 ships inside the binary so the agent can read it before acting.
 
 ## Setup
@@ -169,13 +169,25 @@ The decision is made **per subcommand**, not per tool.
 | | What it covers | Examples |
 |---|---|---|
 | Runs straight away | Reading, and commands writing to a free path outside the game installation | `texture list`, `loc export` to a new file, `as decompile`, `voice extract` |
-| Asks you first, whatever is on disk | Changing the game installation, deleting user content, or replacing a shared catalog — nothing you pass can make these harmless | `mod deploy`, `mod undeploy`, `mgr apply`, `mgr reset`, `mgr remove`, `mgr import`, `texture deploy`, `texture undeploy`, `texture replace`, `gen`, `deploy-shared`, `loc extract`, `audio restore` |
+| Asks you first, whatever is on disk | Changing the game installation, deleting or replacing Manager-library content, deleting other user content, or replacing a shared catalog — nothing you pass can make these harmless | `mod deploy`, `mod undeploy`, `mgr apply`, `mgr reset`, `mgr recover`, `mgr remove`, `mgr import`, `texture deploy`, `texture undeploy`, `texture replace`, `gen`, `deploy-shared`, `loc extract`, `audio restore` |
 | Asks you only when something is in the way | Overwriting an output file that already exists, writing into a directory that already holds files, rebuilding a bundle folder that is there, or rewriting a file in place | `catalog dump` onto an existing file, `texture index` without an output path, `loc import` without an output path, `mod build` over an existing bundle, `stubs`, `audio extract` and `as emit-all` into a non-empty directory |
 | Asks you first | Starting the game to compile AngelScript | `as compile`, `as compile-module` |
 
 Many commands sidestep the question entirely: passing an output argument turns an
 in-place rewrite into a new file. `loc import --out new.lcache` runs straight
 away; omitting `--out` overwrites the game's own file and asks.
+
+Three Manager snapshot calls are a deliberate exception to the simple
+read/write wording: `mgr list`, `mgr analyze`, and `mgr status` may finish an
+interrupted library replacement and persist the canonical reconciliation of a
+valid loadout. They remain ungated because that repair is part of opening
+authoritative Manager-owned state, but the MCP annotations do not call them
+read-only. `mgr preflight` is the separate genuinely read-only inspection.
+
+`mgr enable`, `mgr disable`, and `mgr order` are another explicit Manager-state
+class: they update the reversible target loadout immediately, are labelled
+`updates Manager loadout`, and intentionally remain ungated. They do not touch
+the game until a separately confirmed `mgr apply`.
 
 ### Which clients can ask
 
@@ -249,7 +261,7 @@ approval layer — you can answer once at startup instead:
 
 | Flag | Environment variable | Effect |
 |---|---|---|
-| `--allow-write` | `GORE_MCP_ALLOW_WRITE` | Installation changes and in-place rewrites run without asking |
+| `--allow-write` | `GORE_MCP_ALLOW_WRITE` | Installation changes, Manager-library mutations, deletions, and in-place rewrites run without asking |
 | `--allow-game-launch` | `GORE_MCP_ALLOW_GAME_LAUNCH` | The same for starting the game. Compiling needs **both**, because it also stages files in the installation |
 | `--no-consent-prompts` | `GORE_MCP_NO_CONSENT_PROMPTS` | Never ask, and refuse anything that would need it. The strict posture, for a server exposed to an agent whose calls nobody reviews. It cannot be combined with the two above — that would be asking for a looser and a stricter server at once, and the server refuses to start rather than pick one |
 
@@ -264,7 +276,8 @@ maps both permissions through it.
 
 In Claude Code you never touch a variable: the plugin declares them under
 `userConfig`, so enabling it asks you, in a dialog, whether GORE may change the
-game without confirming each time. Leave both off unless you have a reason.
+game, replace Manager-library content, or perform another protected write
+without confirming each time. Leave both off unless you have a reason.
 `${user_config.…}` is a Claude Code substitution. Codex reads the direct
 `.mcp.json` map and Cursor reads the wrapped `mcp.json` map; both pass the
 placeholder text through untouched, which the server reads as "not set" rather
@@ -317,8 +330,11 @@ line:
   cannot be checked *and* the folder cannot either, the command asks outright:
   `gen` (target folder named inside the `overrides.toml` it reads),
   `texture replace` (cooked files under a path derived from the asset name,
-  deleting a stale `.ubulk`), and `mgr import` (re-importing the same mod
-  deletes the payload of the entry it replaces).
+  deleting a stale `.ubulk`), and `mgr import`. The latter resolves a verified
+  existing entry by entry id, source identity, or content identity; a changed
+  match replaces that library payload during import, while an unchanged match
+  is a no-op. The consent gate runs before that identity decision, so import
+  still asks up front.
   Every check here happens before the command starts, so it is a decision point
   and not a lock: a file created *while* a command runs is still overwritten.
   Closing that window would mean making these commands refuse to re-run at all,
@@ -358,14 +374,16 @@ Two more flags tune behaviour rather than permissions:
 
 ## The tools
 
-Twelve tools mirror the CLI's command families; each takes a `subcommand` plus
-its arguments. Two more are specific to the server.
+Fourteen tools mirror the CLI's command families; each takes a `subcommand`
+plus its arguments. Two more are specific to the server.
 
 | Tool | Covers | Guide |
 |---|---|---|
 | `gore_guide` | Search and read these pages | — |
 | `gore_help` | `gore <cmd> --help` for any command | [cli-reference](cli-reference.md) |
 | `gore_config` | `config` | [getting-started](getting-started.md) |
+| `gore_doctor` | `doctor` | [getting-started](getting-started.md) |
+| `gore_find` | `find` | [find](find.md) |
 | `gore_catalog` | `dump` · `stubs` · `catalog` · `story-catalog` · `location-catalog` · `gui-model` · `sync` · `dump-mod` | [catalogs](catalogs-and-models.md) |
 | `gore_location` | `location` | [catalogs](catalogs-and-models.md) |
 | `gore_project` | `scaffold` · `gen` · `package` · `deploy-shared` | [items](items.md) |
@@ -378,7 +396,7 @@ its arguments. Two more are specific to the server.
 | `gore_mgr` | `mgr` | [mod-manager](mod-manager.md) |
 | `gore_as` | `as` | [scripts](scripts.md) |
 
-Twelve tools rather than 82 keeps a client's tool list navigable while still
+Sixteen tools rather than 87 keeps a client's tool list navigable while still
 covering every command. `gore_catalog` and `gore_project` have no matching CLI
 subcommand — they group top-level commands that belong to one workflow.
 

--- a/docs/guide/mod-manager.md
+++ b/docs/guide/mod-manager.md
@@ -9,25 +9,36 @@ library and loadout files.
 ## Library and loadout
 
 The library is the set of mods you have imported. The loadout is what is
-enabled and in which order. Both default to a shared per-user location; every
-subcommand accepts `--library <DIR>` and `--loadout <FILE>` to work on a
-different set.
+enabled and in which order. Both default to a shared per-user location. Every
+library/loadout subcommand accepts `--library <DIR>` and `--loadout <FILE>`;
+when overriding them, pass both together so one library is never paired with an
+unintended loadout. `reset` and token-bound `recover` work only from ownership
+or recovery evidence in the game installation and accept neither option.
 
 ```powershell
 gore mgr import C:\Downloads\SomeMod.zip   # folder, .zip, or a single game file
 gore mgr list                             # library joined to loadout state
-gore mgr remove <ID>                      # drop from library and loadout
+gore mgr remove <ID>                      # drop from library and target loadout
 ```
+
+`remove` does not rewrite an already deployed game installation. If the entry
+was active, run `apply` afterwards to deploy the updated target loadout.
 
 `import` accepts built GORE bundles (a folder or zip with a root
 `gore-mod.json`), foreign mod zips and folders, loose `_P.pak` files, IoStore
-triplets (`.utoc`/`.ucas`/`.pak`), UE4SS Lua mod folders, and raw game-file
-replacements. `list` prints the entry ids the other commands take.
+pairs (`.utoc`/`.ucas`) with an optional same-stem `.pak`, UE4SS Lua mod
+folders, and raw `.lcache`, `.bank`, or `PrecompiledScript*.Cache` game-file
+replacements. Extract `.7z` and `.rar` downloads before importing them.
+Partitioned/multipart IoStore members are unsupported; an incomplete pair,
+unknown content, unsafe path, or corrupt input is refused without publishing a
+partial library entry or changing the loadout. `list` prints the entry ids the
+other commands take.
 
-The foreign path has been walked once end to end against a real install: on
-BuildID 24539464 a triplet produced by `gore asset pack` — not a GORE bundle,
-with no `gore-mod.json` anywhere in it — was imported, classified as a foreign
-triplet, and applied with a load-order filename prefix.
+Both GORE-produced foreign inputs and genuine downloads have crossed the real
+install boundary. The 2026-08-18 campaign applied Nexus #244 Main Menu Replacer
+— Remake, #512 Mainmenu Sleeper Enhanced, #269 Gothic UI Reposition, and Attack
+Input V4. That proves those exact packages on one installation, not every
+archive shape or a third-party AngelScript mod.
 
 ### Stable import identity and native result
 
@@ -178,10 +189,10 @@ mods, same id, nothing rebuilt.
 gore mgr analyze
 ```
 
-Reports conflicts among the **enabled** mods across localization, audio,
-texture/asset, item overrides (CDO), scripts, and raw-file replacements, and
-which mod the analyzed loadout evidence marks as the intended winner for each
-recognized target.
+Reports conflicts among the **enabled** mods across localization, audio, voice
+archives, texture/asset containers, item overrides (CDO), scripts, loose and
+packed game-file claims, and raw-file replacements, and which mod the analyzed
+loadout evidence marks as the intended winner for each recognized target.
 
 The Manager app qualifies that result per component with derived footprint
 coverage. **Exact** means the component metadata gives conflict analysis a
@@ -192,6 +203,11 @@ describe target knowledge only; even Exact does not prove the game's runtime
 priority. If any enabled component is not Exact, a zero-result analysis is
 therefore shown as "no recognized conflicts" with an incomplete-knowledge
 warning, never as proof that the loadout is conflict-free.
+
+The CLI uses the same wording. When no recognized conflict rows exist but any
+enabled footprint is Partial, Advisory, or Opaque, it prints the coverage-gap
+warning and counts for those grades instead of the unqualified phrase "no
+conflicts".
 
 The same view spells out the intended order: low priority is listed first and
 later mods have higher intended priority. That order predicts winners only
@@ -221,14 +237,18 @@ manager cannot prove what they touch, so it cannot rule out a conflict with
 them.
 
 A soft localization clash has been watched resolve in game in both order
-directions. The #244/#512 main-menu container clash was also observed in both
-directions with the old equal-priority names: `gm000` won both times, exposing
-the ordering bug. The new numeric priorities have not yet been confirmed in a
-running game. Script splices and three-way conflicts also remain untested there.
+directions. An earlier #244/#512 main-menu run with equal-priority names let
+`gm000` win both directions and exposed the ordering bug. After migration to
+numeric priorities, the 2026-08-18 campaign confirmed the corrected behavior:
+`#244 -> #512` showed the Sleeper/Gothic-II menu and `#512 -> #244` showed the
+red Remake artwork. A GORE-authored AngelScript fixture also composed and
+rendered live, but no third-party AngelScript mod or three-way script conflict
+has been qualified.
 
 ## Apply
 
 ```powershell
+gore mgr preflight --game "$GAME" # read-only setup and recovery evidence
 gore mgr apply  --game "$GAME"    # compose the enabled loadout into one deployment
 gore mgr status --game "$GAME"    # is the install in sync with the target loadout?
 gore mgr reset  --game "$GAME"    # undeploy everything the manager has active
@@ -244,12 +264,31 @@ schema marker is reported as changes pending even when its loadout is unchanged.
 The next Apply migrates only its receipt- and hash-owned old names; Reset then
 cleans the new names through the same ownership evidence.
 
-`reset` restores the pristine install.
+`reset` restores the pristine install only when the validated deployment owner
+is Manager. It rechecks that ownership in the protected mutation path and
+refuses a Studio-owned deployment without changing it.
+
+`preflight` is read-only. It returns seven fixed-order checks for the game root,
+install, loadout, deployment, install mutation, UE4SS, and write access. Its
+`--json` envelope is:
+
+```text
+{ "ok": true, "preflight": { "format": 1, "checks": [<seven check objects>] } }
+```
+
+Only a check whose action is `recover_manager_mutation` carries an
+`action_token`; that token names one exact abandoned Manager operation and is
+not general cleanup authority.
+
+`status --json` emits `{ "ok": true, "status": { ... } }` with the full native
+status report. Its optional `manager_owned` groups are the same bounded,
+record-derived path evidence described below; absence is not an empty ownership
+claim.
 
 ### Interrupted Manager changes
 
 An interrupted Apply or Reset can leave an installation lock together with
-recovery data. The Mod Manager app distinguishes three cases:
+recovery data. Preflight and the Mod Manager app distinguish three cases:
 
 - If the Manager operation is still active, wait for it to finish and check
   again.
@@ -264,9 +303,27 @@ recovery data. The Mod Manager app distinguishes three cases:
   operation created it, Manager does not change the installation and shows the
   recovery guidance instead.
 
-Do not delete installation lock files by hand. This confirmation flow is a Mod
-Manager app action; `gore mgr status` and `gore doctor` only report the next
-step and do not perform this recovery.
+Do not delete installation lock files by hand. The app offers the confirmation
+flow directly. The equivalent CLI sequence copies the exact `action_token` from
+preflight and supplies it as the expected guard:
+
+```powershell
+gore mgr preflight --game "$GAME" --json
+gore mgr recover --game "$GAME" --expected-guard-id <TOKEN>
+```
+
+`recover` probes before writing and refuses missing, still-active,
+compiler-owned, ambiguous, invalid, or changed recovery state. The guard token
+is required, is bounded to 512 bytes, and must still match exactly. By default
+the CLI shows the planned recovery and requires an exact `y`/`N` answer;
+`--yes` is the explicit non-interactive approval. `--json` requires `--yes` and
+returns `{ "ok": <BOOL>, "outcome": "..." }` after the authoritative recovery
+result. Busy, compiler-recovery, and inspection-failure outcomes set `ok` to
+`false` and exit nonzero so automation cannot continue as if recovery ran.
+`gore mgr preflight` and `gore doctor` remain strictly read-only.
+`gore mgr status` never performs install recovery, but opening its authoritative
+Store snapshot may persist the same valid loadout reconciliation as `list` and
+`analyze`.
 
 The Mod Manager app's deployment-details dialog can expand **Recorded ownership
 evidence** when the same validated deploy-record snapshot has the exact owner
@@ -293,24 +350,43 @@ prove deterministic files, owned cleanup, and receipt state. Those checks do
 not prove that Unreal mounts one pak ahead of another, that the game reads the
 selected bytes, or that any runtime behavior changed.
 
-One session has gone past that line. On 2026-08-07, against Gothic 1 Remake at
-Steam BuildID 24539464 with `gore` built from commit `90940340`, a real install
-was imported into, enabled, analyzed, applied, launched, reordered, re-applied
-and reset by hand. The two-mod localization conflict resolved on screen the way
-`analyze` had named it, in both order directions; a foreign `gore asset pack`
-triplet imported and applied; and `reset` left the install pristine, verified on
-disk afterwards — `~mods\` empty, not one `*.gore-bak` anywhere, no deploy
-record, no mutation lock, and every rewritten file back at its original byte
-count, the numbers being the ones in
+Two manually observed campaigns have gone past that line on one maintainer's
+installation. The first, on 2026-08-07 against Steam BuildID 24539464 with
+`gore` built from commit `90940340`, imported, enabled, analyzed, applied,
+launched, reordered, re-applied, and reset GORE-produced inputs. The two-mod
+localization conflict resolved on screen the way `analyze` named it in both
+directions; a foreign `gore asset pack` triplet applied; and Reset left the
+installation pristine on disk — `~mods\` empty, no `*.gore-bak`, deploy record,
+or mutation lock, and every rewritten file restored to its original byte count.
+The detailed counts remain in
 [bundles](bundles.md#what-is-proven-and-by-what).
 
-That is one person, one install, one build, one sitting. It moves import, apply,
-reorder, reset and the localization conflict from "deterministic offline" to
-"seen working once on the real game", and it leaves every other conflict kind
-where it was. Nothing re-runs it, and nothing in the toolkit observes the
-screen.
+The second campaign, on 2026-08-18, used a packaged Manager built from the PR
+#90 merge and four genuine Nexus mods: #244 Main Menu Replacer — Remake, #512
+Mainmenu Sleeper Enhanced, #269 Gothic UI Reposition, and Attack Input V4. It
+observed the corrected numeric container priorities in both #244/#512 order
+directions, loaded a new game and an existing save, and exercised the tested
+enable, disable, reorder, Apply, and Reset paths. It also rendered the
+GORE-authored Viper choice `[Gore probe] UI fixture`; `UE4SS.log` recorded
+`ARMED`, `CHOICE_PASS`, and `RENDER_PASS` with `exact_count=1`. That script
+probe used the PR #91-fixed app-local Core DLL, so it qualifies that GORE
+fixture and composition path only — not a genuine third-party AngelScript mod
+or a three-way script conflict. #269 was disabled for the probe after its own
+UE4SS Lua loop had crashed while calling `FindAllOf` off the game thread; no
+GORE or AngelScript frame was present, and no save was written during the
+probe.
 
-Neither the offline checks nor that session grants any authority to modify a
+Postflight restored the captured loadout byte-for-byte, removed every temporary
+campaign entry and game-tree payload, restored the original signed Core DLL,
+and reported the original four-mod deployment in sync. It did not reset that
+user baseline to a pristine install. These remain manual observations by one
+person on one installation; nothing in the toolkit observes the screen.
+
+The separate clean-Windows portable, installer, recovery, Reset, and uninstall
+acceptance pass remains open. The real-install campaign is not evidence for
+that packaging boundary.
+
+Neither the offline checks nor these sessions grant any authority to modify a
 real installation, launch the game, or read or mutate a save; those steps
 require separate qualified safety gates.
 
@@ -318,9 +394,12 @@ require separate qualified safety gates.
 
 | Flag | Commands | Meaning |
 |---|---|---|
-| `--library <DIR>` | all except `reset` | Library dir. Default: the shared per-user library. |
-| `--loadout <FILE>` | all except `reset` | Loadout file. Default: the shared per-user loadout. |
-| `--game <PATH>` | `apply`, `status`, `reset` | Game root containing `G1R\`. Falls back to the configured path. |
+| `--library <DIR>` | all except `reset`, `recover` | Library dir. Default: the shared per-user library. Supply it together with `--loadout`. |
+| `--loadout <FILE>` | all except `reset`, `recover` | Loadout file. Default: the shared per-user loadout. Supply it together with `--library`. |
+| `--game <PATH>` | `apply`, `status`, `reset`, `preflight`, `recover` | Game root containing `G1R\`. Falls back to the configured path. |
+| `--expected-guard-id <TOKEN>` | `recover` | Exact `action_token` from the current abandoned-Manager preflight check; required, max 512 bytes. |
+| `--yes` | `recover` | Approve the exact token-bound recovery without the interactive `y`/`N` prompt; required with `--json`. |
+| `--json` | `preflight`, `recover`, `status` | Emit one machine-readable result document. |
 
 ## Related
 

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -209,6 +209,20 @@ target the same module, the later loadout entry is the displayed and deployed
 winner. A complete raw cache is a base rather than a winner over compatible
 module patches; those patches are applied on top of it in either order.
 
+Prepared minis and raw extracted minis intentionally encode private
+StaticNames operands differently. A prepared mini addresses a private row after
+the pristine pool; a raw mini uses its compact local row. The loadout composer
+now preserves that distinction, reuses matching names, and fails closed if a
+prepared operand has no row. Do not rewrite those numeric operands by hand; the
+wire-level contract is in [`gore-as/FORMAT.md`](../../crates/gore-as/FORMAT.md#staticnames-indices-in-raw-and-prepared-minis).
+
+This composition path has one current live observation. On 2026-08-18 the
+GORE-authored Viper fixture rendered `[Gore probe] UI fixture`; `UE4SS.log`
+recorded `ARMED`, `CHOICE_PASS`, and `RENDER_PASS` with `exact_count=1`. The run
+used the PR #91-fixed app-local Core DLL. It was not a genuine third-party
+AngelScript mod or a three-way script conflict, and no save was written during
+the check. See the [Manager evidence boundary](mod-manager.md#evidence-boundary).
+
 The `-o` form of `compile` leaves the install exactly as it was, so the live
 `PrecompiledScript_Shipping.Cache` is still the pristine cache these commands
 use as `vanilla.Cache`.

--- a/docs/reference/dialog-runtime.md
+++ b/docs/reference/dialog-runtime.md
@@ -44,6 +44,31 @@ byte-identical. The only difference was three ASCII digits in the already-known
 `/Engine/Transient.GothicScreenshotsSave_*` object name in
 `PersistentDataList.sav`; its other bytes and every slot save were unchanged.
 
+## Current version-3 live observation
+
+On 2026-08-18, on Steam BuildID `24539464`, the version-3 Viper registration
+runtime crossed the live render boundary again as part of the Mod Manager
+campaign. The visible choice was `[Gore probe] UI fixture`, and `UE4SS.log`
+recorded the ordered `ARMED`, `CHOICE_PASS`, and `RENDER_PASS` states with
+`exact_count=1` at `2026-08-18 19:54:38`. The user opened the Viper conversation
+but did not select the fixture, and no save was written during this check.
+
+This was a GORE-authored fixture, not a third-party AngelScript mod. The
+packaged Manager was built from the PR #90 merge, while the app-local Core DLL
+used for this script check contained the PR #91 prepared-StaticNames fix. The
+third-party #269 Gothic UI Reposition mod was disabled for this observation
+after an earlier crash had been isolated to its own UE4SS Lua loop calling
+`FindAllOf("W_Hotbar_C")` off the game thread; that crash contained no GORE or
+AngelScript frame.
+
+Postflight restored the captured four-mod loadout byte-for-byte, removed the
+temporary campaign entries and Viper payload, restored the original signed
+Core DLL, and reported the user's original four-mod deployment in sync. This is
+one live proof of the current version-3 GORE path on one installation. It does
+not retroactively qualify the frozen `24169431` artifact below, a third-party
+AngelScript package, topic selection or persistence, or a three-way script
+conflict.
+
 ## Historical version-3 requalification candidates
 
 The production generator emitted runtime version 3 for the retained Viper
@@ -138,12 +163,12 @@ separate behavioral qualification because selecting its fixture can change
 quest/save state. The offline evidence qualifies its hotfix-remapped
 build/composition only, not selection, effects, persistence, or save/reload.
 
-The central generation registry now also contains Steam build `24340829`, but
-only for its separately recorded bounded offline authoring evidence. No
-dialog-runtime candidate or qualification has been retained for `24340829`,
-and none of the `24169431` runtime evidence carries forward across that
-generation boundary. Offline composition and any separately authorized live
-runtime requalification therefore remain open for the current build.
+The central generation registry also contains Steam build `24340829`, but only
+for its separately recorded bounded offline authoring evidence. No dialog-
+runtime candidate or qualification has been retained for `24340829`, and none
+of the `24169431` evidence carries across a generation boundary. Build
+`24539464` instead has the separate version-3 live observation recorded above;
+it does not convert either historical candidate into a qualified artifact.
 
 ## Discovery versus insertion
 
@@ -175,10 +200,11 @@ locality-qualified registrations before mutation. Conversation-local
 participant or exact-sentinel-topic mismatches remain registration-specific
 skips. Classes are resolved at the natural callback rather than loader startup
 because they may load lazily. This preflight-atomic behavior is covered by the
-version-3 mock-runtime suite; it is not transactional if a native `AddTopic`
+version-3 mock-runtime suite, and the build-`24539464` Viper observation covers
+one successful live render path. It is not transactional if a native `AddTopic`
 call itself fails. Such a failure stops all later mutation attempts, but the
 failing call or an earlier successful call may already have mutated and neither
-has a proven safe inverse. Version 3 is not yet a live-game proof.
+has a proven safe inverse; the live proof did not force that failure path.
 The runtime never selects or removes a topic, scans global objects, starts a
 conversation, uses a timer or console command, grants/activates an ability, or
 writes a save/quest/knowledge field.
@@ -198,13 +224,13 @@ writes a save/quest/knowledge field.
   9 June 2026 build timestamp, which is consistent with that, and a file
   creation date of 7 August 2026, which is not evidence either way because
   re-extracting the same archive resets it. Both the reviewed v0.4 fixture and version 1 of the exact adapter
-  emitted by the parameterized production generator completed the clean live
-  visual proof. Runtime version 3 has a frozen offline candidate for the older
-  build `24169431`: its deterministic builds, batch class preflight, observer
-  behavior, forbidden-operation boundary, and exact sandbox closure were
-  qualified offline, but its exact artifact never completed the same clean
-  visual requalification. Build `24340829` has no dialog-runtime qualification
-  at all. Other game, UE4SS, and runtime combinations remain to be qualified.
+  emitted by the parameterized production generator completed the original
+  clean live visual proof. Runtime version 3 has both the current
+  build-`24539464` GORE-fixture observation above and a frozen offline candidate
+  for older build `24169431`; that older exact artifact never completed the
+  same live requalification. Build `24340829` has no dialog-runtime
+  qualification at all. Other game, UE4SS, and runtime combinations remain to
+  be qualified.
 - Topic selection, authored knowledge/quest changes, recorded voice, and
   selection-side save effects are not certified by the insertion proof.
 - The exact native ordering of knowledge rules, `IsVisible_Implementation`,

--- a/plugins/gore/.claude-plugin/plugin.json
+++ b/plugins/gore/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gore",
-  "description": "Mod Gothic 1 Remake with the GORE toolkit: the MCP server that exposes every gore CLI command, plus the workflow knowledge that keeps an assistant from modding something the engine never reads.",
-  "version": "0.2.0",
+  "description": "Author Gothic 1 Remake mods or safely import, enable, order, analyze, preflight, apply, check status, recover, remove, and reset GORE or external mods.",
+  "version": "0.3.0",
   "author": {
     "name": "Daniel Hoer"
   },
@@ -19,8 +19,8 @@
   "userConfig": {
     "allow_write": {
       "type": "boolean",
-      "title": "Change the game without confirming each time",
-      "description": "Off by default: every change to your installation is confirmed with you first. Turn this on only where nobody is watching, such as a scripted run.",
+      "title": "Change the install or protected Manager content without confirming",
+      "description": "Off by default: installation changes and protected Manager import, replacement, removal, recovery, and Reset calls are confirmed first. Reversible enable, disable, and order edits update the target loadout immediately without this setting.",
       "default": false
     },
     "allow_game_launch": {

--- a/plugins/gore/.codex-plugin/plugin.json
+++ b/plugins/gore/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gore",
-  "version": "0.2.0",
-  "description": "Mod Gothic 1 Remake with the GORE toolkit: textures, localized text, dialog, audio, voice-over, item values and AngelScript, built into one bundle and deployed as a unit.",
+  "version": "0.3.0",
+  "description": "Author Gothic 1 Remake mods or safely import, enable, order, analyze, preflight, apply, check status, recover, remove, and reset GORE or external mods.",
   "author": {
     "name": "Daniel Hoer",
     "url": "https://github.com/dh0er"
@@ -21,8 +21,8 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "GORE",
-    "shortDescription": "Mod Gothic 1 Remake — textures, text, audio, voice and scripts in one bundle",
-    "longDescription": "Guides an agent through modding Gothic 1 Remake with the gore CLI: choosing a target the engine actually reads, relaying the consent gate that guards the installation, and saying afterwards what a deploy did and did not prove. The plugin bundles the MCP server configuration and the facts live in the guide shipped inside gore.exe, so they never drift from the version you are running. Needs only the gore CLI installed and on PATH.",
+    "shortDescription": "Author and safely manage Gothic 1 Remake mods",
+    "longDescription": "Guides an agent through authoring Gothic 1 Remake mods and through the complete Mod Manager lifecycle for GORE and external mods: import, enable, order, analyze, preflight, apply, status, recovery, removal and reset. It relays the consent gate and keeps runtime claims honest. The plugin bundles the MCP server configuration; current facts live in the guide shipped inside gore.exe. Needs the gore CLI installed and on PATH.",
     "developerName": "Daniel Hoer",
     "category": "Coding",
     "capabilities": [
@@ -32,7 +32,7 @@
     ],
     "defaultPrompt": [
       "Build me a test mod for Gothic 1 Remake so I can see modding works.",
-      "Change some menu text in Gothic 1 Remake and tell me how to undo it."
+      "Import these Gothic 1 Remake mods, check their conflicts, apply them safely, and show me how to reset."
     ],
     "websiteURL": "https://github.com/dh0er/gore",
     "screenshots": []

--- a/plugins/gore/.cursor-plugin/plugin.json
+++ b/plugins/gore/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "gore",
   "displayName": "GORE",
-  "description": "Mod Gothic 1 Remake: textures, localized text, dialog, audio, voice-over, item values and AngelScript, built into one bundle and deployed as a unit. Bundles the skill and MCP server configuration; needs the gore CLI on PATH.",
-  "version": "0.2.0",
+  "description": "Author Gothic 1 Remake mods or safely import, enable, order, analyze, preflight, apply, check status, recover, remove, and reset GORE or external mods. Bundles the skill and MCP server configuration; needs the gore CLI on PATH.",
+  "version": "0.3.0",
   "author": {
     "name": "Daniel Hoer",
     "url": "https://github.com/dh0er"

--- a/plugins/gore/README.md
+++ b/plugins/gore/README.md
@@ -55,13 +55,16 @@ not the plugin. Fix that and restart the client.
 
 | | |
 |---|---|
-| `.mcp.json`, `mcp.json` | the server: every `gore` command, as twelve command-family tools plus `gore_guide` and `gore_help`. The same server map in the direct Claude/Codex shape and Cursor's wrapped shape |
+| `.mcp.json`, `mcp.json` | the server: every `gore` command, as fourteen command-family tools plus `gore_guide` and `gore_help`. The same server map in the direct Claude/Codex shape and Cursor's wrapped shape |
 | `skills/gore-modding/` | when to reach for which tool, the consent gate, and what a deploy does and does not prove |
 | `.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/` | the same plugin, described the way each client wants it |
 
 Enabling the plugin in Claude Code asks whether GORE may change your game
-installation without confirming each call, and whether it may start the game to
-compile AngelScript. Both are off unless you say otherwise; they map to
+installation or perform protected Manager import, replacement, removal,
+recovery, or Reset calls without confirming each call, and whether it may start
+the game to compile AngelScript. Reversible `enable`, `disable`, and `order`
+edits update the target loadout immediately and are intentionally ungated. Both
+settings are off unless you say otherwise; they map to
 `GORE_MCP_ALLOW_WRITE` and `GORE_MCP_ALLOW_GAME_LAUNCH`, which is also how to set
 them on a client that does not ask.
 

--- a/plugins/gore/skills/gore-modding/SKILL.md
+++ b/plugins/gore/skills/gore-modding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gore-modding
-description: Use when modding Gothic 1 Remake with the GORE tools - changing textures, localized text, dialog, audio, voice-over, item values or AngelScript, or building and deploying a mod bundle. Covers what the tools can and cannot reach, the consent gate, and what "deployed" does and does not prove.
+description: Use when modding Gothic 1 Remake with GORE - changing textures, localized text, dialog, audio, voice-over, item values or AngelScript; building a bundle; or importing, enabling, ordering, analyzing, preflighting, applying, checking status, recovering, removing, and resetting GORE or external mods with the Mod Manager. Covers the consent gate and what "deployed" does and does not prove.
 ---
 
 # Modding Gothic 1 Remake with GORE
@@ -26,6 +26,58 @@ Call `gore_guide` for the page that covers your domain: `textures`, `audio`,
 small. `gore_help` gives exact current flags; the guide gives the order to do
 things in and what breaks when a step is skipped.
 
+## Manage a loadout as one declarative deployment
+
+For installing or managing mods, use `gore_mgr`, not a sequence of direct
+`gore_mod deploy` calls. A Manager loadout is one owned deployment; Apply
+rebuilds its complete enabled state from the pristine base.
+
+Read `gore_guide` page `mod-manager` and the exact `gore_help` entry first. The
+guide is the authority for the current accepted GORE bundles, external folders,
+archives, loose files, containers, UE4SS mods, and mixed packages. Do not infer
+support for a format from its extension or from where the mod came from.
+
+Use this lifecycle:
+
+1. If the setup is unknown or already looks wrong, run `gore_doctor` once; do
+   not repeat it between ordinary Manager steps. `gore_mgr import` the package
+   and keep the returned entry id. Import writes
+   protected Manager library/loadout state, not the game installation; it still
+   needs consent because a verified re-import may replace the stored payload.
+2. `gore_mgr enable` the intended entries, use `order` when needed, then run
+   `analyze`. Position 0 goes first and loses recognized ordered conflicts. An
+   intended winner is evidence from the analyzer, not proof of runtime priority.
+   `enable`, `disable`, and `order` update the reversible target loadout
+   immediately and intentionally do not open the protected-write consent gate;
+   state the intended edit before the call and report the resulting order.
+3. Immediately before an installation change, run `gore_mgr preflight` for the
+   exact read-only readiness/recovery report. An active Studio deployment, game
+   drift, or interrupted operation is a state to resolve, not something to
+   overwrite.
+4. Before `apply`, summarize the enabled loadout and observable effects, give
+   the exact Apply and Reset commands, and obtain consent. Apply writes the game
+   installation. Follow it with `status` and then a concrete in-game checklist.
+5. `remove` deletes the library entry and its loadout slot, but does not change
+   bytes already deployed in the game. Apply the remaining loadout afterwards
+   to make the installation match, then check `status` again.
+6. `reset` is the terminal cleanup path for a Manager-owned deployment and must
+   refuse rather than remove a Studio deployment. Check `status` afterwards;
+   never treat a successful command as proof that the game displayed or executed
+   every component.
+
+`list`, `analyze`, and `status` are not advertised as read-only because opening
+the authoritative Manager store may reconcile its loadout; list and analyze may
+also finish recovery of an interrupted library replacement. They remain ungated,
+but their result must still be treated as authoritative refreshed state.
+
+Never delete a GORE installation lock or recovery directory by hand. If an
+operation is still active, wait. If `preflight` identifies an abandoned Manager
+operation, pass its exact opaque action token as `expected_guard_id` to
+`gore_mgr recover` and obtain consent for that call. Recovery atomically rechecks
+the token; never guess or reuse one after the state changes. Compiler-owned,
+ambiguous, or invalid recovery state gets help, not an improvised reset. Re-run
+`preflight` and `status` after recovery before Apply or Reset.
+
 ## Pick a target that the engine actually reads
 
 This is where mods silently fail, and the tools cannot warn you: they will
@@ -36,7 +88,7 @@ containers, which is what `gore_texture` and `gore_asset` reach. A short,
 enumerable set sits loose on disk under `G1R\Content` — the FMOD banks, the Bink
 movies and their subtitles, the splash bitmap, and the mouse-cursor PNGs — and
 none of those is reachable through the texture commands. Read
-`gore_guide{page:"textures"}` before choosing, and check which world your target
+`gore_guide{action:"read",page:"textures"}` before choosing, and check which world your target
 is in. A bundle's `files` section replaces a loose file; `texture` replaces a
 cooked one. Using the wrong one deploys cleanly and changes nothing.
 
@@ -101,8 +153,12 @@ user in any form, tell them four things:
 1. **What the mod changes**, domain by domain — for each one, what they will see
    or hear, and where. Not the spec; what it does.
 2. **Where the bundle is**, as a full path.
-3. **The deploy command**, spelled out, so they can run it themselves.
-4. **The undeploy command** that removes all of it.
+3. **The installation route**, spelled out. For a Manager loadout this is
+   `mgr import`, `enable`, and `apply`; use direct `mod deploy` only when the user
+   explicitly chose the single-bundle route and no Manager deployment owns the
+   installation.
+4. **The matching cleanup route**: Manager `remove` plus Apply, or Manager Reset;
+   direct `mod undeploy` only for a direct deployment.
 
 Then ask.
 
@@ -118,9 +174,9 @@ conversation.
 
 ## After deploying, be honest about what is proven
 
-`gore mod deploy` verifies that the bytes it wrote are the bytes it meant to
-write, by hash. Nothing observes the screen. A successful deploy is not evidence
-that the change is visible.
+`gore mod deploy` and `gore mgr apply` verify that the bytes they wrote are the
+bytes they meant to write, by hash. Nothing observes the screen. A successful
+deploy or Apply is not evidence that the change is visible.
 
 So follow it with a checklist the user can actually run: what to look at, in what
 order, and what each item would look like if it worked. Mark the items you could


### PR DESCRIPTION
## Summary
- add read-only Manager preflight, exact token-bound recovery, status JSON, and a race-safe Manager-only CLI reset
- make analyze/remove output and MCP safety metadata match the actual Manager state model
- expand the GORE plugin skill to the full 12-action lifecycle and bump plugin metadata to 0.3.0
- update guides and release notes with the completed Nexus, load-order, save, AngelScript, and restoration evidence plus remaining caveats

## Validation
- `cargo test -p gore-mod` (505 passed)
- `cargo test -p gore` (full suite passed)
- `cargo test -p gore-mcp` (315 passed)
- `python scripts/check_plugin.py`
- `python scripts/check_docs_links.py`
- `quick_validate.py plugins/gore/skills/gore-modding`
- independent final diff review: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes installation recovery, undeploy ownership boundaries, and MCP consent classification for Manager operations—areas that can brick or mislead automation if wrong—but the diff adds extensive integration tests and keeps recovery token-bound and fail-closed.
> 
> **Overview**
> **Manager CLI and engine** gain read-only `mgr preflight`, token-bound `mgr recover` (with `--yes`/`--json`), richer `status --json`, and **Reset** that only undeploys Manager-owned state while refusing Studio deployments (including owner races). `analyze` and `remove` messaging now distinguish “no recognized conflicts” from incomplete footprint knowledge and remind users to **Apply** after removal.
> 
> **MCP (87 commands)** introduces finer Manager safety classes (`ManagerWrite`, reconcile, loadout edits), reclassifies `mgr import` as protected library state (not an install mutation), documents ungated but non-read-only `list`/`analyze`/`status`, and wires `recover` to force non-interactive confirmation over stdio.
> 
> **AngelScript composition** documents and implements correct handling of prepared-mini **StaticNames** operands during loadout-wide remap (fail-closed on missing rows).
> 
> **Plugin 0.3.0** and guides/changelogs expand copy to the full import→recover lifecycle, update consent wording, and record the 2026-08-18 Nexus/load-order/script probe campaign with explicit qualification limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b2cd7672a4981d1cfe49c41584186809caa713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->