### PR TITLE
Save Editor: serialize and time-limit the portable update check

### DIFF
--- a/apps/save-editor/CHANGELOG.md
+++ b/apps/save-editor/CHANGELOG.md
@@ -6,6 +6,17 @@ notes, so every release needs an entry.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- The portable update check could hang, stack prompts, or do nothing. It had no
+  request timeout, so a stalled connection blocked every later check; the
+  hourly timer could open one more prompt per hour on an unattended machine;
+  and Download silently did nothing when no browser was registered. Checks are
+  now serialized and time-limited, and a download page that will not open says
+  so with its address.
+
 ## [1.3.0] - 2026-08-17
 
 ### Added

--- a/apps/save-editor/lib/features/app/domain/desktop_updater.dart
+++ b/apps/save-editor/lib/features/app/domain/desktop_updater.dart
@@ -25,13 +25,17 @@ String _releasePageUrl(String version) =>
 
 const _checkIntervalSeconds = 3600;
 
+/// Cap for each feed network step. Without it a stalled connection or a server
+/// that opens a response and never finishes it would hang the check forever,
+/// and with it the in-flight guard below.
+const _feedTimeout = Duration(seconds: 20);
+
 /// Attached to the GoRouter so a background update check (which has no widget
 /// context of its own) can still surface a dialog. See [router.dart].
 final updaterNavigatorKey = GlobalKey<NavigatorState>();
 
 bool? _innoInstalled;
 bool _feedConfigured = false;
-Timer? _portableTimer;
 
 /// Inno Setup always places an uninstaller (unins*.exe) next to the app;
 /// the portable zip ships without one. Distinguishes the installed copy
@@ -40,11 +44,11 @@ Timer? _portableTimer;
 bool _isInnoInstalled() {
   try {
     return File(Platform.resolvedExecutable).parent.listSync().any(
-          (entry) =>
-              entry is File &&
-              p.basename(entry.path).toLowerCase().startsWith('unins') &&
-              entry.path.toLowerCase().endsWith('.exe'),
-        );
+      (entry) =>
+          entry is File &&
+          p.basename(entry.path).toLowerCase().startsWith('unins') &&
+          entry.path.toLowerCase().endsWith('.exe'),
+    );
   } catch (error) {
     debugPrint('goresave updater install check failed: $error');
     return false;
@@ -113,17 +117,23 @@ Future<bool> _ensureFeedConfigured() async {
 /// any failure (network, redirect, malformed feed). The appcast is the same
 /// signed feed WinSparkle reads; here we only need the version string.
 Future<String?> _fetchLatestVersion() async {
-  final client = HttpClient();
+  final client = HttpClient()..connectionTimeout = _feedTimeout;
   try {
-    final request = await client.getUrl(Uri.parse(_appcastUrl));
-    final response = await request.close();
+    final request = await client
+        .getUrl(Uri.parse(_appcastUrl))
+        .timeout(_feedTimeout);
+    final response = await request.close().timeout(_feedTimeout);
     if (response.statusCode != HttpStatus.ok) {
       return null;
     }
-    final body = await response.transform(utf8.decoder).join();
-    final match =
-        RegExp(r'<sparkle:version>\s*([^<\s]+)\s*</sparkle:version>')
-            .firstMatch(body);
+    // A response can stall mid-body, so bound the read as well as the connect.
+    final body = await response
+        .transform(utf8.decoder)
+        .join()
+        .timeout(_feedTimeout);
+    final match = RegExp(
+      r'<sparkle:version>\s*([^<\s]+)\s*</sparkle:version>',
+    ).firstMatch(body);
     return match?.group(1);
   } catch (error) {
     debugPrint('goresave portable update check failed: $error');
@@ -133,59 +143,201 @@ Future<String?> _fetchLatestVersion() async {
   }
 }
 
-/// Compares dotted numeric versions (e.g. "0.4.0"). Returns true when
-/// [latest] is strictly newer than [current]. Non-numeric or missing
-/// components are treated as 0, so "0.4" < "0.4.1".
-bool _isNewer(String latest, String current) {
+/// What a finished portable check has to tell the user.
+enum PortableUpdateReport { checkFailed, upToDate, downloadPageFailed }
+
+/// Everything outside this file that a portable check touches: the feed, this
+/// build's version, the two prompts, and the browser.
+///
+/// Injected because the interesting behaviour here is timing — a background
+/// tick meeting a manual click, a stalled feed, a prompt left unanswered — and
+/// none of that is reachable through the real network, real windows, and a
+/// release-mode-only entry point.
+@visibleForTesting
+class PortableUpdateHooks {
+  const PortableUpdateHooks({
+    required this.fetchLatestVersion,
+    required this.currentVersion,
+    required this.report,
+    required this.askDownload,
+    required this.openReleasePage,
+  });
+
+  /// The advertised version, or null when the feed could not be read.
+  final Future<String?> Function() fetchLatestVersion;
+  final Future<String> Function() currentVersion;
+
+  /// Tells the user how the check ended. [releaseUrl] is only meaningful for
+  /// [PortableUpdateReport.downloadPageFailed].
+  final Future<void> Function(PortableUpdateReport report, String releaseUrl)
+  report;
+
+  /// Shows the update prompt; true when the user chose Download.
+  final Future<bool> Function(String latest, String current) askDownload;
+
+  /// Opens the release page; false when the shell refused or failed.
+  final Future<bool> Function(String latest) openReleasePage;
+}
+
+/// Runs portable update checks, one at a time.
+///
+/// The whole point of this class is the queueing rules, which is why they live
+/// somewhere a test can reach:
+///  * a background tick yields to a running check — it exists to be
+///    unobtrusive, and the running check already covers this interval;
+///  * a manual check waits its turn and then runs, because the button promises
+///    a result; it re-reads the slot after each wait so two queued clicks
+///    cannot both wake up and start overlapping checks;
+///  * the slot is claimed before the check's first suspension point, since an
+///    async body runs up to its first await before returning its future;
+///  * a check never throws, because callers fire it unawaited and a manual
+///    check may be awaiting someone else's.
+@visibleForTesting
+class PortableUpdateChecker {
+  PortableUpdateChecker(
+    this.hooks, {
+    this.interval = const Duration(seconds: _checkIntervalSeconds),
+  });
+
+  final PortableUpdateHooks hooks;
+  final Duration interval;
+
+  Future<void>? _active;
+  Timer? _timer;
+
+  /// True while the background poll is armed.
+  bool get isPolling => _timer != null;
+
+  /// True while a check is running, including while its prompt is open.
+  @visibleForTesting
+  bool get isChecking => _active != null;
+
+  Future<void> run({required bool background}) async {
+    if (background && _active != null) return;
+    var active = _active;
+    while (active != null) {
+      await active;
+      active = _active;
+    }
+    final done = Completer<void>();
+    _active = done.future;
+    try {
+      await _runOnce(background: background);
+    } finally {
+      if (identical(_active, done.future)) _active = null;
+      done.complete();
+    }
+  }
+
+  Future<void> _runOnce({required bool background}) async {
+    try {
+      await _body(background: background);
+    } catch (error) {
+      debugPrint('goresave portable update check failed: $error');
+    }
+  }
+
+  Future<void> _body({required bool background}) async {
+    final latest = await hooks.fetchLatestVersion();
+    final current = await hooks.currentVersion();
+
+    if (latest == null) {
+      if (!background) {
+        await hooks.report(PortableUpdateReport.checkFailed, '');
+      }
+      return;
+    }
+    if (!isNewerVersion(latest, current)) {
+      if (!background) {
+        await hooks.report(PortableUpdateReport.upToDate, '');
+      }
+      return;
+    }
+    // Auto-check may have been switched off while this tick was fetching; a
+    // cancelled poll must not still produce an unsolicited prompt. A manual
+    // check always shows.
+    if (background && !isPolling) return;
+
+    if (!await hooks.askDownload(latest, current)) return;
+    // Still inside the lock: doing this in the prompt's own button callback
+    // would outlive the prompt, freeing the slot while the follow-up message
+    // is on screen.
+    if (await hooks.openReleasePage(latest)) return;
+    await hooks.report(
+      PortableUpdateReport.downloadPageFailed,
+      _releasePageUrl(latest),
+    );
+  }
+
+  /// One check now, then one per [interval]. Guarded so re-enabling cannot
+  /// stack a second poll.
+  Future<void> startPolling() async {
+    if (_timer != null) return;
+    _timer = Timer.periodic(interval, (_) {
+      unawaited(run(background: true));
+    });
+    await run(background: true);
+  }
+
+  /// Stops the poll so disabling auto-check takes effect immediately, matching
+  /// WinSparkle's interval-0 behaviour on the installed build.
+  void stopPolling() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}
+
+/// Compares dotted numeric versions (e.g. "0.4.0"). Returns true when [latest]
+/// is strictly newer than [current]. Non-numeric or missing components count
+/// as 0, so "0.4" < "0.4.1".
+@visibleForTesting
+bool isNewerVersion(String latest, String current) {
   final a = latest.split('.');
   final b = current.split('.');
   for (var i = 0; i < (a.length > b.length ? a.length : b.length); i++) {
     final x = i < a.length ? int.tryParse(a[i]) ?? 0 : 0;
     final y = i < b.length ? int.tryParse(b[i]) ?? 0 : 0;
-    if (x != y) {
-      return x > y;
-    }
+    if (x != y) return x > y;
   }
   return false;
 }
 
-/// Runs a portable check. When an update exists, shows a dialog offering to
-/// open the releases page in the browser. When [silentIfNoUpdate] is false
-/// (manual check), also reports the up-to-date and failure cases.
-Future<void> _runPortableCheck({required bool silentIfNoUpdate}) async {
-  // Do every await up front so the context, once captured, is used without
-  // an async gap (avoids stale-context use after the widget tree changes).
-  final latest = await _fetchLatestVersion();
-  final current = (await PackageInfo.fromPlatform()).version;
+/// Production wiring: real feed, real package info, real dialogs, real browser.
+final PortableUpdateHooks _realPortableHooks = PortableUpdateHooks(
+  fetchLatestVersion: _fetchLatestVersion,
+  currentVersion: () async => (await PackageInfo.fromPlatform()).version,
+  report: (report, releaseUrl) async {
+    final context = updaterNavigatorKey.currentContext;
+    if (context == null || !context.mounted) return;
+    final l10n = AppLocalizations.of(context);
+    await _showInfoDialog(context, switch (report) {
+      PortableUpdateReport.checkFailed => l10n.updateCheckFailed,
+      PortableUpdateReport.upToDate => l10n.updateUpToDate,
+      PortableUpdateReport.downloadPageFailed => l10n.updateOpenFailed(
+        releaseUrl,
+      ),
+    });
+  },
+  askDownload: (latest, current) async {
+    final context = updaterNavigatorKey.currentContext;
+    if (context == null || !context.mounted) return false;
+    return _showUpdateAvailableDialog(
+      context,
+      version: latest,
+      current: current,
+    );
+  },
+  openReleasePage: _openReleasePage,
+);
 
-  final context = updaterNavigatorKey.currentContext;
-  if (context == null || !context.mounted) {
-    return;
-  }
-  final l10n = AppLocalizations.of(context);
+PortableUpdateChecker _portable = PortableUpdateChecker(_realPortableHooks);
 
-  if (latest == null) {
-    if (!silentIfNoUpdate) {
-      await _showInfoDialog(context, l10n.updateCheckFailed);
-    }
-    return;
-  }
-
-  if (!_isNewer(latest, current)) {
-    if (!silentIfNoUpdate) {
-      await _showInfoDialog(context, l10n.updateUpToDate);
-    }
-    return;
-  }
-
-  // A silent (background) check may have been in flight when the user turned
-  // auto-check off; the cancelled timer leaves _portableTimer null. Don't
-  // surface an unsolicited dialog in that case. Manual checks always show.
-  if (silentIfNoUpdate && _portableTimer == null) {
-    return;
-  }
-
-  await _showUpdateAvailableDialog(context, version: latest, current: current);
+/// Swaps the checker so tests can drive the queueing rules directly. Passing
+/// null restores the production wiring.
+@visibleForTesting
+void debugSetPortableUpdateChecker(PortableUpdateChecker? checker) {
+  _portable.stopPolling();
+  _portable = checker ?? PortableUpdateChecker(_realPortableHooks);
 }
 
 Future<void> _showInfoDialog(BuildContext context, String message) {
@@ -194,7 +346,7 @@ Future<void> _showInfoDialog(BuildContext context, String message) {
     context: context,
     builder: (context) => AlertDialog(
       title: Text(l10n.updatesTitle),
-      content: Text(message),
+      content: SelectionArea(child: Text(message)),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
@@ -205,37 +357,47 @@ Future<void> _showInfoDialog(BuildContext context, String message) {
   );
 }
 
-Future<void> _showUpdateAvailableDialog(
+/// Opens the release page in the user's browser. Returns false when the shell
+/// refused or failed — `launchUrl` reports both by returning false and by
+/// throwing — so the caller can say so rather than leave a dead button.
+Future<bool> _openReleasePage(String version) async {
+  try {
+    return await launchUrl(
+      Uri.parse(_releasePageUrl(version)),
+      mode: LaunchMode.externalApplication,
+    );
+  } catch (error) {
+    debugPrint('goresave could not open the release page: $error');
+    return false;
+  }
+}
+
+/// Asks whether to download. Returns true when the user chose Download; the
+/// caller does the launching so it stays inside the check's lock.
+Future<bool> _showUpdateAvailableDialog(
   BuildContext context, {
   required String version,
   required String current,
-}) {
+}) async {
   final l10n = AppLocalizations.of(context);
-  return showDialog<void>(
+  final download = await showDialog<bool>(
     context: context,
     builder: (context) => AlertDialog(
       title: Text(l10n.updateAvailableTitle),
       content: Text(l10n.updateAvailableMessage(version, current)),
       actions: [
         TextButton(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: () => Navigator.of(context).pop(false),
           child: Text(l10n.updateLater),
         ),
         FilledButton(
-          onPressed: () {
-            Navigator.of(context).pop();
-            unawaited(
-              launchUrl(
-                Uri.parse(_releasePageUrl(version)),
-                mode: LaunchMode.externalApplication,
-              ),
-            );
-          },
+          onPressed: () => Navigator.of(context).pop(true),
           child: Text(l10n.updateDownload),
         ),
       ],
     ),
   );
+  return download ?? false;
 }
 
 // --------------------------------------------------------------------------- #
@@ -253,7 +415,7 @@ Future<void> initDesktopUpdater({required bool autoCheckEnabled}) async {
     return;
   }
   if (!isInstalledBuild) {
-    unawaited(_pollPortablePeriodically());
+    unawaited(_portable.startPolling());
     return;
   }
   try {
@@ -269,28 +431,6 @@ Future<void> initDesktopUpdater({required bool autoCheckEnabled}) async {
   }
 }
 
-/// Portable background poll: one check now, then every hour. WinSparkle owns
-/// its own scheduler; for portable we run a plain timer loop. Guarded so a
-/// re-enable can't stack a second loop; [_stopPortablePolling] cancels it.
-Future<void> _pollPortablePeriodically() async {
-  if (_portableTimer != null) {
-    return;
-  }
-  _portableTimer =
-      Timer.periodic(const Duration(seconds: _checkIntervalSeconds), (_) {
-    unawaited(_runPortableCheck(silentIfNoUpdate: true));
-  });
-  await _runPortableCheck(silentIfNoUpdate: true);
-}
-
-/// Stops the portable background poll so disabling auto-check takes effect
-/// immediately, matching WinSparkle's interval-0 behavior on the installed
-/// build.
-void _stopPortablePolling() {
-  _portableTimer?.cancel();
-  _portableTimer = null;
-}
-
 /// User-triggered check: always reports the result, including the up-to-date
 /// and failure cases. Works even while automatic checks are off.
 Future<void> checkForUpdatesManually() async {
@@ -298,7 +438,7 @@ Future<void> checkForUpdatesManually() async {
     return;
   }
   if (!isInstalledBuild) {
-    await _runPortableCheck(silentIfNoUpdate: false);
+    await _portable.run(background: false);
     return;
   }
   try {
@@ -321,9 +461,9 @@ Future<void> setAutoUpdateCheckEnabled(bool enabled) async {
   }
   if (!isInstalledBuild) {
     if (enabled) {
-      unawaited(_pollPortablePeriodically());
+      unawaited(_portable.startPolling());
     } else {
-      _stopPortablePolling();
+      _portable.stopPolling();
     }
     return;
   }

--- a/apps/save-editor/lib/l10n/app_de.arb
+++ b/apps/save-editor/lib/l10n/app_de.arb
@@ -431,6 +431,7 @@
   "updateAvailableTitle": "Update verfügbar",
   "updateAvailableMessage": "Version {version} ist verfügbar. Du hast {current}.",
   "updateDownload": "Herunterladen",
+  "updateOpenFailed": "Die Download-Seite konnte nicht geöffnet werden. Du erreichst sie unter {url}",
   "updateLater": "Später",
   "updateUpToDate": "Du verwendest die neueste Version.",
   "updateCheckFailed": "Suche nach Updates fehlgeschlagen. Bitte später erneut versuchen.",

--- a/apps/save-editor/lib/l10n/app_en.arb
+++ b/apps/save-editor/lib/l10n/app_en.arb
@@ -709,6 +709,14 @@
     }
   },
   "updateDownload": "Download",
+  "updateOpenFailed": "Could not open the download page. You can reach it at {url}",
+  "@updateOpenFailed": {
+    "placeholders": {
+      "url": {
+        "type": "String"
+      }
+    }
+  },
   "updateLater": "Later",
   "updateUpToDate": "You are using the latest version.",
   "updateCheckFailed": "Could not check for updates. Please try again later.",

--- a/apps/save-editor/lib/l10n/app_es.arb
+++ b/apps/save-editor/lib/l10n/app_es.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "Actualización disponible",
   "updateAvailableMessage": "La versión {version} está disponible. Tienes la {current}.",
   "updateDownload": "Descargar",
+  "updateOpenFailed": "No se pudo abrir la página de descarga. Puedes acceder a ella en {url}",
   "updateLater": "Más tarde",
   "updateUpToDate": "Estás usando la última versión.",
   "updateCheckFailed": "No se pudo buscar actualizaciones. Inténtalo de nuevo más tarde.",

--- a/apps/save-editor/lib/l10n/app_fr.arb
+++ b/apps/save-editor/lib/l10n/app_fr.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "Mise à jour disponible",
   "updateAvailableMessage": "La version {version} est disponible. Vous avez la {current}.",
   "updateDownload": "Télécharger",
+  "updateOpenFailed": "Impossible d'ouvrir la page de téléchargement. Vous pouvez y accéder à {url}",
   "updateLater": "Plus tard",
   "updateUpToDate": "Vous utilisez la dernière version.",
   "updateCheckFailed": "Impossible de rechercher des mises à jour. Veuillez réessayer plus tard.",

--- a/apps/save-editor/lib/l10n/app_it.arb
+++ b/apps/save-editor/lib/l10n/app_it.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "Aggiornamento disponibile",
   "updateAvailableMessage": "La versione {version} è disponibile. Hai la {current}.",
   "updateDownload": "Scarica",
+  "updateOpenFailed": "Non è stato possibile aprire la pagina di download. Puoi raggiungerla su {url}",
   "updateLater": "Più tardi",
   "updateUpToDate": "Stai usando l'ultima versione.",
   "updateCheckFailed": "Impossibile verificare gli aggiornamenti. Riprova più tardi.",

--- a/apps/save-editor/lib/l10n/app_ja.arb
+++ b/apps/save-editor/lib/l10n/app_ja.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "アップデートがあります",
   "updateAvailableMessage": "バージョン {version} が利用可能です。現在は {current} です。",
   "updateDownload": "ダウンロード",
+  "updateOpenFailed": "ダウンロードページを開けませんでした。{url} からアクセスできます。",
   "updateLater": "後で",
   "updateUpToDate": "最新バージョンを使用しています。",
   "updateCheckFailed": "アップデートを確認できませんでした。後でもう一度お試しください。",

--- a/apps/save-editor/lib/l10n/app_localizations.dart
+++ b/apps/save-editor/lib/l10n/app_localizations.dart
@@ -2624,6 +2624,12 @@ abstract class AppLocalizations {
   /// **'Download'**
   String get updateDownload;
 
+  /// No description provided for @updateOpenFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open the download page. You can reach it at {url}'**
+  String updateOpenFailed(String url);
+
   /// No description provided for @updateLater.
   ///
   /// In en, this message translates to:

--- a/apps/save-editor/lib/l10n/app_localizations_de.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_de.dart
@@ -1489,6 +1489,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get updateDownload => 'Herunterladen';
 
   @override
+  String updateOpenFailed(String url) {
+    return 'Die Download-Seite konnte nicht geöffnet werden. Du erreichst sie unter $url';
+  }
+
+  @override
   String get updateLater => 'Später';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_en.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_en.dart
@@ -1482,6 +1482,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get updateDownload => 'Download';
 
   @override
+  String updateOpenFailed(String url) {
+    return 'Could not open the download page. You can reach it at $url';
+  }
+
+  @override
   String get updateLater => 'Later';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_es.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_es.dart
@@ -1491,6 +1491,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get updateDownload => 'Descargar';
 
   @override
+  String updateOpenFailed(String url) {
+    return 'No se pudo abrir la página de descarga. Puedes acceder a ella en $url';
+  }
+
+  @override
   String get updateLater => 'Más tarde';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_fr.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_fr.dart
@@ -1500,6 +1500,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get updateDownload => 'Télécharger';
 
   @override
+  String updateOpenFailed(String url) {
+    return 'Impossible d\'ouvrir la page de téléchargement. Vous pouvez y accéder à $url';
+  }
+
+  @override
   String get updateLater => 'Plus tard';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_it.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_it.dart
@@ -1493,6 +1493,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get updateDownload => 'Scarica';
 
   @override
+  String updateOpenFailed(String url) {
+    return 'Non è stato possibile aprire la pagina di download. Puoi raggiungerla su $url';
+  }
+
+  @override
   String get updateLater => 'Più tardi';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_ja.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ja.dart
@@ -1451,6 +1451,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get updateDownload => 'ダウンロード';
 
   @override
+  String updateOpenFailed(String url) {
+    return 'ダウンロードページを開けませんでした。$url からアクセスできます。';
+  }
+
+  @override
   String get updateLater => '後で';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_pl.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pl.dart
@@ -1506,6 +1506,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get updateDownload => 'Pobierz';
 
   @override
+  String updateOpenFailed(String url) {
+    return 'Nie udało się otworzyć strony pobierania. Znajdziesz ją pod $url';
+  }
+
+  @override
   String get updateLater => 'Później';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_pt.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_pt.dart
@@ -1491,6 +1491,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get updateDownload => 'Transferir';
 
   @override
+  String updateOpenFailed(String url) {
+    return 'Não foi possível abrir a página de transferência. Podes aceder a ela em $url';
+  }
+
+  @override
   String get updateLater => 'Mais tarde';
 
   @override
@@ -4400,6 +4405,11 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get updateDownload => 'Baixar';
+
+  @override
+  String updateOpenFailed(String url) {
+    return 'Não foi possível abrir a página de download. Você pode acessá-la em $url';
+  }
 
   @override
   String get updateLater => 'Mais tarde';

--- a/apps/save-editor/lib/l10n/app_localizations_ru.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_ru.dart
@@ -1503,6 +1503,11 @@ class AppLocalizationsRu extends AppLocalizations {
   String get updateDownload => 'Скачать';
 
   @override
+  String updateOpenFailed(String url) {
+    return 'Не удалось открыть страницу загрузки. Она доступна по адресу $url';
+  }
+
+  @override
   String get updateLater => 'Позже';
 
   @override

--- a/apps/save-editor/lib/l10n/app_localizations_zh.dart
+++ b/apps/save-editor/lib/l10n/app_localizations_zh.dart
@@ -1425,6 +1425,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get updateDownload => '下载';
 
   @override
+  String updateOpenFailed(String url) {
+    return '无法打开下载页面。你可以通过 $url 访问。';
+  }
+
+  @override
   String get updateLater => '稍后';
 
   @override
@@ -4212,6 +4217,11 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get updateDownload => '下载';
+
+  @override
+  String updateOpenFailed(String url) {
+    return '无法打开下载页面。你可以通过 $url 访问。';
+  }
 
   @override
   String get updateLater => '稍后';

--- a/apps/save-editor/lib/l10n/app_pl.arb
+++ b/apps/save-editor/lib/l10n/app_pl.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "Dostępna aktualizacja",
   "updateAvailableMessage": "Wersja {version} jest dostępna. Masz {current}.",
   "updateDownload": "Pobierz",
+  "updateOpenFailed": "Nie udało się otworzyć strony pobierania. Znajdziesz ją pod {url}",
   "updateLater": "Później",
   "updateUpToDate": "Używasz najnowszej wersji.",
   "updateCheckFailed": "Nie udało się sprawdzić aktualizacji. Spróbuj ponownie później.",

--- a/apps/save-editor/lib/l10n/app_pt.arb
+++ b/apps/save-editor/lib/l10n/app_pt.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "Atualização disponível",
   "updateAvailableMessage": "A versão {version} está disponível. Tem a {current}.",
   "updateDownload": "Transferir",
+  "updateOpenFailed": "Não foi possível abrir a página de transferência. Podes aceder a ela em {url}",
   "updateLater": "Mais tarde",
   "updateUpToDate": "Está a usar a versão mais recente.",
   "updateCheckFailed": "Não foi possível procurar atualizações. Tente novamente mais tarde.",

--- a/apps/save-editor/lib/l10n/app_pt_BR.arb
+++ b/apps/save-editor/lib/l10n/app_pt_BR.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "Atualização disponível",
   "updateAvailableMessage": "A versão {version} está disponível. Você tem a {current}.",
   "updateDownload": "Baixar",
+  "updateOpenFailed": "Não foi possível abrir a página de download. Você pode acessá-la em {url}",
   "updateLater": "Mais tarde",
   "updateUpToDate": "Você está usando a versão mais recente.",
   "updateCheckFailed": "Não foi possível verificar atualizações. Tente novamente mais tarde.",

--- a/apps/save-editor/lib/l10n/app_ru.arb
+++ b/apps/save-editor/lib/l10n/app_ru.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "Доступно обновление",
   "updateAvailableMessage": "Доступна версия {version}. У вас {current}.",
   "updateDownload": "Скачать",
+  "updateOpenFailed": "Не удалось открыть страницу загрузки. Она доступна по адресу {url}",
   "updateLater": "Позже",
   "updateUpToDate": "У вас установлена последняя версия.",
   "updateCheckFailed": "Не удалось проверить обновления. Повторите попытку позже.",

--- a/apps/save-editor/lib/l10n/app_zh.arb
+++ b/apps/save-editor/lib/l10n/app_zh.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "有可用更新",
   "updateAvailableMessage": "版本 {version} 可用。您当前为 {current}。",
   "updateDownload": "下载",
+  "updateOpenFailed": "无法打开下载页面。你可以通过 {url} 访问。",
   "updateLater": "稍后",
   "updateUpToDate": "您正在使用最新版本。",
   "updateCheckFailed": "无法检查更新，请稍后重试。",

--- a/apps/save-editor/lib/l10n/app_zh_Hans.arb
+++ b/apps/save-editor/lib/l10n/app_zh_Hans.arb
@@ -396,6 +396,7 @@
   "updateAvailableTitle": "有可用更新",
   "updateAvailableMessage": "版本 {version} 可用。您当前为 {current}。",
   "updateDownload": "下载",
+  "updateOpenFailed": "无法打开下载页面。你可以通过 {url} 访问。",
   "updateLater": "稍后",
   "updateUpToDate": "您正在使用最新版本。",
   "updateCheckFailed": "无法检查更新，请稍后重试。",

--- a/apps/save-editor/test/portable_update_checker_test.dart
+++ b/apps/save-editor/test/portable_update_checker_test.dart
@@ -1,0 +1,260 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goresave/features/app/domain/desktop_updater.dart';
+
+/// Records what a check did and lets a test park any step of it.
+class _Recorder {
+  _Recorder({this.latest = '9.9.9', this.current = '0.1.0'});
+
+  String? latest;
+  String current;
+
+  /// Parks the feed read until completed, so a check can be held mid-flight.
+  Completer<void>? parkFetch;
+
+  /// Parks the update prompt, standing in for a dialog nobody answered.
+  Completer<bool>? parkPrompt;
+
+  bool downloadAnswer = false;
+  bool openSucceeds = true;
+  Object? fetchThrows;
+
+  int fetches = 0;
+  int prompts = 0;
+  int opens = 0;
+  final List<PortableUpdateReport> reports = [];
+  final List<String> reportUrls = [];
+
+  /// Highest number of steps observed running at once. Anything above 1 means
+  /// two checks overlapped.
+  int concurrent = 0;
+  int _inFlight = 0;
+
+  void _enter() {
+    _inFlight++;
+    if (_inFlight > concurrent) concurrent = _inFlight;
+  }
+
+  void _leave() => _inFlight--;
+
+  PortableUpdateHooks get hooks => PortableUpdateHooks(
+    fetchLatestVersion: () async {
+      _enter();
+      fetches++;
+      try {
+        // Always suspend at least once. A step that returns without yielding
+        // can never be observed overlapping another, which would make the
+        // serialization assertions below pass no matter what.
+        await Future<void>.delayed(Duration.zero);
+        if (parkFetch != null) await parkFetch!.future;
+        if (fetchThrows != null) throw fetchThrows!;
+        return latest;
+      } finally {
+        _leave();
+      }
+    },
+    currentVersion: () async => current,
+    report: (report, url) async {
+      reports.add(report);
+      reportUrls.add(url);
+    },
+    askDownload: (latest, current) async {
+      _enter();
+      prompts++;
+      try {
+        await Future<void>.delayed(Duration.zero);
+        if (parkPrompt != null) return await parkPrompt!.future;
+        return downloadAnswer;
+      } finally {
+        _leave();
+      }
+    },
+    openReleasePage: (latest) async {
+      opens++;
+      return openSucceeds;
+    },
+  );
+}
+
+PortableUpdateChecker _checker(_Recorder rec, {Duration? interval}) =>
+    PortableUpdateChecker(
+      rec.hooks,
+      interval: interval ?? const Duration(milliseconds: 20),
+    );
+
+void main() {
+  group('isNewerVersion', () {
+    test('compares components numerically and pads missing ones', () {
+      expect(isNewerVersion('0.2.0', '0.1.0'), isTrue);
+      expect(isNewerVersion('0.1.0', '0.2.0'), isFalse);
+      expect(isNewerVersion('0.1.0', '0.1.0'), isFalse);
+      expect(isNewerVersion('0.4.1', '0.4'), isTrue);
+      expect(isNewerVersion('0.4', '0.4.1'), isFalse);
+      // A malformed component counts as 0 rather than throwing.
+      expect(isNewerVersion('1.x.0', '0.9.9'), isTrue);
+    });
+  });
+
+  test('a background tick yields to a running check', () async {
+    final rec = _Recorder()..parkFetch = Completer<void>();
+    final checker = _checker(rec);
+
+    final first = checker.run(background: true);
+    await pumpEventQueue();
+    expect(checker.isChecking, isTrue);
+
+    // The hourly tick landing on a busy checker must do nothing at all.
+    await checker.run(background: true);
+    expect(rec.fetches, 1);
+
+    rec.parkFetch!.complete();
+    await first;
+    expect(rec.concurrent, 1);
+  });
+
+  test(
+    'a manual check waits for a running one instead of being dropped',
+    () async {
+      final park = Completer<void>();
+      final rec = _Recorder()..parkFetch = park;
+      final checker = _checker(rec);
+
+      final background = checker.run(background: true);
+      await pumpEventQueue();
+
+      final manual = checker.run(background: false);
+      await pumpEventQueue();
+      // Still queued behind the background check, not silently discarded.
+      expect(rec.fetches, 1);
+
+      rec.parkFetch = null;
+      park.complete();
+      await Future.wait([background, manual]);
+
+      expect(rec.fetches, 2, reason: 'the manual check still ran');
+      expect(rec.concurrent, 1, reason: 'never at the same time');
+    },
+  );
+
+  test('two queued manual checks do not overlap', () async {
+    final park = Completer<void>();
+    final rec = _Recorder()..parkFetch = park;
+    final checker = _checker(rec);
+
+    final running = checker.run(background: true);
+    await pumpEventQueue();
+
+    // Both clicks land while the first check holds the slot.
+    final a = checker.run(background: false);
+    final b = checker.run(background: false);
+    await pumpEventQueue();
+
+    rec.parkFetch = null;
+    park.complete();
+    await Future.wait([running, a, b]);
+
+    expect(rec.fetches, 3);
+    expect(rec.concurrent, 1, reason: 'queued clicks must stay serialized');
+  });
+
+  test('an unanswered prompt does not let the next tick in', () async {
+    final rec = _Recorder()..parkPrompt = Completer<bool>();
+    final checker = _checker(rec);
+
+    // Manual, so the prompt is reached without arming the poll — the point
+    // here is the open prompt holding the slot, not who opened it.
+    final first = checker.run(background: false);
+    await pumpEventQueue();
+    expect(rec.prompts, 1);
+
+    // An hour later, with the prompt still open.
+    await checker.run(background: true);
+    expect(rec.prompts, 1, reason: 'no second modal on top of the first');
+
+    rec.parkPrompt!.complete(false);
+    await first;
+    expect(rec.concurrent, 1);
+  });
+
+  test('a failing check releases the slot', () async {
+    final rec = _Recorder()..fetchThrows = StateError('feed exploded');
+    final checker = _checker(rec);
+
+    // Must not throw out of run(): callers fire it unawaited.
+    await checker.run(background: false);
+    expect(checker.isChecking, isFalse);
+
+    // And the next check still works.
+    rec.fetchThrows = null;
+    await checker.run(background: false);
+    expect(rec.fetches, 2);
+  });
+
+  test('only a manual check reports an uneventful outcome', () async {
+    final rec = _Recorder(latest: '0.1.0', current: '0.1.0');
+    final checker = _checker(rec);
+
+    await checker.run(background: true);
+    expect(rec.reports, isEmpty, reason: 'a silent tick stays silent');
+
+    await checker.run(background: false);
+    expect(rec.reports, [PortableUpdateReport.upToDate]);
+
+    rec.latest = null;
+    await checker.run(background: false);
+    expect(rec.reports.last, PortableUpdateReport.checkFailed);
+  });
+
+  test('a cancelled poll cannot still raise a prompt', () async {
+    final park = Completer<void>();
+    final rec = _Recorder()..parkFetch = park;
+    final checker = _checker(rec, interval: const Duration(hours: 1));
+
+    // startPolling awaits its own first check, which is parked on the feed —
+    // so hold its future rather than awaiting it here.
+    final polling = checker.startPolling();
+    await pumpEventQueue();
+    checker.stopPolling();
+    park.complete();
+    await polling;
+
+    expect(rec.prompts, 0, reason: 'auto-check was switched off mid-flight');
+  });
+
+  test('a failed download page is reported with its address', () async {
+    final rec = _Recorder()
+      ..downloadAnswer = true
+      ..openSucceeds = false;
+    final checker = _checker(rec);
+
+    await checker.run(background: false);
+
+    expect(rec.opens, 1);
+    expect(rec.reports, [PortableUpdateReport.downloadPageFailed]);
+    expect(rec.reportUrls.single, contains('gore-save-editor-v9.9.9'));
+  });
+
+  test('a successful download page says nothing further', () async {
+    final rec = _Recorder()
+      ..downloadAnswer = true
+      ..openSucceeds = true;
+    final checker = _checker(rec);
+
+    await checker.run(background: false);
+
+    expect(rec.opens, 1);
+    expect(rec.reports, isEmpty);
+  });
+
+  test('declining the prompt never opens anything', () async {
+    final rec = _Recorder()..downloadAnswer = false;
+    final checker = _checker(rec);
+
+    await checker.run(background: false);
+
+    expect(rec.prompts, 1);
+    expect(rec.opens, 0);
+    expect(rec.reports, isEmpty);
+  });
+}


### PR DESCRIPTION
## Why

The Mod Manager's updater was ported *from* the Save Editor. Six review rounds on #95 found a run of defects in it — and because the code came from here, the shipped 1.3.0 has the same ones.

## What was wrong

- **No timeout on the feed request.** No `connectionTimeout`, no `.timeout()` on request, response, or body read. A stalled connection hung the check indefinitely.
- **Hourly timer with no in-flight guard.** The check awaits its own dialog, so an unattended machine with an update available stacked one more modal — and one more request — every hour the prompt went unanswered.
- **`launchUrl` result discarded.** It reports failure both by returning false and by throwing. With no browser registered, Download closed the dialog and did nothing, with a possible unhandled async error alongside.

## What changed

Ported `PortableUpdateChecker` and its hooks from the Manager rather than patching each defect separately. The queueing rules there also cover things the reviewers only surfaced after the first fixes: a manual check stays answerable instead of being silently dropped, two queued clicks cannot both proceed, the download launch stays inside the check's lock, and failures are contained so an unawaited call cannot surface as an unhandled async error.

`updateOpenFailed` is new in all twelve locales — the Save Editor had no string for a download page that will not open.

## Verification

`flutter analyze` clean, 612 tests (up from 601).

The eleven ported tests were each checked against the bug they exist for, by reintroducing that bug and confirming the test fails:

| reintroduced bug | failing tests |
|---|---|
| no guard at all | 4 |
| guard also blocks manual checks | 2 |
| slot not re-read after waiting | 1 |
| launch result discarded | 1 |

## Not covered

The feed timeouts themselves — they live in the real `HttpClient` call and need an HTTP fake. Same gap as in the Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop update-check concurrency, network timeouts, and browser launch for portable builds. Installed WinSparkle path is unchanged, but a queueing bug could still drop or stack user-facing prompts.
> 
> **Overview**
> Fixes portable-build update checks that could hang forever, stack hourly prompts, or silently fail when no browser was registered.
> 
> `PortableUpdateChecker` now runs one check at a time: background ticks drop if a check (including an open prompt) is already in flight; manual checks wait their turn. Feed connect/read is capped at 20s. Download stays inside the lock, and a failed `launchUrl` shows a copyable `updateOpenFailed` message with the release URL.
> 
> Queueing and reporting are covered by new unit tests; HTTP timeouts themselves are not faked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1786684d5e61dae0c7e81a1b26763ce92ce2524e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->