### PR TITLE
test(as): tolerate slow CI startup

### DIFF
--- a/crates/gore-as/src/standalone_sidecar.rs
+++ b/crates/gore-as/src/standalone_sidecar.rs
@@ -3511,6 +3511,11 @@ mod tests {
             relative_path: "Module.as",
         }];
 
+    // These FullGraph fixtures start a Python process and perform several filesystem operations.
+    // Windows CI can spend more than five seconds starting that process under concurrent load;
+    // the production timeout is unrelated and remains unchanged.
+    const FULL_GRAPH_FAKE_SIDECAR_TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
     struct TestFixture {
         root: PathBuf,
         profile_root: PathBuf,
@@ -4413,7 +4418,7 @@ output = pathlib.Path(request["output"]["cache_path"])
 output.write_bytes(data)
 print(json.dumps({"response_version":1,"ok":True,"output":{"cache_path":str(output),"byte_len":len(data),"sha256":hashlib.sha256(data).hexdigest(),"profile_sha256":request["profile"]["profile_sha256"]},"diagnostics":[]}))
 "#,
-            Duration::from_secs(5),
+            FULL_GRAPH_FAKE_SIDECAR_TEST_TIMEOUT,
         ) else {
             eprintln!("python unavailable; fake-sidecar FullGraph test skipped");
             return;
@@ -4484,7 +4489,7 @@ output = pathlib.Path(request["output"]["cache_path"])
 output.write_bytes(data)
 print(json.dumps({"response_version":1,"ok":True,"output":{"cache_path":str(output),"byte_len":len(data),"sha256":hashlib.sha256(data).hexdigest(),"profile_sha256":request["profile"]["profile_sha256"]},"diagnostics":[]}))
 "#,
-            Duration::from_secs(5),
+            FULL_GRAPH_FAKE_SIDECAR_TEST_TIMEOUT,
         ) else {
             eprintln!("python unavailable; fake-sidecar delete-only test skipped");
             return;


### PR DESCRIPTION
## Summary
- give the two FullGraph fake-process tests enough time for Windows runner startup under load
- keep production sidecar timeout behavior unchanged

## Evidence
- the same two tests exceeded their 5-second test timeout in CI runs 32745384567 attempt 1 and 32750482736
- the unchanged PR code passed run 32745384567 attempt 2
- local targeted tests: 2/2 passed
- local full gore-as library tests: 438 passed, 14 ignored, 0 failed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout adjustment in `standalone_sidecar.rs`; no production sidecar or compiler behavior changes.
> 
> **Overview**
> Raises the **fake Python sidecar** timeout from 5s to **30s** for the two FullGraph v2 integration tests that spawn a Python process and exercise filesystem I/O.
> 
> Adds `FULL_GRAPH_FAKE_SIDECAR_TEST_TIMEOUT` with a short comment that slow Windows CI startup under load caused flakes; **production** sidecar limits (`DEFAULT_SIDECAR_TIMEOUT`, etc.) are untouched. Other fake-sidecar tests still use the 5s harness timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a19241bd30e8ab74c1dd60bfd22c6fb8dd80b9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->