### PR TITLE
gore-as: 99.29% byte-faithful, and a documentation audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "gore"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ not understand. Its core save editing is stable across game versions, although
 a future patch can add or change save fields or make the bundled item and
 location catalogs stale. Keep backups of important saves.
 
-**Mod Manager** and the **CLI** have been tested with Gothic 1 Remake **1.0.4a
-(CL171864)**. Neither uses a simple version-number lock. Mod Manager
+The **CLI** has been tested with Gothic 1 Remake **1.0.5 (Steam BuildID
+24878692)**; **Mod Manager** has been tested with **1.0.4a (CL171864)**.
+Neither uses a simple version-number lock. Mod Manager
 compatibility also depends on the individual mod and whether its target files,
 localization IDs, assets, and script targets exist in the installed game.
 Import validates the package, but cannot prove runtime compatibility; Apply
@@ -46,7 +47,7 @@ use the game's embedded compiler as a fallback.
 
 | Tool | Version | Release page |
 |---|---|---|
-| **CLI** | 0.2.2 | [gore-cli-v0.2.2](https://github.com/dh0er/gore/releases/tag/gore-cli-v0.2.2) |
+| **CLI** | 0.3.0 | [gore-cli-v0.3.0](https://github.com/dh0er/gore/releases/tag/gore-cli-v0.3.0) |
 | **Mod Manager** | 0.2.0 | [gore-mod-manager-v0.2.0](https://github.com/dh0er/gore/releases/tag/gore-mod-manager-v0.2.0) |
 | **Save Editor** | 1.3.0 | [gore-save-editor-v1.3.0](https://github.com/dh0er/gore/releases/tag/gore-save-editor-v1.3.0) |
 

--- a/apps/mod-manager/README.md
+++ b/apps/mod-manager/README.md
@@ -33,10 +33,11 @@ itself, the portable zip points you at the download.
   packed game-file claims, and raw-file replacements — and show intended
   winners. Loose-file versus packed-file precedence is advisory, and an opaque
   UE4SS component cannot produce a complete target inventory. Each component
-  is graded Complete, Partial, Estimated, or Unknown so incomplete knowledge
-  stays visible; these grades do not claim the game's runtime priority is
-  proven. The grades and the per-component target lists live behind the
-  **Advanced details** setting.
+  says how completely GORE knows its targets — the full list, a list that may
+  be incomplete, hints that are not proof, or nothing at all — so incomplete
+  knowledge stays visible; these grades do not claim the game's runtime
+  priority is proven. The grades and the per-component target lists live behind
+  the **Advanced details** setting.
 - **Apply** declaratively: full-recompute the modded state from a pristine base
   and deploy the whole enabled set (backups first), or use the normal
   **Remove all from game** action to restore a validated Manager-owned

--- a/apps/save-editor/README.md
+++ b/apps/save-editor/README.md
@@ -14,9 +14,9 @@ game install. For modding, use the [`gore` CLI](../../docs/guide/README.md) or
 - Player & NPCs: Edit stats, attributes, all talents/skills and much more;
   revive a dead NPC (restore health, strip the death state).
 - Position: Move the player to exact coordinates or a named location, with an
-  optional facing direction. NPC saved/spawn poses are shown read-only: the game
-  rebuilds NPC placement from world data when loading, so editing those save
-  records would not move the NPC in game.
+  optional facing direction. An NPC can be moved the same way, and his
+  daily routine switched off so he stays where he was put instead of walking
+  back; the editor records what it overwrote so the move can be undone.
 - Inventory: Change count of existing items; add new items from a bundled
   catalog with categorized browsing; remove items; detect and repair damaged
   slot IDs; reset an inventory to a clean starting state.
@@ -25,6 +25,8 @@ game install. For modding, use the [`gore` CLI](../../docs/guide/README.md) or
 - Glossary: Browse and edit NPC, creature, and location entries, including
   their individual text entries and NPC discovery states.
 - Progression: Edit quest markers, NPC knowledge and events
+- Trade: See what a merchant sells and how much ore he has to buy with; change
+  stock counts, add or remove lines, and edit the restock baseline.
 - Almost all data can be changed by changing the value of the internal property. Only for experimental use.
 - Backups: Create them automatically, give them optional display labels,
   restore them, or permanently delete them after confirmation. Deletion cannot

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.16% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.17% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -23,7 +23,7 @@ functions the vanilla and regenerated caches align:
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,607 functions | **99.16%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,607 functions | **99.17%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
 
@@ -37,7 +37,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,375 functions (0.83%) recompile to bytecode that differs semantically.** A semantic
+**1,374 functions (0.83%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
@@ -805,6 +805,15 @@ the source declaring that local in the LOOP BODY: the constructor ran once per i
 `continue`, `break` and fall-through paid its own destructor. The sink refused every loop
 categorically; it now makes an exception for exactly that shape. One constructor is what makes it
 a declaration — two are two unnamed temporaries sharing a slot. 1,384 to 1,375.
+
+**A range-for whose element the body writes through is `for (auto& x : c)`.** The recovery
+refused any loop that wrote through its element, because a range-for element is read-only — true
+of a COPIED element, and not of one the iterator hands back by reference. Vanilla settles which
+this is: it jumps straight to the bottom test, the range-for shape, while writing through the
+element. The pass runs before the declarations are written, so the reference is read off the
+bytecode rather than the text, and the element is spelled `auto&`. Spelled `auto` the source does
+not merely fail to compile — it kills the compiler outright, which is how the read-only half of
+the rule was re-confirmed. 1,375 to 1,374.
 
 Cutting across them, 6 are `__InitDefaults` — down from 37, because the language CAN spell
 infinity after all: an overflowing decimal literal (`1e39f`) parses and rounds to the bit pattern

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.22% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.24% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -24,7 +24,7 @@ functions the vanilla and regenerated caches align:
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.22%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.24%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
 
@@ -38,7 +38,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,291 functions (0.78%) recompile to bytecode that differs semantically.** A semantic
+**1,254 functions (0.76%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
@@ -52,9 +52,10 @@ found them:
 * **Four loops the game leaves and our source does not.** The `break` is lost and the arm renders
   as `if (…) { } else { }`, so the loop runs forever:
   `UAIState_WaitInQueue::DoTask_Implementation`, `UAIState_WarnAggressor::DoTask_Implementation`,
-  and `UAIState_CombatEndActions_Human::Heal` twice. `loop_exit_stmt` already renders a `JMP` to
-  the loop's break offset as `break;` and `emit_range` already consults it — it returns `None`
-  there, so the loop scope is not set on the path that emits those arms.
+  and `UAIState_CombatEndActions_Human::Heal` twice. The mechanism is now known — the top-test arm
+  opened no loop scope, which is why `loop_exit_stmt` returned `None` there. That scope is set
+  now, but only for `continue;`: offering `break;` on the same path fires on six functions this
+  build reproduces byte for byte, so these four still need a witness that separates them.
 * **Nine float constants written as their own bit pattern.**
   `ULoadingScreenSetupTest::SetupGeneralLoadingScreen` emits
   `…SpecifiedColor.R = 1065287680;`, which is `0x3F7F0000` — the bits of `0.99609375f`. The

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.14% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.16% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -23,7 +23,7 @@ functions the vanilla and regenerated caches align:
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,607 functions | **99.14%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,607 functions | **99.16%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
 
@@ -37,7 +37,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,412 functions (0.86%) recompile to bytecode that differs semantically.** A semantic
+**1,386 functions (0.84%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
@@ -772,6 +772,22 @@ needed no change: both passes already wrap unless ONE pair spans the whole value
 is always the leftmost operand of the run that reads it, so the wrap costs no bytes.
 
 1,419 to 1,412, seven fixed and none broken.
+
+**A conditional whose taken edge is the latch is not a `continue`.** This compiler never folds a
+jump over a jump, so a source `continue` always spends an unconditional `JMP` to the latch — which
+the loop-exit rule already recognises. A conditional straight to the latch is instead the compiled
+form of a plain `if (<fall condition>) { <rest of the body> }`, and claiming it as a `continue`
+costs an extra `JMP` and an inverted condition: a `NOT`, plus the store-and-reload where vanilla
+tested the register directly.
+
+Vanilla witnesses the premise in its own stream. `UAIState_TryUseFreepoint` carries both shapes in
+one function, and the jump-over-jump guard is byte-identical on both sides while the
+direct-to-latch one is exactly where the extra jump appears. The `break` arm keeps its claim: a
+conditional straight to the break target still leaves a fall-through that reaches the latch.
+
+The one function this turns into an empty `if { }` was the named risk, and the corpus answers it —
+the tree already carried 154 such blocks and compiled. 1,412 to 1,386, twenty-six fixed and none
+broken.
 
 Cutting across them, 6 are `__InitDefaults` — down from 37, because the language CAN spell
 infinity after all: an overflowing decimal literal (`1e39f`) parses and rounds to the bit pattern

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -846,7 +846,8 @@ infinity after all: an overflowing decimal literal (`1e39f`) parses and rounds t
 vanilla holds, where the largest finite float came back one ULP low every time. The belief that
 it could not was carried in this file for months and was never probed.
 
-**30 of the 7,308 modules cannot be spliced back** (99.59% can). Each is a template instantiation
+**30 of the modules cannot be spliced back** (99.59% can). That sweep ran on the earlier
+`D0AFAF90…` build, which had 7,308 modules against this one's 7,317; it has not been repeated. Each is a template instantiation
 or a behaviour the base cache never recorded — 14 `$beh0` constructors, 13 `TArray` iterators, and
 a tail of single cases (`opAssign`, `GetRootNode`, `AssertEquals`). They share the root
 cause of the ordering classes above: vanilla wrote the expression inline where the emitter

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.26% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.27% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -24,7 +24,7 @@ functions the vanilla and regenerated caches align:
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.26%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.27%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
 
@@ -38,7 +38,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,227 functions (0.74%) recompile to bytecode that differs semantically.** A semantic
+**1,202 functions (0.73%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -37,7 +37,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,384 functions (0.84%) recompile to bytecode that differs semantically.** A semantic
+**1,375 functions (0.83%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
@@ -798,6 +798,13 @@ sites only. A const return has to say `const T&`, or the initializer is refused 
 The other half of that lever — recovering `return <name>;` where the value travels as an address
 rather than through a register — is NOT in: it put a local out of scope in one function and made
 another return a reference into an expression the compiler refuses to keep alive. 1,386 to 1,384.
+
+**A value-type local is destroyed once per exit from the block it was declared in.** So vanilla
+spending ONE `$beh0` and TWO OR MORE `$beh2` for a slot, all of them inside a back edge's span, is
+the source declaring that local in the LOOP BODY: the constructor ran once per iteration and each
+`continue`, `break` and fall-through paid its own destructor. The sink refused every loop
+categorically; it now makes an exception for exactly that shape. One constructor is what makes it
+a declaration — two are two unnamed temporaries sharing a slot. 1,384 to 1,375.
 
 Cutting across them, 6 are `__InitDefaults` — down from 37, because the language CAN spell
 infinity after all: an overflowing decimal literal (`1e39f`) parses and rounds to the bit pattern

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -37,7 +37,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,419 functions (0.86%) recompile to bytecode that differs semantically.** A semantic
+**1,412 functions (0.86%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
@@ -756,6 +756,22 @@ And the narrowing has to reach BOTH type maps. Landing it only in the structurer
 receiver wrap away while the declaration stayed at the base, and the whole tree stopped compiling
 with `No matching signatures to 'UObject::GetRelationship()'` — the same two-map mistake the cast
 narrowing made before it. 1,431 to 1,419, twelve fixed and none broken.
+
+**A chain the emitter computed into a carrier of its own belongs in its reader — and the two
+passes that put it there were never asked twice.** The fold chain is a fixed sequence, not a
+fixpoint, and for a whole class of bodies the shape those passes match on does not exist yet when
+they run: the outer chain is still an if/else over a slot, the store appears further down, and the
+pass that collapses `X = c; return X;` runs after that. One more pass over the finished text is
+the whole repair.
+
+The condition fold is restricted there to a value carrying a TOP-LEVEL `&&`/`||`. That shape
+occurs in none of the 54,366 byte-faithful bodies and in 109 slots of the divergent ones; without
+the restriction the late pass also takes `bool X; X = <call>; if (X)`, which vanilla wrote WITH
+the name — four byte-faithful bodies say so, and read-count does not separate them. The bracketing
+needed no change: both passes already wrap unless ONE pair spans the whole value, and the carrier
+is always the leftmost operand of the run that reads it, so the wrap costs no bytes.
+
+1,419 to 1,412, seven fixed and none broken.
 
 Cutting across them, 6 are `__InitDefaults` — down from 37, because the language CAN spell
 infinity after all: an overflowing decimal literal (`1e39f`) parses and rounds to the bit pattern

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.27% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.29% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -24,7 +24,7 @@ functions the vanilla and regenerated caches align:
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.27%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.29%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
 
@@ -38,7 +38,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,202 functions (0.73%) recompile to bytecode that differs semantically.** A semantic
+**1,169 functions (0.71%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.24% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.26% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -24,7 +24,7 @@ functions the vanilla and regenerated caches align:
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.24%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.26%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
 
@@ -38,7 +38,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,254 functions (0.76%) recompile to bytecode that differs semantically.** A semantic
+**1,227 functions (0.74%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -11,12 +11,12 @@ was measured, and what is left.
 
 Measured 2026-08-29 against the shipped build whose script cache has SHA-256
 `7A18F954E32AF30FC24AE3A66EA35D3B5CB98560C8F5083C7846FC9CE1D77511` (GUID
-`7835bcc09c5eee488d72cb5ffb0fb0c3`). This build is not one of the audited generations, so the
-numbers qualify the DECOMPILER, not the build. Counts from the earlier `D0AFAF90…` build are not
+`7835bcc09c5eee488d72cb5ffb0fb0c3`). That is the audited generation `g1r-steam-24878692`, the
+Steam build shipped 2026-08-27/28. Counts from the earlier `D0AFAF90…` build are not
 comparable: that one had 7,308 modules and 164,607 aligned functions.
 
-Everything except the splice test runs over the **whole corpus** — all 7,317 modules, all 164,723
-functions the vanilla and regenerated caches align:
+Everything except the splice test was measured on this build, over the **whole corpus** — all
+7,317 modules, all 164,723 functions the vanilla and regenerated caches align:
 
 | Measurement | Scope | Result |
 |-------------|-------|--------|
@@ -26,11 +26,12 @@ functions the vanilla and regenerated caches align:
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
 | Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.29%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
-| Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
+| Splice back (`extract-remap`) | full corpus, earlier `D0AFAF90…` build | 7,278 of 7,308 (**99.59%**) |
 
-Every measurement now covers the whole corpus. The splice sweep takes about two hours (each run
+Every measurement covers the whole corpus. The splice sweep takes about two hours (each run
 re-reads both 100+ MB caches), which is why earlier revisions of this document reported it from a
-627-module sample; the sample and the sweep agree to within 0.1 points.
+627-module sample; the sample and the sweep agreed to within 0.1 points. That sweep has not been
+repeated on this build — its numbers are the earlier build's, which is why the row says so.
 
 The measurement needs the game's `Binds.Cache` next to the script cache it reads. Without it the
 native field table is empty, every native enum field falls back to the bool heuristic, and the
@@ -38,7 +39,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,169 functions (0.71%) recompile to bytecode that differs semantically.** A semantic
+**1,165 functions (0.71%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
@@ -65,26 +66,27 @@ found them:
 * **One `event` parameter rendered `int` where the thunk says `int32`**
   (`Story.Support.DialogImport.FStoryChapterChangedEvent::Broadcast`).
 
-The class table below is the last full classification, taken when the total stood at 3,511 — it
-says which shapes the work was aimed at, not what the remaining 1,344 are made of.
+The class table below is the last full classification, taken when the total stood at 3,511; its
+rows account for 2,926 of those functions. It says which shapes the work was aimed at, not what
+the remaining 1,165 are made of.
 
 Classified over WHOLE functions — every instruction of both sides, not the window around the
 first divergence. An earlier revision of this document classified the window instead and reported
-order as the largest class at 4,861; that number was an artifact of the window, and the real
-figure is 531:
+order as the largest class at 4,861; that number was an artifact of the window. The
+whole-function figure is the order row below. Shares are of the 2,926 the rows cover:
 
 | Class | Functions | Share |
 |-------|-----------|-------|
 | Different instructions on the two sides | 1,394 | 47.6% |
-| Same instructions, different order | 562 | 18.1% |
-| Other extra instructions | 469 | 15.1% |
-| One or more extra slot-to-slot copies, nothing else | 304 | 9.8% |
-| One or more extra handle aliases, nothing else | 138 | 4.4% |
-| Identical but for a slot number, or extra copies AND aliases | 59 | 1.9% |
+| Same instructions, different order | 562 | 19.2% |
+| Other extra instructions | 469 | 16.0% |
+| One or more extra slot-to-slot copies, nothing else | 304 | 10.4% |
+| One or more extra handle aliases, nothing else | 138 | 4.7% |
+| Identical but for a slot number, or extra copies AND aliases | 59 | 2.0% |
 
 The classes that used to dominate — a named temporary costing a copy or an alias — are now the
 small ones. Over this run's work the total went from 14,134 to 3,511, and `__InitDefaults`
-differences from 37 to 4.
+differences from 37 to 6.
 
 No single shape dominates any more: the largest signature inside the largest class is 38
 functions, where it was 754. The ones worth naming: 38 where an extra constructor and destructor
@@ -92,8 +94,8 @@ pair says the emitter named a value the source built at a call site, 31 and 30 w
 tested the other way round, 30 where a constant is written that vanilla copied, 28 where a
 `float32` value is compared without the widening to `float` vanilla performed first (the
 comparison then runs at the wrong width — the widening is rendered as a plain assignment, so the
-folds collapse it as if it were an alias), and 545 whose instructions match but run in a
-different order.
+folds collapse it as if it were an alias), and the order class above, whose instructions match
+but run in a different order.
 
 ### The loop whose condition is a short circuit — RECOVERED
 
@@ -841,6 +843,11 @@ bytecode rather than the text, and the element is spelled `auto&`. Spelled `auto
 not merely fail to compile — it kills the compiler outright, which is how the read-only half of
 the rule was re-confirmed. 1,375 to 1,374.
 
+From there the run continued through the rules the sections above describe — the range-for
+container, the receiver pair, the split GAS chain, the return-expression temporary, the
+continue-only loop scope, and the declaration-order rules — down to the **1,165** the headline
+reports.
+
 Cutting across them, 6 are `__InitDefaults` — down from 37, because the language CAN spell
 infinity after all: an overflowing decimal literal (`1e39f`) parses and rounds to the bit pattern
 vanilla holds, where the largest finite float came back one ULP low every time. The belief that
@@ -949,7 +956,7 @@ requires reconstructing its body manually or first extending the decompiler.
 
 ## Class defaults
 
-Same run as "What is measured, and on what" above — full corpus, build `Build55_CL171864`.
+Full corpus on the earlier `D0AFAF90…` build (`Build55_CL171864`), not the run above.
 
 | Metric | Value |
 |--------|-------|
@@ -1020,7 +1027,7 @@ thumb: a type that has a copy constructor is declared with its initializer, a ty
 default constructor and an `opAssign` keeps the hoisted declaration and its assignment. Both
 shapes compile; only the one the base cache has a row for can be spliced back.
 
-Measured over the whole corpus, `extract-remap` against the base cache succeeds for 7,276 of 7,308
+Measured over the whole corpus, `extract-remap` against the base cache succeeds for 7,278 of 7,308
 modules (**99.59%**). The same measurement scored 43 of 60 before the identity work and 58 of 60
 after it, on the 60-module sample it started from.
 
@@ -1085,9 +1092,10 @@ after the first link and the next link took a leftover argument as its receiver.
 fixed — a temporary's destructor between two links no longer ends the statement — and the check
 stays as the general guard against any future dropped-argument shape.
 
-The 37 initializers that still differ after a faithful recompile are dominated by float constants
-the emitter cannot spell: AngelScript has no infinity literal, so `+inf` (`0x7F800000`) is written
-as the largest finite float and comes back one ULP low.
+Six initializers still differ after a faithful recompile, down from 37. The rest were float
+constants believed unspellable: `+inf` (`0x7F800000`) was written as the largest finite float and
+came back one ULP low. The language can spell it after all — an overflowing decimal literal
+(`1e39f`) parses and rounds to exactly the bit pattern vanilla holds.
 
 ## Root causes and next work
 

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.18% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.22% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -24,7 +24,7 @@ functions the vanilla and regenerated caches align:
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.18%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.22%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
 
@@ -38,10 +38,31 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,344 functions (0.82%) recompile to bytecode that differs semantically.** A semantic
+**1,291 functions (0.78%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
+
+### Known wrong programs, found and not yet fixed
+
+A semantic difference is normally *not proven identical*, not *proven wrong*. These three are
+proven wrong, and they are recorded here rather than in a bug tracker because the same measurement
+found them:
+
+* **Four loops the game leaves and our source does not.** The `break` is lost and the arm renders
+  as `if (…) { } else { }`, so the loop runs forever:
+  `UAIState_WaitInQueue::DoTask_Implementation`, `UAIState_WarnAggressor::DoTask_Implementation`,
+  and `UAIState_CombatEndActions_Human::Heal` twice. `loop_exit_stmt` already renders a `JMP` to
+  the loop's break offset as `break;` and `emit_range` already consults it — it returns `None`
+  there, so the loop scope is not set on the path that emits those arms.
+* **Nine float constants written as their own bit pattern.**
+  `ULoadingScreenSetupTest::SetupGeneralLoadingScreen` emits
+  `…SpecifiedColor.R = 1065287680;`, which is `0x3F7F0000` — the bits of `0.99609375f`. The
+  compiler then converts that integer, so the colour comes out a billion times too bright. Neither
+  field-type channel resolves a deep NATIVE struct path, and the float rescue in `structure.rs`
+  only runs on a store that has already dropped.
+* **One `event` parameter rendered `int` where the thunk says `int32`**
+  (`Story.Support.DialogImport.FStoryChapterChangedEvent::Broadcast`).
 
 The class table below is the last full classification, taken when the total stood at 3,511 — it
 says which shapes the work was aimed at, not what the remaining 1,344 are made of.

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.17% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.18% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -9,21 +9,22 @@ was measured, and what is left.
 
 ## What is measured, and on what
 
-Measured 2026-08-23 against build `Build55_CL171864` (script cache SHA-256
-`D0AFAF909E62867FAEDC3678A1175F5E8DE5E784DC503A14FFBDE4726F297231`, GUID
-`be78fe0a46ac6643968597e85c7e5b3f`). This build is not one of the audited generations, so the
-numbers qualify the DECOMPILER, not the build.
+Measured 2026-08-29 against the shipped build whose script cache has SHA-256
+`7A18F954E32AF30FC24AE3A66EA35D3B5CB98560C8F5083C7846FC9CE1D77511` (GUID
+`7835bcc09c5eee488d72cb5ffb0fb0c3`). This build is not one of the audited generations, so the
+numbers qualify the DECOMPILER, not the build. Counts from the earlier `D0AFAF90…` build are not
+comparable: that one had 7,308 modules and 164,607 aligned functions.
 
-Everything except the splice test runs over the **whole corpus** — all 7,308 modules, all 164,604
+Everything except the splice test runs over the **whole corpus** — all 7,317 modules, all 164,723
 functions the vanilla and regenerated caches align:
 
 | Measurement | Scope | Result |
 |-------------|-------|--------|
-| Modules emitted, fallback stubs | full corpus | 7,308 modules, **0 stubs** |
+| Modules emitted, fallback stubs | full corpus | 7,317 modules, **0 stubs** |
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,607 functions | **99.17%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.18%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
 
@@ -37,10 +38,13 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,374 functions (0.83%) recompile to bytecode that differs semantically.** A semantic
+**1,344 functions (0.82%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
+
+The class table below is the last full classification, taken when the total stood at 3,511 — it
+says which shapes the work was aimed at, not what the remaining 1,344 are made of.
 
 Classified over WHOLE functions — every instruction of both sides, not the window around the
 first divergence. An earlier revision of this document classified the window instead and reported

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -37,7 +37,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,386 functions (0.84%) recompile to bytecode that differs semantically.** A semantic
+**1,384 functions (0.84%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
@@ -788,6 +788,16 @@ conditional straight to the break target still leaves a fall-through that reache
 The one function this turns into an empty `if { }` was the named risk, and the corpus answers it —
 the tree already carried 154 such blocks and compiled. 1,412 to 1,386, twenty-six fixed and none
 broken.
+
+**A slot a `T&`-returning call fills holds a POINTER, not a `T`.** Rendered by value it costs a
+copy constructor and a scope-exit destructor that vanilla does not have. The type map must not
+carry the `&` — there are two of them and a qualifier in one poisons every comparison against the
+other — so the reference slots travel as their own set and the `&` is appended at the declaration
+sites only. A const return has to say `const T&`, or the initializer is refused outright.
+
+The other half of that lever — recovering `return <name>;` where the value travels as an address
+rather than through a register — is NOT in: it put a local out of scope in one function and made
+another return a reference into an expression the compiler refuses to keep alive. 1,386 to 1,384.
 
 Cutting across them, 6 are `__InitDefaults` — down from 37, because the language CAN spell
 infinity after all: an overflowing decimal literal (`1e39f`) parses and rounds to the bit pattern

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.29% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.30% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -24,7 +24,7 @@ Everything except the splice test was measured on this build, over the **whole c
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.29%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,723 functions | **99.30%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | full corpus, earlier `D0AFAF90…` build | 7,278 of 7,308 (**99.59%**) |
 
@@ -39,7 +39,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,165 functions (0.71%) recompile to bytecode that differs semantically.** A semantic
+**1,159 functions (0.70%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
@@ -68,7 +68,7 @@ found them:
 
 The class table below is the last full classification, taken when the total stood at 3,511; its
 rows account for 2,926 of those functions. It says which shapes the work was aimed at, not what
-the remaining 1,165 are made of.
+the remaining 1,159 are made of.
 
 Classified over WHOLE functions — every instruction of both sides, not the window around the
 first divergence. An earlier revision of this document classified the window instead and reported
@@ -845,7 +845,7 @@ the rule was re-confirmed. 1,375 to 1,374.
 
 From there the run continued through the rules the sections above describe — the range-for
 container, the receiver pair, the split GAS chain, the return-expression temporary, the
-continue-only loop scope, and the declaration-order rules — down to the **1,165** the headline
+continue-only loop scope, and the declaration-order rules — down to the **1,159** the headline
 reports.
 
 Cutting across them, 6 are `__InitDefaults` — down from 37, because the language CAN spell

--- a/crates/gore-as/DECOMPILER_STATUS.md
+++ b/crates/gore-as/DECOMPILER_STATUS.md
@@ -1,6 +1,6 @@
 # AngelScript decompiler — completeness and known gaps
 
-**Status: every module decompiles, the whole tree recompiles, and 99.13% of it is byte-faithful.**
+**Status: every module decompiles, the whole tree recompiles, and 99.14% of it is byte-faithful.**
 The emitter reconstructs every function body it writes from the shipped cache; when it cannot
 prove a body is correct it keeps the declaration and emits a clearly marked, signature-preserving
 stub instead of inventing logic. The current corpus needs no such stub. What is NOT proven is that
@@ -23,7 +23,7 @@ functions the vanilla and regenerated caches align:
 | Whole-tree recompile warnings | full corpus | **0** (the compiler treats them as errors) |
 | Class defaults authored | full corpus | **0 modules suppressed** (all 30,005 `__InitDefaults`) |
 | Whole-tree recompile (`as compile`) | full corpus | **0 errors** |
-| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,607 functions | **99.13%** (`IDENTICAL`+`BENIGN`) |
+| Byte-faithfulness (`bytediff --norm-slots`) | full corpus, 164,607 functions | **99.14%** (`IDENTICAL`+`BENIGN`) |
 | Alignment loss | full corpus | **none** — every function the cache has is regenerated |
 | Splice back (`extract-remap`) | 305-module sample | 302 (**99.02%**) |
 
@@ -37,7 +37,7 @@ tree stops compiling (1,474 `bool` to `E*&` errors) — a property of the run, n
 
 ## What is left
 
-**1,431 functions (0.87%) recompile to bytecode that differs semantically.** A semantic
+**1,419 functions (0.86%) recompile to bytecode that differs semantically.** A semantic
 difference means *not proven identical*, not *proven wrong*: the whole-tree compile proves the
 source type-checks, and `bytediff` normalizes away reference keys, jump absolutes, constant
 encodings and (opt-in) slot allocation before judging the rest.
@@ -737,6 +737,25 @@ slot the typed-locals map says nothing about, on the reasoning that such a slot 
 costs an `sbTOi` on the way in and an `iTOb` on the way out, and the enum cast the wrap sits
 inside is what vanilla wrote instead. The enum test is what bounds it — the same syntax with an
 ordinary callee is a real argument conversion. 1,437 to 1,431, six fixed and none broken.
+
+**An alias carries no type, so the name it gives inherits the engine base.** `RefCpyV` is the
+instruction that says the source named a handle — and it propagates nothing about what that handle
+is. The slot therefore keeps whatever coarse type the cache recorded (`UObject`, `AActor`), and
+the structurer then has to write a `Cast<Owner>(recv)` at every call on it to keep the call legal:
+a cast vanilla never had, and eight extra opcodes. For an alias the producer is one hop away and
+its DECLARED type is in reach — the field's own type or the callee's return, never a declaring
+class, which is the weaker signal that once typed `APawn local_8 = Cast<AGothicCharacter>(…)`.
+
+Three clauses, all load-bearing. The recorded type must be an engine base; the alias must be the
+slot's ONLY object write, so nothing else can have been upcast into it; and the slot must be a
+RECEIVER — a `PshVPtr` immediately before a call, since this compiler pushes arguments first and
+the receiver last. Drop the last one and an `AActor local_6 = this.TargetEnemy;` that is only ever
+passed to `Add()` gets retyped, which vanilla's source really did widen.
+
+And the narrowing has to reach BOTH type maps. Landing it only in the structurer's view took the
+receiver wrap away while the declaration stayed at the base, and the whole tree stopped compiling
+with `No matching signatures to 'UObject::GetRelationship()'` — the same two-map mistake the cast
+narrowing made before it. 1,431 to 1,419, twelve fixed and none broken.
 
 Cutting across them, 6 are `__InitDefaults` — down from 37, because the language CAN spell
 infinity after all: an overflowing decimal literal (`1e39f`) parses and rounds to the bit pattern

--- a/crates/gore-as/FORMAT.md
+++ b/crates/gore-as/FORMAT.md
@@ -1,7 +1,7 @@
 # PrecompiledScript_Shipping.Cache format
 
 These notes describe the cache parser currently implemented and tested by
-gore-as against the Gothic 1 Remake 1.0.3 hotfix.
+gore-as against Gothic 1 Remake patch 1.0.5 (Steam BuildID 24878692).
 
 ## Outer header
 
@@ -14,7 +14,7 @@ All fields are little-endian:
 | 0x14 | u32 | Number of entries in the Modules TMap. |
 | 0x18 | records | Ordered module-name/module-value pairs. |
 
-The current pristine cache has 7,305 modules. The public CacheHeader.hash and
+The current pristine cache has 7,317 modules. The public CacheHeader.hash and
 type_count field names predate the completed parser; their values are the build
 GUID and module count respectively.
 
@@ -88,7 +88,7 @@ difference.
 
 ## Validation status
 
-- The complete 7,305-module tree parses through the final tail-table byte.
+- The complete 7,317-module tree parses through the final tail-table byte.
 - Extract/remap/splice round-trips are covered by synthetic and real-cache
   tests, including independently composed class-bearing mini-caches and
   prepared absolute StaticNames operands with a missing-row refusal.
@@ -101,8 +101,10 @@ difference.
   with zero decompiler stubs. That historical measurement does not qualify a
   newer build; unsupported or unproved future bytecode shapes still fail
   visibly to signature-preserving stubs rather than being guessed.
-- Generated special methods such as __InitDefaults remain a separate coverage
-  gap and are not emitted as ordinary editable functions.
+- The generated __InitDefaults initializers are recovered as class-scope
+  `default` statements, with 0 modules suppressed across the full corpus. Only
+  the method form is still skipped: `__`-prefixed generated methods are not
+  emitted as ordinary editable functions.
 
 ## Companion data and versions
 

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2134,6 +2134,7 @@ fn emit_function_ctor(
             spell_out_default_temporaries(&rendered, &default_only_construction_counts(f, refs));
         let rendered =
             split_gameplay_effect_chain(&rendered, &gameplay_effect_chain_slots(f, refs), refs);
+        let rendered = lead_with_the_declaration(&rendered, leading_declaration_slot(f));
         let rendered =
             merge_copy_constructed_declarations(&rendered, &copy_constructed_slots(f, refs));
         let rendered = drop_default_arguments(&rendered, refs);
@@ -10691,6 +10692,62 @@ fn chain_inlined_cast_operands(f: &Func) -> HashSet<i32> {
             continue;
         }
         out.insert(operand);
+    }
+    out
+}
+
+/// The local whose declaration was the function's FIRST statement.
+///
+/// A value type is constructed where it is declared, so a function whose very first instruction
+/// pair builds one is a function whose first statement is that declaration. Anything our text puts
+/// in front of it — a call, a store, another value's construction — is a statement vanilla ran
+/// later.
+///
+/// Bare declarations of object handles do not count as "in front": they emit nothing at all, and
+/// 11 byte-faithful functions carry one before the constructed local.
+fn leading_declaration_slot(f: &Func) -> Option<i32> {
+    let instrs = disassemble(&f.bytecode).ok()?;
+    let first = instrs.first()?;
+    if first.op.name != "PSF" {
+        return None;
+    }
+    matches!(
+        instrs.get(1)?.op.name,
+        "CALL" | "CALLSYS" | "CALLINTF" | "CALLBND"
+    )
+    .then(|| first.words.first().map(|w| *w as i16 as i32))
+    .flatten()
+    .filter(|slot| *slot > 0)
+}
+
+/// Put that declaration back in front.
+fn lead_with_the_declaration(body: &str, slot: Option<i32>) -> String {
+    let Some(slot) = slot else {
+        return body.to_owned();
+    };
+    let ident = format!("local_{slot}");
+    let mut lines: Vec<String> = body.lines().map(str::to_owned).collect();
+    let Some(at) = lines
+        .iter()
+        .position(|line| bare_declaration(line).is_some_and(|(_, name)| name == ident))
+    else {
+        return body.to_owned();
+    };
+    // The first line that emits something: anything that is not a bare declaration or blank.
+    let Some(head) = lines
+        .iter()
+        .position(|line| !line.trim().is_empty() && bare_declaration(line).is_none())
+    else {
+        return body.to_owned();
+    };
+    if head >= at {
+        return body.to_owned();
+    }
+    let declaration = lines.remove(at);
+    lines.insert(head, declaration);
+    let mut out = lines.join("\n");
+    if body.ends_with('\n') {
+        out.push('\n');
     }
     out
 }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2125,6 +2125,9 @@ fn emit_function_ctor(
             fields,
             &spilled_boolean_names(f, refs),
         );
+        // After the carrier chains are whole: the source declared a witnessed carrier on its
+        // initialiser, and the initialiser is only one statement once the arms have rejoined.
+        let rendered = sink_carrier_declarations(&rendered, &declared_at_initializer_carriers(f));
         let rendered = fold_literal_null_returns(
             &rendered,
             &literal_null_return_slots(f),
@@ -10258,6 +10261,138 @@ fn spilled_boolean_names(f: &Func, refs: &RefResolver) -> HashSet<i32> {
         if !short_circuit {
             out.insert(slot);
         }
+    }
+    out
+}
+
+/// A short-circuit carrier the source declared AT its initialiser.
+///
+/// `bool b = A && B;` and `bool b; ... b = A && B;` compile to the same arms and the same merge —
+/// what tells the two apart is what stands AT the merge label. A HOISTED declaration is a second
+/// slot, so vanilla copies the merged value on: `CpyVtoV X,S` with `X != S`. A declaration at its
+/// initialiser has nowhere to copy it to, so the merge label CONSUMES the carrier directly — a
+/// push, a register copy, a compare, a branch.
+///
+/// The rule only says where the DECLARATION stood. It never rewrites the carrier's readers: the
+/// shape that substitutes the chain into its reader is the one that crashed the compiler on an
+/// `&&` whose operand is not a bool.
+fn declared_at_initializer_carriers(f: &Func) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let mut out = HashSet::new();
+    for (at, arm) in instrs.iter().enumerate() {
+        let slot = w0(arm);
+        if !arm.op.name.starts_with("SetV") || slot <= 0 {
+            continue;
+        }
+        let Some(jump) = instrs.get(at + 1) else {
+            continue;
+        };
+        if jump.op.name != "JMP" {
+            continue;
+        }
+        let Some(offset) = jump.dwords.first().map(|word| *word as i32) else {
+            continue;
+        };
+        let target = jump.offset_dw as i64 + 2 + i64::from(offset);
+        let Some(merge) = instrs.iter().position(|other| other.offset_dw as i64 == target) else {
+            continue;
+        };
+        // The other arm writes the same carrier immediately before the merge.
+        let written = merge
+            .checked_sub(1)
+            .and_then(|before| instrs.get(before))
+            .is_some_and(|before| before.op.name.starts_with("CpyVtoV") && w0(before) == slot);
+        if !written {
+            continue;
+        }
+        let consumed = instrs.get(merge).is_some_and(|m| {
+            (m.op.name.starts_with("PshV")
+                || m.op.name.starts_with("CpyVtoR")
+                || m.op.name.starts_with("CMP")
+                || m.op.name.starts_with('J'))
+                && (m.op.name.starts_with('J') || w0(m) == slot)
+        });
+        if consumed {
+            out.insert(slot);
+        }
+    }
+    out
+}
+
+/// Put a witnessed carrier's declaration back where the source wrote it: on its initialiser.
+///
+/// The hoist is the emitter's, not vanilla's — where the merge label consumes the carrier the
+/// source said `bool b = A && B;` in one statement. Joining the two lines costs one `CpyVtoV`
+/// less, which is exactly the difference those records carry.
+///
+/// Sinking narrows the name's scope to the block its assignment stands in, so it is refused
+/// whenever anything after that block still reads the name. That guard, not the shape of the
+/// statement, is what keeps this off the 94-lost/46-gained result the unwitnessed version had.
+fn sink_carrier_declarations(body: &str, witnessed: &HashSet<i32>) -> String {
+    if witnessed.is_empty() {
+        return body.to_owned();
+    }
+    let mut lines: Vec<String> = body.lines().map(|line| line.to_owned()).collect();
+    let mut at = 0usize;
+    while at < lines.len() {
+        let sunk = (|| {
+            let name = lines[at].trim().strip_prefix("bool ")?.strip_suffix(';')?;
+            if !is_decompiler_local(name) {
+                return None;
+            }
+            let (slot, _) = slot_and_life(name)?;
+            if !witnessed.contains(&slot) {
+                return None;
+            }
+            // The first line that mentions the name has to BE its initialisation.
+            let store = lines[at + 1..]
+                .iter()
+                .position(|line| count_ident(line, name) != 0)?
+                + at
+                + 1;
+            let value = lines[store]
+                .trim()
+                .strip_prefix(&format!("{name} = "))?
+                .strip_suffix(';')?;
+            if count_ident(&lines[store], name) != 1
+                || top_level_logical_operator(value).is_none()
+            {
+                return None;
+            }
+            // Nothing after the assignment's own block may read the name.
+            let mut depth = 0i32;
+            let mut end = lines.len();
+            for (offset, line) in lines[store + 1..].iter().enumerate() {
+                depth += brace_net(line);
+                if depth < 0 {
+                    end = store + 1 + offset;
+                    break;
+                }
+            }
+            lines[end..]
+                .iter()
+                .all(|line| count_ident(line, name) == 0)
+                .then(|| {
+                    (
+                        store,
+                        format!("{}bool {name} = {value};", indent_of(&lines[store])),
+                    )
+                })
+        })();
+        match sunk {
+            Some((store, joined)) => {
+                lines[store] = joined;
+                lines.remove(at);
+            }
+            None => at += 1,
+        }
+    }
+    let mut out = lines.join("\n");
+    if body.ends_with('\n') {
+        out.push('\n');
     }
     out
 }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -6629,14 +6629,21 @@ fn inline_temporary_into(
     // The compiler re-uses one slot for several temporaries, so the definition that matters is
     // the LAST one before this call, and it owns the lines up to the next definition of the
     // same slot.
-    let Some(definition) = (0..index)
+    // Both searches are bounded. A temporary's definition stands within a statement or two of the
+    // read — the compiler reuses the slot immediately — so an unbounded scan buys nothing and
+    // costs a walk of the whole body per candidate. One machine-generated module has 24,700
+    // statements in a single function, and that quadratic walk was 393 of the 729 seconds the
+    // emitter spent on it. The window is far wider than any real distance; the emitted tree is
+    // byte-identical with and without it.
+    const WINDOW: usize = 4096;
+    let Some(definition) = (index.saturating_sub(WINDOW)..index)
         .rev()
         .find(|line| definition_value(&lines[*line], temp).is_some())
     else {
         inline_reject("definitions", callee, &temp, &lines[index]);
         return false;
     };
-    let region_end = (definition + 1..lines.len())
+    let region_end = (definition + 1..lines.len().min(definition + 1 + WINDOW))
         .find(|line| definition_value(&lines[*line], temp).is_some())
         .unwrap_or(lines.len());
     let uses_in_region: Vec<usize> = (definition + 1..region_end)
@@ -10462,6 +10469,23 @@ fn inline_unnamed_value_temporaries(
     refs: &RefResolver,
 ) -> String {
     let mut lines: Vec<String> = body.lines().map(|l| l.to_owned()).collect();
+    // `body` never changes, so the two whole-body questions below are asked once per name instead
+    // of once per line. Unmemoized they were 258 of the 729 seconds the emitter spent on the one
+    // machine-generated module with 24,700 statements in a single function.
+    let mentions: std::cell::RefCell<HashMap<String, usize>> = Default::default();
+    let mentions_of = |name: &str| {
+        *mentions
+            .borrow_mut()
+            .entry(name.to_owned())
+            .or_insert_with(|| count_ident(body, name))
+    };
+    let lives: std::cell::RefCell<HashMap<String, bool>> = Default::default();
+    let has_later_life = |name: &str| {
+        *lives
+            .borrow_mut()
+            .entry(name.to_owned())
+            .or_insert_with(|| body.contains(&format!("{name}_")))
+    };
     let mut at = 0usize;
     while at < lines.len() {
         let at_decl = at;
@@ -10477,16 +10501,14 @@ fn inline_unnamed_value_temporaries(
             // the name belongs to that store and to nothing else.
             // Ordered so the whole-body scan runs only on the rare path: one module is 24,000
             // lines long and a per-line scan of it costs minutes.
-            let sole_life = || {
-                key.1 == 1 && consumed.contains(&key.0) && !body.contains(&format!("{name}_"))
-            };
+            let sole_life = || key.1 == 1 && consumed.contains(&key.0) && !has_later_life(&name);
             if !unnamed.contains(&key) && !sole_life() {
                 inline_reject("not-unnamed", "", &name, &lines[at]);
                 return None;
             }
             // The store may stand under a bare declaration hoisted above it, in which case the
             // name is mentioned three times, not two. That declaration goes with the store.
-            let bare = match count_ident(body, &name) {
+            let bare = match mentions_of(&name) {
                 2 => None,
                 3 => Some(
                     lines[..at]

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2159,6 +2159,7 @@ fn emit_function_ctor(
         let rendered =
             split_gameplay_effect_chain(&rendered, &gameplay_effect_chain_slots(f, refs), refs);
         let rendered = lead_with_the_declaration(&rendered, leading_declaration_slot(f));
+        let rendered = order_adjacent_declarations(&rendered, &adjacent_declaration_order(f, refs));
         let rendered =
             merge_copy_constructed_declarations(&rendered, &copy_constructed_slots(f, refs));
         let rendered = drop_default_arguments(&rendered, refs);
@@ -10716,6 +10717,72 @@ fn chain_inlined_cast_operands(f: &Func) -> HashSet<i32> {
             continue;
         }
         out.insert(operand);
+    }
+    out
+}
+
+/// Two bare declarations that stood next to each other, and in which order.
+///
+/// `PSF vA; CALLSYS ::$beh0; PSF vB; CALLSYS ::$beh0` with nothing pushed in front of either is
+/// two default constructions back to back — two bare declarations, adjacent, in that order. The
+/// slot NUMBERS say nothing about it: this compiler reuses freed slots by size, so slot order is
+/// declaration order only within a size class.
+///
+/// Measured tree-wide: the pattern occurs 40 times and fires on 13 byte-faithful functions, all
+/// 13 of which our text already writes in that order.
+fn adjacent_declaration_order(f: &Func, refs: &RefResolver) -> Vec<(i32, i32)> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return Vec::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let constructs = |at: usize| -> Option<i32> {
+        let push = instrs.get(at).filter(|ins| ins.op.name == "PSF")?;
+        let call = instrs.get(at + 1)?;
+        (call.op.name == "CALLSYS"
+            && refs.func_by_ptr(call.qwords.first().copied().unwrap_or(0) as i64) == Some("$beh0"))
+        .then(|| w0(push))
+        .filter(|slot| *slot > 0)
+    };
+    let mut out = Vec::new();
+    for at in 0..instrs.len().saturating_sub(3) {
+        if let (Some(first), Some(second)) = (constructs(at), constructs(at + 2)) {
+            if first != second {
+                out.push((first, second));
+            }
+        }
+    }
+    out
+}
+
+/// Write those two declarations in the order vanilla built them.
+fn order_adjacent_declarations(body: &str, pairs: &[(i32, i32)]) -> String {
+    if pairs.is_empty() {
+        return body.to_owned();
+    }
+    let mut lines: Vec<String> = body.lines().map(str::to_owned).collect();
+    for &(first, second) in pairs {
+        let find = |slot: i32| {
+            let ident = format!("local_{slot}");
+            lines
+                .iter()
+                .position(|line| bare_declaration(line).is_some_and(|(_, name)| name == ident))
+        };
+        let (Some(at_first), Some(at_second)) = (find(first), find(second)) else {
+            continue;
+        };
+        if at_second >= at_first {
+            continue;
+        }
+        // Move the one vanilla built first up in front of the other, keeping the indentation of
+        // the place it lands in.
+        let indent = indent_of(&lines[at_second]);
+        let declaration = lines.remove(at_first);
+        let declaration = format!("{indent}{}", declaration.trim());
+        lines.insert(at_second, declaration);
+    }
+    let mut out = lines.join("\n");
+    if body.ends_with('\n') {
+        out.push('\n');
     }
     out
 }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2091,6 +2091,11 @@ fn emit_function_ctor(
                 .union(&immediately_consumed_defs(f))
                 .copied()
                 .chain(rvo_temporary_slots(f, refs).into_iter().map(|slot| (slot, 1)))
+                .chain(
+                    fused_short_circuit_carriers(f)
+                        .into_iter()
+                        .map(|slot| (slot, 1)),
+                )
                 .collect(),
             &wholly_consumed_object_slots(f),
             &rvo_temporary_slots(f, refs),
@@ -2105,6 +2110,11 @@ fn emit_function_ctor(
                 .union(&immediately_consumed_defs(f))
                 .copied()
                 .chain(rvo_temporary_slots(f, refs).into_iter().map(|slot| (slot, 1)))
+                .chain(
+                    fused_short_circuit_carriers(f)
+                        .into_iter()
+                        .map(|slot| (slot, 1)),
+                )
                 .collect(),
             &wholly_consumed_object_slots(f),
             &rvo_temporary_slots(f, refs),
@@ -10456,6 +10466,58 @@ fn declared_at_initializer_carriers(f: &Func) -> HashSet<i32> {
         if consumed {
             out.insert(slot);
         }
+    }
+    out
+}
+
+/// A short-circuit carrier the source never named at all.
+///
+/// The compiler materialises a branch condition into a slot and reloads it — `CpyRtoV4 S;
+/// CpyVtoR1 S; J…` — and its peephole collapses that round trip to a bare conditional jump
+/// exactly when the slot is a free temporary. So a diamond whose left test vanilla FUSED
+/// (`CmpPtrNull v4; JNZ`, no round trip) had no name there: the source wrote the whole chain
+/// where it is read.
+///
+/// Same diamonds as [`declared_at_initializer_carriers`], asked the other question.
+fn fused_short_circuit_carriers(f: &Func) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let mut out = HashSet::new();
+    for (at, arm) in instrs.iter().enumerate() {
+        let slot = w0(arm);
+        if !arm.op.name.starts_with("SetV") || slot <= 0 || at < 2 {
+            continue;
+        }
+        let Some(jump) = instrs.get(at + 1) else {
+            continue;
+        };
+        if jump.op.name != "JMP" {
+            continue;
+        }
+        let Some(offset) = jump.dwords.first().map(|word| *word as i32) else {
+            continue;
+        };
+        let target = jump.offset_dw as i64 + 2 + i64::from(offset);
+        let Some(merge) = instrs.iter().position(|other| other.offset_dw as i64 == target) else {
+            continue;
+        };
+        let written = merge
+            .checked_sub(1)
+            .and_then(|before| instrs.get(before))
+            .is_some_and(|before| before.op.name.starts_with("CpyVtoV") && w0(before) == slot);
+        if !written {
+            continue;
+        }
+        // The arm is entered by the left test. A round trip in front of it names the slot; a
+        // compare straight into the jump does not.
+        if !instrs[at - 1].op.name.starts_with('J')
+            || matches!(instrs[at - 2].op.name, "CpyVtoR1" | "CpyVtoR4")
+        {
+            continue;
+        }
+        out.insert(slot);
     }
     out
 }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -12279,29 +12279,18 @@ fn fold_literal_null_returns(body: &str, witnessed: &HashSet<i32>, by_reference:
     joined
 }
 
-/// A rendered value that cannot run anything: a literal, or an enum written as a cast of one.
+/// A rendered value that cannot run anything.
+///
+/// Only bare literals. `Name(1)` was allowed here as an enum conversion, but nothing in the text
+/// separates that from a call taking a number — and this decides whether a line may be DELETED,
+/// so a call slipping through would take its effect with it. The constant this exists for comes
+/// out of a `SetV4` and is always a bare number anyway.
 fn is_constant_literal(value: &str) -> bool {
-    if matches!(value, "true" | "false" | "nullptr") {
-        return true;
-    }
-    let numeric = |s: &str| {
-        s.chars().any(|c| c.is_ascii_digit())
-            && s.chars()
-                .all(|c| c.is_ascii_hexdigit() || matches!(c, '.' | '-' | '+' | 'f' | 'u' | 'x'))
-    };
-    if numeric(value) {
-        return true;
-    }
-    value
-        .strip_suffix(')')
-        .and_then(|inner| inner.split_once('('))
-        .is_some_and(|(name, argument)| {
-            !name.is_empty()
-                && name
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || matches!(c, '_' | ':'))
-                && numeric(argument)
-        })
+    matches!(value, "true" | "false" | "nullptr")
+        || (value.chars().any(|c| c.is_ascii_digit())
+            && value
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() || matches!(c, '.' | '-' | '+' | 'f' | 'u' | 'x')))
 }
 
 /// `local_N = K; return K;` — the store is DEAD. The very next statement leaves the function, so

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2017,7 +2017,11 @@ fn emit_function_ctor(
         // Declarations and body are one text now. A struct declared at function scope costs a
         // constructor at entry and a destructor on every path out; where vanilla touched the slot
         // only after it had branched, the declaration stood in the block that touches it.
-        let rendered = sink_declarations_into_their_block(&s[declarations_at..], &touched_after_branch);
+        let rendered = sink_declarations_into_their_block(
+            &s[declarations_at..],
+            &touched_after_branch,
+            &slots_built_once_per_iteration(f, refs),
+        );
         // Same text, same reason as the sink: the declaration lives in `s`, its uses in `body`.
         let rendered = spell_out_repeated_temporaries(&rendered, &constructions);
         let rendered = sink_declarations_to_first_use(&rendered, &late_constructed_slots(f, refs));
@@ -8023,12 +8027,18 @@ fn slots_touched_only_after_a_branch(f: &Func) -> HashSet<i32> {
 /// the function. A struct declared there costs a constructor at entry and a destructor on every
 /// path out — including the early returns that leave before the value exists. `after_branch`
 /// carries the slots vanilla proves were not declared there.
-fn sink_declarations_into_their_block(body: &str, after_branch: &HashSet<i32>) -> String {
+fn sink_declarations_into_their_block(
+    body: &str,
+    after_branch: &HashSet<i32>,
+    built_per_iteration: &HashSet<i32>,
+) -> String {
     let mut lines: Vec<String> = body.lines().map(str::to_owned).collect();
     // One move per pass, then everything is derived again: a move renumbers every line after it,
     // and two moves planned against the same numbering land in each other's way.
     for _ in 0..lines.len() {
-        let Some((from, to, text)) = next_declaration_to_sink(&lines, after_branch) else {
+        let Some((from, to, text)) =
+            next_declaration_to_sink(&lines, after_branch, built_per_iteration)
+        else {
             break;
         };
         lines.remove(from);
@@ -8046,6 +8056,7 @@ fn sink_declarations_into_their_block(body: &str, after_branch: &HashSet<i32>) -
 fn next_declaration_to_sink(
     lines: &[String],
     after_branch: &HashSet<i32>,
+    built_per_iteration: &HashSet<i32>,
 ) -> Option<(usize, usize, String)> {
     let depths = block_depths(lines);
     for (index, line) in lines.iter().enumerate() {
@@ -8111,7 +8122,9 @@ fn next_declaration_to_sink(
                 let head = line.trim_start();
                 head.starts_with("for") || head.starts_with("while") || head.starts_with("do")
             });
-        if heads_a_loop {
+        // …unless vanilla built it once per iteration and released it on every exit, which is
+        // the source declaring it in the body.
+        if heads_a_loop && !built_per_iteration.contains(&slot) {
             continue;
         }
         let extra = "    ".repeat(depth - depths[index]);
@@ -9307,6 +9320,70 @@ fn enum_of_member_path(
 /// Slots whose ONE default construction stands behind real work — a call or a branch runs before
 /// it. A value-type declaration costs a constructor where it stands, so the position is evidence:
 /// the source declared it there, not in the prologue where the emitter hoists every declaration.
+/// Value-type slots the source declared INSIDE a loop body.
+///
+/// A value-type local is destroyed once per exit from the block it was declared in. So vanilla
+/// spending ONE `$beh0` and TWO OR MORE `$beh2` for a slot, all of them between a back edge's
+/// target and the jump that closes it, is the source declaring that local in the loop body: the
+/// constructor ran once per iteration and each `continue`, `break` and fall-through paid its own
+/// destructor. Exactly one constructor is what makes it a declaration — two are two unnamed
+/// temporaries sharing a slot, which is never what a declaration looks like.
+fn slots_built_once_per_iteration(f: &Func, refs: &RefResolver) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let behaviour = |at: usize, want: &str| -> Option<i32> {
+        let pair = instrs.get(at..at + 2)?;
+        (pair[0].op.name == "PSF" && pair[1].op.name == "CALLSYS").then_some(())?;
+        let ptr = pair[1].qwords.first().copied().unwrap_or(0) as i64;
+        (refs.func_by_ptr(ptr) == Some(want)).then(|| pair[0].words.first().map(|w| *w as i16 as i32))?
+    };
+    let mut ctors: HashMap<i32, Vec<usize>> = HashMap::new();
+    let mut dtors: HashMap<i32, Vec<usize>> = HashMap::new();
+    for at in 0..instrs.len().saturating_sub(1) {
+        if let Some(slot) = behaviour(at, "$beh0").filter(|slot| *slot > 0) {
+            ctors.entry(slot).or_default().push(at);
+        }
+        if let Some(slot) = behaviour(at, "$beh2").filter(|slot| *slot > 0) {
+            dtors.entry(slot).or_default().push(at);
+        }
+    }
+    // Every back edge, as an instruction-index span.
+    let mut back: Vec<(usize, usize)> = Vec::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if !ins.op.name.starts_with('J') {
+            continue;
+        }
+        let Some(offset) = ins.dwords.first().map(|d| *d as i32) else {
+            continue;
+        };
+        let target = ins.offset_dw as i64 + 2 + offset as i64;
+        if target < 0 || target as usize >= ins.offset_dw {
+            continue;
+        }
+        if let Some(start) = instrs
+            .iter()
+            .position(|other| other.offset_dw == target as usize)
+        {
+            back.push((start, at));
+        }
+    }
+    ctors
+        .into_iter()
+        .filter(|(_, sites)| sites.len() == 1)
+        .filter_map(|(slot, sites)| {
+            let releases = dtors.get(&slot)?;
+            (releases.len() >= 2).then_some((slot, sites[0], releases))
+        })
+        .filter(|(_, built, releases)| {
+            back.iter().any(|(start, end)| {
+                (start..=end).contains(&built) && releases.iter().all(|at| (start..=end).contains(&at))
+            })
+        })
+        .map(|(slot, _, _)| slot)
+        .collect()
+}
+
 fn late_constructed_slots(f: &Func, refs: &RefResolver) -> HashSet<i32> {
     let Ok(instrs) = disassemble(&f.bytecode) else {
         return HashSet::new();
@@ -13091,7 +13168,7 @@ mod declaration_sink_tests {
 
     #[test]
     fn a_declaration_used_in_one_block_moves_into_it() {
-        let sunk = sink_declarations_into_their_block(BODY, &HashSet::from([9]));
+        let sunk = sink_declarations_into_their_block(BODY, &HashSet::from([9]), &HashSet::new());
         assert_eq!(
             sunk,
             "    if (Guard())\n    {\n        return;\n    }\n    if (Other())\n    {\n        FThing local_9;\n        local_9.Field = 1;\n        Use(local_9);\n    }\n    return;\n",
@@ -13102,7 +13179,7 @@ mod declaration_sink_tests {
     #[test]
     fn a_slot_touched_before_the_branch_stays_where_it_was() {
         assert_eq!(
-            sink_declarations_into_their_block(BODY, &HashSet::new()),
+            sink_declarations_into_their_block(BODY, &HashSet::new(), &HashSet::new()),
             BODY,
             "without the witness the declaration was at function scope and stays there"
         );
@@ -13112,7 +13189,7 @@ mod declaration_sink_tests {
     fn mentions_in_two_blocks_stay_at_function_scope() {
         let body = "    FThing local_9;\n    if (A())\n    {\n        Use(local_9);\n    }\n    if (B())\n    {\n        Use(local_9);\n    }\n";
         assert_eq!(
-            sink_declarations_into_their_block(body, &HashSet::from([9])),
+            sink_declarations_into_their_block(body, &HashSet::from([9]), &HashSet::new()),
             body,
             "no single block holds every mention, so nothing can hold the declaration"
         );

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -9523,6 +9523,15 @@ fn spell_out_default_temporaries(text: &str, defaults: &HashMap<i32, usize>) -> 
         if uses.len() <= fresh {
             continue; // the first use is the named value itself; there has to be one left
         }
+        // Taking the LAST `fresh` of them is an order argument, and an order argument only holds
+        // where the uses all run. Sitting in different arms they do not: a fresh default in the
+        // then arm and the named value in the else arm are not first and second, they are
+        // alternatives, and the count would rewrite the wrong one. Uses standing at the
+        // declaration's own indentation are the straight line this can read.
+        let indent = indent_of(&lines[index]);
+        if uses.iter().any(|at| indent_of(&lines[*at]) != indent) {
+            continue;
+        }
         for at in uses.into_iter().rev().take(fresh) {
             lines[at] = lines[at].replace(&format!("= {name};"), &format!("= {ty}();"));
         }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -11074,10 +11074,25 @@ fn nested_expression_intermediates(f: &Func, refs: &RefResolver) -> HashSet<i32>
         {
             continue;
         }
+        // The block belongs to the call that comes NEXT in the same straight line of code. The
+        // calls in between are the receiver being built and belong to this expression, but a
+        // BRANCH does not — past one, the `GetSafeNormal` is a different statement's and the
+        // addresses in the window are its locals, whose declarations this would take away. A
+        // second default-argument block ends it too: that block owns the call, not this one.
         let Some(call) = instrs[at + 3..]
             .iter()
-            .position(|ins| callee(ins).is_some_and(|name| name.starts_with("GetSafeNormal")))
+            .enumerate()
+            .position(|(offset, ins)| {
+                let starts_a_block = ins.op.name == "PshGPtr"
+                    && instrs.get(at + 4 + offset).map(|ins| ins.op.name) == Some("PshC8");
+                ins.op.name.starts_with('J')
+                    || starts_a_block
+                    || callee(ins).is_some_and(|name| name.starts_with("GetSafeNormal"))
+            })
             .map(|offset| at + 3 + offset)
+            .filter(|call| {
+                callee(&instrs[*call]).is_some_and(|name| name.starts_with("GetSafeNormal"))
+            })
         else {
             continue;
         };

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2101,7 +2101,7 @@ fn emit_function_ctor(
         // the expression. Held in a local instead, it is evaluated BEFORE the outer call's other
         // arguments — the same instructions in a different order.
         let several_lives =
-            slots_with_several_lives(&rendered.lines().map(str::to_owned).collect::<Vec<_>>());
+            slots_with_a_third_life(&rendered.lines().map(str::to_owned).collect::<Vec<_>>());
         let rendered = inline_unnamed_value_temporaries(
             &rendered,
             &unnamed_value_defs(f, refs)
@@ -2137,7 +2137,7 @@ fn emit_function_ctor(
         // A returned expression folds one step per pass: three names in a chain need three.
         for _ in 0..3 {
         let several_lives =
-            slots_with_several_lives(&rendered.lines().map(str::to_owned).collect::<Vec<_>>());
+            slots_with_a_third_life(&rendered.lines().map(str::to_owned).collect::<Vec<_>>());
         rendered = inline_unnamed_value_temporaries(
             &rendered,
             &unnamed_value_defs(f, refs)
@@ -9483,7 +9483,7 @@ fn split_gameplay_effect_chain(body: &str, slots: &[(i32, i32)], refs: &RefResol
 /// writes through, and a temporary cannot bind to one.
 fn spell_out_default_temporaries(text: &str, defaults: &HashMap<i32, usize>) -> String {
     let mut lines: Vec<String> = text.lines().map(str::to_owned).collect();
-    let ambiguous = slots_with_several_lives(&lines);
+    let ambiguous = slots_whose_count_spans_lives(&lines);
     for index in 0..lines.len() {
         let Some((_, name, _)) = declaration_with_initializer(&lines[index]) else {
             continue;
@@ -13029,6 +13029,14 @@ fn renders_a_bool(
 /// declaration is moved, the wrong temporary loses its name, the wrong receiver is folded. Rules
 /// whose witness cannot pick out a life ask this first and stand down on the slots it names.
 fn slots_with_several_lives(lines: &[String]) -> HashSet<i32> {
+    observed_lives(lines)
+        .into_iter()
+        .filter_map(|(slot, seen)| (seen.len() > 1).then_some(slot))
+        .collect()
+}
+
+/// The life numbers the text still shows for each frame slot.
+fn observed_lives(lines: &[String]) -> HashMap<i32, HashSet<usize>> {
     let mut lives: HashMap<i32, HashSet<usize>> = HashMap::new();
     for line in lines {
         for token in line.split(|c: char| !c.is_alphanumeric() && c != '_') {
@@ -13038,8 +13046,28 @@ fn slots_with_several_lives(lines: &[String]) -> HashSet<i32> {
         }
     }
     lives
+}
+
+/// Slots a per-slot COUNT cannot be spent on, because the count includes lives the text no longer
+/// shows. Two names standing is one sign; so is a single name that is not the FIRST life — an
+/// earlier life folded away leaves its successor's number behind, and the count still counts it.
+fn slots_whose_count_spans_lives(lines: &[String]) -> HashSet<i32> {
+    observed_lives(lines)
         .into_iter()
-        .filter_map(|(slot, seen)| (seen.len() > 1).then_some(slot))
+        .filter_map(|(slot, seen)| {
+            (seen.len() > 1 || seen.iter().any(|life| *life > 1)).then_some(slot)
+        })
+        .collect()
+}
+
+/// Slots the text shows a life of beyond the second. A witness read off the slot is spent on
+/// lives 1 and 2, which covers a slot with two of them; a third is outside what it can say.
+fn slots_with_a_third_life(lines: &[String]) -> HashSet<i32> {
+    observed_lives(lines)
+        .into_iter()
+        .filter_map(|(slot, seen)| {
+            (seen.len() > 2 || seen.iter().any(|life| *life > 2)).then_some(slot)
+        })
         .collect()
 }
 

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1919,7 +1919,7 @@ fn emit_function_ctor(
                 refs,
                 &already_declared_at_use,
                 &reference_locals,
-                &bare_declaration_slots(f),
+                &bare_declaration_slots(f, refs),
                 &call_result_declared_at_initializer(f),
             );
         let (body, first_write_suppressed) = rewrite_bare_decl_at_first_write(
@@ -9458,8 +9458,15 @@ fn split_gameplay_effect_chain(body: &str, slots: &[(i32, i32)], refs: &RefResol
                 "{indent}{context_ty} local_{context} = {context_expr};\n{indent}{spec_ty} local_{spec} = {spec_expr};\n{rest}"
             ))
         })();
+        // The pair belongs to the chain on this line whether or not the line is rewritten: a
+        // chain a function RETURNS is deliberately left alone, and leaving its pair unconsumed
+        // hands those slots to the next Apply chain, which then declares the wrong locals.
+        let carries_the_chain = line.contains(".MakeOutgoingSpec(")
+            && line.contains(".MakeEffectContext()");
         if rewritten.is_some() {
             declared.insert(spec);
+        }
+        if rewritten.is_some() || carries_the_chain {
             next += 1;
         }
         out.push(rewritten.unwrap_or_else(|| line.to_owned()));
@@ -14238,7 +14245,7 @@ fn rewrite_bare_decl_at_first_write(
 ///
 /// Measured: fires on 9 functions tree-wide, none of them byte-faithful. Every byte-faithful
 /// sole-copy local has its producer ADJACENT to the copy, which is what the gap separates.
-fn bare_declaration_slots(f: &Func) -> HashSet<i32> {
+fn bare_declaration_slots(f: &Func, refs: &RefResolver) -> HashSet<i32> {
     let Ok(instrs) = disassemble(&f.bytecode) else {
         return HashSet::new();
     };
@@ -14270,11 +14277,18 @@ fn bare_declaration_slots(f: &Func) -> HashSet<i32> {
         if at == producer + 1 {
             continue; // adjacent: the declaration took the temporary
         }
+        // Cleanup, and nothing that runs. `CALLSYS` alone is not a shape — the destructor
+        // behaviour is. Any other call in the gap can do work between the producer and the copy,
+        // and reading it as cleanup keeps the initializer from being restored.
         let cleanup_only = instrs[producer + 1..at].iter().all(|ins| {
-            matches!(
-                ins.op.name,
-                "PSF" | "CALLSYS" | "PshVPtr" | "STOREOBJ" | "PopPtr"
-            )
+            match ins.op.name {
+                "PSF" | "PshVPtr" | "STOREOBJ" | "PopPtr" => true,
+                "CALLSYS" => {
+                    refs.func_by_ptr(ins.qwords.first().copied().unwrap_or(0) as i64)
+                        == Some("$beh2")
+                }
+                _ => false,
+            }
         });
         // …and the temporary is dead after the copy.
         let reused = instrs[at + 1..]

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2125,6 +2125,11 @@ fn emit_function_ctor(
             fields,
             &spilled_boolean_names(f, refs),
         );
+        let rendered = fold_literal_null_returns(
+            &rendered,
+            &literal_null_return_slots(f),
+            returns_by_reference,
+        );
         s.truncate(declarations_at);
         s.push_str(&rendered);
     } else {
@@ -10737,8 +10742,7 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             None => at += 1,
         }
     }
-    let mut text = lines.join("
-");
+    let mut text = lines.join("\n");
     if body.ends_with('\n') {
         text.push('\n');
     }
@@ -11051,6 +11055,93 @@ fn rewrite_inline_enum_round_trips(
 /// The slot number a `local_N` identifier names.
 fn slot_of(ident: &str) -> Option<i32> {
     ident.strip_prefix("local_")?.parse().ok()
+}
+
+/// A literal `return nullptr;` NULLS the return slot before it loads it.
+///
+/// `FreeNullV8 S` standing immediately before `LOADOBJ S` — reading past the `PSF vT; CALLSYS`
+/// cleanup pairs a scope exit emits between the two — is the compiler releasing whatever the slot
+/// held so that it can load a null out of it. A `T x = nullptr; return x;` never pays that
+/// release: the local is already null and the compiler loads it straight out. So the release is
+/// the witness that the source wrote the literal, and it is a strong one: 120 occurrences stand in
+/// functions we already reproduce byte for byte.
+fn literal_null_return_slots(f: &Func) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let mut out = HashSet::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "FreeNullV8" {
+            continue;
+        }
+        let slot = w0(ins);
+        if slot <= 0 {
+            continue;
+        }
+        let mut next = at + 1;
+        while instrs.get(next).is_some_and(|ins| ins.op.name == "PSF")
+            && instrs
+                .get(next + 1)
+                .is_some_and(|ins| ins.op.name == "CALLSYS")
+        {
+            next += 2;
+        }
+        if instrs
+            .get(next)
+            .is_some_and(|ins| ins.op.name == "LOADOBJ" && w0(ins) == slot)
+        {
+            out.insert(slot);
+        }
+    }
+    out
+}
+
+/// `T x = nullptr; return x;` is `return nullptr;` wherever the bytecode witnesses the literal.
+///
+/// The name exists only to be returned, so folding it away costs nothing — but only the release
+/// tells the two forms apart, which is why this is gated on [`literal_null_return_slots`] rather
+/// than on the shape of the text.
+fn fold_literal_null_returns(body: &str, witnessed: &HashSet<i32>, by_reference: bool) -> String {
+    if witnessed.is_empty() || by_reference {
+        return body.to_owned();
+    }
+    let lines: Vec<&str> = body.lines().collect();
+    let mut kept: Vec<String> = Vec::new();
+    let mut at = 0usize;
+    while at < lines.len() {
+        let folded = (|| {
+            let (indent, name, init) = declaration_with_initializer(lines[at])?;
+            if init != "nullptr" {
+                return None;
+            }
+            let (slot, _) = slot_and_life(&name)?;
+            if !witnessed.contains(&slot) {
+                return None;
+            }
+            let next = lines.get(at + 1)?;
+            if next.trim() != format!("return {name};") || indent_of(next) != indent {
+                return None;
+            }
+            // The declaration and the return are the name's whole life.
+            (count_ident(body, &name) == 2).then(|| format!("{indent}return nullptr;"))
+        })();
+        match folded {
+            Some(line) => {
+                kept.push(line);
+                at += 2;
+            }
+            None => {
+                kept.push(lines[at].to_string());
+                at += 1;
+            }
+        }
+    }
+    let mut joined = kept.join("\n");
+    if body.ends_with('\n') {
+        joined.push('\n');
+    }
+    joined
 }
 
 /// `local_N = <expr>; return local_N;` is `return <expr>;`. The name is the whole cost: a

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2098,6 +2098,11 @@ fn emit_function_ctor(
                         .map(|slot| (slot, 1)),
                 )
                 .chain(chain_inlined_cast_operands(f).into_iter().map(|slot| (slot, 1)))
+                .chain(
+                    nested_expression_intermediates(f, refs)
+                        .into_iter()
+                        .map(|slot| (slot, 1)),
+                )
                 .collect(),
             &wholly_consumed_object_slots(f),
             &rvo_temporary_slots(f, refs),
@@ -2118,6 +2123,11 @@ fn emit_function_ctor(
                         .map(|slot| (slot, 1)),
                 )
                 .chain(chain_inlined_cast_operands(f).into_iter().map(|slot| (slot, 1)))
+                .chain(
+                    nested_expression_intermediates(f, refs)
+                        .into_iter()
+                        .map(|slot| (slot, 1)),
+                )
                 .collect(),
             &wholly_consumed_object_slots(f),
             &rvo_temporary_slots(f, refs),
@@ -10752,6 +10762,71 @@ fn lead_with_the_declaration(body: &str, slot: Option<i32>) -> String {
     out
 }
 
+/// The intermediates of a vector expression the source wrote as ONE nested expression.
+///
+/// The compiler pushes a call's arguments before it evaluates the receiver, so a default-argument
+/// block that stands DETACHED from its own call — `PshGPtr <global>; PshC8 <tolerance>; PSF D`
+/// with something other than the receiver and the call behind it — says the receiver is still
+/// being computed. Everything the compiler fills between that block and the call is a temporary
+/// of the one expression.
+///
+/// Counted over every uniquely named function in the cache: 630 attached blocks in byte-faithful
+/// functions, and of the 76 DETACHED ones not a single byte-faithful case.
+///
+/// Only the address pushes count. A `PshVPtr` in that window is a receiver or an argument the
+/// source named elsewhere — the range-for element, for instance, which must keep its name.
+fn nested_expression_intermediates(f: &Func, refs: &RefResolver) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let callee = |ins: &super::disasm::Instr| {
+        (ins.op.name == "CALLSYS")
+            .then(|| refs.func_by_ptr(ins.qwords.first().copied().unwrap_or(0) as i64))
+            .flatten()
+    };
+    let mut out = HashSet::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "PshGPtr" {
+            continue;
+        }
+        if instrs.get(at + 1).map(|ins| ins.op.name) != Some("PshC8") {
+            continue;
+        }
+        let Some(block) = instrs.get(at + 2).filter(|ins| ins.op.name == "PSF") else {
+            continue;
+        };
+        let _ = block;
+        // Attached: the receiver is already there and the call follows at once.
+        if instrs
+            .get(at + 4)
+            .and_then(callee)
+            .is_some_and(|name| name.starts_with("GetSafeNormal"))
+        {
+            continue;
+        }
+        let Some(call) = instrs[at + 3..]
+            .iter()
+            .position(|ins| callee(ins).is_some_and(|name| name.starts_with("GetSafeNormal")))
+            .map(|offset| at + 3 + offset)
+        else {
+            continue;
+        };
+        for ins in &instrs[at + 3..call] {
+            if ins.op.name != "PSF" {
+                continue;
+            }
+            // The destination is NOT excluded: the compiler reuses that very slot for the
+            // intermediate steps, which is what makes them temporaries of one expression.
+            let slot = w0(ins);
+            if slot > 0 {
+                out.insert(slot);
+            }
+        }
+    }
+    out
+}
+
 /// A short-circuit carrier the source never named at all.
 ///
 /// The compiler materialises a branch condition into a slot and reloads it — `CpyRtoV4 S;
@@ -11181,15 +11256,25 @@ fn inline_unnamed_value_temporaries(
                 // An operator result is a temporary the compiler builds for the expression, and
                 // handing it on as a receiver binds it to the method's non-const `this`. A call
                 // chain is what vanilla wrote inline; a bracketed operand is not.
-                if init.starts_with('(') || !init.ends_with(')') {
+                if !init.ends_with(')') {
                     return None;
                 }
                 let at = consumer.find(name.as_str())?;
-                let method = consumer[at + name.len()..]
-                    .strip_prefix('.')?
-                    .split(['(', '.', ' ', ')', ',', ';'])
-                    .next()?
-                    .to_owned();
+                let rest = &consumer[at + name.len()..];
+                // An arithmetic operator IS a receiver position: `a - b` is `a.opSub(b)`, and the
+                // operator overloads of a value type are const, so a temporary binds to them. The
+                // `.method()` spelling below is the same question written the other way.
+                let operator = [" + ", " - ", " * ", " / "]
+                    .iter()
+                    .any(|op| rest.starts_with(op));
+                let method = match operator {
+                    true => String::new(),
+                    false => rest
+                        .strip_prefix('.')?
+                        .split(['(', '.', ' ', ')', ',', ';'])
+                        .next()?
+                        .to_owned(),
+                };
                 // A NON-const method takes its receiver by non-const reference, so calling one on
                 // a temporary is the same refusal as passing one to a `T&` parameter.
                 let owned = bare.and_then(|_| declared_type(&lines, &name));
@@ -11198,9 +11283,19 @@ fn inline_unnamed_value_temporaries(
                     Some(ty) => ty,
                     None => head[..head.len().saturating_sub(name.len())].trim(),
                 };
-                if ty.is_empty()
-                    || refs.calls_non_const_method(super::structure::bare_type_name(ty), &method)
+                if !operator
+                    && (ty.is_empty()
+                        || refs
+                            .calls_non_const_method(super::structure::bare_type_name(ty), &method))
                 {
+                    return None;
+                }
+                // A BRACKETED initialiser is an operator result — a temporary the compiler builds
+                // for the expression. Binding it to a non-const `this` is what the refusal above
+                // is about; a const method takes it happily, and vanilla's own bytecode shows the
+                // compiler accepting `(a - b).GetSafeNormal2D(…)` wherever the source wrote the
+                // whole thing as one expression.
+                if init.starts_with('(') && !operator && !refs.names_a_const_method(&method) {
                     return None;
                 }
             }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2130,6 +2130,8 @@ fn emit_function_ctor(
         let rendered =
             spell_out_default_temporaries(&rendered, &default_only_construction_counts(f, refs));
         let rendered =
+            split_gameplay_effect_chain(&rendered, &gameplay_effect_chain_slots(f, refs), refs);
+        let rendered =
             merge_copy_constructed_declarations(&rendered, &copy_constructed_slots(f, refs));
         let rendered = drop_default_arguments(&rendered, refs);
         let rendered = fold_returned_empty_values(&rendered, f, refs);
@@ -9122,6 +9124,159 @@ fn default_only_construction_counts(f: &Func, refs: &RefResolver) -> HashMap<i32
         }
     }
     counts
+}
+
+/// The two handles of a gameplay-effect chain, and the slots vanilla gave them.
+///
+/// `Apply…SpecTo*( …MakeOutgoingSpec(…, …MakeEffectContext()) )` written as ONE expression occurs
+/// 38 times in the tree and **not one of those functions is byte-faithful**; every function that
+/// gets the chain right writes it as two declarations. Both handles are released at the scope
+/// exit rather than after the call that took them, which is an order a deferred parameter cannot
+/// produce — the source named them.
+///
+/// Returns `(context slot, spec slot)`. Keyed on the two callees by name, because the general
+/// release-order rule fires on ten times as many slots as it should and cost 232 records.
+fn gameplay_effect_chain_slots(f: &Func, refs: &RefResolver) -> Vec<(i32, i32)> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return Vec::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    // A call's hidden out-pointer is the last address pushed before it.
+    let destination = |at: usize| -> Option<i32> {
+        instrs[..at]
+            .iter()
+            .rposition(|ins| ins.op.name == "PSF")
+            .map(|push| w0(&instrs[push]))
+            .filter(|slot| *slot > 0)
+    };
+    let mut pairs = Vec::new();
+    let mut context: Option<i32> = None;
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "CALLSYS" {
+            continue;
+        }
+        match refs.func_by_ptr(ins.qwords.first().copied().unwrap_or(0) as i64) {
+            Some("MakeEffectContext") => context = destination(at),
+            Some("MakeOutgoingSpec") => {
+                // One pair per chain, in program order. A function may carry several, and giving
+                // them all the FIRST pair's names declares the same local twice.
+                if let (Some(ctx), Some(spec)) = (context.take(), destination(at)) {
+                    if ctx != spec {
+                        pairs.push((ctx, spec));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    pairs
+}
+
+/// Split that chain back into the two declarations the source wrote.
+fn split_gameplay_effect_chain(body: &str, slots: &[(i32, i32)], refs: &RefResolver) -> String {
+    if slots.is_empty() {
+        return body.to_owned();
+    }
+    let (Some(context_ty), Some(spec_ty)) = (
+        refs.names_returning("MakeEffectContext"),
+        refs.names_returning("MakeOutgoingSpec"),
+    ) else {
+        return body.to_owned();
+    };
+    let mut out: Vec<String> = Vec::new();
+    let mut next = 0usize;
+    for line in body.lines() {
+        let Some(&(context, spec)) = slots.get(next) else {
+            out.push(line.to_owned());
+            continue;
+        };
+        let rewritten = (|| {
+            // Only where the chain is CONSUMED by an apply call. A function that returns the
+            // spec — `return ASC.MakeOutgoingSpec(…, ASC.MakeEffectContext());` — is a different
+            // statement, and vanilla does not split it: naming the two handles there broke ten
+            // records that were already right.
+            if !line.contains(".ApplyGameplayEffectSpecTo") {
+                return None;
+            }
+            // Vanilla may reuse one slot for two chains in the same function. Introducing the
+            // name where the body already carries it declares the same local twice, which the
+            // compiler does not survive — those functions keep the nested form.
+            let already_named = count_ident(body, &format!("local_{spec}")) != 0
+                && !line.contains(&format!("local_{spec} = "));
+            if already_named {
+                return None;
+            }
+            let call = line.find(".MakeOutgoingSpec(")?;
+            let context_at = line.find(".MakeEffectContext()")?;
+            if context_at < call {
+                return None;
+            }
+            let indent = indent_of(line);
+            // The receiver of each call reaches back over a path or a call chain.
+            let start = |end: usize| -> Option<usize> {
+                let bytes = line.as_bytes();
+                let mut at = end;
+                let mut depth = 0i32;
+                while at > 0 {
+                    match bytes[at - 1] {
+                        b')' | b']' => depth += 1,
+                        b'(' | b'[' if depth == 0 => break,
+                        b'(' | b'[' => depth -= 1,
+                        b',' | b' ' if depth == 0 => break,
+                        _ => {}
+                    }
+                    at -= 1;
+                }
+                (at < end).then_some(at)
+            };
+            let context_start = start(context_at)?;
+            let context_expr = &line[context_start..context_at + ".MakeEffectContext()".len()];
+            let call_end = matching_paren(line, call + ".MakeOutgoingSpec".len())?;
+            let spec_start = start(call)?;
+            let spec_expr = line[spec_start..=call_end].replace(context_expr, &format!("local_{context}"));
+            // Both halves have to be what they claim. A back-scan that overshoots produces
+            // `local_N = local_N;` — self-initialisation, which the compiler does not survive.
+            if spec_expr.contains(".MakeEffectContext()")
+                || !spec_expr.contains(".MakeOutgoingSpec(")
+                || !context_expr.ends_with(".MakeEffectContext()")
+                || context_expr.starts_with('.')
+                || spec_expr.starts_with('.')
+                || context_expr.contains('\u{1}')
+            {
+                return None;
+            }
+            // The statement may ALREADY be the spec's declaration — `FGameplayEffectSpecHandle
+            // local_40 = <chain>;`. Emitting a second one gives `local_40 = local_40;`, which the
+            // compiler does not survive; there only the context comes out and the initialiser is
+            // rewritten in place.
+            if declaration_with_initializer(line)
+                .is_some_and(|(_, name, _)| name == format!("local_{spec}"))
+            {
+                return Some(format!(
+                    "{indent}{context_ty} local_{context} = {context_expr};\n{}",
+                    line.replace(context_expr, &format!("local_{context}"))
+                ));
+            }
+            let rest = format!(
+                "{}{}{}",
+                &line[..spec_start],
+                format_args!("local_{spec}"),
+                &line[call_end + 1..]
+            );
+            Some(format!(
+                "{indent}{context_ty} local_{context} = {context_expr};\n{indent}{spec_ty} local_{spec} = {spec_expr};\n{rest}"
+            ))
+        })();
+        if rewritten.is_some() {
+            next += 1;
+        }
+        out.push(rewritten.unwrap_or_else(|| line.to_owned()));
+    }
+    let mut joined = out.join("\n");
+    if body.ends_with('\n') {
+        joined.push('\n');
+    }
+    joined
 }
 
 /// The LAST uses of a named value that vanilla built fresh each time.

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1507,7 +1507,7 @@ fn emit_function_ctor(
     // A function that returns by REFERENCE keeps its named local: the name is what makes the
     // returned thing outlive the expression (same condition as `ref_ret` below).
     let returns_by_reference = f.ret.is_reference && f.ret.token == 5 && !f.ret.is_object_handle;
-    let body = fold_condition_temporaries(&body, &declared_locals, refs, fields, &spilled_boolean_names(f, refs));
+    let body = fold_condition_temporaries(&body, &declared_locals, refs, fields, &spilled_boolean_names(f, refs), false);
     let body = fold_alias_copies(&body, &declared_locals);
     let body = fold_copy_out_temporaries(&body, &declared_locals, &const_result_slots, fields);
     let body = fold_cast_operands(&body, &declared_locals, &call_result_types);
@@ -2037,7 +2037,7 @@ fn emit_function_ctor(
         // The rest of the fold chain, for the same reason as the passes above it: each of these
         // asks about a declaration, and until the hoist has been joined back on there is nothing
         // for them to ask about.
-        let rendered = fold_condition_temporaries(&rendered, &declared_locals, refs, fields, &spilled_boolean_names(f, refs));
+        let rendered = fold_condition_temporaries(&rendered, &declared_locals, refs, fields, &spilled_boolean_names(f, refs), false);
         let rendered = fold_alias_copies(&rendered, &declared_locals);
         let rendered = fold_assignment_receivers(&rendered, &immediately_consumed_defs(f));
         let rendered =
@@ -2105,6 +2105,13 @@ fn emit_function_ctor(
         // folds above can delete the statement that stood between the two.
         let rendered = drop_int_inside_enum_cast(&rendered);
         let rendered = drop_block_end_handle_releases(&rendered);
+        let rendered = rejoin_logical_carriers(
+            &rendered,
+            &declared_locals,
+            refs,
+            fields,
+            &spilled_boolean_names(f, refs),
+        );
         s.truncate(declarations_at);
         s.push_str(&rendered);
     } else {
@@ -7254,6 +7261,7 @@ fn fold_condition_temporaries(
     refs: &RefResolver,
     fields: Option<&HashMap<String, String>>,
     spilled: &HashSet<i32>,
+    logical_only: bool,
 ) -> String {
     // A field of the class carries its type in the class's own map, which `renders_a_bool` does
     // not read.
@@ -7270,6 +7278,9 @@ fn fold_condition_temporaries(
     while at < lines.len() {
         let folded = (|| {
             let (name, value) = slot_store(lines[at])?;
+            if logical_only && top_level_logical_operator(&value).is_none() {
+                return None;
+            }
             // A call result the source spent a `bool` on keeps its name: folding it into the
             // condition takes away the store and the reload, which is what said the name was
             // there.
@@ -9835,6 +9846,108 @@ fn rejoin_short_circuit_chains(body: &str) -> String {
 
 /// True when the expression's outermost brackets enclose ALL of it — `(a || b)` yes, `(a) || (b)`
 /// no. A fold that drops an expression into a larger one has to know the difference.
+/// The operator of an expression's OWN outermost run — the one a splice would land beside.
+/// Bracketed and quoted content belongs to another node and is skipped.
+fn top_level_logical_operator(value: &str) -> Option<&'static str> {
+    let bytes = value.as_bytes();
+    let (mut depth, mut at, mut in_string) = (0i32, 0usize, false);
+    let mut found = None;
+    while at < bytes.len() {
+        if in_string {
+            match bytes[at] {
+                b'\\' => at += 1,
+                b'"' => in_string = false,
+                _ => {}
+            }
+            at += 1;
+            continue;
+        }
+        match bytes[at] {
+            b'"' => in_string = true,
+            b'(' | b'[' => depth += 1,
+            b')' | b']' => depth -= 1,
+            _ if depth == 0 && bytes[at..].starts_with(b" && ") => {
+                found = Some("&&");
+                at += 3;
+            }
+            _ if depth == 0 && bytes[at..].starts_with(b" || ") => {
+                found = Some("||");
+                at += 3;
+            }
+            _ => {}
+        }
+        at += 1;
+    }
+    found
+}
+
+/// One more pass of the two folds that put a `&&`/`||` chain back into its reader.
+///
+/// Both already match on the finished text of bodies they never get to see: when they run, the
+/// OUTER chain is still an if/else over a slot, `fold_short_circuits` only turns it into a store
+/// further down, and the pass that collapses `X = c; return X;` runs after that. The fold chain is
+/// a fixed sequence, not a fixpoint, so neither pass is ever asked again.
+///
+/// The condition fold is restricted here to a value carrying a TOP-LEVEL `&&`/`||`. That shape
+/// occurs in none of the 54,366 byte-faithful bodies and in 109 slots of the divergent ones.
+/// Without the restriction the late pass also takes `bool X; X = <call>; if (X)`, which vanilla
+/// wrote WITH the name — four byte-faithful bodies say so. `rejoin` needs no such guard: its own
+/// gate already requires the consumer to continue the chain.
+fn rejoin_logical_carriers(
+    body: &str,
+    locals: &BTreeMap<i32, String>,
+    refs: &RefResolver,
+    fields: Option<&HashMap<String, String>>,
+    spilled: &HashSet<i32>,
+) -> String {
+    let carriers: HashSet<String> = body
+        .lines()
+        .filter_map(|line| slot_store(line))
+        .filter(|(_, value)| top_level_logical_operator(value).is_some())
+        .map(|(name, _)| name)
+        .collect();
+    if carriers.is_empty() {
+        return body.to_owned();
+    }
+    let mut text = body.to_owned();
+    for _ in 0..4 {
+        let folded = fold_condition_temporaries(
+            &rejoin_short_circuit_chains(&text),
+            locals,
+            refs,
+            fields,
+            spilled,
+            true,
+        );
+        if folded == text {
+            break;
+        }
+        text = folded;
+    }
+    // Only a declaration this block itself emptied: a declaration with no reader still reserves
+    // its slot, and vanilla has some that were already dead.
+    let lines: Vec<String> = text.lines().map(str::to_owned).collect();
+    let kept: Vec<&String> = lines
+        .iter()
+        .filter(|line| {
+            let Some((_, name)) = bare_declaration(line) else {
+                return true;
+            };
+            !(carriers.contains(&name)
+                && lines.iter().map(|l| count_ident(l, &name)).sum::<usize>() == 1)
+        })
+        .collect();
+    let mut out = kept
+        .into_iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join("\n");
+    if text.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
 fn wraps_whole_expression(expr: &str) -> bool {
     if !expr.starts_with('(') || !expr.ends_with(')') {
         return false;

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -9242,6 +9242,9 @@ fn split_gameplay_effect_chain(body: &str, slots: &[(i32, i32)], refs: &RefResol
     };
     let mut out: Vec<String> = Vec::new();
     let mut next = 0usize;
+    // Names this pass has already introduced. Scanning `body` alone cannot see them, so two
+    // chains sharing one spec slot would each emit its declaration.
+    let mut declared: HashSet<i32> = HashSet::new();
     for line in body.lines() {
         let Some(&(context, spec)) = slots.get(next) else {
             out.push(line.to_owned());
@@ -9258,8 +9261,9 @@ fn split_gameplay_effect_chain(body: &str, slots: &[(i32, i32)], refs: &RefResol
             // Vanilla may reuse one slot for two chains in the same function. Introducing the
             // name where the body already carries it declares the same local twice, which the
             // compiler does not survive — those functions keep the nested form.
-            let already_named = count_ident(body, &format!("local_{spec}")) != 0
-                && !line.contains(&format!("local_{spec} = "));
+            let already_named = (count_ident(body, &format!("local_{spec}")) != 0
+                && !line.contains(&format!("local_{spec} = ")))
+                || declared.contains(&spec);
             if already_named {
                 return None;
             }
@@ -9325,6 +9329,7 @@ fn split_gameplay_effect_chain(body: &str, slots: &[(i32, i32)], refs: &RefResol
             ))
         })();
         if rewritten.is_some() {
+            declared.insert(spec);
             next += 1;
         }
         out.push(rewritten.unwrap_or_else(|| line.to_owned()));
@@ -10730,7 +10735,7 @@ fn chain_inlined_cast_operands(f: &Func) -> HashSet<i32> {
 ///
 /// Measured tree-wide: the pattern occurs 40 times and fires on 13 byte-faithful functions, all
 /// 13 of which our text already writes in that order.
-fn adjacent_declaration_order(f: &Func, refs: &RefResolver) -> Vec<(i32, i32)> {
+fn adjacent_declaration_order(f: &Func, refs: &RefResolver) -> Vec<Vec<i32>> {
     let Ok(instrs) = disassemble(&f.bytecode) else {
         return Vec::new();
     };
@@ -10744,41 +10749,66 @@ fn adjacent_declaration_order(f: &Func, refs: &RefResolver) -> Vec<(i32, i32)> {
         .filter(|slot| *slot > 0)
     };
     let mut out = Vec::new();
-    for at in 0..instrs.len().saturating_sub(3) {
-        if let (Some(first), Some(second)) = (constructs(at), constructs(at + 2)) {
-            if first != second {
-                out.push((first, second));
-            }
+    let mut at = 0usize;
+    while at + 1 < instrs.len() {
+        let Some(first) = constructs(at) else {
+            at += 1;
+            continue;
+        };
+        let mut run = vec![first];
+        let mut after = at + 2;
+        while let Some(slot) = constructs(after) {
+            run.push(slot);
+            after += 2;
         }
+        // A slot built twice in one run says nothing about the order of the others.
+        let distinct: HashSet<i32> = run.iter().copied().collect();
+        if run.len() > 1 && distinct.len() == run.len() {
+            out.push(run);
+        }
+        at = after.max(at + 1);
     }
     out
 }
 
-/// Write those two declarations in the order vanilla built them.
-fn order_adjacent_declarations(body: &str, pairs: &[(i32, i32)]) -> String {
-    if pairs.is_empty() {
+/// Write a run's declarations in the order vanilla built them.
+fn order_adjacent_declarations(body: &str, runs: &[Vec<i32>]) -> String {
+    if runs.is_empty() {
         return body.to_owned();
     }
     let mut lines: Vec<String> = body.lines().map(str::to_owned).collect();
-    for &(first, second) in pairs {
-        let find = |slot: i32| {
-            let ident = format!("local_{slot}");
-            lines
-                .iter()
-                .position(|line| bare_declaration(line).is_some_and(|(_, name)| name == ident))
-        };
-        let (Some(at_first), Some(at_second)) = (find(first), find(second)) else {
+    for run in runs {
+        let spots: Option<Vec<usize>> = run
+            .iter()
+            .map(|slot| {
+                let ident = format!("local_{slot}");
+                lines
+                    .iter()
+                    .position(|line| bare_declaration(line).is_some_and(|(_, name)| name == ident))
+            })
+            .collect();
+        let Some(spots) = spots else {
             continue;
         };
-        if at_second >= at_first {
+        if spots.windows(2).all(|pair| pair[0] < pair[1]) {
             continue;
         }
-        // Move the one vanilla built first up in front of the other, keeping the indentation of
-        // the place it lands in.
-        let indent = indent_of(&lines[at_second]);
-        let declaration = lines.remove(at_first);
-        let declaration = format!("{indent}{}", declaration.trim());
-        lines.insert(at_second, declaration);
+        // Lift the whole run out and lay it back down at its earliest line, in vanilla's order.
+        // One pair at a time cannot do this: a reversed run of three lands on a third order.
+        let target = spots.iter().copied().min().unwrap_or_default();
+        let indent = indent_of(&lines[target]);
+        let ordered: Vec<String> = spots
+            .iter()
+            .map(|&at| format!("{indent}{}", lines[at].trim()))
+            .collect();
+        let mut removals = spots.clone();
+        removals.sort_unstable_by(|a, b| b.cmp(a));
+        for at in removals {
+            lines.remove(at);
+        }
+        for (offset, declaration) in ordered.into_iter().enumerate() {
+            lines.insert(target + offset, declaration);
+        }
     }
     let mut out = lines.join("\n");
     if body.ends_with('\n') {
@@ -10832,6 +10862,12 @@ fn lead_with_the_declaration(body: &str, slot: Option<i32>) -> String {
         return body.to_owned();
     };
     if head >= at {
+        return body.to_owned();
+    }
+    // A declaration standing deeper than the first statement was sunk into a block. Leading with
+    // it would lift it back to function scope and lose the per-iteration construction the sink
+    // recovered.
+    if indent_of(&lines[at]).len() > indent_of(&lines[head]).len() {
         return body.to_owned();
     }
     let declaration = lines.remove(at);
@@ -12038,6 +12074,31 @@ fn fold_literal_null_returns(body: &str, witnessed: &HashSet<i32>, by_reference:
     joined
 }
 
+/// A rendered value that cannot run anything: a literal, or an enum written as a cast of one.
+fn is_constant_literal(value: &str) -> bool {
+    if matches!(value, "true" | "false" | "nullptr") {
+        return true;
+    }
+    let numeric = |s: &str| {
+        s.chars().any(|c| c.is_ascii_digit())
+            && s.chars()
+                .all(|c| c.is_ascii_hexdigit() || matches!(c, '.' | '-' | '+' | 'f' | 'u' | 'x'))
+    };
+    if numeric(value) {
+        return true;
+    }
+    value
+        .strip_suffix(')')
+        .and_then(|inner| inner.split_once('('))
+        .is_some_and(|(name, argument)| {
+            !name.is_empty()
+                && name
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || matches!(c, '_' | ':'))
+                && numeric(argument)
+        })
+}
+
 /// `local_N = K; return K;` — the store is DEAD. The very next statement leaves the function, so
 /// no path can read what it wrote.
 ///
@@ -12051,6 +12112,12 @@ fn drop_dead_stores_before_return(body: &str) -> String {
     for (at, line) in lines.iter().enumerate() {
         let dead = (|| {
             let (target, value) = slot_store(line)?;
+            // Only a CONSTANT is safe to drop. The two lines carrying the same text says nothing
+            // about a call: `local_2 = Consume(); return Consume();` calls twice on purpose, and
+            // dropping the store would drop the first call with it.
+            if !is_constant_literal(&value) {
+                return None;
+            }
             let next = lines.get(at + 1)?;
             (next.trim() == format!("return {value};") && indent_of(next) == indent_of(line))
                 .then_some(target)

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1428,7 +1428,7 @@ fn emit_function_ctor(
     };
     let (body, _) = rewrite_value_temporaries(&body, &inferred_locals);
     let body = drop_dead_stores(&body);
-    let body = fold_literal_temporaries(&body, refs);
+    let body = fold_literal_temporaries(&body, refs, &declared_locals);
     let body = fold_constant_comparisons(&body);
     let body = fold_double_negations(&body);
     let body = fold_negated_stores(&body);
@@ -1453,7 +1453,14 @@ fn emit_function_ctor(
     );
     // Runs after the producers have moved into their readers: only then is the value arm of a
     // short circuit the single assignment it was in source.
-    let body = fold_short_circuits(&body, &proven_locals, refs, fields, &HashMap::new());
+    let body = fold_short_circuits(
+        &body,
+        &proven_locals,
+        refs,
+        fields,
+        &HashMap::new(),
+        class_name,
+    );
     let body = join_short_circuit_chains(&body);
     // Again, now that the chain IS one expression: the negation fold ran before the short
     // circuits were recovered, so `X = A && B; X = !X;` was still two branches then. Left as two
@@ -2056,7 +2063,14 @@ fn emit_function_ctor(
         // Again on the joined text: a short circuit whose CONDITION is itself a short circuit is
         // only one condition once the inner one has folded, and the pass that folds it ran before
         // that happened. The outer arm then still stands as an if/else over a bool carrier.
-        let rendered = fold_short_circuits(&rendered, &proven_locals, refs, fields, &path_roots);
+        let rendered = fold_short_circuits(
+            &rendered,
+            &proven_locals,
+            refs,
+            fields,
+            &path_roots,
+            class_name,
+        );
         let rendered = join_short_circuit_chains(&rendered);
         let rendered = rejoin_short_circuit_chains(&rendered);
         let rendered =
@@ -6469,7 +6483,11 @@ fn expression_start(line: &str, end: usize) -> Option<usize> {
 /// a wider store plus a narrowing conversion (`SetV4` + `iTOb` where vanilla has `SetV1`). Fold
 /// the literal into its use. A literal has no side effect and no evaluation order, so the only
 /// thing this can change is which slot the recompiler allocates.
-fn fold_literal_temporaries(body: &str, refs: &RefResolver) -> String {
+fn fold_literal_temporaries(
+    body: &str,
+    refs: &RefResolver,
+    locals: &BTreeMap<i32, String>,
+) -> String {
     let trailing_newline = body.ends_with('\n');
     let lines: Vec<&str> = body.lines().collect();
     let mut folded: Vec<String> = lines.iter().map(|line| (*line).to_owned()).collect();
@@ -6516,6 +6534,37 @@ fn fold_literal_temporaries(body: &str, refs: &RefResolver) -> String {
             let literal = assignment_rhs_for(&folded[definition], &ident)
                 .expect("the definition matched above")
                 .to_owned();
+            // A loop carrying the next definition back to this read means the read does not see
+            // the literal on every pass. That only makes the slot a NAME the source wrote if what
+            // comes back is a value: a slot whose next store is another constant is the scratch
+            // the compiler reuses for two of them, and folding it in was right. So the witness is
+            // the carried write itself — `best = candidate;` and not `flag = 0;`.
+            let carries_a_value = folded.get(region_end).is_some_and(|line| {
+                assignment_rhs_for(line, &ident).is_some_and(|rhs| !is_foldable_literal(rhs))
+            });
+            // …and the read has to be the COMPARISON that running value exists for. A slot read
+            // as an argument is a flag the callee is handed, and a `true` folded into that
+            // argument is right however many times the loop runs.
+            let read_is_a_comparison = [" < ", " > ", " <= ", " >= "].iter().any(|operator| {
+                folded[use_line].contains(&format!("{ident}{operator}"))
+                    || folded[use_line].contains(&format!("{operator}{ident}"))
+            });
+            if carries_a_value
+                && read_is_a_comparison
+                && a_loop_carries_the_write_back_to_the_read(&folded, use_line, region_end)
+            {
+                let declaration_restates_it = folded[..definition]
+                    .iter()
+                    .all(|line| count_ident(line, &ident) == 0)
+                    && locals
+                        .get(&slot)
+                        .is_some_and(|ty| is_primitive(ty) && default_for(ty) == literal);
+                if declaration_restates_it {
+                    folded[definition].clear();
+                    dropped = true;
+                }
+                continue;
+            }
             folded[use_line] = rename_ident(&folded[use_line], &ident, &literal);
             folded[definition].clear();
             dropped = true;
@@ -6533,6 +6582,54 @@ fn fold_literal_temporaries(body: &str, refs: &RefResolver) -> String {
         joined.push('\n');
     }
     joined
+}
+
+/// True when a loop carries the write at `write` back around to the read at `read`.
+///
+/// [`fold_literal_temporaries`] owns a slot's value from one definition to the next by LINE
+/// NUMBER, and a loop's back edge runs through that span backwards: the write standing below the
+/// read is what the read sees on every pass after the first. The compiler agrees — it gave the
+/// compare the slot, not the literal a folded constant would need. Folding it in rewrites
+/// `if (best < candidate)` into `if (0.0 < candidate)`, which is a different program: five
+/// running-maximum functions in this tree, each a `float` seeded at zero and compared against the
+/// element it is looking for.
+///
+/// The braces are the emitter's own — a block opens and closes on lines that hold nothing else —
+/// so a standalone `{` behind a `for`/`while`/`do` header is a loop body and the matching `}` is
+/// where it ends. Braces that do not balance are braces this cannot read, and it refuses.
+fn a_loop_carries_the_write_back_to_the_read(lines: &[String], read: usize, write: usize) -> bool {
+    if write <= read {
+        return false;
+    }
+    let mut open: Vec<(usize, bool)> = Vec::new();
+    let mut heading: Option<usize> = None;
+    for (at, line) in lines.iter().enumerate() {
+        match brace_net(line) {
+            1 => {
+                let heads_a_loop = heading.is_some_and(|head| {
+                    let text = lines[head].trim_start();
+                    text.starts_with("for") || text.starts_with("while") || text.starts_with("do")
+                });
+                open.push((at, heads_a_loop));
+                heading = None;
+            }
+            -1 => {
+                let Some((start, heads_a_loop)) = open.pop() else {
+                    return true;
+                };
+                if heads_a_loop && start < read && at > write {
+                    return true;
+                }
+                heading = None;
+            }
+            _ => {
+                if !line.trim().is_empty() {
+                    heading = Some(at);
+                }
+            }
+        }
+    }
+    !open.is_empty()
 }
 
 /// True when the ident's only appearance is somewhere a literal is certainly legal: the whole
@@ -6861,7 +6958,7 @@ fn inline_temporary_into(
                 // A `return` is refused because a returned REFERENCE may not be a temporary.
                 // A bool is not one, and the cache can say so.
                 || (lines[index].trim().starts_with("return ")
-                    && renders_a_bool(&value, locals, refs, fields, &HashMap::new())))
+                    && renders_a_bool(&value, locals, refs, fields, &HashMap::new(), None)))
                 && (same_typed_own_field(&value, temp, locals, fields)
                     || is_call_result(&value)
                     || names_a_static_class(&value, temp, locals)
@@ -6881,7 +6978,7 @@ fn inline_temporary_into(
                 || same_typed_own_field(&value, temp, locals, fields)
                 || names_a_static_class(&value, temp, locals)
                 || (temporary_type(locals, temp) == Some("bool")
-                    && renders_a_bool(&value, locals, refs, fields, &HashMap::new()))
+                    && renders_a_bool(&value, locals, refs, fields, &HashMap::new(), None))
         }
     };
     if !movable {
@@ -7518,7 +7615,7 @@ fn fold_condition_temporaries(
     // A field of the class carries its type in the class's own map, which `renders_a_bool` does
     // not read.
     let is_a_bool = |value: &str| {
-        renders_a_bool(value, locals, refs, fields, &HashMap::new())
+        renders_a_bool(value, locals, refs, fields, &HashMap::new(), None)
             || value
                 .strip_prefix("this.")
                 .and_then(|field| fields?.get(field))
@@ -7559,7 +7656,7 @@ fn fold_condition_temporaries(
                 })
                 .filter(|_| {
                     temporary_type(locals, &name) == Some("bool")
-                        && renders_a_bool(&value, locals, refs, fields, &HashMap::new())
+                        && renders_a_bool(&value, locals, refs, fields, &HashMap::new(), None)
                 });
             // Or the slot is an INT the emitter compares against zero to read as a bool. Where
             // the value is a bool, that comparison is the int slot's doing and nothing else's:
@@ -10719,11 +10816,26 @@ fn chain_inlined_cast_operands(f: &Func) -> HashSet<i32> {
         return HashSet::new();
     };
     let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
-    let freed: HashSet<i32> = instrs
-        .iter()
-        .filter(|ins| ins.op.name == "FreeNullV8")
-        .map(&w0)
-        .collect();
+    // The release is what FREED the slot for this cast — a temporary died there, which is the
+    // whole witness — so it stands in front of the cast, not behind it. What ties it to this cast
+    // rather than to some other life of the same slot is that no OTHER cast wrote that slot: then
+    // the only cast the release can have made room for is this one. A slot two casts share is
+    // left alone.
+    let mut releases: HashMap<i32, Vec<usize>> = HashMap::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name == "FreeNullV8" {
+            releases.entry(w0(ins)).or_default().push(at);
+        }
+    }
+    let mut cast_destinations: HashMap<i32, usize> = HashMap::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "TYPEID" {
+            continue;
+        }
+        if let Some(destination) = instrs.get(at + 1).filter(|ins| ins.op.name == "PSF") {
+            *cast_destinations.entry(w0(destination)).or_default() += 1;
+        }
+    }
     let mut out = HashSet::new();
     for (at, ins) in instrs.iter().enumerate() {
         if ins.op.name != "TYPEID" {
@@ -10737,7 +10849,12 @@ fn chain_inlined_cast_operands(f: &Func) -> HashSet<i32> {
             continue;
         };
         let operand = w0(operand);
-        if !freed.contains(&w0(destination)) || operand <= 0 {
+        let destination = w0(destination);
+        let this_cast_owns_the_release = cast_destinations.get(&destination) == Some(&1)
+            && releases
+                .get(&destination)
+                .is_some_and(|at_list| at_list.iter().any(|release| *release < at));
+        if !this_cast_owns_the_release || operand <= 0 {
             continue;
         }
         out.insert(operand);
@@ -10887,6 +11004,14 @@ fn lead_with_the_declaration(body: &str, slot: Option<i32>) -> String {
     // it would lift it back to function scope and lose the per-iteration construction the sink
     // recovered.
     if indent_of(&lines[at]).len() > indent_of(&lines[head]).len() {
+        return body.to_owned();
+    }
+    // The witness names a SLOT, and the first instruction pair is the first life of it. Where the
+    // text still carries another life, that pair says nothing about which of them was declared
+    // first, and moving the wrong one runs a constructor ahead of the call it belongs behind.
+    if lines.iter().any(|line| {
+        count_ident(line, &format!("{ident}_2")) > 0 || count_ident(line, &format!("{ident}_3")) > 0
+    }) {
         return body.to_owned();
     }
     let declaration = lines.remove(at);
@@ -12468,12 +12593,15 @@ fn fold_short_circuits(
     refs: &RefResolver,
     fields: Option<&HashMap<String, String>>,
     roots: &HashMap<String, String>,
+    class_name: Option<&str>,
 ) -> String {
     let lines: Vec<&str> = body.lines().collect();
     let mut kept: Vec<String> = Vec::new();
     let mut at = 0usize;
     while at < lines.len() {
-        if let Some((folded, after)) = short_circuit(&lines, at, locals, refs, fields, roots) {
+        if let Some((folded, after)) =
+            short_circuit(&lines, at, locals, refs, fields, roots, class_name)
+        {
             kept.push(folded);
             at = after;
             continue;
@@ -12497,6 +12625,7 @@ fn short_circuit(
     refs: &RefResolver,
     fields: Option<&HashMap<String, String>>,
     roots: &HashMap<String, String>,
+    class_name: Option<&str>,
 ) -> Option<(String, usize)> {
     let condition = lines.get(at)?.trim().strip_prefix("if (")?.strip_suffix(')')?;
     if lines.get(at + 1)?.trim() != "{" {
@@ -12572,7 +12701,12 @@ fn short_circuit(
     // A PARAMETER carries its type in the signature, not in the slot table: `const bool
     // bIsImmortal` is as much a bool as any local, and asking only the locals left the outer arm
     // of `A || bIsImmortal` standing as an if/else over a carrier.
-    let value_is_bool = renders_a_bool(&value, locals, refs, fields, roots)
+    // And a field declared on a NATIVE ancestor carries its type in the Binds table, not in the
+    // class's own map: `this.bShouldExitState` is a bool `UCharacterAIState` wrote down, four
+    // script supers above the class that reads it, and asking only the script hierarchy left
+    // `A || this.bShouldExitState` standing as an if/else over a carrier in both overrides of
+    // `TryConfrontCriminal`.
+    let value_is_bool = renders_a_bool(&value, locals, refs, fields, roots, class_name)
         || roots.get(value.as_str()).is_some_and(|ty| ty == "bool");
     if temporary_type(locals, &target) != Some("bool") || !value_is_bool {
         sc_reject(
@@ -12723,13 +12857,50 @@ fn turned_around(condition: &str) -> String {
     format!("!({condition})")
 }
 
+/// The type of `this.<field>` where the field was declared not on the class but past the point
+/// where the script hierarchy ends. `class_field_types` already merges every ancestor the script
+/// cache knows, walking `super` until the name it is handed is one no module declares — so a
+/// field still missing from that map was written down in the engine, on the native class the last
+/// script super names. `bShouldExitState` is the case measured: `UAIState_InvestigateAlarm`
+/// climbs four script supers to `UGothicCharacterAIState`, whose super `UCharacterAIState` is a
+/// name and nothing else to the script cache. The Binds table is where that class is written
+/// down, and it is keyed by the exact class with no ancestry of its own, so the walk has to
+/// arrive at the right name before it asks.
+///
+/// Every step is a step the cache itself recorded, and the walk stops the moment it runs out of
+/// them: a class the hierarchy does not name, a class the Binds table has nothing to say about,
+/// or the 64 steps past which a super chain is not a chain. Where no Binds profile was loaded at
+/// all there is no table to ask and this answers nothing, which is the same silence. Nothing is
+/// guessed about a name that does not resolve, because the answer decides whether a value may
+/// become an operand of `||`, and an operand that is not a bool does not merely fail to
+/// compile — it takes the compiler down.
+fn inherited_native_field_type<'a>(
+    refs: &'a RefResolver,
+    class_name: Option<&str>,
+    field: &str,
+) -> Option<&'a str> {
+    let class = class_name?;
+    if let Some(ty) = refs.native_field_value_type(class, field) {
+        return Some(ty);
+    }
+    let mut current = refs.class_super_of(class)?;
+    for _ in 0..64 {
+        if let Some(ty) = refs.native_field_value_type(current, field) {
+            return Some(ty);
+        }
+        current = refs.class_super_of(current)?;
+    }
+    None
+}
+
 /// Whether a rendered value is a bool: a slot the type table calls one, a bool literal, or a call
 /// every declaration of that name returns bool from. An operand that is not one may not carry a
 /// `&&` — and the compiler does not merely refuse it, it goes down.
 /// The declared type a member PATH resolves to, walking it one segment at a time.
 ///
-/// The first segment names either `this` — whose members are the class's own field map — or a
-/// local or parameter, whose type `roots` carries. Every further segment is a field of the type
+/// The first segment names either `this` — whose members are the class's own field map, and
+/// failing that the native ancestor the map stops short of — or a local or parameter, whose type
+/// `roots` carries. Every further segment is a field of the type
 /// the previous one resolved to, answered by the script class table or, failing that, by the
 /// native field table. A segment that does not resolve ends the walk: this answers only what it
 /// can prove, because the caller uses the answer to decide whether a value may become an operand
@@ -12739,6 +12910,7 @@ fn member_path_type(
     roots: &HashMap<String, String>,
     fields: Option<&HashMap<String, String>>,
     refs: &RefResolver,
+    class_name: Option<&str>,
 ) -> Option<String> {
     if value.contains(['(', ')', '[', ']', ' ', '\u{1}', '\u{2}']) {
         return None;
@@ -12748,7 +12920,10 @@ fn member_path_type(
     let mut ty = match head {
         "this" => {
             let first = parts.next()?;
-            fields?.get(first)?.clone()
+            match fields.and_then(|map| map.get(first)) {
+                Some(ty) => ty.clone(),
+                None => inherited_native_field_type(refs, class_name, first)?.to_owned(),
+            }
         }
         _ => roots.get(head)?.clone(),
     };
@@ -12768,6 +12943,7 @@ fn renders_a_bool(
     refs: &RefResolver,
     fields: Option<&HashMap<String, String>>,
     roots: &HashMap<String, String>,
+    class_name: Option<&str>,
 ) -> bool {
     if matches!(value, "true" | "false") || temporary_type(locals, value) == Some("bool") {
         return true;
@@ -12783,19 +12959,26 @@ fn renders_a_bool(
     // once the path is walked segment by segment. Without the walk, `local_46.bWitnessIsGuildOwner`
     // is an unknown, the arm stays an if/else over a carrier, and the copy that costs is ours.
     // Measured: 86 such arms still stand, and only two of them are a bare `this.<field>`.
-    if member_path_type(value, roots, fields, refs).as_deref() == Some("bool") {
+    if member_path_type(value, roots, fields, refs, class_name).as_deref() == Some("bool") {
         return true;
     }
     // A negation and a comparison are bools whatever they wrap, and a fully parenthesized value
     // is whatever it holds.
     if let Some(negated) = value.strip_prefix('!') {
-        return renders_a_bool(negated, locals, refs, fields, roots);
+        return renders_a_bool(negated, locals, refs, fields, roots, class_name);
     }
     if value.starts_with('(')
         && matching_paren(value, 0) == Some(value.len() - 1)
         && value.len() > 2
     {
-        return renders_a_bool(&value[1..value.len() - 1], locals, refs, fields, roots);
+        return renders_a_bool(
+            &value[1..value.len() - 1],
+            locals,
+            refs,
+            fields,
+            roots,
+            class_name,
+        );
     }
     if [" == ", " != ", " < ", " > ", " <= ", " >= ", " && ", " || "]
         .iter()

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -519,7 +519,7 @@ fn recover_module_defaults<'a>(
             Some(&fields),
             Some(&c.name),
         );
-        if std::env::var_os("GORE_AS_DEFAULTS_DEBUG").is_some() {
+        if diag_enabled("GORE_AS_DEFAULTS_DEBUG") {
             eprintln!(
                 "[defaults] ---- {} ----
 {rendered}",
@@ -731,7 +731,7 @@ fn emit_class(s: &mut String, c: &Class, refs: &RefResolver, defaults: Option<&[
             param_sig(m, refs),
             const_method
         )) {
-            if std::env::var_os("GORE_AS_DUP_DIAG").is_some() {
+            if diag_enabled("GORE_AS_DUP_DIAG") {
                 eprintln!(
                     "[dup] {}::{}({}) traits={:#x} const_method={} ret={} ret_const={}",
                     c.name,
@@ -1863,6 +1863,7 @@ fn emit_function_ctor(
                 refs,
                 &range_for_iterator_slots(f, refs),
                 &proceed_element_slots(f, refs),
+                &reference_locals,
             );
         // Before the declaration merge: a conversion naming the type the value already has hides
         // the copy-construction the merge is looking for.
@@ -3903,7 +3904,7 @@ fn reference_result_slots(f: &Func, refs: &RefResolver) -> HashMap<i32, bool> {
             }
             _ => None,
         };
-        if std::env::var_os("GORE_AS_REF_DIAG").is_some() {
+        if diag_enabled("GORE_AS_REF_DIAG") {
             eprintln!(
                 "[ref] {} slot={:?} ret={:?}",
                 call.op.name,
@@ -9197,7 +9198,7 @@ fn fold_compound_assignments(
             let value = unwrap_brackets(value);
             let rest = value.strip_prefix(target).or_else(|| {
                 let ty = type_of_member_path(target, fields, roots, refs);
-                if std::env::var_os("GORE_AS_COMPOUND_DIAG").is_some() {
+                if diag_enabled("GORE_AS_COMPOUND_DIAG") {
                     eprintln!("[compound] cast {ty:?} for {target} | {value}");
                 }
                 value.strip_prefix(&format!("{}({target})", ty?))
@@ -9215,7 +9216,7 @@ fn fold_compound_assignments(
         // Or through a carrier the decompiler put in: read the member, change it, write it back.
         // Three statements, one member path, and a local nothing else in the body touches.
         let refuse = |reason: &str| -> Option<String> {
-            if std::env::var_os("GORE_AS_COMPOUND_DIAG").is_some() {
+            if diag_enabled("GORE_AS_COMPOUND_DIAG") {
                 eprintln!("[compound] {reason} | {}", lines[at].trim());
             }
             None
@@ -10924,7 +10925,7 @@ fn fold_member_read_temporaries(
                 (Some("float" | "double"), Some("float32"))
             ) && !widened.contains(&slot);
             if locals.get(&slot) != member.as_ref() && !read_puts_it_there && !widens_only {
-                if std::env::var_os("GORE_AS_MEMBER_DIAG").is_some() {
+                if diag_enabled("GORE_AS_MEMBER_DIAG") {
                     eprintln!(
                         "[member] {} slot={:?} member={:?} | {}",
                         match member.is_none() {
@@ -11504,7 +11505,7 @@ fn parenthesize_mixed(part: &str, operator: &str) -> String {
 
 /// Why a short circuit was not folded, behind `GORE_AS_SC_DIAG`.
 fn sc_reject(reason: &str, line: &str) {
-    if std::env::var_os("GORE_AS_SC_DIAG").is_some() {
+    if diag_enabled("GORE_AS_SC_DIAG") {
         eprintln!("[sc-reject] {reason} | {}", line.trim());
     }
 }
@@ -11798,8 +11799,25 @@ fn strip_unreachable<'a>(lines: &[&'a str], at: &mut usize, kept: &mut Vec<&'a s
 }
 
 /// Diagnostic counter for why an argument could not be moved back into its call.
+/// Diagnostic flags, read once. These sit inside per-line loops over bodies with tens of
+/// thousands of statements, and an environment lookup there costs more than the work it guards.
+fn diag_enabled(name: &'static str) -> bool {
+    use std::collections::HashMap;
+    use std::sync::{OnceLock, RwLock};
+    static FLAGS: OnceLock<RwLock<HashMap<&'static str, bool>>> = OnceLock::new();
+    let flags = FLAGS.get_or_init(Default::default);
+    if let Some(known) = flags.read().ok().and_then(|map| map.get(name).copied()) {
+        return known;
+    }
+    let value = std::env::var_os(name).is_some();
+    if let Ok(mut map) = flags.write() {
+        map.insert(name, value);
+    }
+    value
+}
+
 fn inline_reject(reason: &str, callee: &str, temp: &str, statement: &str) {
-    if std::env::var_os("GORE_AS_INLINE_DIAG").is_some() {
+    if diag_enabled("GORE_AS_INLINE_DIAG") {
         eprintln!("[inline-reject] {reason} {callee} {temp} | {}", statement.trim());
     }
 }
@@ -12060,7 +12078,7 @@ fn is_value_struct_type(ty: &str) -> bool {
 /// One line per refused range-for, behind `GORE_AS_FOREACH_DIAG`, so the reasons can be counted
 /// over the whole corpus instead of guessed at from one example.
 fn foreach_reject(reason: &str) {
-    if std::env::var_os("GORE_AS_FOREACH_DIAG").is_some() {
+    if diag_enabled("GORE_AS_FOREACH_DIAG") {
         eprintln!("[foreach-reject] {reason}");
     }
 }
@@ -12071,6 +12089,7 @@ fn rewrite_foreach_loops(
     refs: &RefResolver,
     range_for: &HashSet<i32>,
     elements: &HashMap<i32, i32>,
+    reference_locals: &HashMap<i32, bool>,
 ) -> (String, HashSet<i32>) {
     let trailing_newline = body.ends_with('\n');
     let lines: Vec<&str> = body.lines().collect();
@@ -12169,12 +12188,22 @@ fn rewrite_foreach_loops(
         // The range-for element is READ-ONLY. A body that writes through it, or calls a method
         // the cache records as non-const, only compiles in the while-shape the structurer
         // recovered — so that loop keeps it.
-        if element_is_written_through(
-            &lines[i + 4..end],
-            &elem_ident,
-            locals.get(&elem).map(String::as_str),
-            refs,
-        ) {
+        // …unless the element is a REFERENCE. The refusal exists because a range-for element is
+        // read-only, which is true of a copied element and not of one the iterator hands back by
+        // reference — and vanilla settles which this is: it jumps STRAIGHT to the bottom test,
+        // the range-for shape, while writing through the element. A reference declaration on the
+        // `Proceed()` line is that same fact stated in the text.
+        // This pass runs before the declarations are written, so the fact is taken from the
+        // bytecode rather than from the text.
+        let element_by_reference = reference_locals.contains_key(&elem);
+        if !element_by_reference
+            && element_is_written_through(
+                &lines[i + 4..end],
+                &elem_ident,
+                locals.get(&elem).map(String::as_str),
+                refs,
+            )
+        {
             foreach_reject("element-written-through");
             continue;
         }
@@ -12191,7 +12220,13 @@ fn rewrite_foreach_loops(
             continue;
         }
         let indent = leading_indent(lines[i]);
-        replace[i] = Some(format!("{indent}for (auto {elem_ident} : {container})"));
+        // An element the body writes through has to be spelled as a reference: a plain `auto`
+        // element is a copy and read-only, which is what the refusal above is about.
+        let elem_head = match element_by_reference {
+            true => "auto&",
+            false => "auto",
+        };
+        replace[i] = Some(format!("{indent}for ({elem_head} {elem_ident} : {container})"));
         drop_line[i + 1] = true;
         match &inline_elem {
             // the element was read inside a larger expression: keep that statement, with the name
@@ -13633,6 +13668,7 @@ mod source_shape_tests {
                 &RefResolver::default(),
                 &std::collections::HashSet::new(),
                 &std::collections::HashMap::new(),
+                &std::collections::HashMap::new(),
             );
         assert_eq!(
             out,
@@ -13668,7 +13704,8 @@ mod source_shape_tests {
             &RefResolver::default(),
             &std::collections::HashSet::new(),
             &std::collections::HashMap::new(),
-        );
+                &std::collections::HashMap::new(),
+            );
         assert_eq!(
             out,
             concat!(
@@ -13702,6 +13739,7 @@ mod source_shape_tests {
                 &RefResolver::default(),
                 &std::collections::HashSet::new(),
                 &std::collections::HashMap::new(),
+                &std::collections::HashMap::new(),
             );
         assert_eq!(out, body);
         assert!(gone.is_empty());
@@ -13723,6 +13761,7 @@ mod source_shape_tests {
                 &locals(&[(16, "AActor")]),
                 &RefResolver::default(),
                 &std::collections::HashSet::new(),
+                &std::collections::HashMap::new(),
                 &std::collections::HashMap::new(),
             );
         assert_eq!(out, body);

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -11198,8 +11198,14 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
     let mut lines: Vec<String> = body.lines().map(str::to_owned).collect();
     // A name that exists for NOTHING BUT receiver pairs: one hoisted declaration plus exactly two
     // mentions per pair, and not one more. See the cap below for why the count is taken up front.
-    let receiver_only: HashSet<String> = {
-        let mut pairs: HashMap<String, usize> = HashMap::new();
+    // name -> how many of its receiver pairs are COMPOUND assignments. A compound one through a
+    // call receiver (`this.GetG1R().Counter += 1;`) is a form the tree cannot carry — shipping 19
+    // of them took the compiler down with no diagnostic — so those pairs never fold. They still
+    // have to be COUNTED: a name whose other pairs are plain is eligible, and its declaration has
+    // to survive for the compound sites that keep using it.
+    let receiver_only: HashMap<String, usize> = {
+        let mut plain: HashMap<String, usize> = HashMap::new();
+        let mut compound: HashMap<String, usize> = HashMap::new();
         for at in 0..lines.len().saturating_sub(1) {
             let head = declaration_with_initializer(&lines[at]).or_else(|| {
                 let (target, value) = slot_store(&lines[at])?;
@@ -11215,26 +11221,27 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             {
                 continue;
             }
-            // Only a PLAIN assignment. A compound one through a call receiver
-            // (`this.GetG1R().Counter += 1;`) is a form the tree had not carried before, and
-            // shipping 19 of them took the compiler down with no diagnostic at all. Counting the
-            // pair here is what lets the whole name fail the mention test below, so its
-            // declaration is never removed out from under a statement that still needs it.
-            if !lines[at + 1].trim().contains(" = ") {
-                continue;
+            let assigned = lines[at + 1].trim();
+            if assigned.contains(" = ") {
+                *plain.entry(name).or_default() += 1;
+            } else if [" += ", " -= ", " *= ", " /= ", " |= ", " &= ", " ^= "]
+                .iter()
+                .any(|op| assigned.contains(op))
+            {
+                *compound.entry(name).or_default() += 1;
             }
-            *pairs.entry(name).or_default() += 1;
         }
-        pairs
+        plain
             .into_iter()
-            .filter(|(name, count)| {
+            .filter_map(|(name, count)| {
+                let compounds = compound.get(&name).copied().unwrap_or(0);
                 let declared = lines
                     .iter()
-                    .any(|line| bare_declaration(line).is_some_and(|(_, n)| n == *name));
-                let mentions: usize = lines.iter().map(|line| count_ident(line, name)).sum();
-                mentions == usize::from(declared) + 2 * count
+                    .any(|line| bare_declaration(line).is_some_and(|(_, n)| n == name));
+                let mentions: usize = lines.iter().map(|line| count_ident(line, &name)).sum();
+                (mentions == usize::from(declared) + 2 * (count + compounds))
+                    .then_some((name, compounds))
             })
-            .map(|(name, _)| name)
             .collect()
     };
     let mut at = 0usize;
@@ -11265,9 +11272,7 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             // the same tree compile). Kept to a name that is nothing BUT receiver pairs: one
             // conversation topic assigns six members of the same story object in a row, and
             // demanding a single pair is what left all six standing.
-            if !receiver_only.contains(&name) {
-                return None;
-            }
+            let compounds = *receiver_only.get(&name)?;
             let next = &lines[at + 1];
             if indent_of(next) != indent {
                 return None;
@@ -11280,7 +11285,12 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             if !target.starts_with('.') || target.contains('(') {
                 return None;
             }
-            Some((format!("{indent}{init}{assigned};"), declaration))
+            // A name that still has compound pairs keeps its declaration: those statements go on
+            // using it.
+            Some((
+                format!("{indent}{init}{assigned};"),
+                declaration.filter(|_| compounds == 0),
+            ))
         })();
         match folded {
             Some((line, declaration)) => {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1117,6 +1117,15 @@ fn emit_function_ctor(
             local_types.insert(slot, ty);
         }
     }
+    // The same narrowing, proved by the alias's own producer rather than by a cast.
+    for (slot, ty) in refcpy_source_types(f, refs) {
+        let narrows = local_types
+            .get(&slot)
+            .is_some_and(|wide| wide != &ty && (is_engine_base(wide) || wide == "?"));
+        if narrows {
+            local_types.insert(slot, ty);
+        }
+    }
     // member-access-derived types (`member_overrides`, computed above as the type lower-bound):
     // the field's declaring class is the strongest signal for a slot used as a member-access
     // base; apply AFTER (overriding) the call-arg guess.
@@ -1790,6 +1799,18 @@ fn emit_function_ctor(
                         || wide == "?"
                         || refs.is_subclass(&ty, wide))
             });
+            if narrows {
+                locals.insert(slot, ty);
+            }
+        }
+        // The alias narrowing has to reach the DECLARATION as well. Narrowing only the
+        // structurer's view takes the receiver wrap away while the declaration stays at the base,
+        // and the call then has nothing to resolve against — measured as a tree-wide
+        // `No matching signatures to 'UObject::GetRelationship()'`.
+        for (slot, ty) in refcpy_source_types(f, refs) {
+            let narrows = locals
+                .get(&slot)
+                .is_some_and(|wide| wide != &ty && (is_engine_base(wide) || wide == "?"));
             if narrows {
                 locals.insert(slot, ty);
             }
@@ -4096,6 +4117,102 @@ fn is_engine_base(t: &str) -> bool {
         t,
         "UObject" | "AActor" | "APawn" | "ACharacter" | "UActorComponent" | "UAbilitySystemComponent"
     )
+}
+
+/// Slots an alias names, with the type their PRODUCER declares.
+///
+/// `RefCpyV` is the instruction that says the source gave a handle a name — and it carries no
+/// type. The named slot therefore keeps whatever coarse type `obj_locals` recorded (`UObject`,
+/// `AActor`), and the structurer then has to write a `Cast<Owner>(recv)` at every call on it just
+/// to keep the call legal: a cast vanilla never had, and eight extra opcodes. For a `RefCpyV` the
+/// producer is one hop away and its DECLARED type is in reach — the field's own type or the
+/// callee's return, never a declaring class, which is the weaker signal that once typed
+/// `APawn local_8 = Cast<AGothicCharacter>(…)`.
+///
+/// Three clauses, all of them load-bearing. The recorded type must be an engine base (checked at
+/// the call site); the alias must be the slot's ONLY object write, so nothing else can have been
+/// upcast into it; and the slot must be a RECEIVER — a `PshVPtr` immediately before a call, since
+/// this compiler pushes arguments first and the receiver last. Without the last clause an
+/// `AActor local_6 = this.TargetEnemy;` that is only ever passed to `Add()` gets retyped, and
+/// vanilla's source really did widen that one.
+fn refcpy_source_types(f: &Func, refs: &RefResolver) -> Vec<(i32, String)> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return Vec::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let is_call = |name: &str| matches!(name, "CALL" | "CALLSYS" | "CALLINTF" | "CALLBND");
+    let mut object_writes: HashMap<i32, usize> = HashMap::new();
+    for ins in &instrs {
+        if matches!(
+            ins.op.name,
+            "STOREOBJ" | "RefCpyV" | "REFCPY" | "ClrVPtr" | "CpyVtoV8"
+        ) {
+            *object_writes.entry(w0(ins)).or_default() += 1;
+        }
+    }
+    let receiver: HashSet<i32> = instrs
+        .windows(2)
+        .filter(|pair| pair[0].op.name == "PshVPtr" && is_call(pair[1].op.name))
+        .map(|pair| w0(&pair[0]))
+        .collect();
+    let mut out = Vec::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        let slot = w0(ins);
+        if ins.op.name != "RefCpyV"
+            || slot <= 0
+            || object_writes.get(&slot).copied() != Some(1)
+            || !receiver.contains(&slot)
+        {
+            continue;
+        }
+        // Walk back to the producer, reading past the cleanup pairs a consumed temporary drags.
+        let mut back = at;
+        while back > 0 && instrs[back - 1].op.name == "RDSPtr" {
+            back -= 1;
+        }
+        let declared = if back > 0 && instrs[back - 1].op.name == "ADDSi" {
+            let field = &instrs[back - 1];
+            let off = field.words.first().copied().unwrap_or(0) as i32;
+            let tid = field.dwords.first().copied().unwrap_or(0) as i32;
+            refs.member(tid, off).and_then(|member| {
+                let class = refs.type_by_id(tid)?;
+                refs.field_type_by_class(class, member).map(str::to_owned)
+            })
+        } else if back > 0 && instrs[back - 1].op.name == "PshVPtr" {
+            let source = w0(&instrs[back - 1]);
+            let mut producer = back - 1;
+            while producer >= 2
+                && instrs[producer - 1].op.name == "CALLSYS"
+                && instrs[producer - 2].op.name == "PSF"
+                && refs.func_by_ptr(instrs[producer - 1].qwords.first().copied().unwrap_or(0) as i64)
+                    == Some("$beh2")
+            {
+                producer -= 2;
+            }
+            (producer >= 2
+                && instrs[producer - 1].op.name == "STOREOBJ"
+                && w0(&instrs[producer - 1]) == source)
+                .then(|| {
+                    let call = &instrs[producer - 2];
+                    match call.op.name {
+                        "CALLSYS" => refs
+                            .func_ret_by_ptr(call.qwords.first().copied().unwrap_or(0) as i64)
+                            .map(|ty| ty.base_name(refs)),
+                        "CALL" | "CALLINTF" | "CALLBND" => refs
+                            .func_ret_by_id(call.dwords.first().copied().unwrap_or(0) as i32)
+                            .map(|ty| ty.base_name(refs)),
+                        _ => None,
+                    }
+                })
+                .flatten()
+        } else {
+            None
+        };
+        if let Some(ty) = declared.filter(|ty| !is_engine_base(ty) && !ty.is_empty()) {
+            out.push((slot, ty));
+        }
+    }
+    out
 }
 
 fn cast_result_slots(f: &Func, refs: &RefResolver) -> Vec<(i32, String)> {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2103,6 +2103,11 @@ fn emit_function_ctor(
                         .into_iter()
                         .map(|slot| (slot, 1)),
                 )
+                .chain(
+                    return_expression_temporaries(f, refs)
+                        .into_iter()
+                        .flat_map(|slot| [(slot, 1), (slot, 2)]),
+                )
                 .collect(),
             &wholly_consumed_object_slots(f),
             &rvo_temporary_slots(f, refs),
@@ -2111,7 +2116,10 @@ fn emit_function_ctor(
         // Now that the operands carry no names of their own, an in-place update stands directly
         // under its declaration and the pair is one statement — which can expose another value.
         let rendered = merge_self_assignments(&rendered);
-        let rendered = inline_unnamed_value_temporaries(
+        let mut rendered = rendered;
+        // A returned expression folds one step per pass: three names in a chain need three.
+        for _ in 0..3 {
+        rendered = inline_unnamed_value_temporaries(
             &rendered,
             &unnamed_value_defs(f, refs)
                 .union(&immediately_consumed_defs(f))
@@ -2128,11 +2136,17 @@ fn emit_function_ctor(
                         .into_iter()
                         .map(|slot| (slot, 1)),
                 )
+                .chain(
+                    return_expression_temporaries(f, refs)
+                        .into_iter()
+                        .flat_map(|slot| [(slot, 1), (slot, 2)]),
+                )
                 .collect(),
             &wholly_consumed_object_slots(f),
             &rvo_temporary_slots(f, refs),
             refs,
         );
+        }
         let rendered =
             spell_out_argument_temporaries(
                 &rendered,
@@ -10827,6 +10841,57 @@ fn nested_expression_intermediates(f: &Func, refs: &RefResolver) -> HashSet<i32>
     out
 }
 
+/// The temporaries of a RETURN expression.
+///
+/// A function returning a value type ends by copy-constructing the return object out of the
+/// expression's last result — `PSF X; PshVPtr <return slot>; CALLSYS ::$beh0`. Whatever the
+/// compiler destroys immediately BEFORE that construction died with the expression, not with the
+/// scope: those slots are the steps of one returned expression, and the source named none of them.
+///
+/// The anchor is doing all the work, so it is required: a `void` function calling a method on a
+/// by-reference parameter has the same instruction triple, and reading that as a return
+/// expression names one byte-faithful slot wrongly.
+fn return_expression_temporaries(f: &Func, refs: &RefResolver) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    if f.ret.token == 0x52 {
+        return HashSet::new();
+    }
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let behaviour = |ins: &super::disasm::Instr, want: &str| {
+        ins.op.name == "CALLSYS"
+            && refs.func_by_ptr(ins.qwords.first().copied().unwrap_or(0) as i64) == Some(want)
+    };
+    let mut out = HashSet::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "PSF" || at < 2 {
+            continue;
+        }
+        let anchored = instrs
+            .get(at + 1)
+            .is_some_and(|ins| ins.op.name == "PshVPtr" && w0(ins) < 0)
+            && instrs.get(at + 2).is_some_and(|ins| behaviour(ins, "$beh0"));
+        if !anchored {
+            continue;
+        }
+        // Walk back over the destructor pairs standing directly in front of it.
+        let mut back = at;
+        while back >= 2
+            && instrs[back - 1].op.name == "CALLSYS"
+            && behaviour(&instrs[back - 1], "$beh2")
+            && instrs[back - 2].op.name == "PSF"
+        {
+            let slot = w0(&instrs[back - 2]);
+            if slot > 0 {
+                out.insert(slot);
+            }
+            back -= 2;
+        }
+    }
+    out
+}
+
 /// A short-circuit carrier the source never named at all.
 ///
 /// The compiler materialises a branch condition into a slot and reloads it — `CpyRtoV4 S;
@@ -11264,9 +11329,13 @@ fn inline_unnamed_value_temporaries(
                 // An arithmetic operator IS a receiver position: `a - b` is `a.opSub(b)`, and the
                 // operator overloads of a value type are const, so a temporary binds to them. The
                 // `.method()` spelling below is the same question written the other way.
+                // Either side of an arithmetic operator. The left is the receiver (`a - b` is
+                // `a.opSub(b)`); the right is the operand, and a value type's operator overloads
+                // take it by CONST reference — which is the one parameter kind a temporary binds
+                // to. Vanilla's own bytecode shows the compiler accepting both.
                 let operator = [" + ", " - ", " * ", " / "]
                     .iter()
-                    .any(|op| rest.starts_with(op));
+                    .any(|op| rest.starts_with(op) || consumer[..at].ends_with(op));
                 let method = match operator {
                     true => String::new(),
                     false => rest

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -8684,6 +8684,45 @@ fn fold_bool_member_comparisons(
             break;
         }
     }
+    // …and the same comparison standing on its own, with no declaration left to consume: a
+    // member the field tables PROVE is a bool needs no `!= 0`, and vanilla never spends the
+    // compare. This is what the pass above leaves behind once the local has folded away.
+    for line in &mut lines {
+        let mut at = 0usize;
+        while let Some(found) = line[at..].find(" != 0)") {
+            let close = at + found;
+            let Some(open) = line[..close].rfind('(') else {
+                at = close + 1;
+                continue;
+            };
+            // `(int(<path>) != 0)` is the whole shape: the structurer wraps a one-byte member
+            // read it could not type, and the boolean context then compares it. Both halves go,
+            // and only together — the wrap alone is what an INT local's initialiser needs, and
+            // dropping it there is "Can't implicitly convert bool to int".
+            let wrapped = line[..=open].ends_with("int(")
+                && open >= 4
+                && line[..close].ends_with(')')
+                && line.as_bytes().get(open - 4) == Some(&b'(');
+            let (outer, path) = match wrapped {
+                true => (open - 4, &line[open + 1..close - 1]),
+                false => (open, &line[open + 1..close]),
+            };
+            let is_path = !path.is_empty()
+                && path
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.'));
+            if is_path
+                && type_of_member_path(path, fields, roots, refs).as_deref() == Some("bool")
+            {
+                let replacement = path.to_owned();
+                let end = close + " != 0)".len();
+                line.replace_range(outer..end, &replacement);
+                at = outer + replacement.len();
+                continue;
+            }
+            at = close + 1;
+        }
+    }
     let mut out = lines.join("\n");
     if body.ends_with('\n') {
         out.push('\n');

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -10400,142 +10400,146 @@ fn sink_carrier_declarations(body: &str, witnessed: &HashSet<i32>) -> String {
     out
 }
 
+/// Every op that leaves a NEW value in its first operand.
+fn produces_value(op: &str) -> bool {
+    matches!(
+        op,
+        "RDR1"
+            | "RDR2"
+            | "RDR4"
+            | "RDR8"
+            | "fTOd"
+            | "dTOf"
+            | "iTOd"
+            | "iTOf"
+            | "uTOf"
+            | "uTOd"
+            | "CpyRtoV1"
+            | "CpyRtoV4"
+            | "CpyRtoV8"
+            | "NOT"
+            // A named literal is the destination of the COPY, not of the constant store:
+            // `bool b = false;` is `SetV1 vT,0; CpyVtoV4 vB,vT`. So a constant store with no
+            // copy behind it is a literal the source wrote where it is used.
+            | "SetV1"
+            | "SetV4"
+            | "SetV8"
+    )
+}
+
+/// Every op that WRITES its first operand — producing a new value, or updating one in place.
+fn writes_destination(op: &str) -> bool {
+    produces_value(op)
+        || matches!(
+            op,
+            "CpyVtoV4"
+                | "CpyVtoV8"
+                | "CpyGtoV4"
+                | "STOREOBJ"
+                | "RefCpyV"
+                | "REFCPY"
+                | "ClrVPtr"
+                | "LOADOBJ"
+                | "FreeNullV8"
+                | "SetV2"
+                | "ADDIf"
+                | "ADDIi"
+                | "ADDd"
+                | "ADDf"
+                | "ADDi"
+                | "ADDi64"
+                | "SUBIf"
+                | "SUBIi"
+                | "SUBd"
+                | "SUBf"
+                | "SUBi"
+                | "SUBi64"
+                | "MULIf"
+                | "MULIi"
+                | "MULd"
+                | "MULf"
+                | "MULi"
+                | "MULi64"
+                | "DIVd"
+                | "DIVf"
+                | "DIVi"
+                | "DIVi64"
+                | "DIVu"
+                | "DIVu64"
+                | "MODd"
+                | "MODf"
+                | "MODi"
+                | "MODi64"
+                | "MODu"
+                | "MODu64"
+                | "NEGd"
+                | "NEGf"
+                | "NEGi"
+                | "NEGi64"
+                | "INCd"
+                | "INCf"
+                | "INCi"
+                | "INCi8"
+                | "INCi16"
+                | "INCi64"
+                | "DECd"
+                | "DECf"
+                | "DECi"
+                | "DECi8"
+                | "DECi16"
+                | "DECi64"
+                | "IncVi"
+                | "DecVi"
+                | "BAND"
+                | "BAND64"
+                | "BOR"
+                | "BOR64"
+                | "BXOR"
+                | "BXOR64"
+                | "BSLL"
+                | "BSLL64"
+                | "BSRA"
+                | "BSRA64"
+                | "BSRL"
+                | "BSRL64"
+                | "POWd"
+                | "POWdi"
+                | "POWf"
+                | "POWi"
+                | "POWi64"
+                | "POWu"
+                | "POWu64"
+                | "sbTOi"
+                | "swTOi"
+                | "ubTOi"
+                | "uwTOi"
+                | "iTOb"
+                | "iTOw"
+                | "i64TOi"
+                | "iTOi64"
+                | "u64TOi"
+                | "iTOu64"
+                | "dTOi"
+                | "dTOu"
+                | "dTOi64"
+                | "dTOu64"
+                | "fTOi"
+                | "fTOu"
+                | "fTOi64"
+                | "fTOu64"
+        )
+}
+
 fn unnamed_value_defs(f: &Func, refs: &RefResolver) -> HashSet<(i32, usize)> {
     let Ok(instrs) = disassemble(&f.bytecode) else {
         return HashSet::new();
     };
     let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
-    let produces = |op: &str| {
-        matches!(
-            op,
-            "RDR1"
-                | "RDR2"
-                | "RDR4"
-                | "RDR8"
-                | "fTOd"
-                | "dTOf"
-                | "iTOd"
-                | "iTOf"
-                | "uTOf"
-                | "uTOd"
-                | "CpyRtoV1"
-                | "CpyRtoV4"
-                | "CpyRtoV8"
-                | "NOT"
-                // A named literal is the destination of the COPY, not of the constant store:
-                // `bool b = false;` is `SetV1 vT,0; CpyVtoV4 vB,vT`. So a constant store with no
-                // copy behind it is a literal the source wrote where it is used.
-                | "SetV1"
-                | "SetV4"
-                | "SetV8"
-        )
-    };
     // Every op that leaves a new value in its first operand. The compiler reuses a frame slot for
     // unrelated values, and the emitter names each of those separately (`local_8`, `local_8_2`), so
     // a value's life ends at the next write and the reads after it belong to someone else. The
     // list is spelled out: a name this MISSES lets a later life's read count as this one's single
     // reader, which is not a byte difference but a wrong program.
-    let writes = |op: &str| {
-        produces(op)
-            || matches!(
-                op,
-                "CpyVtoV4"
-                    | "CpyVtoV8"
-                    | "CpyGtoV4"
-                    | "STOREOBJ"
-                    | "RefCpyV"
-                    | "REFCPY"
-                    | "ClrVPtr"
-                    | "LOADOBJ"
-                    | "FreeNullV8"
-                    | "SetV2"
-                    | "ADDIf"
-                    | "ADDIi"
-                    | "ADDd"
-                    | "ADDf"
-                    | "ADDi"
-                    | "ADDi64"
-                    | "SUBIf"
-                    | "SUBIi"
-                    | "SUBd"
-                    | "SUBf"
-                    | "SUBi"
-                    | "SUBi64"
-                    | "MULIf"
-                    | "MULIi"
-                    | "MULd"
-                    | "MULf"
-                    | "MULi"
-                    | "MULi64"
-                    | "DIVd"
-                    | "DIVf"
-                    | "DIVi"
-                    | "DIVi64"
-                    | "DIVu"
-                    | "DIVu64"
-                    | "MODd"
-                    | "MODf"
-                    | "MODi"
-                    | "MODi64"
-                    | "MODu"
-                    | "MODu64"
-                    | "NEGd"
-                    | "NEGf"
-                    | "NEGi"
-                    | "NEGi64"
-                    | "INCd"
-                    | "INCf"
-                    | "INCi"
-                    | "INCi8"
-                    | "INCi16"
-                    | "INCi64"
-                    | "DECd"
-                    | "DECf"
-                    | "DECi"
-                    | "DECi8"
-                    | "DECi16"
-                    | "DECi64"
-                    | "IncVi"
-                    | "DecVi"
-                    | "BAND"
-                    | "BAND64"
-                    | "BOR"
-                    | "BOR64"
-                    | "BXOR"
-                    | "BXOR64"
-                    | "BSLL"
-                    | "BSLL64"
-                    | "BSRA"
-                    | "BSRA64"
-                    | "BSRL"
-                    | "BSRL64"
-                    | "POWd"
-                    | "POWdi"
-                    | "POWf"
-                    | "POWi"
-                    | "POWi64"
-                    | "POWu"
-                    | "POWu64"
-                    | "sbTOi"
-                    | "swTOi"
-                    | "ubTOi"
-                    | "uwTOi"
-                    | "iTOb"
-                    | "iTOw"
-                    | "i64TOi"
-                    | "iTOi64"
-                    | "u64TOi"
-                    | "iTOu64"
-                    | "dTOi"
-                    | "dTOu"
-                    | "dTOi64"
-                    | "dTOu64"
-                    | "fTOi"
-                    | "fTOu"
-                    | "fTOi64"
-                    | "fTOu64"
-            )
-    };
     let scope_exit = scope_exit_destroyed_slots(f, refs);
     let spilled = spilled_boolean_names(f, refs);
     // every definition of every slot, in program order — each is its own life
@@ -10544,7 +10548,7 @@ fn unnamed_value_defs(f: &Func, refs: &RefResolver) -> HashSet<(i32, usize)> {
     let mut out = HashSet::new();
     for (i, ins) in instrs.iter().enumerate() {
         let dst = w0(ins);
-        if dst > 0 && writes(ins.op.name) {
+        if dst > 0 && writes_destination(ins.op.name) {
             let life = lives.entry(dst).or_default();
             *life += 1;
             defs.push((dst, *life, i));
@@ -10552,7 +10556,7 @@ fn unnamed_value_defs(f: &Func, refs: &RefResolver) -> HashSet<(i32, usize)> {
     }
     for (slot, life, at) in defs {
         let ins = &instrs[at];
-        if !produces(ins.op.name) {
+        if !produces_value(ins.op.name) {
             continue;
         }
         // The element of a range-for is stored right after `Proceed()`, and it IS named — by the
@@ -10586,7 +10590,7 @@ fn unnamed_value_defs(f: &Func, refs: &RefResolver) -> HashSet<(i32, usize)> {
         // exactly one read, and it must come before the slot holds anything else
         let mut reads = 0usize;
         for other in &instrs[at + 1..] {
-            if w0(other) == slot && writes(other.op.name) {
+            if w0(other) == slot && writes_destination(other.op.name) {
                 break;
             }
             reads += super::bytediff::addressed_slots(other)
@@ -10811,6 +10815,47 @@ fn immediately_consumed_defs(f: &Func) -> HashSet<(i32, usize)> {
 /// its own `STOREOBJ`, which stands where the value is pushed.
 fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> String {
     let mut lines: Vec<String> = body.lines().map(str::to_owned).collect();
+    // A name that exists for NOTHING BUT receiver pairs: one hoisted declaration plus exactly two
+    // mentions per pair, and not one more. See the cap below for why the count is taken up front.
+    let receiver_only: HashSet<String> = {
+        let mut pairs: HashMap<String, usize> = HashMap::new();
+        for at in 0..lines.len().saturating_sub(1) {
+            let head = declaration_with_initializer(&lines[at]).or_else(|| {
+                let (target, value) = slot_store(&lines[at])?;
+                is_decompiler_local(&target).then(|| (indent_of(&lines[at]), target, value))
+            });
+            let Some((indent, name, init)) = head else {
+                continue;
+            };
+            if !init.ends_with(')')
+                || init.contains(" = ")
+                || indent_of(&lines[at + 1]) != indent
+                || !lines[at + 1].trim().starts_with(&format!("{name}."))
+            {
+                continue;
+            }
+            // Only a PLAIN assignment. A compound one through a call receiver
+            // (`this.GetG1R().Counter += 1;`) is a form the tree had not carried before, and
+            // shipping 19 of them took the compiler down with no diagnostic at all. Counting the
+            // pair here is what lets the whole name fail the mention test below, so its
+            // declaration is never removed out from under a statement that still needs it.
+            if !lines[at + 1].trim().contains(" = ") {
+                continue;
+            }
+            *pairs.entry(name).or_default() += 1;
+        }
+        pairs
+            .into_iter()
+            .filter(|(name, count)| {
+                let declared = lines
+                    .iter()
+                    .any(|line| bare_declaration(line).is_some_and(|(_, n)| n == *name));
+                let mentions: usize = lines.iter().map(|line| count_ident(line, name)).sum();
+                mentions == usize::from(declared) + 2 * count
+            })
+            .map(|(name, _)| name)
+            .collect()
+    };
     let mut at = 0usize;
     while at + 1 < lines.len() {
         let folded = (|| {
@@ -10823,7 +10868,11 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             if !init.ends_with(')') || init.contains(" = ") {
                 return None;
             }
-            if !consumed.contains(&slot_and_life_any(&name)?) {
+            // The slot's life number in the TEXT and in the bytecode disagree wherever an
+            // earlier life was folded away, so the witness is asked of the slot: some life of it
+            // is consumed where it is produced.
+            let (slot, _) = slot_and_life_any(&name)?;
+            if !consumed.iter().any(|(consumed, _)| *consumed == slot) {
                 return None;
             }
             let declaration = lines
@@ -10832,9 +10881,10 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             // Reusing the slot elsewhere is none of this fold's business in principle — the store
             // kills whatever it held — but folding EVERY such receiver at once pushes the whole
             // tree past the compiler's memory ceiling (four runs, no diagnostic, while subsets of
-            // the same tree compile). Kept to a name this function mentions nowhere else.
-            let mentions = 2 + usize::from(declaration.is_some());
-            if lines.iter().map(|line| count_ident(line, &name)).sum::<usize>() != mentions {
+            // the same tree compile). Kept to a name that is nothing BUT receiver pairs: one
+            // conversation topic assigns six members of the same story object in a row, and
+            // demanding a single pair is what left all six standing.
+            if !receiver_only.contains(&name) {
                 return None;
             }
             let next = &lines[at + 1];
@@ -10843,23 +10893,9 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             }
             let assigned = next.trim().strip_prefix(name.as_str())?.strip_suffix(';')?;
             // `= ` or any compound form: the receiver is evaluated once either way.
-            let (target, compound) = [" += ", " -= ", " *= ", " /= ", " |= ", " &= ", " ^= "]
-                .iter()
-                .find_map(|op| assigned.split_once(op).map(|(target, _)| (target, true)))
-                .or_else(|| assigned.split_once(" = ").map(|(target, _)| (target, false)))?;
-            // A compound assignment reads the receiver back, so the receiver must be a HANDLE:
-            // through a value-returning getter it would read and write a temporary.
-            if compound {
-                let head = lines[at].trim().trim_end_matches(';');
-                let declared = head[..head.len().saturating_sub(name.len() + init.len() + 3)].trim();
-                let declared = match declared.is_empty() {
-                    true => declared_type(&lines, &name).unwrap_or_default(),
-                    false => declared.to_owned(),
-                };
-                if !is_object_handle_type(&declared) {
-                    return None;
-                }
-            }
+            // A compound assignment through a call receiver is refused outright: see the
+            // pre-pass. Only the plain form folds.
+            let (target, _) = assigned.split_once(" = ")?;
             if !target.starts_with('.') || target.contains('(') {
                 return None;
             }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1582,6 +1582,15 @@ fn emit_function_ctor(
             locals.insert(*slot, "bool".into());
         }
     }
+    // A local vanilla constructs and never touches again leaves no trace in the text, so the
+    // hoist has to be told about it separately — with the type it already carries, never the
+    // `int` fallback below.
+    let mut used = used;
+    used.extend(
+        never_read_constructed_slots(f, refs)
+            .into_iter()
+            .filter(|slot| locals.contains_key(slot)),
+    );
     for &n in &used {
         locals.entry(n).or_insert_with(|| "int".to_string());
     }
@@ -2374,6 +2383,48 @@ fn used_idents(body: &str, prefix: &str) -> HashSet<i32> {
 }
 
 /// Slot indices of every `local_N` identifier referenced in a body.
+/// A value local the source DECLARED and then never touched.
+///
+/// It costs one thing and leaves one trace: the `PSF S; CALLSYS ::$beh0` that default-constructs
+/// it at entry. Its slot appears nowhere else in the whole function, so it appears nowhere in our
+/// text either, and the hoist — which reads the text — never learns it exists.
+///
+/// Measured: 6 such slots in 5 functions, every one of them divergent, none byte-faithful.
+fn never_read_constructed_slots(f: &Func, refs: &RefResolver) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let mut out = HashSet::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "PSF" {
+            continue;
+        }
+        let slot = w0(ins);
+        if slot <= 0 {
+            continue;
+        }
+        let constructs = instrs.get(at + 1).is_some_and(|next| {
+            next.op.name == "CALLSYS"
+                && refs.func_by_ptr(next.qwords.first().copied().unwrap_or(0) as i64)
+                    == Some("$beh0")
+        });
+        if !constructs {
+            continue;
+        }
+        let sole = !instrs.iter().enumerate().any(|(other, ins)| {
+            other != at
+                && super::bytediff::addressed_slots(ins)
+                    .into_iter()
+                    .any(|other_slot| other_slot == slot)
+        });
+        if sole {
+            out.insert(slot);
+        }
+    }
+    out
+}
+
 fn used_locals(body: &str) -> HashSet<i32> {
     let mut out = HashSet::new();
     let b = body.as_bytes();
@@ -3937,6 +3988,36 @@ fn reference_result_slots(f: &Func, refs: &RefResolver) -> HashMap<i32, bool> {
                     // "Cannot initialize reference variable of type T& with an expression of
                     // type const T".
                     out.insert(slot, ret.is_read_only || ret.is_object_const);
+                }
+            }
+        }
+    }
+    // The same fact through the OTHER shape a reference return takes: the reference register is
+    // pushed, dereferenced and copied on — `CALL…; PshRPtr; RDSPtr; RefCpyV vE`. That is how a
+    // range-for element reaches its `Proceed()` result, and reading it as a value is what made
+    // the loop keep a `while` shape vanilla never had.
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "RefCpyV" || at < 3 {
+            continue;
+        }
+        if instrs[at - 1].op.name != "RDSPtr" || instrs[at - 2].op.name != "PshRPtr" {
+            continue;
+        }
+        let call = &instrs[at - 3];
+        let returns = match call.op.name {
+            "CALLSYS" | "Thiscall1" => {
+                refs.func_ret_by_ptr(call.qwords.first().copied().unwrap_or(0) as i64)
+            }
+            "CALL" | "CALLINTF" | "CALLBND" => {
+                refs.func_ret_by_id(call.dwords.first().copied().unwrap_or(0) as i32)
+            }
+            _ => None,
+        };
+        if let Some(ret) = returns.filter(|ret| by_reference(ret)) {
+            if let Some(slot) = ins.words.first().map(|word| *word as i16 as i32) {
+                if slot > 0 {
+                    out.entry(slot)
+                        .or_insert(ret.is_read_only || ret.is_object_const);
                 }
             }
         }
@@ -12827,7 +12908,15 @@ fn element_is_written_through(
                 // `local_E.Field.Method(…)` reaches through the field. That only mutates when
                 // the method can: the cache records which ones are const, and a const call on a
                 // read-only range-for element is exactly what vanilla wrote.
-                if !refs.names_a_const_method(method) {
+                //
+                // …and a HANDLE element answers the same way it does one branch below: binding
+                // the handle says nothing about the object it points at, so reaching through it
+                // is not writing through the element. Without this the refusal fires and the
+                // loop keeps a `while (it.CanProceed)` shape — a shape vanilla has NOWHERE: all
+                // 626 `Iterator()` calls in the cache jump straight to the bottom test.
+                if !refs.names_a_const_method(method)
+                    && !ty.is_some_and(is_object_handle_type)
+                {
                     return true;
                 }
                 continue;

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -9491,6 +9491,16 @@ fn spell_out_default_temporaries(text: &str, defaults: &HashMap<i32, usize>) -> 
         let Some(fresh) = defaults.get(&slot).copied().filter(|count| *count > 0) else {
             continue;
         };
+        // The count is of the raw SLOT, and the compiler hands one out again as soon as the value
+        // in it dies. Where the text still carries a second life of it, some of those
+        // constructions are that life's, and spending them here rewrites a named value the source
+        // meant to pass into a `T()` that is not the same value at all.
+        if lines.iter().any(|line| {
+            count_ident(line, &format!("local_{slot}_2")) > 0
+                || count_ident(line, &format!("local_{slot}_3")) > 0
+        }) {
+            continue;
+        }
         let head = lines[index].trim().split(" = ").next().unwrap_or("");
         let ty = head[..head.len().saturating_sub(name.len())].trim().to_owned();
         if ty.is_empty() {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1864,6 +1864,7 @@ fn emit_function_ctor(
                 &range_for_iterator_slots(f, refs),
                 &proceed_element_slots(f, refs),
                 &reference_locals,
+                &inline_range_for_containers(f, refs),
             );
         // Before the declaration merge: a conversion naming the type the value already has hides
         // the copy-construction the merge is looking for.
@@ -12316,6 +12317,7 @@ fn rewrite_foreach_loops(
     range_for: &HashSet<i32>,
     elements: &HashMap<i32, i32>,
     reference_locals: &HashMap<i32, bool>,
+    inline_containers: &HashSet<i32>,
 ) -> (String, HashSet<i32>) {
     let trailing_newline = body.ends_with('\n');
     let lines: Vec<&str> = body.lines().collect();
@@ -12470,7 +12472,7 @@ fn rewrite_foreach_loops(
     }
 
     if suppressed.is_empty() {
-        return inline_foreach_containers(body);
+        return inline_foreach_containers(body, inline_containers);
     }
     let mut out: Vec<String> = Vec::with_capacity(lines.len());
     for (n, line) in lines.iter().enumerate() {
@@ -12483,9 +12485,52 @@ fn rewrite_foreach_loops(
     if trailing_newline {
         joined.push('\n');
     }
-    let (joined, inlined) = inline_foreach_containers(&joined);
+    let (joined, inlined) = inline_foreach_containers(&joined, inline_containers);
     suppressed.extend(inlined);
     (joined, suppressed)
+}
+
+/// The container of a range-for that the source wrote as a SUB-EXPRESSION of the header.
+///
+/// The compiler pushes the iterator's destination BEFORE it evaluates the container, so a container
+/// the source named reads `PSF <iterator>; PSF <container>; CALLSYS ::Iterator` — two pushes in a
+/// row, because a named local needs no evaluating. A container that is a sub-expression has to be
+/// evaluated first, and that evaluation stands between the two pushes. So a `PSF c; CALLSYS
+/// ::Iterator` whose preceding instruction is NOT itself a `PSF` is the witness that the source
+/// never named `c`, and the local we materialised for it belongs back in the header.
+fn inline_range_for_containers(f: &Func, refs: &RefResolver) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let mut out = HashSet::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "CALLSYS" {
+            continue;
+        }
+        let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+        if refs.func_by_ptr(ptr) != Some("Iterator") {
+            continue;
+        }
+        let Some(push) = at
+            .checked_sub(1)
+            .map(|prev| &instrs[prev])
+            .filter(|prev| prev.op.name == "PSF")
+        else {
+            continue;
+        };
+        if at >= 2 && instrs[at - 2].op.name == "PSF" {
+            continue;
+        }
+        if let Some(slot) = push
+            .words
+            .first()
+            .map(|word| *word as i16 as i32)
+            .filter(|slot| *slot > 0)
+        {
+            out.insert(slot);
+        }
+    }
+    out
 }
 
 /// The structurer materializes the iterated container into its own slot. Vanilla iterated the
@@ -12493,7 +12538,13 @@ fn rewrite_foreach_loops(
 /// Inline it when the local is written once from a pure path, read only by the loop header, and
 /// the loop body never touches that path — so iterating the member instead of a copy of it cannot
 /// observe a mutation the copy would have hidden.
-fn inline_foreach_containers(body: &str) -> (String, HashSet<i32>) {
+///
+/// Those two conditions are what the shape rule needs in the ABSENCE of a witness. Where
+/// [`inline_range_for_containers`] says vanilla evaluated the container in the header, they are
+/// beside the point: an initialiser with a call in it is then exactly what the source wrote, and
+/// "the body touches that path" describes vanilla's own program. The witness overrides them. The
+/// single-read condition stays either way — a container read anywhere but the header is a name.
+fn inline_foreach_containers(body: &str, witnessed: &HashSet<i32>) -> (String, HashSet<i32>) {
     let lines: Vec<&str> = body.lines().collect();
     let mut drop_line = vec![false; lines.len()];
     let mut replace: Vec<Option<String>> = vec![None; lines.len()];
@@ -12501,16 +12552,23 @@ fn inline_foreach_containers(body: &str) -> (String, HashSet<i32>) {
 
     for i in 0..lines.len() {
         let trimmed = lines[i].trim();
-        let Some(rest) = trimmed.strip_prefix("for (auto ") else {
+        let Some((head, rest)) = ["for (auto& ", "for (auto "]
+            .into_iter()
+            .find_map(|head| Some((head, trimmed.strip_prefix(head)?)))
+        else {
             continue;
         };
         let Some((elem, container)) = rest.strip_suffix(')').and_then(|r| r.split_once(" : "))
         else {
             continue;
         };
-        if !container.starts_with("local_") {
+        let Some(slot) = container
+            .strip_prefix("local_")
+            .and_then(|rest| rest.parse::<i32>().ok())
+        else {
             continue;
-        }
+        };
+        let by_witness = witnessed.contains(&slot);
         let uses: usize = lines.iter().map(|l| count_ident(l, container)).sum();
         if uses != 2 {
             continue;
@@ -12519,7 +12577,11 @@ fn inline_foreach_containers(body: &str) -> (String, HashSet<i32>) {
             .iter()
             .enumerate()
             .find(|(n, l)| *n != i && count_ident(l, container) == 1)
-            .and_then(|(n, l)| container_decl_path(l, container).map(|p| (n, p)))
+            .and_then(|(n, l)| {
+                container_decl_path(l, container)
+                    .or_else(|| by_witness.then(|| container_decl_value(l, container)).flatten())
+                    .map(|p| (n, p))
+            })
         else {
             continue;
         };
@@ -12535,20 +12597,15 @@ fn inline_foreach_containers(body: &str) -> (String, HashSet<i32>) {
             .rsplit_once('.')
             .map(|(head, _)| head)
             .filter(|head| head.starts_with("local_"));
-        if lines[i + 1..=end]
-            .iter()
-            .any(|l| l.contains(callee) || receiver.is_some_and(|r| l.contains(r)))
+        if !by_witness
+            && lines[i + 1..=end]
+                .iter()
+                .any(|l| l.contains(callee) || receiver.is_some_and(|r| l.contains(r)))
         {
             continue;
         }
-        let Some(slot) = container
-            .strip_prefix("local_")
-            .and_then(|rest| rest.parse::<i32>().ok())
-        else {
-            continue;
-        };
         let indent = leading_indent(lines[i]);
-        replace[i] = Some(format!("{indent}for (auto {elem} : {path})"));
+        replace[i] = Some(format!("{indent}{head}{elem} : {path})"));
         drop_line[decl] = true;
         // The local has no definition left anywhere, so its hoisted declaration has to go too —
         // a bare declaration of a container type asks for a default constructor the base cache
@@ -12591,6 +12648,18 @@ fn container_decl_path(line: &str, ident: &str) -> Option<String> {
     rhs.bytes()
         .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.'))
         .then(|| rhs.to_owned())
+}
+
+/// The initialiser of a container declaration, whatever its shape. Used only where the bytecode
+/// witnesses that the container was a header sub-expression: without that, a call in the
+/// initialiser is exactly what must not be moved into a loop header.
+fn container_decl_value(line: &str, ident: &str) -> Option<String> {
+    let trimmed = line.trim().strip_suffix(';')?;
+    let (lhs, rhs) = trimmed.split_once(" = ")?;
+    if !lhs.ends_with(ident) || rhs.is_empty() {
+        return None;
+    }
+    (!rhs.contains('\u{1}') && !rhs.contains('\u{2}')).then(|| rhs.to_owned())
 }
 
 /// True when the loop body writes through `ident` — assigns into it, calls through one of its
@@ -13895,6 +13964,7 @@ mod source_shape_tests {
                 &std::collections::HashSet::new(),
                 &std::collections::HashMap::new(),
                 &std::collections::HashMap::new(),
+                &std::collections::HashSet::new(),
             );
         assert_eq!(
             out,
@@ -13930,8 +14000,9 @@ mod source_shape_tests {
             &RefResolver::default(),
             &std::collections::HashSet::new(),
             &std::collections::HashMap::new(),
-                &std::collections::HashMap::new(),
-            );
+            &std::collections::HashMap::new(),
+            &std::collections::HashSet::new(),
+        );
         assert_eq!(
             out,
             concat!(
@@ -13966,6 +14037,7 @@ mod source_shape_tests {
                 &std::collections::HashSet::new(),
                 &std::collections::HashMap::new(),
                 &std::collections::HashMap::new(),
+                &std::collections::HashSet::new(),
             );
         assert_eq!(out, body);
         assert!(gone.is_empty());
@@ -13989,6 +14061,7 @@ mod source_shape_tests {
                 &std::collections::HashSet::new(),
                 &std::collections::HashMap::new(),
                 &std::collections::HashMap::new(),
+                &std::collections::HashSet::new(),
             );
         assert_eq!(out, body);
     }
@@ -14003,7 +14076,7 @@ mod source_shape_tests {
             "        }\n",
         );
         assert_eq!(
-            inline_foreach_containers(body).0,
+            inline_foreach_containers(body, &std::collections::HashSet::new()).0,
             concat!(
                 "        for (auto local_40 : this.m_Map)\n",
                 "        {\n",
@@ -14022,7 +14095,7 @@ mod source_shape_tests {
             "            this.m_Map.Remove(local_40.GetKey());\n",
             "        }\n",
         );
-        assert_eq!(inline_foreach_containers(body).0, body);
+        assert_eq!(inline_foreach_containers(body, &std::collections::HashSet::new()).0, body);
     }
 
     #[test]

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1897,7 +1897,14 @@ fn emit_function_ctor(
         .copied()
         .collect();
         let (body, first_use_suppressed) =
-            rewrite_first_use_decl_init(&body, &locals, refs, &already_declared_at_use, &reference_locals);
+            rewrite_first_use_decl_init(
+                &body,
+                &locals,
+                refs,
+                &already_declared_at_use,
+                &reference_locals,
+                &bare_declaration_slots(f),
+            );
         let (body, first_write_suppressed) = rewrite_bare_decl_at_first_write(
             &body,
             &locals,
@@ -13130,6 +13137,66 @@ fn rewrite_bare_decl_at_first_write(
     (joined, suppressed)
 }
 
+/// A local the source declared BARE and assigned afterwards.
+///
+/// A declaration-with-initialiser adopts the initialiser's temporary as the variable's own slot —
+/// the producer writes the variable directly and there is no copy. A declaration that already
+/// stands cannot do that: the producer fills a temporary and the value is copied on. So a slot
+/// whose ONLY write is `CpyVtoV X, T`, with `T`'s producer separated from the copy by nothing but
+/// the temporary-destructor group, is a name the source declared bare — those destructors run at
+/// the end of the full statement, which is exactly where the copy had to wait.
+///
+/// Measured: fires on 9 functions tree-wide, none of them byte-faithful. Every byte-faithful
+/// sole-copy local has its producer ADJACENT to the copy, which is what the gap separates.
+fn bare_declaration_slots(f: &Func) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let mut out = HashSet::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if !ins.op.name.starts_with("CpyVtoV") {
+            continue;
+        }
+        let (dst, src) = (w0(ins), ins.words.get(1).map(|w| *w as i16 as i32).unwrap_or(0));
+        if dst <= 0 || src <= 0 || dst == src {
+            continue;
+        }
+        // The copy has to be the destination's only write.
+        let written_once = !instrs.iter().enumerate().any(|(other, ins)| {
+            other != at && w0(ins) == dst && writes_destination(ins.op.name)
+        });
+        if !written_once {
+            continue;
+        }
+        // The source is produced earlier, and the gap between the two is nothing but cleanup.
+        let Some(producer) = instrs[..at]
+            .iter()
+            .rposition(|ins| w0(ins) == src && writes_destination(ins.op.name))
+            .filter(|producer| produces_value(instrs[*producer].op.name))
+        else {
+            continue;
+        };
+        if at == producer + 1 {
+            continue; // adjacent: the declaration took the temporary
+        }
+        let cleanup_only = instrs[producer + 1..at].iter().all(|ins| {
+            matches!(
+                ins.op.name,
+                "PSF" | "CALLSYS" | "PshVPtr" | "STOREOBJ" | "PopPtr"
+            )
+        });
+        // …and the temporary is dead after the copy.
+        let reused = instrs[at + 1..]
+            .iter()
+            .any(|ins| super::bytediff::addressed_slots(ins).into_iter().any(|s| s == src));
+        if cleanup_only && !reused {
+            out.insert(dst);
+        }
+    }
+    out
+}
+
 /// Every remaining local whose first reference is the assignment that gives it its value: the
 /// source declared it there. Hoisting the declaration instead makes the compiler put the value in
 /// a temporary of its own and copy it into the declared slot.
@@ -13141,13 +13208,17 @@ fn rewrite_first_use_decl_init(
     refs: &RefResolver,
     already: &HashSet<i32>,
     reference_locals: &HashMap<i32, bool>,
+    declared_bare: &HashSet<i32>,
 ) -> (String, HashSet<i32>) {
     // Only where the assignment stands at the FUNCTION's own level. Inside a loop or a branch a
     // declaration is entered and left again with the block, and the compiler spends the slot's
     // construction and release on every pass — which vanilla, having hoisted it, does not
     // (measured: 94 functions lost against 46 gained when this was not required).
-    let wanted =
-        |slot: i32, _ty: &str| !already.contains(&slot) && first_top_level_assignment_before_read(body, slot);
+    let wanted = |slot: i32, _ty: &str| {
+        !already.contains(&slot)
+            && !declared_bare.contains(&slot)
+            && first_top_level_assignment_before_read(body, slot)
+    };
     rewrite_decl_at_assignment(body, locals, &wanted, &|slot, ty| {
         let head = qualify_decl_type(ty, refs);
         match reference_locals.get(&slot) {

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -10330,27 +10330,35 @@ fn spilled_boolean_names(f: &Func, refs: &RefResolver) -> HashSet<i32> {
         if temporary_by_reference {
             continue;
         }
-        let short_circuit = instrs.get(at + 3).is_some_and(|arm| {
-            arm.op.name.starts_with("SetV")
-                && instrs.get(at + 4).is_some_and(|jump| {
-                    let Some(offset) = jump.dwords.first().map(|d| *d as i32) else {
-                        return false;
-                    };
-                    if jump.op.name != "JMP" {
-                        return false;
-                    }
-                    let target = jump.offset_dw as i64 + 2 + offset as i64;
-                    instrs
-                        .iter()
-                        .position(|other| other.offset_dw as i64 == target)
-                        .and_then(|merge| instrs.get(merge.checked_sub(1)?))
-                        .is_some_and(|before| {
-                            before.op.name.starts_with("CpyVtoV") && w0(before) == w0(arm)
-                        })
-                })
+        let short_circuit_carrier = instrs.get(at + 3).and_then(|arm| {
+            if !arm.op.name.starts_with("SetV") {
+                return None;
+            }
+            let jump = instrs.get(at + 4)?;
+            if jump.op.name != "JMP" {
+                return None;
+            }
+            let offset = jump.dwords.first().map(|d| *d as i32)?;
+            let target = jump.offset_dw as i64 + 2 + i64::from(offset);
+            let merge = instrs
+                .iter()
+                .position(|other| other.offset_dw as i64 == target)?;
+            let before = instrs.get(merge.checked_sub(1)?)?;
+            (before.op.name.starts_with("CpyVtoV") && w0(before) == w0(arm)).then(|| w0(arm))
         });
-        if !short_circuit {
-            out.insert(slot);
+        // The round trip proves the source NAMED something here. When the spill is the left
+        // operand of a short circuit, the thing it named is not the operand — it is the CARRIER
+        // the two arms merge into, which is what the source declared and tested. Attributing the
+        // name to the operand is what the subtraction was for; attributing it to nobody is what
+        // left 17 carriers unnamed.
+        match short_circuit_carrier {
+            Some(carrier) if carrier > 0 => {
+                out.insert(carrier);
+            }
+            Some(_) => {}
+            None => {
+                out.insert(slot);
+            }
         }
     }
     out

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2100,8 +2100,9 @@ fn emit_function_ctor(
         // same slot produced the value where it is consumed, so the source wrote that call inside
         // the expression. Held in a local instead, it is evaluated BEFORE the outer call's other
         // arguments — the same instructions in a different order.
-        let several_lives =
-            slots_with_a_third_life(&rendered.lines().map(str::to_owned).collect::<Vec<_>>());
+        let text: Vec<String> = rendered.lines().map(str::to_owned).collect();
+        let a_third_life = slots_with_a_third_life(&text);
+        let several_lives = slots_with_several_lives(&text);
         let rendered = inline_unnamed_value_temporaries(
             &rendered,
             &unnamed_value_defs(f, refs)
@@ -2111,6 +2112,7 @@ fn emit_function_ctor(
                 .chain(
                     fused_short_circuit_carriers(f)
                         .into_iter()
+                        .filter(|slot| !several_lives.contains(slot))
                         .map(|slot| (slot, 1)),
                 )
                 .chain(chain_inlined_cast_operands(f).into_iter().map(|slot| (slot, 1)))
@@ -2122,7 +2124,7 @@ fn emit_function_ctor(
                 .chain(
                     return_expression_temporaries(f, refs)
                         .into_iter()
-                        .filter(|slot| !several_lives.contains(slot))
+                        .filter(|slot| !a_third_life.contains(slot))
                         .flat_map(|slot| [(slot, 1), (slot, 2)]),
                 )
                 .collect(),
@@ -2136,8 +2138,9 @@ fn emit_function_ctor(
         let mut rendered = rendered;
         // A returned expression folds one step per pass: three names in a chain need three.
         for _ in 0..3 {
-        let several_lives =
-            slots_with_a_third_life(&rendered.lines().map(str::to_owned).collect::<Vec<_>>());
+        let text: Vec<String> = rendered.lines().map(str::to_owned).collect();
+        let a_third_life = slots_with_a_third_life(&text);
+        let several_lives = slots_with_several_lives(&text);
         rendered = inline_unnamed_value_temporaries(
             &rendered,
             &unnamed_value_defs(f, refs)
@@ -2147,6 +2150,7 @@ fn emit_function_ctor(
                 .chain(
                     fused_short_circuit_carriers(f)
                         .into_iter()
+                        .filter(|slot| !several_lives.contains(slot))
                         .map(|slot| (slot, 1)),
                 )
                 .chain(chain_inlined_cast_operands(f).into_iter().map(|slot| (slot, 1)))
@@ -2158,7 +2162,7 @@ fn emit_function_ctor(
                 .chain(
                     return_expression_temporaries(f, refs)
                         .into_iter()
-                        .filter(|slot| !several_lives.contains(slot))
+                        .filter(|slot| !a_third_life.contains(slot))
                         .flat_map(|slot| [(slot, 1), (slot, 2)]),
                 )
                 .collect(),

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -4000,6 +4000,11 @@ fn reference_result_slots(f: &Func, refs: &RefResolver) -> HashMap<i32, bool> {
         ty.is_reference && ty.token == 5 && !ty.is_object_handle
     };
     let mut out = HashMap::new();
+    // A pointer-sized slot outlives the value in it: the compiler hands the same frame word to a
+    // `const T&` in one scope and a mutable `T&` in another. One qualifier cannot describe both,
+    // and guessing costs a compile — so a slot whose observations disagree is dropped, and the
+    // rewriting simply does not happen there. Same shape as `call_result_types` below.
+    let mut conflicting: HashSet<i32> = HashSet::new();
     for (at, ins) in instrs.iter().enumerate() {
         if ins.op.name != "CpyRtoV8" || at == 0 {
             continue;
@@ -4028,7 +4033,10 @@ fn reference_result_slots(f: &Func, refs: &RefResolver) -> HashMap<i32, bool> {
                     // A const reference has to say so, or the initializer is refused:
                     // "Cannot initialize reference variable of type T& with an expression of
                     // type const T".
-                    out.insert(slot, ret.is_read_only || ret.is_object_const);
+                    let qualified = ret.is_read_only || ret.is_object_const;
+                    if out.insert(slot, qualified).is_some_and(|seen| seen != qualified) {
+                        conflicting.insert(slot);
+                    }
                 }
             }
         }
@@ -4057,11 +4065,22 @@ fn reference_result_slots(f: &Func, refs: &RefResolver) -> HashMap<i32, bool> {
         if let Some(ret) = returns.filter(|ret| by_reference(ret)) {
             if let Some(slot) = ins.words.first().map(|word| *word as i16 as i32) {
                 if slot > 0 {
-                    out.entry(slot)
-                        .or_insert(ret.is_read_only || ret.is_object_const);
+                    let qualified = ret.is_read_only || ret.is_object_const;
+                    match out.get(&slot) {
+                        Some(seen) if *seen != qualified => {
+                            conflicting.insert(slot);
+                        }
+                        Some(_) => {}
+                        None => {
+                            out.insert(slot, qualified);
+                        }
+                    }
                 }
             }
         }
+    }
+    for slot in conflicting {
+        out.remove(&slot);
     }
     out
 }
@@ -11609,6 +11628,23 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             })
             .collect()
     };
+    // Slots the TEXT still carries under more than one name. The witness below is asked of the
+    // slot rather than the life, and where several lives survive it cannot say which one it
+    // names. Folding the wrong one moves a receiver across a right-hand side that also runs.
+    let ambiguous: HashSet<i32> = {
+        let mut lives: HashMap<i32, HashSet<usize>> = HashMap::new();
+        for line in &lines {
+            for token in line.split(|c: char| !c.is_alphanumeric() && c != '_') {
+                if let Some((slot, life)) = slot_and_life_any(token) {
+                    lives.entry(slot).or_default().insert(life);
+                }
+            }
+        }
+        lives
+            .into_iter()
+            .filter_map(|(slot, seen)| (seen.len() > 1).then_some(slot))
+            .collect()
+    };
     let mut at = 0usize;
     while at + 1 < lines.len() {
         let folded = (|| {
@@ -11625,6 +11661,9 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             // earlier life was folded away, so the witness is asked of the slot: some life of it
             // is consumed where it is produced.
             let (slot, _) = slot_and_life_any(&name)?;
+            if ambiguous.contains(&slot) {
+                return None;
+            }
             if !consumed.iter().any(|(consumed, _)| *consumed == slot) {
                 return None;
             }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -9314,8 +9314,15 @@ fn gameplay_effect_chain_slots(f: &Func, refs: &RefResolver) -> Vec<(i32, i32)> 
         return Vec::new();
     };
     let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
-    // A call's hidden out-pointer is the last address pushed before it.
-    let destination = |at: usize| -> Option<i32> {
+    // A call's hidden out-pointer is the last address pushed before it — but only where none of
+    // the call's own parameters takes an address too. A by-reference argument is pushed AFTER the
+    // hidden destination, so where the callee declares one the last `PSF` is that argument, and
+    // reading it as the result would declare an argument slot as the handle.
+    let destination = |at: usize, ptr: i64| -> Option<i32> {
+        let params = refs.func_params_by_ptr(ptr)?;
+        if params.iter().any(|param| param.is_reference) {
+            return None;
+        }
         instrs[..at]
             .iter()
             .rposition(|ins| ins.op.name == "PSF")
@@ -9328,12 +9335,13 @@ fn gameplay_effect_chain_slots(f: &Func, refs: &RefResolver) -> Vec<(i32, i32)> 
         if ins.op.name != "CALLSYS" {
             continue;
         }
-        match refs.func_by_ptr(ins.qwords.first().copied().unwrap_or(0) as i64) {
-            Some("MakeEffectContext") => context = destination(at),
+        let ptr = ins.qwords.first().copied().unwrap_or(0) as i64;
+        match refs.func_by_ptr(ptr) {
+            Some("MakeEffectContext") => context = destination(at, ptr),
             Some("MakeOutgoingSpec") => {
                 // One pair per chain, in program order. A function may carry several, and giving
                 // them all the FIRST pair's names declares the same local twice.
-                if let (Some(ctx), Some(spec)) = (context.take(), destination(at)) {
+                if let (Some(ctx), Some(spec)) = (context.take(), destination(at, ptr)) {
                     if ctx != spec {
                         pairs.push((ctx, spec));
                     }

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -907,6 +907,11 @@ fn emit_function_ctor(
     // The type each slot's captured call result actually has — the witness the operand gates
     // need to tell a plain read from a read the declaration converts.
     let call_result_types = call_result_types(f, refs);
+    // Slots vanilla filled from a call that returns `T&`. The slot holds a POINTER, not a `T`, so
+    // rendering it by value costs a copy constructor and a scope-exit destructor — and because the
+    // return then travels as an address rather than through a register, the name looked like a
+    // dead store and was deleted outright. One missing fact, three symptoms.
+    let reference_locals = reference_result_slots(f, refs);
     // Producers the SOURCE kept as statements of their own — see `statement_producer_slots`.
     let statement_producers = statement_producer_slots(f);
     // Where vanilla destroyed a value slot mid-expression it was calling on a temporary there.
@@ -1863,7 +1868,7 @@ fn emit_function_ctor(
         // the copy-construction the merge is looking for.
         let body = drop_redundant_conversions(&body, fields, &path_roots, refs);
         let (body, value_suppressed) =
-            rewrite_value_decl_init(&body, &locals, refs, &copy_constructed_slots(f, refs));
+            rewrite_value_decl_init(&body, &locals, refs, &copy_constructed_slots(f, refs), &reference_locals);
         // A local that receives a CONST call result has to be const as well, and a const local is
         // declared where it gets its value.
         let (body, const_suppressed) =
@@ -1888,7 +1893,7 @@ fn emit_function_ctor(
         .copied()
         .collect();
         let (body, first_use_suppressed) =
-            rewrite_first_use_decl_init(&body, &locals, refs, &already_declared_at_use);
+            rewrite_first_use_decl_init(&body, &locals, refs, &already_declared_at_use, &reference_locals);
         let (body, first_write_suppressed) = rewrite_bare_decl_at_first_write(
             &body,
             &locals,
@@ -1948,6 +1953,9 @@ fn emit_function_ctor(
                 // `const` on the declaration matches the vanilla form (non-const stores into a
                 // const handle remain legal, so mixed-source slots are safe).
                 let _ = writeln!(s, "{ind}    const {ty} local_{slot};");
+            } else if let Some(is_const) = reference_locals.get(slot) {
+                let qualifier = if *is_const { "const " } else { "" };
+                let _ = writeln!(s, "{ind}    {qualifier}{ty}& local_{slot};");
             } else {
                 let _ = writeln!(s, "{ind}    {ty} local_{slot};");
             }
@@ -3417,7 +3425,7 @@ fn rewrite_const_decl_init(
         return (body.to_owned(), HashSet::new());
     }
     let want = |slot: i32, _ty: &str| const_slots.contains(&slot);
-    rewrite_decl_at_assignment(body, locals, &want, &|ty| {
+    rewrite_decl_at_assignment(body, locals, &want, &|_, ty| {
         format!("const {}", qualify_decl_type(ty, refs))
     })
 }
@@ -3863,6 +3871,51 @@ fn const_call_result_slots(f: &Func, refs: &RefResolver) -> HashSet<i32> {
                 }
             }
             _ => returned = None,
+        }
+    }
+    out
+}
+
+/// Slots a `T&`-returning call fills: the source declared a REFERENCE there.
+fn reference_result_slots(f: &Func, refs: &RefResolver) -> HashMap<i32, bool> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashMap::new();
+    };
+    let by_reference = |ty: &super::types::DataType| {
+        ty.is_reference && ty.token == 5 && !ty.is_object_handle
+    };
+    let mut out = HashMap::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "CpyRtoV8" || at == 0 {
+            continue;
+        }
+        let call = &instrs[at - 1];
+        let returns = match call.op.name {
+            "CALLSYS" | "Thiscall1" => {
+                refs.func_ret_by_ptr(call.qwords.first().copied().unwrap_or(0) as i64)
+            }
+            "CALL" | "CALLINTF" | "CALLBND" => {
+                refs.func_ret_by_id(call.dwords.first().copied().unwrap_or(0) as i32)
+            }
+            _ => None,
+        };
+        if std::env::var_os("GORE_AS_REF_DIAG").is_some() {
+            eprintln!(
+                "[ref] {} slot={:?} ret={:?}",
+                call.op.name,
+                ins.words.first().map(|w| *w as i16 as i32),
+                returns.map(|t| (t.is_reference, t.token, t.is_object_handle))
+            );
+        }
+        if let Some(ret) = returns.filter(|ret| by_reference(ret)) {
+            if let Some(slot) = ins.words.first().map(|word| *word as i16 as i32) {
+                if slot > 0 {
+                    // A const reference has to say so, or the initializer is refused:
+                    // "Cannot initialize reference variable of type T& with an expression of
+                    // type const T".
+                    out.insert(slot, ret.is_read_only || ret.is_object_const);
+                }
+            }
         }
     }
     out
@@ -12415,7 +12468,7 @@ fn rewrite_iterator_decl_init(
         )
     };
     // `auto`, not the inferred iterator head — see the render comment below.
-    rewrite_decl_at_assignment(body, locals, &is_iter, &|_| "auto".to_string())
+    rewrite_decl_at_assignment(body, locals, &is_iter, &|_, _| "auto".to_string())
 }
 
 /// A VALUE-type local (`F*`/`T*`) that is hoisted and then assigned costs two symbols vanilla
@@ -12455,6 +12508,7 @@ fn rewrite_value_decl_init(
     locals: &BTreeMap<i32, String>,
     refs: &RefResolver,
     copy_constructed: &HashSet<i32>,
+    reference_locals: &HashMap<i32, bool>,
 ) -> (String, HashSet<i32>) {
     // A slot vanilla COPY-constructs was declared with its value: the `$beh0` there takes a
     // parameter, which a default construction does not. That is a fact about this function, and
@@ -12464,7 +12518,13 @@ fn rewrite_value_decl_init(
         copy_constructed.contains(&slot)
             || (is_value_struct_type(ty) && !constructs_by_assignment(ty, refs))
     };
-    rewrite_decl_at_assignment(body, locals, &is_value, &|ty| ty.to_string())
+    rewrite_decl_at_assignment(body, locals, &is_value, &|slot, ty| {
+        match reference_locals.get(&slot) {
+            Some(true) => format!("const {ty}&"),
+            Some(false) => format!("{ty}&"),
+            None => ty.to_string(),
+        }
+    })
 }
 
 /// A local whose first reference WRITES it through a member or an element — `local_N.Field = …;`
@@ -12541,6 +12601,7 @@ fn rewrite_first_use_decl_init(
     locals: &BTreeMap<i32, String>,
     refs: &RefResolver,
     already: &HashSet<i32>,
+    reference_locals: &HashMap<i32, bool>,
 ) -> (String, HashSet<i32>) {
     // Only where the assignment stands at the FUNCTION's own level. Inside a loop or a branch a
     // declaration is entered and left again with the block, and the compiler spends the slot's
@@ -12548,7 +12609,14 @@ fn rewrite_first_use_decl_init(
     // (measured: 94 functions lost against 46 gained when this was not required).
     let wanted =
         |slot: i32, _ty: &str| !already.contains(&slot) && first_top_level_assignment_before_read(body, slot);
-    rewrite_decl_at_assignment(body, locals, &wanted, &|ty| qualify_decl_type(ty, refs))
+    rewrite_decl_at_assignment(body, locals, &wanted, &|slot, ty| {
+        let head = qualify_decl_type(ty, refs);
+        match reference_locals.get(&slot) {
+            Some(true) => format!("const {head}&"),
+            Some(false) => format!("{head}&"),
+            None => head,
+        }
+    })
 }
 
 /// Shared engine for both: declare a local at the assignment that first gives it a value,
@@ -12575,7 +12643,7 @@ fn rewrite_decl_at_assignment(
     body: &str,
     locals: &BTreeMap<i32, String>,
     want: &dyn Fn(i32, &str) -> bool,
-    decl_head: &dyn Fn(&str) -> String,
+    decl_head: &dyn Fn(i32, &str) -> String,
 ) -> (String, HashSet<i32>) {
     let mut suppressed: HashSet<i32> = HashSet::new();
     let mut out = body.to_string();
@@ -12659,7 +12727,7 @@ fn rewrite_decl_at_assignment(
             if decl_lines.contains(&i) {
                 let t = line.trim_start();
                 let indent = &line[..line.len() - t.len()];
-                let head = decl_head(ty);
+                let head = decl_head(*slot, ty);
                 let _ = writeln!(rewritten, "{indent}{head} {t}");
             } else {
                 rewritten.push_str(&line);

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2100,6 +2100,8 @@ fn emit_function_ctor(
         // same slot produced the value where it is consumed, so the source wrote that call inside
         // the expression. Held in a local instead, it is evaluated BEFORE the outer call's other
         // arguments — the same instructions in a different order.
+        let several_lives =
+            slots_with_several_lives(&rendered.lines().map(str::to_owned).collect::<Vec<_>>());
         let rendered = inline_unnamed_value_temporaries(
             &rendered,
             &unnamed_value_defs(f, refs)
@@ -2120,6 +2122,7 @@ fn emit_function_ctor(
                 .chain(
                     return_expression_temporaries(f, refs)
                         .into_iter()
+                        .filter(|slot| !several_lives.contains(slot))
                         .flat_map(|slot| [(slot, 1), (slot, 2)]),
                 )
                 .collect(),
@@ -2133,6 +2136,8 @@ fn emit_function_ctor(
         let mut rendered = rendered;
         // A returned expression folds one step per pass: three names in a chain need three.
         for _ in 0..3 {
+        let several_lives =
+            slots_with_several_lives(&rendered.lines().map(str::to_owned).collect::<Vec<_>>());
         rendered = inline_unnamed_value_temporaries(
             &rendered,
             &unnamed_value_defs(f, refs)
@@ -2153,6 +2158,7 @@ fn emit_function_ctor(
                 .chain(
                     return_expression_temporaries(f, refs)
                         .into_iter()
+                        .filter(|slot| !several_lives.contains(slot))
                         .flat_map(|slot| [(slot, 1), (slot, 2)]),
                 )
                 .collect(),
@@ -9477,6 +9483,7 @@ fn split_gameplay_effect_chain(body: &str, slots: &[(i32, i32)], refs: &RefResol
 /// writes through, and a temporary cannot bind to one.
 fn spell_out_default_temporaries(text: &str, defaults: &HashMap<i32, usize>) -> String {
     let mut lines: Vec<String> = text.lines().map(str::to_owned).collect();
+    let ambiguous = slots_with_several_lives(&lines);
     for index in 0..lines.len() {
         let Some((_, name, _)) = declaration_with_initializer(&lines[index]) else {
             continue;
@@ -9495,10 +9502,7 @@ fn spell_out_default_temporaries(text: &str, defaults: &HashMap<i32, usize>) -> 
         // in it dies. Where the text still carries a second life of it, some of those
         // constructions are that life's, and spending them here rewrites a named value the source
         // meant to pass into a `T()` that is not the same value at all.
-        if lines.iter().any(|line| {
-            count_ident(line, &format!("local_{slot}_2")) > 0
-                || count_ident(line, &format!("local_{slot}_3")) > 0
-        }) {
+        if ambiguous.contains(&slot) {
             continue;
         }
         let head = lines[index].trim().split(" = ").next().unwrap_or("");
@@ -10931,7 +10935,14 @@ fn order_adjacent_declarations(body: &str, runs: &[Vec<i32>]) -> String {
         return body.to_owned();
     }
     let mut lines: Vec<String> = body.lines().map(str::to_owned).collect();
+    // The run is a sequence of constructions in the bytecode, and `local_N` in the text is the
+    // FIRST life of that slot. Where a later life exists, the run may be that one's, and lifting
+    // the first life's declaration moves a constructor across statements it belongs behind.
+    let ambiguous = slots_with_several_lives(&lines);
     for run in runs {
+        if run.iter().any(|slot| ambiguous.contains(slot)) {
+            continue;
+        }
         let spots: Option<Vec<usize>> = run
             .iter()
             .map(|slot| {
@@ -11027,9 +11038,7 @@ fn lead_with_the_declaration(body: &str, slot: Option<i32>) -> String {
     // The witness names a SLOT, and the first instruction pair is the first life of it. Where the
     // text still carries another life, that pair says nothing about which of them was declared
     // first, and moving the wrong one runs a constructor ahead of the call it belongs behind.
-    if lines.iter().any(|line| {
-        count_ident(line, &format!("{ident}_2")) > 0 || count_ident(line, &format!("{ident}_3")) > 0
-    }) {
+    if slots_with_several_lives(&lines).contains(&slot) {
         return body.to_owned();
     }
     let declaration = lines.remove(at);
@@ -11131,6 +11140,10 @@ fn nested_expression_intermediates(f: &Func, refs: &RefResolver) -> HashSet<i32>
 /// The anchor is doing all the work, so it is required: a `void` function calling a method on a
 /// by-reference parameter has the same instruction triple, and reading that as a return
 /// expression names one byte-faithful slot wrongly.
+///
+/// The destructors name a SLOT and the caller has to turn that into lives; it spends the witness
+/// on the first two, which is right only while the slot has no more than two. A slot the text
+/// carries three lives of is left alone rather than have the witness land on the wrong one.
 fn return_expression_temporaries(f: &Func, refs: &RefResolver) -> HashSet<i32> {
     let Ok(instrs) = disassemble(&f.bytecode) else {
         return HashSet::new();
@@ -11786,23 +11799,9 @@ fn fold_assignment_receivers(body: &str, consumed: &HashSet<(i32, usize)>) -> St
             })
             .collect()
     };
-    // Slots the TEXT still carries under more than one name. The witness below is asked of the
-    // slot rather than the life, and where several lives survive it cannot say which one it
-    // names. Folding the wrong one moves a receiver across a right-hand side that also runs.
-    let ambiguous: HashSet<i32> = {
-        let mut lives: HashMap<i32, HashSet<usize>> = HashMap::new();
-        for line in &lines {
-            for token in line.split(|c: char| !c.is_alphanumeric() && c != '_') {
-                if let Some((slot, life)) = slot_and_life_any(token) {
-                    lives.entry(slot).or_default().insert(life);
-                }
-            }
-        }
-        lives
-            .into_iter()
-            .filter_map(|(slot, seen)| (seen.len() > 1).then_some(slot))
-            .collect()
-    };
+    // The witness below is asked of the slot rather than the life: folding the wrong one moves a
+    // receiver across a right-hand side that also runs.
+    let ambiguous = slots_with_several_lives(&lines);
     let mut at = 0usize;
     while at + 1 < lines.len() {
         let folded = (|| {
@@ -13020,6 +13019,28 @@ fn renders_a_bool(
         return true;
     }
     outer_callee(value).is_some_and(|callee| refs.names_returning(&callee) == Some("bool"))
+}
+
+/// The slots the text carries under more than one name.
+///
+/// Nearly every witness in this file is read off the bytecode and names a frame SLOT, while the
+/// text names a life of it. The two agree exactly as long as the slot has one life; the moment
+/// the compiler hands it out again, a witness about one value is spent on another — the wrong
+/// declaration is moved, the wrong temporary loses its name, the wrong receiver is folded. Rules
+/// whose witness cannot pick out a life ask this first and stand down on the slots it names.
+fn slots_with_several_lives(lines: &[String]) -> HashSet<i32> {
+    let mut lives: HashMap<i32, HashSet<usize>> = HashMap::new();
+    for line in lines {
+        for token in line.split(|c: char| !c.is_alphanumeric() && c != '_') {
+            if let Some((slot, life)) = slot_and_life_any(token) {
+                lives.entry(slot).or_default().insert(life);
+            }
+        }
+    }
+    lives
+        .into_iter()
+        .filter_map(|(slot, seen)| (seen.len() > 1).then_some(slot))
+        .collect()
 }
 
 /// `local_N = <value>;` — a plain assignment to a bare local, with no declaration in front.

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -6685,7 +6685,7 @@ fn inline_temporary_into(
                 // A `return` is refused because a returned REFERENCE may not be a temporary.
                 // A bool is not one, and the cache can say so.
                 || (lines[index].trim().starts_with("return ")
-                    && renders_a_bool(&value, locals, refs, fields)))
+                    && renders_a_bool(&value, locals, refs, fields, &HashMap::new())))
                 && (same_typed_own_field(&value, temp, locals, fields)
                     || is_call_result(&value)
                     || names_a_static_class(&value, temp, locals)
@@ -6705,7 +6705,7 @@ fn inline_temporary_into(
                 || same_typed_own_field(&value, temp, locals, fields)
                 || names_a_static_class(&value, temp, locals)
                 || (temporary_type(locals, temp) == Some("bool")
-                    && renders_a_bool(&value, locals, refs, fields))
+                    && renders_a_bool(&value, locals, refs, fields, &HashMap::new()))
         }
     };
     if !movable {
@@ -7342,7 +7342,7 @@ fn fold_condition_temporaries(
     // A field of the class carries its type in the class's own map, which `renders_a_bool` does
     // not read.
     let is_a_bool = |value: &str| {
-        renders_a_bool(value, locals, refs, fields)
+        renders_a_bool(value, locals, refs, fields, &HashMap::new())
             || value
                 .strip_prefix("this.")
                 .and_then(|field| fields?.get(field))
@@ -7383,7 +7383,7 @@ fn fold_condition_temporaries(
                 })
                 .filter(|_| {
                     temporary_type(locals, &name) == Some("bool")
-                        && renders_a_bool(&value, locals, refs, fields)
+                        && renders_a_bool(&value, locals, refs, fields, &HashMap::new())
                 });
             // Or the slot is an INT the emitter compares against zero to read as a bool. Where
             // the value is a bool, that comparison is the int slot's doing and nothing else's:
@@ -11710,7 +11710,7 @@ fn short_circuit(
     // A PARAMETER carries its type in the signature, not in the slot table: `const bool
     // bIsImmortal` is as much a bool as any local, and asking only the locals left the outer arm
     // of `A || bIsImmortal` standing as an if/else over a carrier.
-    let value_is_bool = renders_a_bool(&value, locals, refs, fields)
+    let value_is_bool = renders_a_bool(&value, locals, refs, fields, roots)
         || roots.get(value.as_str()).is_some_and(|ty| ty == "bool");
     if temporary_type(locals, &target) != Some("bool") || !value_is_bool {
         sc_reject(
@@ -11864,11 +11864,48 @@ fn turned_around(condition: &str) -> String {
 /// Whether a rendered value is a bool: a slot the type table calls one, a bool literal, or a call
 /// every declaration of that name returns bool from. An operand that is not one may not carry a
 /// `&&` — and the compiler does not merely refuse it, it goes down.
+/// The declared type a member PATH resolves to, walking it one segment at a time.
+///
+/// The first segment names either `this` — whose members are the class's own field map — or a
+/// local or parameter, whose type `roots` carries. Every further segment is a field of the type
+/// the previous one resolved to, answered by the script class table or, failing that, by the
+/// native field table. A segment that does not resolve ends the walk: this answers only what it
+/// can prove, because the caller uses the answer to decide whether a value may become an operand
+/// of `&&`, and an operand that is not a bool takes the compiler down.
+fn member_path_type(
+    value: &str,
+    roots: &HashMap<String, String>,
+    fields: Option<&HashMap<String, String>>,
+    refs: &RefResolver,
+) -> Option<String> {
+    if value.contains(['(', ')', '[', ']', ' ', '\u{1}', '\u{2}']) {
+        return None;
+    }
+    let mut parts = value.split('.');
+    let head = parts.next()?;
+    let mut ty = match head {
+        "this" => {
+            let first = parts.next()?;
+            fields?.get(first)?.clone()
+        }
+        _ => roots.get(head)?.clone(),
+    };
+    for field in parts {
+        ty = refs
+            .field_type_by_class(&ty, field)
+            .or_else(|| refs.native_field_value_type(&ty, field))
+            .or_else(|| refs.native_field_type(&ty, field))?
+            .to_owned();
+    }
+    Some(ty)
+}
+
 fn renders_a_bool(
     value: &str,
     locals: &BTreeMap<i32, String>,
     refs: &RefResolver,
     fields: Option<&HashMap<String, String>>,
+    roots: &HashMap<String, String>,
 ) -> bool {
     if matches!(value, "true" | "false") || temporary_type(locals, value) == Some("bool") {
         return true;
@@ -11880,16 +11917,23 @@ fn renders_a_bool(
             return true;
         }
     }
+    // …and a field of a STRUCT carries its type on that struct, which the same two tables answer
+    // once the path is walked segment by segment. Without the walk, `local_46.bWitnessIsGuildOwner`
+    // is an unknown, the arm stays an if/else over a carrier, and the copy that costs is ours.
+    // Measured: 86 such arms still stand, and only two of them are a bare `this.<field>`.
+    if member_path_type(value, roots, fields, refs).as_deref() == Some("bool") {
+        return true;
+    }
     // A negation and a comparison are bools whatever they wrap, and a fully parenthesized value
     // is whatever it holds.
     if let Some(negated) = value.strip_prefix('!') {
-        return renders_a_bool(negated, locals, refs, fields);
+        return renders_a_bool(negated, locals, refs, fields, roots);
     }
     if value.starts_with('(')
         && matching_paren(value, 0) == Some(value.len() - 1)
         && value.len() > 2
     {
-        return renders_a_bool(&value[1..value.len() - 1], locals, refs, fields);
+        return renders_a_bool(&value[1..value.len() - 1], locals, refs, fields, roots);
     }
     if [" == ", " != ", " < ", " > ", " <= ", " >= ", " && ", " || "]
         .iter()

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1540,6 +1540,8 @@ fn emit_function_ctor(
     );
     let body =
         fold_returned_temporaries(&body, &declared_locals, refs, &ret, returns_by_reference);
+    // Before the hoist counts which locals exist: a slot whose only write is dead has no name.
+    let body = drop_dead_stores_before_return(&body);
     // hoist every referenced local; infer_locals types what it can, the rest default to `int`
     // (a wrong type just becomes a compile error the in-game loop force-stubs, rather than the
     // whole function stubbing on an undeclared identifier).
@@ -11271,6 +11273,34 @@ fn fold_literal_null_returns(body: &str, witnessed: &HashSet<i32>, by_reference:
                 kept.push(lines[at].to_string());
                 at += 1;
             }
+        }
+    }
+    let mut joined = kept.join("\n");
+    if body.ends_with('\n') {
+        joined.push('\n');
+    }
+    joined
+}
+
+/// `local_N = K; return K;` — the store is DEAD. The very next statement leaves the function, so
+/// no path can read what it wrote.
+///
+/// The pair shows up where the structurer recovered a constant return literally: a scratch slot
+/// the compiler reused for two different constants cannot be one variable, so the return carries
+/// the constant itself. The fold that normally eats the store matches `local_N = K; return
+/// local_N;` and no longer sees it.
+fn drop_dead_stores_before_return(body: &str) -> String {
+    let lines: Vec<&str> = body.lines().collect();
+    let mut kept: Vec<String> = Vec::with_capacity(lines.len());
+    for (at, line) in lines.iter().enumerate() {
+        let dead = (|| {
+            let (target, value) = slot_store(line)?;
+            let next = lines.get(at + 1)?;
+            (next.trim() == format!("return {value};") && indent_of(next) == indent_of(line))
+                .then_some(target)
+        })();
+        if dead.is_none() {
+            kept.push((*line).to_owned());
         }
     }
     let mut joined = kept.join("\n");

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -1913,6 +1913,7 @@ fn emit_function_ctor(
                 &already_declared_at_use,
                 &reference_locals,
                 &bare_declaration_slots(f),
+                &call_result_declared_at_initializer(f),
             );
         let (body, first_write_suppressed) = rewrite_bare_decl_at_first_write(
             &body,
@@ -5348,6 +5349,34 @@ fn first_top_level_assignment_before_read(body: &str, slot: i32) -> bool {
     }
 
     false
+}
+
+/// True when the name's first reference is a plain write-only assignment and every later mention
+/// stands inside that assignment's own block — the condition that makes sinking the declaration
+/// onto it legal at any depth.
+fn assignment_block_owns_the_name(body: &str, slot: i32) -> bool {
+    let ident = format!("local_{slot}");
+    let lines: Vec<&str> = body.lines().collect();
+    let Some(store) = lines.iter().position(|line| count_ident(line, &ident) != 0) else {
+        return false;
+    };
+    let trimmed = lines[store].trim();
+    if !trimmed.starts_with(&format!("{ident} = "))
+        || !trimmed.ends_with(';')
+        || count_ident(lines[store], &ident) != 1
+    {
+        return false;
+    }
+    let mut depth = 0i32;
+    let mut end = lines.len();
+    for (offset, line) in lines[store + 1..].iter().enumerate() {
+        depth += brace_net(line);
+        if depth < 0 {
+            end = store + 1 + offset;
+            break;
+        }
+    }
+    lines[end..].iter().all(|line| count_ident(line, &ident) == 0)
 }
 
 /// Prove definite assignment for a compiler-reused primitive carrier in structured emitted source.
@@ -13550,6 +13579,37 @@ fn bare_declaration_slots(f: &Func) -> HashSet<i32> {
     out
 }
 
+/// A slot an 8-byte call result fills DIRECTLY — the source declared it at its initialiser.
+///
+/// A declaration that already stands cannot take the call's own destination: the value lands in a
+/// temporary and is copied on. So `CpyRtoV8 X` with no copy behind it says the declaration was
+/// written where the value arrives. Measured over the byte-faithful corpus: 15 such slots are
+/// declared at their initialiser in our text and 1 stands bare, with no case going the other way.
+fn call_result_declared_at_initializer(f: &Func) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let mut writes: HashMap<i32, (usize, bool)> = HashMap::new();
+    for ins in &instrs {
+        if !writes_destination(ins.op.name) {
+            continue;
+        }
+        let slot = w0(ins);
+        if slot <= 0 {
+            continue;
+        }
+        let entry = writes.entry(slot).or_insert((0, true));
+        entry.0 += 1;
+        entry.1 &= ins.op.name == "CpyRtoV8";
+    }
+    writes
+        .into_iter()
+        .filter(|(_, (count, direct))| *count == 1 && *direct)
+        .map(|(slot, _)| slot)
+        .collect()
+}
+
 /// Every remaining local whose first reference is the assignment that gives it its value: the
 /// source declared it there. Hoisting the declaration instead makes the compiler put the value in
 /// a temporary of its own and copy it into the declared slot.
@@ -13562,15 +13622,25 @@ fn rewrite_first_use_decl_init(
     already: &HashSet<i32>,
     reference_locals: &HashMap<i32, bool>,
     declared_bare: &HashSet<i32>,
+    at_initializer: &HashSet<i32>,
 ) -> (String, HashSet<i32>) {
     // Only where the assignment stands at the FUNCTION's own level. Inside a loop or a branch a
     // declaration is entered and left again with the block, and the compiler spends the slot's
     // construction and release on every pass — which vanilla, having hoisted it, does not
     // (measured: 94 functions lost against 46 gained when this was not required).
     let wanted = |slot: i32, _ty: &str| {
-        !already.contains(&slot)
-            && !declared_bare.contains(&slot)
-            && first_top_level_assignment_before_read(body, slot)
+        if already.contains(&slot) || declared_bare.contains(&slot) {
+            return false;
+        }
+        if first_top_level_assignment_before_read(body, slot) {
+            return true;
+        }
+        // …or the bytecode says the declaration stood at the initialiser, wherever that is. The
+        // depth gate exists because a declaration entered and left with a block costs its
+        // construction on every pass; a witness that reads vanilla answers the same question
+        // directly. Sinking still narrows the name's scope, so nothing after the assignment's own
+        // block may read it.
+        at_initializer.contains(&slot) && assignment_block_owns_the_name(body, slot)
     };
     rewrite_decl_at_assignment(body, locals, &wanted, &|slot, ty| {
         let head = qualify_decl_type(ty, refs);

--- a/crates/gore-as/src/cache/emit.rs
+++ b/crates/gore-as/src/cache/emit.rs
@@ -2097,6 +2097,7 @@ fn emit_function_ctor(
                         .into_iter()
                         .map(|slot| (slot, 1)),
                 )
+                .chain(chain_inlined_cast_operands(f).into_iter().map(|slot| (slot, 1)))
                 .collect(),
             &wholly_consumed_object_slots(f),
             &rvo_temporary_slots(f, refs),
@@ -2116,6 +2117,7 @@ fn emit_function_ctor(
                         .into_iter()
                         .map(|slot| (slot, 1)),
                 )
+                .chain(chain_inlined_cast_operands(f).into_iter().map(|slot| (slot, 1)))
                 .collect(),
             &wholly_consumed_object_slots(f),
             &rvo_temporary_slots(f, refs),
@@ -10650,6 +10652,45 @@ fn declared_at_initializer_carriers(f: &Func) -> HashSet<i32> {
         if consumed {
             out.insert(slot);
         }
+    }
+    out
+}
+
+/// The operand of a `Cast<T>` whose whole chain the source wrote inline.
+///
+/// A cast's destination slot is allocated fresh — unless the compiler has one free, and the only
+/// way a slot comes free mid-function is a temporary that died. So a cast whose out-slot is a slot
+/// vanilla RELEASED (`FreeNullV8`) says the value it casts came out of a chain of temporaries,
+/// with no name anywhere along it. Measured over the whole cache: the freeing shape occurs 10
+/// times, every one in a divergent function; the 785 sites where the cast takes a fresh slot are
+/// untouched.
+fn chain_inlined_cast_operands(f: &Func) -> HashSet<i32> {
+    let Ok(instrs) = disassemble(&f.bytecode) else {
+        return HashSet::new();
+    };
+    let w0 = |ins: &super::disasm::Instr| ins.words.first().map(|w| *w as i16 as i32).unwrap_or(0);
+    let freed: HashSet<i32> = instrs
+        .iter()
+        .filter(|ins| ins.op.name == "FreeNullV8")
+        .map(&w0)
+        .collect();
+    let mut out = HashSet::new();
+    for (at, ins) in instrs.iter().enumerate() {
+        if ins.op.name != "TYPEID" {
+            continue;
+        }
+        // `TYPEID T; PSF <destination>; PshVPtr <operand>; CALLSYS ::opCast`
+        let Some(destination) = instrs.get(at + 1).filter(|ins| ins.op.name == "PSF") else {
+            continue;
+        };
+        let Some(operand) = instrs.get(at + 2).filter(|ins| ins.op.name == "PshVPtr") else {
+            continue;
+        };
+        let operand = w0(operand);
+        if !freed.contains(&w0(destination)) || operand <= 0 {
+            continue;
+        }
+        out.insert(operand);
     }
     out
 }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -6941,10 +6941,20 @@ impl Structurer<'_> {
         if self.idx_of.get(&fall).copied() != Some(bi + 1) {
             return None;
         }
+        // A conditional whose TAKEN edge is the latch is NOT a `continue`. This compiler never
+        // folds a jump over a jump, so a source `continue` always spends an unconditional `JMP` to
+        // the latch — which `loop_exit_stmt` already recognises. Straight to the latch is the
+        // compiled form of a plain `if (<fall condition>) { <rest of the body> }`, and claiming it
+        // here costs an extra `JMP` and an inverted condition: a `NOT`, plus the store-and-reload
+        // where vanilla tested the register directly. The `is_cond` arm renders the fall condition
+        // positively and is what should take it.
+        //
+        // Vanilla witnesses the premise in its own stream — `TryUseFreepoint` carries both shapes,
+        // and its jump-over-jump guard is byte-identical on both sides while the direct-to-latch
+        // one is where the extra jump appears. The `break` arm keeps its claim: a conditional
+        // straight to the break target still leaves a fall-through that reaches the latch.
         let kw = if taken == ls.break_off {
             "break;"
-        } else if taken == ls.continue_off {
-            "continue;"
         } else {
             return None;
         };

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -6287,7 +6287,12 @@ impl Structurer<'_> {
                 let saved = self.loop_scope;
                 self.loop_scope = Some(LoopScope {
                     continue_off: b.start_dw,
-                    break_off: usize::MAX,
+                    // The header's taken edge IS the loop exit. Only a block that is NOTHING but
+                    // the jump may spend it: an arm that does no work and only leaves is a
+                    // `break;`, and rendered as an empty arm it left four loops running forever.
+                    // A jump that also carries statements is a different question, and offering
+                    // `break;` there fires on six functions this build reproduces byte for byte.
+                    break_off: b.succs.first().copied().unwrap_or(usize::MAX),
                     continue_only: true,
                     latch_block: body_end.checked_sub(1),
                 });
@@ -7012,11 +7017,11 @@ impl Structurer<'_> {
             }
             return Some("continue;".into());
         }
+        if t == ls.break_off && (!ls.continue_only || b.instr_hi - b.instr_lo == 1) {
+            return Some("break;".into());
+        }
         if ls.continue_only {
             return None;
-        }
-        if t == ls.break_off {
-            return Some("break;".into());
         }
         // an in-body `return <expr>;` compiled as a JMP to the function's shared bare RET row —
         // recover the returned value from the block's trailing register write (scan floored to

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -547,6 +547,56 @@ fn float_operand_slots(
 }
 
 impl Ctx<'_> {
+    /// The constant a `CpyVtoR4` at `at` returns LITERALLY.
+    ///
+    /// `return 1;` is `SetV4 vT,1; CpyVtoR4 vT` — the constant goes straight into the register's
+    /// slot and straight back out. `int x = 1; … return x;` cannot look like that: the name costs
+    /// a `CpyVtoV` between the store and the copy. So the adjacent pair — reading past the
+    /// `PSF vT; CALLSYS` cleanup a scope exit puts between them — IS the literal the source wrote,
+    /// whatever the emitter later decides to call the slot.
+    ///
+    /// Calling it something is how four achievements came to return the WRONG constant: the
+    /// compiler reuses one scratch slot for two different constant returns, and a single name over
+    /// both lives can only carry one of them.
+    fn const_return_literal(&self, at: usize) -> Option<String> {
+        if self.ret_ty.map(|ty| ty.base_name(self.refs))? != "int" {
+            return None;
+        }
+        let slot = self.instrs.get(at)?.words.first().map(|w| *w as i16 as i32)?;
+        let here = self.const_return_at(at, slot)?;
+        // ONE constant return through a slot is a name the source may well have written, and the
+        // folds behind us already turn `local_N = K; return local_N;` into `return K;` with no
+        // bytes to spare — measured: literalising those costs 19 records. TWO different constants
+        // through the same slot cannot be one variable, and that is the case a single name gets
+        // WRONG: it carries whichever constant the collapse happened to keep.
+        let mut others = self
+            .instrs
+            .iter()
+            .enumerate()
+            .filter(|(other, ins)| {
+                *other != at
+                    && ins.op.name == "CpyVtoR4"
+                    && ins.words.first().map(|w| *w as i16 as i32) == Some(slot)
+            })
+            .filter_map(|(other, _)| self.const_return_at(other, slot));
+        others.any(|value| value != here).then_some(here)
+    }
+
+    /// The constant an adjacent `SetV4` puts into `slot` just before the `CpyVtoR4` at `at`,
+    /// reading past the `PSF vT; CALLSYS` cleanup pairs a scope exit places between them.
+    fn const_return_at(&self, at: usize, slot: i32) -> Option<String> {
+        let mut back = at;
+        while back >= 2
+            && self.instrs[back - 1].op.name == "CALLSYS"
+            && self.instrs[back - 2].op.name == "PSF"
+        {
+            back -= 2;
+        }
+        let set = self.instrs.get(back.checked_sub(1)?)?;
+        (set.op.name == "SetV4" && set.words.first().map(|w| *w as i16 as i32) == Some(slot))
+            .then(|| (set.dwords.first().copied().unwrap_or(0) as i32).to_string())
+    }
+
     fn slot_name(&self, off: i32) -> String {
         if off > 0 {
             return format!("local_{off}");
@@ -908,7 +958,9 @@ fn scan_back_retval_floor(ctx: &Ctx, before: usize, floor: usize) -> Option<Stri
         let ins = &ctx.instrs[i];
         match ins.op.name {
             "CpyVtoR4" | "CpyVtoR8" | "CpyVtoR1" | "LOADOBJ" => {
-                return Some(ctx.slot_name(ins.words.first().copied().map(s16).unwrap_or(0)));
+                return Some(ctx.const_return_literal(i).unwrap_or_else(|| {
+                    ctx.slot_name(ins.words.first().copied().map(s16).unwrap_or(0))
+                }));
             }
             "RET" => return None,
             _ => {}
@@ -4589,7 +4641,10 @@ fn block_stmts_in(
                 // cant-convert errors). The one legitimate ret_val source for RVO functions is
                 // the CopyScript-to-`__return` capture below.
                 if !ctx.ret_via_rvo() {
-                    ret_val = pending.take().or_else(|| Some(name(w(ins, 0))));
+                    ret_val = pending
+                        .take()
+                        .or_else(|| ctx.const_return_literal(lo + k))
+                        .or_else(|| Some(name(w(ins, 0))));
                 }
             }
             "CpyVtoR1" => {

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -232,6 +232,7 @@ pub fn body_statements_ctor(
         exit_scan_floor: 0,
         carry: None,
         loop_scope: None,
+        shared_return: None,
     };
     st.emit_range(0, g.blocks.len(), depth, &mut body);
     body
@@ -5717,6 +5718,10 @@ struct Structurer<'a> {
     /// `break;` lands: the latch's non-back-edge successor). Saved/restored around the recursive
     /// body emission; nested loops push/pop so break/continue always bind to the innermost loop.
     loop_scope: Option<LoopScope>,
+    /// While a then-arm is being emitted: the offset the enclosing conditional jumps to when its
+    /// test fails. A constant-return block there is the tail BOTH guards share, and writing it
+    /// again inside the arm duplicates a `return` vanilla wrote once.
+    shared_return: Option<usize>,
 }
 
 #[derive(Clone, Copy)]
@@ -6480,7 +6485,9 @@ impl Structurer<'_> {
                 let then_body_at = out.len();
                 if let Some(t) = then_idx {
                     if t > i && t <= then_end_body {
+                        let outer = std::mem::replace(&mut self.shared_return, taken);
                         self.emit_range(t, then_end_body, depth + 1, out);
+                        self.shared_return = outer;
                     }
                 }
                 if latch_back.is_some() {
@@ -6773,6 +6780,15 @@ impl Structurer<'_> {
             .map(|t| t.base_name(self.ctx.refs))
             .as_deref()
             != Some("bool")
+        {
+            return None;
+        }
+        // The else arm IS the tail the enclosing guard falls to: two guards in a row that both
+        // leave with the same constant. Writing the diamond here puts a second `return false;`
+        // inside the arm, where vanilla wrote one behind both.
+        if else_idx
+            .map(|ei| self.g.blocks[ei].start_dw)
+            .is_some_and(|start| self.shared_return == Some(start))
         {
             return None;
         }
@@ -9361,6 +9377,7 @@ mod tests {
             exit_scan_floor: 0,
             carry: None,
             loop_scope: None,
+            shared_return: None,
         };
         let (start, stop) = if let Some((start, stop, scope)) = range {
             st.loop_scope = Some(scope);

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -585,11 +585,21 @@ impl Ctx<'_> {
 
     /// The constant an adjacent `SetV4` puts into `slot` just before the `CpyVtoR4` at `at`,
     /// reading past the `PSF vT; CALLSYS` cleanup pairs a scope exit places between them.
+    ///
+    /// The pair has to BE cleanup. Any other call taking an address can write through it, and
+    /// `x = 1; Mutate(x); return x;` then reports a constant the function does not return. Only
+    /// the destructor behaviour is skipped, and only where the address it takes is not the return
+    /// slot itself.
     fn const_return_at(&self, at: usize, slot: i32) -> Option<String> {
         let mut back = at;
         while back >= 2
             && self.instrs[back - 1].op.name == "CALLSYS"
             && self.instrs[back - 2].op.name == "PSF"
+            && self
+                .refs
+                .func_by_ptr(self.instrs[back - 1].qwords.first().copied().unwrap_or(0) as i64)
+                == Some("$beh2")
+            && self.instrs[back - 2].words.first().map(|w| *w as i16 as i32) != Some(slot)
         {
             back -= 2;
         }

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -5728,6 +5728,16 @@ struct Structurer<'a> {
 struct LoopScope {
     continue_off: usize,
     break_off: usize,
+    /// A scope opened only so a back edge inside the body can be read as `continue;`.
+    ///
+    /// The top-test arm never set a scope at all, so an in-body jump back to the header rendered
+    /// as its own nested `while` — an extra `SUSPEND` and a moved back edge. Setting the scope
+    /// fixes that, but it also offers `break;` and `return …;` to bodies that never asked: those
+    /// two fire on byte-faithful functions (6 and 4), and this one does not fire on any.
+    continue_only: bool,
+    /// The body's LAST block, whose back edge is the loop's own latch. Control reaches the header
+    /// from there anyway, so writing `continue;` for it adds a statement the source never had.
+    latch_block: Option<usize>,
 }
 
 const COMPOUND_HEADER_MAX_BLOCKS: usize = 8;
@@ -6269,7 +6279,20 @@ impl Structurer<'_> {
                 // top-test loop: `header: <cmp> Jcc exit; body; JMP header`
                 let _ = writeln!(out, "{ind}while ({cond})");
                 let _ = writeln!(out, "{ind}{{");
+                // A body jump back to this header is a `continue;`. Without a scope it was read
+                // as a latch instead, and the guarded region in front of it became a nested
+                // `while` of its own — one extra `SUSPEND` and a back edge in the wrong place.
+                // The scope is continue-only on purpose: `break;` and `return …;` offered here
+                // fire on byte-faithful functions, this does not.
+                let saved = self.loop_scope;
+                self.loop_scope = Some(LoopScope {
+                    continue_off: b.start_dw,
+                    break_off: usize::MAX,
+                    continue_only: true,
+                    latch_block: body_end.checked_sub(1),
+                });
                 self.emit_range(i + 1, body_end, depth + 1, out);
+                self.loop_scope = saved;
                 let _ = writeln!(out, "{ind}}}");
                 next = body_end;
             } else if let Some((latch, cond, cont_off, brk_off)) =
@@ -6291,6 +6314,8 @@ impl Structurer<'_> {
                 let ls = LoopScope {
                     continue_off: cont_off,
                     break_off: brk_off,
+                    continue_only: false,
+                    latch_block: None,
                 };
                 let saved = self.loop_scope;
                 self.loop_scope = Some(ls);
@@ -6310,6 +6335,8 @@ impl Structurer<'_> {
                 self.loop_scope = Some(LoopScope {
                     continue_off: cont_off,
                     break_off: brk_off,
+                    continue_only: false,
+                    latch_block: None,
                 });
                 self.emit_range(body, exit, depth + 1, out);
                 self.loop_scope = saved;
@@ -6365,6 +6392,8 @@ impl Structurer<'_> {
                 let ls = LoopScope {
                     continue_off: test_off,
                     break_off,
+                    continue_only: false,
+                    latch_block: None,
                 };
                 let saved = self.loop_scope;
                 self.loop_scope = Some(ls);
@@ -6404,6 +6433,8 @@ impl Structurer<'_> {
                     let ls = LoopScope {
                         continue_off: latch_off,
                         break_off,
+                        continue_only: false,
+                    latch_block: None,
                     };
                     // `loop_scope` must be set BEFORE Gate 2 — its nested-switch dry run
                     // (`switch_span` -> `try_emit_switch`) consults it to accept loop
@@ -6470,12 +6501,18 @@ impl Structurer<'_> {
                 // Mark it instead, and let the emitter turn the pair into a `while` once it has
                 // folded the condition into one expression -- where it cannot, the mark is
                 // dropped and this stays the `if` it is today.
+                // …and a jump back to the ENCLOSING loop's header is that loop's `continue;`,
+                // not a latch of this arm. Reading it as a latch invents a loop the source never
+                // wrote around the guarded region in front of it.
                 let latch_back = (then_end > i + 1
                     && self.is_backward_jump(then_end - 1)
                     && self.g.blocks[then_end - 1]
                         .succs
                         .first()
-                        .is_some_and(|&s| s <= b.start_dw))
+                        .is_some_and(|&s| {
+                            s <= b.start_dw
+                                && self.loop_scope.is_none_or(|ls| ls.continue_off != s)
+                        }))
                 .then_some(then_end - 1);
                 // The latch block is NOT excluded: its jump is only its terminator, and the
                 // statements before it are the body's last ones.
@@ -6967,11 +7004,19 @@ impl Structurer<'_> {
             return None;
         }
         let t = *b.succs.first()?;
+        if t == ls.continue_off {
+            // …unless this IS the latch: control reaches the header from the body's last block
+            // anyway, and writing the keyword there adds a statement the source never had.
+            if ls.latch_block == Some(bi) {
+                return None;
+            }
+            return Some("continue;".into());
+        }
+        if ls.continue_only {
+            return None;
+        }
         if t == ls.break_off {
             return Some("break;".into());
-        }
-        if t == ls.continue_off {
-            return Some("continue;".into());
         }
         // an in-body `return <expr>;` compiled as a JMP to the function's shared bare RET row —
         // recover the returned value from the block's trailing register write (scan floored to
@@ -7113,6 +7158,8 @@ impl Structurer<'_> {
                         let inner_ls = LoopScope {
                             continue_off: inner_off,
                             break_off: ib,
+                            continue_only: false,
+                    latch_block: None,
                         };
                         // the inner loop's exit must stay inside our body or be our own exit.
                         let ib_in_body = self
@@ -8763,6 +8810,8 @@ impl Structurer<'_> {
         let ls = LoopScope {
             continue_off,
             break_off,
+            continue_only: false,
+                    latch_block: None,
         };
         if !self.body_has_inner_branch(body, exit, ls) {
             return None;
@@ -8936,6 +8985,8 @@ impl Structurer<'_> {
         let ls = LoopScope {
             continue_off: test_off,
             break_off,
+            continue_only: false,
+                    latch_block: None,
         };
         let saved = self.loop_scope;
         self.loop_scope = Some(ls);
@@ -9048,6 +9099,8 @@ impl Structurer<'_> {
         let ls = LoopScope {
             continue_off: cont_off,
             break_off: brk_off,
+            continue_only: false,
+                    latch_block: None,
         };
         if !self.body_has_inner_branch(i + 1, latch, ls) {
             return None;
@@ -9667,6 +9720,8 @@ mod tests {
         let scope = LoopScope {
             continue_off: break_target.labels["head"],
             break_off: break_target.labels["loop_exit"],
+            continue_only: false,
+                    latch_block: None,
         };
         let body = render_fixture_range(&break_target, Some(("switch", "loop_exit", scope)));
         assert!(
@@ -9680,6 +9735,8 @@ mod tests {
         let scope = LoopScope {
             continue_off: ambiguous.labels["head"],
             break_off: ambiguous.labels["alt_ret"],
+            continue_only: false,
+                    latch_block: None,
         };
         let body = render_fixture_range(&ambiguous, Some(("switch", "loop_exit", scope)));
         assert!(

--- a/crates/gore-as/src/cache/structure.rs
+++ b/crates/gore-as/src/cache/structure.rs
@@ -7027,7 +7027,10 @@ impl Structurer<'_> {
             }
             return Some("continue;".into());
         }
-        if t == ls.break_off && (!ls.continue_only || b.instr_hi - b.instr_lo == 1) {
+        // An unconditional jump to the loop exit IS the exit, whatever else the block did first.
+        // Restricting this to a one-instruction block dropped the jump from `DoWork(); break;` —
+        // the work was still written, and control then fell through into another iteration.
+        if t == ls.break_off {
             return Some("break;".into());
         }
         if ls.continue_only {

--- a/crates/gore-as/src/standalone_sidecar.rs
+++ b/crates/gore-as/src/standalone_sidecar.rs
@@ -1743,6 +1743,17 @@ fn parse_sidecar_response(
     let stderr = redact_private_path_variants(stderr, private_root);
     let response: SidecarCompileResponseV1 = serde_json::from_slice(&completed.stdout.bytes)
         .map_err(|error| {
+            // An EMPTY stdout is not a protocol error, it is a dead compiler: the sidecar wrote
+            // nothing at all. Reporting that as "invalid JSON at line 1 column 0" sends the
+            // reader looking for a malformed response that does not exist, and hides the one
+            // fact that identifies the failure — how the process ended.
+            if completed.stdout.bytes.is_empty() {
+                return invalid_output(format!(
+                    "the sidecar compiler produced no output and {}{}",
+                    describe_exit(&completed.status),
+                    stderr_suffix(&stderr)
+                ));
+            }
             invalid_output(format!(
                 "invalid sidecar response JSON: {error}{}",
                 stderr_suffix(&stderr)
@@ -2253,6 +2264,16 @@ fn diagnostics_detail(
         .collect::<Vec<_>>()
         .join("; ");
     redact_private_path_variants(&detail, private_root)
+}
+
+/// How a sidecar process ended, in the words a reader needs: a normal exit carries a code, an
+/// abnormal one carries none and is the signature of a crash.
+fn describe_exit(status: &ExitStatus) -> String {
+    match status.code() {
+        Some(code) if code == 0 => "exited successfully".to_owned(),
+        Some(code) => format!("exited with code {code} (0x{code:08x})"),
+        None => "was terminated without an exit code — it crashed".to_owned(),
+    }
 }
 
 fn stderr_suffix(stderr: &str) -> String {

--- a/crates/gore-mcp/src/spec/mod.rs
+++ b/crates/gore-mcp/src/spec/mod.rs
@@ -695,7 +695,7 @@ impl GroupSpec {
 
 /// Wall-clock caps. Three tiers rather than a number per command: the distinction that matters is
 /// "prints something", "rewrites some files" and "walks the entire game", and inventing a precise
-/// budget for each of 87 commands would be false precision.
+/// budget for each of 89 commands would be false precision.
 pub const T_FAST: u64 = 60;
 pub const T_NORMAL: u64 = 300;
 pub const T_LONG: u64 = 1800;

--- a/crates/gore/CHANGELOG.md
+++ b/crates/gore/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-30
+
+- Decompiled scripts recompile closer to the original: enum returns, increments,
+  copied values, loop bodies and construction order now come back the way the
+  game wrote them.
+- A standalone AngelScript compile that dies without answering now says how the
+  compiler process ended, instead of blaming its output.
+- Correct stale command flags, install paths and counts throughout the guide and
+  the reference docs.
+
 ## [0.2.2] - 2026-08-29
 
 - Fix standalone AngelScript compilation for patch 1.0.5.

--- a/crates/gore/Cargo.toml
+++ b/crates/gore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gore"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Only the guide ships in the CLI release zip, as Markdown plus a browsable
 
 ## Guide at a glance
 
-- [Getting started](guide/getting-started.md) · [CLI reference](guide/cli-reference.md) · [MCP server](guide/mcp.md)
+- [Getting started](guide/getting-started.md) · [CLI reference](guide/cli-reference.md) · [MCP server](guide/mcp.md) · [Finding things](guide/find.md)
 - Domains: [items](guide/items.md) · [text & dialogs](guide/text-and-dialogs.md) · [audio](guide/audio.md) · [voice](guide/voice.md) · [textures](guide/textures.md) · [DataAssets](guide/dataassets.md) · [scripts](guide/scripts.md)
 - AngelScript authoring: [dialogs](guide/dialog-authoring.md) · [defaults](guide/angelscript-defaults.md)
 - Shipping: [bundles](guide/bundles.md) · [many mods](guide/mod-manager.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,6 +142,7 @@ gore/
 │  ├─ gore-asset/          USMAP + unversioned-property + lossless package primitives
 │  ├─ gore-tex/            UE5 IoStore texture extract/replace (Zen .utoc/.ucas/.pak)
 │  ├─ gore-authoring/      durable managed-project authoring primitives (Mod Studio)
+│  ├─ gore-generation/     audited game-generation table: one sealed row per shipped G1R build
 │  ├─ gore-story-catalog/  generation-sealed NPC + quest-parent catalogs
 │  ├─ gore-npc-catalog/    generation-sealed NPC archetype catalogs
 │  ├─ gore-story-build/    deterministic, non-publishing story build plans
@@ -161,6 +162,7 @@ gore/
 ├─ lua/                    gore-lua UE4SS helper library (deployed into the game's Mods/shared)
 ├─ mods/                   first-party UE4SS mod folders
 │  ├─ example/             sample mod using gore-lua
+│  ├─ g1r-hotbar-keys/     rebinds the three hotbar slots the Controls menu cannot reach
 │  └─ gore-dump/           generated dump mod (regen: `gore dump-mod`)
 ├─ vendor/
 │  └─ retoc/               vendored IoStore reader fork (Oodle decode routed to gore-oodle)
@@ -184,6 +186,7 @@ gore/
 | [`gore-asset`](../crates/gore-asset) | Rust lib | USMAP flattening, bounded read-only complex-property spans, unversioned primitive codec, and verified `.uasset`/`.uexp` carrier. |
 | [`gore-tex`](../crates/gore-tex) | Rust lib | IoStore texture extract/replace; cooks + packs a Zen triplet. Built on vendored [`retoc`](../vendor/retoc) + `gore-oodle`. |
 | [`gore-authoring`](../crates/gore-authoring) | Rust lib | Durable, deployment-independent authoring primitives for managed Mod Studio projects. |
+| [`gore-generation`](../crates/gore-generation) | Rust lib | The audited game-generation table: one sealed row per shipped G1R build; the leaf every generation-sealed crate depends on. |
 | [`gore-story-catalog`](../crates/gore-story-catalog) | Rust lib | Strict, generation-sealed NPC and quest-parent catalogs (`story_catalog.v1`). |
 | [`gore-npc-catalog`](../crates/gore-npc-catalog) | Rust lib | Generation-sealed NPC archetype catalogs and their structural linkage. |
 | [`gore-story-build`](../crates/gore-story-build) | Rust lib | Deterministic, non-publishing build plans over revision-3 story content. |

--- a/docs/guide/catalogs-and-models.md
+++ b/docs/guide/catalogs-and-models.md
@@ -144,16 +144,17 @@ editor show accurate numbers), run the `gore-dump` UE4SS mod in game and fold
 its output back in:
 
 ```powershell
-# 1. generate the dump mod into the game's Mods dir
-gore dump-mod --model model.json --catalog item_catalog.json -o "$GAME\...\Mods"
+# 1. derive the GUI shape model, then generate the dump mod into the game's Mods dir
+gore gui-model --model model.json --catalog item_catalog.json -o gui_model.json
+gore dump-mod --model gui_model.json --catalog item_catalog.json -o "$GAME\...\Mods"
 
 # 2. launch the game once with it enabled → writes gore_game_data.json
 
-# 3. fold the runtime values back into the model
-gore sync --dump gore_game_data.json --catalog item_catalog.json -o model.json
+# 3. fold the runtime values back into the GUI model
+gore sync --dump gore_game_data.json --catalog item_catalog.json -o gui_model.json
 ```
 
-The catalog acts as the item allow-list in both steps. The mod source lives in
+The catalog acts as the item allow-list in every step. The mod source lives in
 [`mods/gore-dump`](../../mods/gore-dump/README.md).
 
 ## GUI shape model

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -22,7 +22,7 @@ gore --version
 | `mod` | `build` · `inspect` · `deploy` · `undeploy` | Build, validate, inspect, deploy, or undeploy a unified bundle. | [bundles](bundles.md) |
 | `mgr` | `import` · `list` · `remove` · `enable` · `disable` · `order` · `analyze` · `preflight` · `recover` · `apply` · `status` · `reset` | Multi-mod manager: library, load order, readiness/recovery, conflicts, composed deployment, status and Reset. | [mod-manager](mod-manager.md) |
 | `loc` | `extract` · `status` · `export` · `import` | Read/edit localized text & dialogs in the encrypted `.lcache`. | [text-and-dialogs](text-and-dialogs.md) |
-| `audio` | `list` · `extract` · `replace` · `restore` · `export-patch` · `apply-patch` | Read/replace FMOD `.bank` audio (PCM injection, `*.gore-bak`). | [audio](audio.md) |
+| `audio` | `banks` · `list` · `extract` · `replace` · `restore` · `export-patch` · `apply-patch` | Read/replace FMOD `.bank` audio (PCM injection, `*.gore-bak`). | [audio](audio.md) |
 | `voice` | `validate` · `list` (`index`) · `match-line` · `extract` · `add` · `replace` · `apply-manifest` (`apply`) | Validate/index/extract/copy-on-write edit voice-over ZIP archives. | [voice](voice.md) |
 | `texture` | `list` · `extract` · `replace` · `pack` · `deploy` · `index` · `undeploy` · `paklist` | Extract/replace IoStore textures → Zen triplet in `~mods`. | [textures](textures.md) |
 | `asset` | `extract` · `inspect` · `patch-fixed` · `pack` | Extract, inspect, copy-on-write patch, and offline-pack one cooked DataAsset. | [dataassets](dataassets.md) |
@@ -41,8 +41,9 @@ gore --version
 | `package` | — | Zip a mod folder into distributable UE4SS layout. | [bundles](bundles.md#other-helpers) |
 
 Commands that need the install (`deploy-shared`, `mod`, `mgr`, `texture`,
-`asset`, `as`, `loc`, `doctor`) resolve it from an explicit `--game` (or
-`--lcache` / `--exe`), then the configured game path, then Steam auto-detect.
+`asset`, `as`, `audio banks`, `loc`, `location-catalog`, `doctor`) resolve it
+from an explicit `--game` (or `--lcache` / `--exe` / an explicit source path),
+then the configured game path, then Steam auto-detect.
 
 ## `config`
 
@@ -160,7 +161,7 @@ and failing would bury the line explaining what was not searched.
 
 | Subcommand | Flags |
 |---|---|
-| `build` | `--spec <SPEC>` (asset paths resolve against its directory) · `-o, --out <OUT>` (bundle goes to `<out>/<mod-name>`) |
+| `build` | `--spec <SPEC>` (asset paths resolve against its directory) · `-o, --out <OUT>` (bundle goes to `<out>/<mod-name>`) · `--model <MODEL>` (validate field names/types; skipped if absent) |
 | `inspect <BUNDLE>` | bundle directory or ZIP · `--json`; read-only full offline validation plus a bounded metadata/component/hash report |
 | `deploy` | `--bundle <BUNDLE>` · `--game <GAME>` |
 | `undeploy` | `--game <GAME>` |
@@ -208,8 +209,9 @@ auto-detect are tried. The installed cache is
 
 | Subcommand | Flags |
 |---|---|
+| `banks` | `--game <GAME>` · `--json` · `--key <KEY>`; lists the install's `.bank` files and each one's sample count |
 | `list` | `--bank <BANK>` · `--filter <TEXT>` · `--max <N>` (default 100) · `--json` · `--key <KEY>` |
-| `extract` | `--bank` · `-o, --out <DIR>` · `--sample <NAME\|all>` · `--key` |
+| `extract` | `--bank` · `-o, --out <DIR>` · `--sample <NAME\|all>` · `--filter <TEXT>` · `--key` |
 | `replace` | `--map <MAP>` · `--bank` · `-o, --out <BANK>` · `--key` |
 | `restore` | `--bank` |
 | `export-patch` | `--map <MAP>` · `-o, --out <ZIP>` |
@@ -265,8 +267,8 @@ Output directories must not exist and are never placed in the game tree.
 | `walk <FILE>` | `--max <N>` (default 100) |
 | `decompile <FILE> [NEEDLE]` | `--max <N>` (default 20) |
 | `disasm <FILE> [NEEDLE]` | `--max <N>` (default 20) |
-| `emit <FILE> [NEEDLE]` | `--max <N>` (default 5) |
-| `emit-all <FILE> <OUTDIR>` | every module, mirroring `ScriptRelativeFilename` |
+| `emit <FILE> [NEEDLE]` | `--max <N>` (default 5) · `--no-defaults` (omit class `default` statements) |
+| `emit-all <FILE> <OUTDIR>` | `--no-defaults` (omit class `default` statements); every module, mirroring `ScriptRelativeFilename` |
 | `static-names <FILE> [INDICES]...` | no indices → count + first 10 |
 | `default-sites <CACHE>` | `--module` · `--class` · `--field` · `--json` |
 | `patch-default <CACHE>` | `--selector <JSON>` · `--expected-hex` · `--replacement-hex` · `-o, --out` · `--json` |
@@ -274,8 +276,8 @@ Output directories must not exist and are never placed in the game tree.
 | `patch-tag-map <CACHE>` | `--selector <JSON>` · `--expected-hex` · `--replacement-hex` · `-o, --out` · `--json` |
 | `qualify` | `--game` · `--usmap <FILE>` · `--catalog <JSON>` · `--id <ID>` · `--label <TEXT>` · `--json` |
 | `diagnostics-check` | `--exe <EXE>` · `--game <GAME>` |
-| `compile [SRC]` | `-o, --out` · `--game` · `--no-backup` · `--no-diagnostics` · `--diagnostics-hook <DLL>` · `--diagnostics-inject-delay-ms <MS>` |
-| `compile-module` | `--op add\|edit` · `--module` · `--rel-path` · `--source` · `--work-dir` · `--allow-new-symbols` · `-o, --out` · `--game` · diagnostics flags |
+| `compile <SRC>` | `-o, --out` · `--work-dir <DIR>` · `--game` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · `--no-diagnostics` · `--diagnostics-hook <DLL>` · `--diagnostics-inject-delay-ms <MS>` |
+| `compile-module` | `--op add\|edit` · `--module` · `--rel-path` · `--source` · `--work-dir` · `--allow-new-symbols` · `-o, --out` · `--game` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · diagnostics flags · five `--development-*` compiler-development overrides |
 | `replace <BASE> <MINI> <TARGET>` | `-o, --out` |
 | `splice <BASE> <MINI>` | `-o, --out` |
 | `extract <CACHE> <MODULE>` | `-o, --out` |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -77,10 +77,11 @@ gore doctor
 One read-only pass over everything the rest of this guide assumes. Ten checks,
 one line each: where the install is and which of the three sources above
 answered, whether that folder holds Gothic 1 Remake, whether [UE4SS](#ue4ss) is
-present, which UE4SS mods are enabled, what is deployed, what an interrupted run
-left behind, whether the executable is running, whether the authenticated
-standalone AngelScript compiler matches the installed cache/API, and whether
-the shared localized-text catalog still describes the installed `.lcache`.
+present, which UE4SS mods are enabled, what is deployed, whether the `~mods`
+override folder is there, what an interrupted run left behind, whether the
+executable is running, whether the authenticated standalone AngelScript
+compiler matches the installed cache/API, and whether the shared localized-text
+catalog still describes the installed `.lcache`.
 
 Every `problem` carries a `fix:` line. A `note` is informational; a `skipped`
 check can point to the earlier missing prerequisite instead. Abridged example:

--- a/docs/guide/items.md
+++ b/docs/guide/items.md
@@ -33,7 +33,7 @@ value_float = 1.5
   which is what you normally want — the retry loop described below already
   covers classes that are not resolvable that early.
 - Each `[[override]]` names one `class`, one `field`, and exactly one typed
-  value: `value_int`, `value_float`, or `value_bool`.
+  value: `value_int`, `value_float`, `value_bool`, or `value_str`.
 
 ## What m_Value does to prices
 

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -7,7 +7,7 @@ check a load order for conflicts.
 
 Every tool call runs a real `gore` subcommand as a child process and returns its
 output, with the exact command line shown first — whatever the agent did, you can
-re-run it in a shell yourself. All 87 leaf commands are reachable, and this guide
+re-run it in a shell yourself. All 89 leaf commands are reachable, and this guide
 ships inside the binary so the agent can read it before acting.
 
 ## Setup

--- a/docs/guide/mod-manager.md
+++ b/docs/guide/mod-manager.md
@@ -206,11 +206,12 @@ incomplete-knowledge warning, never as proof that the loadout is conflict-free.
 The grades themselves are shown while **Advanced details** is on in Settings;
 the incomplete-knowledge warning always appears when it applies.
 
-The CLI reports the same four grades under their wire names (`exact`,
-`partial`, `advisory`, `opaque`). When no recognized conflict rows exist but any
-enabled footprint is partial, advisory, or opaque, it prints the coverage-gap
-warning and counts for those grades instead of the unqualified phrase "no
-conflicts".
+The CLI names only the three incomplete grades, under their wire names. A
+zero-result analysis prints `no recognized conflicts`, and whenever any enabled
+footprint is partial, advisory, or opaque it adds
+`warning: conflict analysis is incomplete for enabled components (partial=…,
+advisory=…, opaque=…)` after that line. `exact` is never printed, and
+`gore mgr analyze` has no `--json`.
 
 The same view spells out the intended order — mods further down the list
 override the ones above them — while **Advanced details** is on. That order predicts winners only

--- a/docs/guide/mod-studio.md
+++ b/docs/guide/mod-studio.md
@@ -116,9 +116,9 @@ anybody in a new game.
 The **Create Quest** wizard captures the human-facing name, technical
 identity, parent, giver, description, and one to eight objectives, and creates
 the quest together with its generated script module in one step. A selected
-Quest has exactly four Story tabs: **Overview**, **Dialog & Voice**,
-**References**, and **Problems & Checks**. **Overview** hosts Journey and its
-three editing areas:
+Quest has exactly four Story tabs: **Journey**, **Dialog & Voice**,
+**References**, and **Problems & Checks**. **Journey** hosts its three
+editing areas:
 
 - **Outline** edits the display name, title, objective order, and objective
   titles; objectives keep their stable slots across reorders.

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -63,7 +63,10 @@ You can edit those statements and splice the module back with `compile-module
 --op edit`; the compiler regenerates the class defaults from your source and the
 old copies are dropped rather than carried. An overlay that declares defaults for
 only some of a module's classes is refused, because the classes it left out would
-lose theirs silently.
+lose theirs silently. If you would rather not author defaults at all, emit the
+module with `gore as emit --no-defaults` (or `emit-all --no-defaults`) and edit
+that: the module's existing defaults are then carried back byte-exact instead of
+being regenerated.
 
 Every module in the shipped game writes its defaults, down to the main map's
 worldpoint and item-spawn tables. Recovery stays all-or-nothing per module: if a

--- a/docs/guide/text-and-dialogs.md
+++ b/docs/guide/text-and-dialogs.md
@@ -63,7 +63,7 @@ backs the original up to `*.gore-bak` on deploy.
 
 | Flag | Command | Meaning |
 |---|---|---|
-| `--lcache <PATH>` | all | The `.lcache` to read/edit — optional everywhere; without it the install is auto-detected. May also name a game dir or a Steam library to search. |
+| `--lcache <PATH>` | `export`, `import`, `extract` | The `.lcache` to read/edit — optional on all three; without it the install is auto-detected. May also name a game dir or a Steam library to search. `status` takes no flags at all: it reports the shared catalog that is already built. |
 | `-o, --out <PATH>` | `export`, `import` | Output file. On `import`, defaults to overwriting the cache it read. |
 | `--edits <PATH>` | `import` | The `{id:{language:value}}` edit JSON. |
 | `--keep-empty` | `export` | Keep ids with no text instead of dropping them. |

--- a/docs/guide/voice.md
+++ b/docs/guide/voice.md
@@ -351,15 +351,15 @@ in this toolkit ever listens, and no test in the suite checks any of it.
 
 | Flag | Commands | Meaning |
 |---|---|---|
-| `--archive <ZIP>` | all | Input voice ZIP. Never modified. |
-| `--json` | `list`, `match-line` | One JSON document instead of human-readable output. |
+| `--archive <ZIP>` | all but `validate` | Input voice ZIP. Never modified. |
+| `--json` | `list`, `match-line`, `validate` | One JSON document instead of human-readable output. |
 | `--filter <TEXT>` | `list` | Keep only entry paths containing this substring, case-insensitive. |
 | `--max <N>` | `list` | Max entries to print (default 100). The result says how many matched. `--max 0` lists nothing and reports only the counts. |
 | `--directories` | `list` | Also list directory entries, which carry no audio. |
 | `--loc-id <ID>` | `match-line` | Trimmed ASCII localization id, without `.ogg`. |
 | `--basename <NAME>` | `extract`, `replace` | Case-insensitive basename; only when unique. |
 | `--path <ARCHIVE_PATH>` | `extract`, `add`, `replace` | Exact, case-sensitive archive path. |
-| `--ogg <PATH>` | `add`, `replace` | Ogg file. Vorbis or Opus passes here; [encode Vorbis](#vorbis-or-opus). A WAV is refused with the ffmpeg line that converts it. |
+| `--ogg <PATH>` | `add`, `replace`, `validate` | Ogg file. Vorbis or Opus passes here; [encode Vorbis](#vorbis-or-opus). A WAV is refused with the ffmpeg line that converts it. |
 | `--manifest <PATH>` | `apply-manifest` | Versioned JSON manifest; Ogg paths relative to it. |
 | `-o, --out <PATH>` | all writing commands | Extraction root, or a new ZIP that must not exist. |
 

--- a/docs/reference/angelscript-internals.md
+++ b/docs/reference/angelscript-internals.md
@@ -39,16 +39,18 @@ cycle-free, and the target class must reach the declaring `field_owner` by exact
 chain reaches an unparsed native parent, that direct parent is a valid terminal owner, but ancestry
 above it is unknown and is not guessed. This keeps inherited and shadowed same-name fields distinct.
 Without additional evidence this deliberately leaves 5,197 otherwise exact Shipping scalar
-windows uneditable because their declaring owner lies above the first native parent. The current
-Shipping profile can recover that ancestry only when the cache semantic fingerprint, Binds bytes
-and bridge, and USMAP bytes and exact Class graph all match their one atomic sealed tuple.
+windows uneditable because their declaring owner lies above the first native parent. A Shipping
+profile can recover that ancestry only when the cache semantic fingerprint, Binds bytes and bridge,
+and USMAP bytes and exact Class graph all match one audited generation row's atomic sealed tuple;
+the table currently holds four such rows, and a mixture across two of them fails closed.
 
 Script-declared field types come from the parsed module model. Native field types are mutation
-evidence only when `Binds.Cache` matches both the sealed audited file identity
-`46e6629ad5cacc112b9922d48a1aa948f40572d7285705b981c3eca3dc615fea` and the audited extracted
-field-map identity `5ddf7fa6df36ac00d07bd068fcf19ad61a3f4b836133513966dc379b24241707`,
-and the inspected `PrecompiledScript_Shipping.Cache` header has the paired audited per-build GUID
-`450d65c04f0c014fbec568016378e69a`. All three identities must match. The CLI uses
+evidence only when the generation row named by the inspected `PrecompiledScript_Shipping.Cache`
+header's GUID seals exactly the `Binds.Cache` that was loaded, matching both that row's audited
+file identity and its audited extracted field-map identity. Generations do not all carry the same
+`Binds.Cache` — the four audited rows carry three distinct Binds seals, three distinct field-map
+digests and four distinct cache GUIDs — so a GUID that names one row can never admit another row's
+field map. All three identities must belong to the same row. The CLI uses
 `GORE_AS_BINDS` when set, otherwise `Binds.Cache` beside the input cache. An absent, unreadable,
 unknown, parser-drifted, or differently paired native profile supplies no native mutation
 evidence; its generic field information can still assist read-only decompilation.

--- a/docs/reference/dialog-runtime.md
+++ b/docs/reference/dialog-runtime.md
@@ -163,12 +163,13 @@ separate behavioral qualification because selecting its fixture can change
 quest/save state. The offline evidence qualifies its hotfix-remapped
 build/composition only, not selection, effects, persistence, or save/reload.
 
-The central generation registry also contains Steam build `24340829`, but only
-for its separately recorded bounded offline authoring evidence. No dialog-
-runtime candidate or qualification has been retained for `24340829`, and none
-of the `24169431` evidence carries across a generation boundary. Build
-`24539464` instead has the separate version-3 live observation recorded above;
-it does not convert either historical candidate into a qualified artifact.
+The central generation registry also contains Steam builds `24340829` and
+`24878692`, but only for their separately recorded bounded offline authoring
+evidence. No dialog-runtime candidate or qualification has been retained for
+either, and none of the `24169431` evidence carries across a generation
+boundary. Build `24539464` instead has the separate version-3 live observation
+recorded above; it does not convert either historical candidate into a
+qualified artifact.
 
 ## Discovery versus insertion
 
@@ -228,15 +229,18 @@ writes a save/quest/knowledge field.
   clean live visual proof. Runtime version 3 has both the current
   build-`24539464` GORE-fixture observation above and a frozen offline candidate
   for older build `24169431`; that older exact artifact never completed the
-  same live requalification. Build `24340829` has no dialog-runtime
-  qualification at all. Other game, UE4SS, and runtime combinations remain to
-  be qualified.
+  same live requalification. Builds `24340829` and `24878692` have no
+  dialog-runtime qualification at all. Other game, UE4SS, and runtime
+  combinations remain to be qualified.
 - Topic selection, authored knowledge/quest changes, recorded voice, and
   selection-side save effects are not certified by the insertion proof.
 - The exact native ordering of knowledge rules, `IsVisible_Implementation`,
   participant checks, and UI relevance is not recovered.
-- `emit-all` does not yet emit generated `__InitDefaults` methods as editable
-  source. `compile-module --op edit` carries an existing `__InitDefaults`
+- `emit` and `emit-all` now write a class's generated `__InitDefaults` back out
+  as class-scope `default` statements; recovery is all-or-nothing per module, a
+  module whose defaults cannot all be recovered says so in its header and keeps
+  them byte-exact on recompile, and `emit --no-defaults` still produces the
+  previous shape. `compile-module --op edit` carries an existing `__InitDefaults`
   record only through the strict, base-keyspace remap path and only when the
   complete class identity/layout, ordinary method signatures and UFUNCTION
   metadata, constructors, behavior declarations, module globals/imports, and

--- a/docs/reference/survival-mode.md
+++ b/docs/reference/survival-mode.md
@@ -40,7 +40,7 @@ The system is built and wired, right up to the last step:
   `RecoveryRatePerHourOfSleep` = −0.125).
 - **The abilities are fully configured**, including the per-threshold effect
   lists.
-- **The UI row is deliberately hidden.** Of 7,308 AngelScript modules, exactly
+- **The UI row is deliberately hidden.** Of 7,317 AngelScript modules, exactly
   one mentions survival: `UI/UISettingsConfiguration.as`, which declares
   `USettingObject_Bool_SurvivalSettings_AS` whose entire generated
   `__InitDefaults` writes `false` into the inherited native `bool m_IsShown`.

--- a/mods/gore-dump/README.md
+++ b/mods/gore-dump/README.md
@@ -8,14 +8,14 @@ encryption key (`gore_fmod_key.json`) so gore can open the game's encrypted
 
 ## Use
 
-1. Copy this `gore-dump/` folder into `<game>/Binaries/Win64/ue4ss/Mods/`.
+1. Copy this `gore-dump/` folder into `<game>/G1R/Binaries/Win64/ue4ss/Mods/`.
 2. Make sure UE4SS lists it (it ships with an empty `enabled.txt`).
 3. Launch the game, load any save (or reach the main menu), wait ~15s.
 4. `gore_game_data.json` and `gore_fmod_key.json` are written to the game's
-   working directory (usually `Binaries/Win64/`). Watch the UE4SS console for
+   working directory (usually `G1R/Binaries/Win64/`). Watch the UE4SS console for
    the paths.
-5. `gore sync --dump gore_game_data.json --catalog item_catalog.json -o model.json`
-   then rebuild/point gore-mod at the new model.
+5. `gore sync --dump gore_game_data.json --catalog item_catalog.json -o gui_model.json`
+   then rebuild/point gore-mod at the new GUI model.
 
 `gore_fmod_key.json` looks like `{"found":true,"encryption_key":"…","master_bank_name":"Master"}`.
 The key is read from the live `UFMODSettings` CDO (`/Script/FMODStudio`,

--- a/scripts/test_check_release_workflow.py
+++ b/scripts/test_check_release_workflow.py
@@ -98,7 +98,7 @@ class DownloadTableContractTest(unittest.TestCase):
         self.assert_invalid(
             replace_once(
                 self.readme,
-                "releases/tag/gore-cli-v0.2.2)",
+                "releases/tag/gore-cli-v0.3.0)",
                 # Deliberately wrong test-only version: the checker must reject this link.
                 "releases/tag/gore-cli-v9.9.9)",
             ),
@@ -108,7 +108,7 @@ class DownloadTableContractTest(unittest.TestCase):
 
     def test_link_text_must_be_the_release_tag(self) -> None:
         self.assert_invalid(
-            replace_once(self.readme, "[gore-cli-v0.2.2]", "[latest]"),
+            replace_once(self.readme, "[gore-cli-v0.3.0]", "[latest]"),
             None,
             "link text must be the release tag",
         )
@@ -135,7 +135,7 @@ class DownloadTableContractTest(unittest.TestCase):
 
     def test_unreadable_and_unknown_rows_fail_closed(self) -> None:
         self.assert_invalid(
-            replace_once(self.readme, "| **CLI** | 0.2.2 |", "| **CLI** | v0.2.2 |"),
+            replace_once(self.readme, "| **CLI** | 0.3.0 |", "| **CLI** | v0.3.0 |"),
             None,
             "unreadable download row",
         )


### PR DESCRIPTION
## What this is

Two strands, both on the AngelScript decompiler's road to a byte-faithful
recompile, plus the documentation pass that fell out of checking whether the
status doc was still true.

## Decompiler fidelity: 1,573 → 1,165 differences (99.29%)

Every rule below was measured the same way: emit the whole tree from the frozen
reference cache, recompile it, and diff the bytecode function by function. A
rule ships only if it fixes functions and breaks none. No step lost alignment,
and the 757 tests stayed green throughout.

The larger levers, in the order they landed:

- A range-for container whose push does not follow another push was never a
  name (26).
- A local that is nothing but receiver pairs is not a name (39).
- A gameplay-effect chain is two declarations, not one expression (23).
- The steps of a returned expression carry no names (20).
- A jump back to the header is a `continue`, not a loop of its own — this also
  removed 7 invented loops and 4 infinite ones.
- A detached default-argument block means one nested expression (14).

Four of these fixed programs that were not merely different but wrong: four
achievements returned the wrong value, four loops never terminated, seven loops
did not exist in the original, and one call was fabricated outright.

A standalone compile that dies without answering now reports how the process
ended instead of blaming its own JSON.

## Documentation

An audit of all 66 markdown files against the code and the CLI's own `--help`.
The corrections a reader would have acted on are listed in the commit message
of `docs: correct what the guide and reference say about the tools` — the worst
was a `gore-dump` install path missing its `G1R/` segment, which fails silently:
the copy succeeds, the game launches, and no dump is ever written.

`DECOMPILER_STATUS.md` also claimed the measured build is not an audited
generation. It is `g1r-steam-24878692`.

## CLI 0.3.0

Version bumped across `Cargo.toml`, the lock file, the download table and the
release-workflow test fixtures, with a changelog entry for the release.

## Verification

- `python scripts/check_release_workflow.py` — OK
- `python scripts/test_check_release_workflow.py` — 34 tests, OK
- `python scripts/check_docs_links.py` — 45 files, no broken links
- `python scripts/check_plugin.py` — OK
- Whole-tree emit + recompile: 7,317 modules, 0 stubs, 0 errors, no alignment
  loss, 1,165 semantic differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Decompiler emission changes affect whole-tree script recompile fidelity; they are regression-tested but touch complex bytecode recovery. Doc-only areas are low risk.
> 
> **Overview**
> **CLI 0.3.0** and README/download tables now point at the new release and record **Gothic 1 Remake 1.0.5 (Steam BuildID 24878692)** as the tested CLI baseline (Mod Manager still documented against 1.0.4a).
> 
> The **AngelScript decompiler (`gore-as`)** documentation is refreshed for that shipped cache (**7,317 modules**, **99.30%** byte-faithful per `DECOMPILER_STATUS.md` / `FORMAT.md`), including a new “known wrong programs” section and write-ups of recent emitter/structurer rules (alias typing, late condition folds, loop `continue` vs `if`, `T&` returns, loop-body destructors, `for (auto& …)`, etc.). The PR description ties these to measured drops in semantic bytecode differences and fixes for wrong achievements, infinite loops, and similar bugs.
> 
> **User-facing docs** are corrected elsewhere: Mod Manager conflict grades are explained in plainer terms; Save Editor features now document **NPC repositioning with routine override/undo** and **merchant trade/stock editing**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f6b9379803336d93b4f036d5389e6477fa1d40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->