### PR TITLE
test(as): serialize sidecar fixtures

### DIFF
--- a/crates/gore-as/src/standalone_sidecar.rs
+++ b/crates/gore-as/src/standalone_sidecar.rs
@@ -4048,8 +4048,13 @@ mod tests {
     }
 
     fn find_python() -> Option<PathBuf> {
-        static PYTHON: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
-        PYTHON.get_or_init(find_python_uncached).clone()
+        static PYTHON: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+        if let Some(python) = PYTHON.get() {
+            return Some(python.clone());
+        }
+        let discovered = find_python_uncached()?;
+        let _ = PYTHON.set(discovered.clone());
+        Some(PYTHON.get().cloned().unwrap_or(discovered))
     }
 
     fn find_python_uncached() -> Option<PathBuf> {

--- a/crates/gore-as/src/standalone_sidecar.rs
+++ b/crates/gore-as/src/standalone_sidecar.rs
@@ -4047,44 +4047,68 @@ mod tests {
         }
     }
 
-    fn find_python() -> Option<PathBuf> {
-        static PYTHON: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
-        if let Some(python) = PYTHON.get() {
-            return Some(python.clone());
-        }
-        let discovered = find_python_uncached()?;
-        let _ = PYTHON.set(discovered.clone());
-        Some(PYTHON.get().cloned().unwrap_or(discovered))
+    enum PythonDiscovery {
+        Found(PathBuf),
+        Absent,
+        Retry,
     }
 
-    fn find_python_uncached() -> Option<PathBuf> {
+    fn find_python() -> Option<PathBuf> {
+        static PYTHON: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+        if let Some(cached) = PYTHON.get() {
+            return cached.clone();
+        }
+        let discovered = match find_python_uncached() {
+            PythonDiscovery::Found(python) => Some(python),
+            PythonDiscovery::Absent => None,
+            // Do not turn a transient canonicalization or process-start failure into a permanent
+            // skip for every remaining Python-backed test.
+            PythonDiscovery::Retry => return None,
+        };
+        let _ = PYTHON.set(discovered.clone());
+        PYTHON.get().cloned().unwrap_or(discovered)
+    }
+
+    fn find_python_uncached() -> PythonDiscovery {
         let names: &[&str] = if cfg!(windows) {
             &["python.exe", "python3.exe"]
         } else {
             &["python3", "python"]
         };
-        for directory in std::env::split_paths(&std::env::var_os("PATH")?) {
+        let Some(path) = std::env::var_os("PATH") else {
+            return PythonDiscovery::Absent;
+        };
+        let mut retry = false;
+        for directory in std::env::split_paths(&path) {
             for name in names {
                 let candidate = directory.join(name);
                 if !candidate.is_file() {
                     continue;
                 }
                 let Ok(candidate) = std::fs::canonicalize(candidate) else {
+                    retry = true;
                     continue;
                 };
-                if Command::new(&candidate)
+                match Command::new(&candidate)
                     .arg("--version")
                     .stdin(Stdio::null())
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())
                     .status()
-                    .is_ok_and(|status| status.success())
                 {
-                    return Some(candidate);
+                    Ok(status) if status.success() => {
+                        return PythonDiscovery::Found(candidate);
+                    }
+                    Ok(_) => {}
+                    Err(_) => retry = true,
                 }
             }
         }
-        None
+        if retry {
+            PythonDiscovery::Retry
+        } else {
+            PythonDiscovery::Absent
+        }
     }
 
     fn executable_seal(path: &Path) -> SidecarExecutableSealV1 {

--- a/crates/gore-as/src/standalone_sidecar.rs
+++ b/crates/gore-as/src/standalone_sidecar.rs
@@ -3519,6 +3519,7 @@ mod tests {
 
     struct TestFixture {
         _process_guard: std::sync::MutexGuard<'static, ()>,
+        python: Option<PathBuf>,
         root: PathBuf,
         profile_root: PathBuf,
         manifest: PathBuf,
@@ -3537,6 +3538,10 @@ mod tests {
             let process_guard = TEST_FIXTURE_PROCESS_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
+            // The manifest and every runner created from this fixture must use one exact sidecar
+            // identity. A later fixture may retry transient discovery, but this fixture may not
+            // switch from the dummy identity to a real interpreter halfway through the test.
+            let python = find_python();
             let root = std::env::temp_dir().join(format!(
                 "gore-as-sidecar-test-{label}-{}-{}",
                 std::process::id(),
@@ -3854,8 +3859,9 @@ mod tests {
             };
             expected_results.seal().unwrap();
             let diagnostics_sha256 = expected_results.results[0].diagnostics_sha256().unwrap();
-            let qualified_sidecar = find_python()
-                .map(|path| executable_seal(&path))
+            let qualified_sidecar = python
+                .as_ref()
+                .map(|path| executable_seal(path))
                 .map(|seal| QualifiedSidecarIdentityV1 {
                     byte_len: seal.byte_len,
                     sha256: seal.sha256,
@@ -3994,6 +4000,7 @@ mod tests {
             std::fs::write(&manifest, serde_json::to_vec(&profile).unwrap()).unwrap();
             Self {
                 _process_guard: process_guard,
+                python,
                 root,
                 profile_root,
                 manifest,
@@ -4010,7 +4017,7 @@ mod tests {
             script: &str,
             timeout: Duration,
         ) -> Option<StandaloneSidecarRunnerV1> {
-            let python = find_python()?;
+            let python = self.python.clone()?;
             let script_path = self.root.join(format!("{label}.py"));
             std::fs::write(&script_path, script).unwrap();
             let mut config = StandaloneSidecarConfigV1::new(
@@ -4304,7 +4311,7 @@ print(json.dumps({"response_version":1,"ok":True,"output":{"cache_path":str(outp
     #[test]
     fn qualification_v3_request_has_no_caller_witness_and_binds_same_process_evidence() {
         let fixture = TestFixture::create("qualification-v3-wire");
-        let Some(python) = find_python() else {
+        let Some(python) = fixture.python.clone() else {
             eprintln!("python unavailable; qualification-v3 wire test skipped");
             return;
         };
@@ -4777,7 +4784,7 @@ time.sleep(30)
     #[test]
     fn sidecar_memory_limit_is_bounded_before_process_start() {
         let fixture = TestFixture::create("memory-limit");
-        let Some(python) = find_python() else {
+        let Some(python) = fixture.python.clone() else {
             eprintln!("python unavailable; sidecar configuration test skipped");
             return;
         };
@@ -4798,7 +4805,7 @@ time.sleep(30)
     #[test]
     fn sidecar_executable_must_match_the_packaged_seal() {
         let fixture = TestFixture::create("executable-seal");
-        let Some(python) = find_python() else {
+        let Some(python) = fixture.python.clone() else {
             eprintln!("python unavailable; sidecar seal test skipped");
             return;
         };

--- a/crates/gore-as/src/standalone_sidecar.rs
+++ b/crates/gore-as/src/standalone_sidecar.rs
@@ -3511,12 +3511,14 @@ mod tests {
             relative_path: "Module.as",
         }];
 
-    // These FullGraph fixtures start a Python process and perform several filesystem operations.
-    // Windows CI can spend more than five seconds starting that process under concurrent load;
-    // the production timeout is unrelated and remains unchanged.
-    const FULL_GRAPH_FAKE_SIDECAR_TEST_TIMEOUT: Duration = Duration::from_secs(30);
+    // The fake sidecars use Python as a process harness. Starting many of them concurrently can
+    // starve suspended-process startup on Windows CI and makes the timeout test measure unrelated
+    // queueing. Production sidecars remain concurrent; only these filesystem/process fixtures are
+    // serialized.
+    static TEST_FIXTURE_PROCESS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     struct TestFixture {
+        _process_guard: std::sync::MutexGuard<'static, ()>,
         root: PathBuf,
         profile_root: PathBuf,
         manifest: PathBuf,
@@ -3532,6 +3534,9 @@ mod tests {
         }
 
         fn create_for_request_version(label: &str, request_version: u32) -> Self {
+            let process_guard = TEST_FIXTURE_PROCESS_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let root = std::env::temp_dir().join(format!(
                 "gore-as-sidecar-test-{label}-{}-{}",
                 std::process::id(),
@@ -3988,6 +3993,7 @@ mod tests {
             let manifest = profile_root.join("profile.json");
             std::fs::write(&manifest, serde_json::to_vec(&profile).unwrap()).unwrap();
             Self {
+                _process_guard: process_guard,
                 root,
                 profile_root,
                 manifest,
@@ -4042,6 +4048,11 @@ mod tests {
     }
 
     fn find_python() -> Option<PathBuf> {
+        static PYTHON: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+        PYTHON.get_or_init(find_python_uncached).clone()
+    }
+
+    fn find_python_uncached() -> Option<PathBuf> {
         let names: &[&str] = if cfg!(windows) {
             &["python.exe", "python3.exe"]
         } else {
@@ -4418,7 +4429,7 @@ output = pathlib.Path(request["output"]["cache_path"])
 output.write_bytes(data)
 print(json.dumps({"response_version":1,"ok":True,"output":{"cache_path":str(output),"byte_len":len(data),"sha256":hashlib.sha256(data).hexdigest(),"profile_sha256":request["profile"]["profile_sha256"]},"diagnostics":[]}))
 "#,
-            FULL_GRAPH_FAKE_SIDECAR_TEST_TIMEOUT,
+            Duration::from_secs(5),
         ) else {
             eprintln!("python unavailable; fake-sidecar FullGraph test skipped");
             return;
@@ -4489,7 +4500,7 @@ output = pathlib.Path(request["output"]["cache_path"])
 output.write_bytes(data)
 print(json.dumps({"response_version":1,"ok":True,"output":{"cache_path":str(output),"byte_len":len(data),"sha256":hashlib.sha256(data).hexdigest(),"profile_sha256":request["profile"]["profile_sha256"]},"diagnostics":[]}))
 "#,
-            FULL_GRAPH_FAKE_SIDECAR_TEST_TIMEOUT,
+            Duration::from_secs(5),
         ) else {
             eprintln!("python unavailable; fake-sidecar delete-only test skipped");
             return;


### PR DESCRIPTION
## Summary
- serialize only Python-backed sidecar test fixtures on Windows CI
- cache Python discovery within the test process
- restore the two FullGraph fixture timeouts from 30 seconds to 5 seconds

Production sidecar concurrency and timeouts are unchanged.

## Validation
- cargo test -p gore-as --lib (438 passed, 14 intentionally ignored)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to fixture locking and Python discovery; production sidecar behavior is unchanged.
> 
> **Overview**
> Stabilizes **Python-backed fake sidecar tests** in `standalone_sidecar.rs` without changing production sidecar concurrency or timeouts.
> 
> A global **`TEST_FIXTURE_PROCESS_LOCK`** serializes fixture setup and process harness runs so concurrent Windows CI does not starve suspended-process startup or inflate timeout assertions. **`TestFixture`** now holds the lock for its lifetime, discovers Python once at creation, and reuses that path for manifest seals and **`runner()`** so a fixture cannot switch interpreter identity mid-test.
> 
> **`find_python()`** caches results in **`OnceLock`** and treats canonicalization or **`--version`** spawn failures as **retry** (return `None` without poisoning the cache) instead of permanently skipping later tests.
> 
> The two FullGraph fake-sidecar tests go back to a **5 second** runner timeout instead of the prior **30 second** CI workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0f533848f7612a146c6aa84115877820de34d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->