### PR TITLE
chore(release): prepare CLI and Manager 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 |---|---|---|
 | **[CLI](docs/guide/README.md)** | All modding from the terminal: item values, text and dialogs, audio, voice, textures, DataAssets, scripts. Start here. | ⚗️ Experimental use |
 | **[Mod Studio](apps/mod-studio/README.md)** | No-code Windows GUI over the same engine, for *authoring* one mod. | 🚧 Work in progress |
-| **[Mod Manager](apps/mod-manager/README.md)** | Windows GUI for installing and ordering *many* mods together. | 🚧 Work in progress |
+| **[Mod Manager](apps/mod-manager/README.md)** | Windows GUI for installing and ordering *many* mods together. | ⚗️ Experimental use |
 | **[Save Editor](apps/save-editor/README.md)** | Windows GUI for editing your save files. Never touches the game install. | ✅ Ready to use |
 | **[gore-lua](lua/README.md)** | Small Lua helper library that ships into the game, for hand-written UE4SS mods. | 🚧 Work in progress |
 | **[Assistant plugin](plugins/gore/README.md)** | The MCP server and the modding skill, installed into Claude Code, Codex or Cursor in one step. | ⚗️ Experimental use |

--- a/apps/mod-manager/CHANGELOG.md
+++ b/apps/mod-manager/CHANGELOG.md
@@ -6,12 +6,13 @@ notes, so every release needs an entry.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.1.0] - Unreleased
+## [Unreleased]
 
-- First Early Alpha release candidate. The real-install workflow has completed
-  one acceptance campaign; publication remains blocked on clean-Windows
-  portable, installer, recovery, Reset, and uninstall acceptance and explicit
-  release authorization.
+## [0.1.0] - 2026-08-18
+
+- First Early Alpha release. The real-install workflow has completed one
+  acceptance campaign. Clean-Windows portable, installer, recovery, Reset, and
+  uninstall acceptance remains a known limitation of this prerelease.
 - Complete Manager lifecycle: import, inspect, enable, disable, reorder, remove,
   analyze, declarative Apply, deployment status, confirmed abandoned-operation
   recovery, Studio takeover, and Reset/Undeploy.

--- a/apps/mod-manager/CHANGELOG.md
+++ b/apps/mod-manager/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.1.0] - 2026-08-18
 
-- First Early Alpha release. The real-install workflow has completed one
+- First experimental release. The real-install workflow has completed one
   acceptance campaign. Clean-Windows portable, installer, recovery, Reset, and
   uninstall acceptance remains a known limitation of this prerelease.
 - Complete Manager lifecycle: import, inspect, enable, disable, reorder, remove,

--- a/apps/mod-manager/README.md
+++ b/apps/mod-manager/README.md
@@ -1,6 +1,6 @@
 # GORE Mod Manager
 
-> **Early Alpha 0.1.0:** this first public prerelease is intended for testing on
+> **Experimental 0.1.0:** this first public prerelease is intended for testing on
 > a non-critical installation; keep your own backups and expect rough edges.
 > For the established expert workflow, use the
 > [`gore` CLI](../../docs/guide/README.md).
@@ -78,7 +78,7 @@ After testing, the captured loadout was restored byte-for-byte, all temporary
 campaign entries and game-tree payloads were removed, the original signed Core
 DLL was restored, and the original four-mod deployment reported in sync. This
 is one person and one Windows installation. Clean-Windows portable, installer,
-recovery, Reset, and uninstall acceptance remains open as a known Early Alpha
+recovery, Reset, and uninstall acceptance remains open as a known experimental
 limitation.
 
 ## What it can not do

--- a/apps/mod-manager/README.md
+++ b/apps/mod-manager/README.md
@@ -1,8 +1,7 @@
 # GORE Mod Manager
 
-> **Early Alpha release candidate:** no Mod Manager release has been published
-> yet. Local and CI-built packages are for acceptance testing on a test
-> installation; keep your own backups and expect rough edges.
+> **Early Alpha 0.1.0:** this first public prerelease is intended for testing on
+> a non-critical installation; keep your own backups and expect rough edges.
 > For the established expert workflow, use the
 > [`gore` CLI](../../docs/guide/README.md).
 
@@ -79,8 +78,8 @@ After testing, the captured loadout was restored byte-for-byte, all temporary
 campaign entries and game-tree payloads were removed, the original signed Core
 DLL was restored, and the original four-mod deployment reported in sync. This
 is one person and one Windows installation. Clean-Windows portable, installer,
-recovery, Reset, and uninstall acceptance remains open, so 0.1.0 is not yet a
-published release.
+recovery, Reset, and uninstall acceptance remains open as a known Early Alpha
+limitation.
 
 ## What it can not do
 

--- a/crates/gore/CHANGELOG.md
+++ b/crates/gore/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-18
+
 First release. Command-line toolkit for modding Gothic 1 Remake.
 
 - `mod` — build and transactionally deploy one bundle containing item


### PR DESCRIPTION
## Summary
- cut gore CLI 0.1.0 release notes
- cut Mod Manager 0.1.0 Early Alpha release notes
- update Manager README from release-candidate to prerelease wording

## Validation
- `python build.py gore-cli release 0.1.0 --changelog --dry-run`
- `python build.py gore-mod-manager release 0.1.0 --changelog --dry-run`
- `python scripts/check_release_workflow.py`
- `python scripts/check_docs_links.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and changelog-only; no runtime, build, or release workflow logic changes in this diff.
> 
> **Overview**
> Documentation-only release prep for **gore CLI** and **Mod Manager 0.1.0** (dated 2026-08-18).
> 
> **`crates/gore/CHANGELOG.md`** adds a `[0.1.0]` section (first CLI release notes) and leaves `[Unreleased]` empty for follow-on work. **`apps/mod-manager/CHANGELOG.md`** moves the prior unreleased Early Alpha text into **`[0.1.0]`**, reframes it as the first **experimental** public prerelease, and drops language that blocked publication pending clean-Windows acceptance—those gaps are now called out as known limitations instead.
> 
> **`README.md`** bumps Mod Manager’s tools table status from work in progress to **Experimental use**, aligned with CLI and the assistant plugin. **`apps/mod-manager/README.md`** replaces “Early Alpha release candidate / not published yet” with **Experimental 0.1.0** prerelease guidance and matches the acceptance wording to the changelog (open items are experimental limitations, not a release gate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5018e2a9ba2378e195b3d161d95c80f2f0df70de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->