### PR TITLE
Support multi-module mini-caches for script modding

### DIFF
--- a/crates/gore-as/src/cache/remap.rs
+++ b/crates/gore-as/src/cache/remap.rs
@@ -35,7 +35,7 @@ pub enum RemapError {
     Wire(#[from] WireError),
     #[error("disasm error: {0}")]
     Disasm(String),
-    #[error("mini-cache must contain exactly 1 module, found {0}")]
+    #[error("mini-cache must contain at least 1 module, found {0}")]
     NotSingle(u32),
     #[error(
         "unresolved {kind} ref in op {op} (regen key {key:#x}, name {name:?}): \
@@ -3195,16 +3195,15 @@ impl StaticNameRebaseContext {
 ///
 /// T6 is identity-by-text. Existing names (including duplicates inside this mini) are therefore
 /// safely deduplicated; genuinely new rows retain their source order. Bytecode is patched in every
-/// function-like record collected by [`collect_module_spans`] (`Functions`, methods, constructors,
-/// behavior functions, and global init functions).
+/// function-like record of every module collected by [`collect_module_spans`] (`Functions`,
+/// methods, constructors, behavior functions, and global init functions).
 pub(super) fn rebase_static_names_for_composition(
     mini: &[u8],
     context: &StaticNameRebaseContext,
     prior_contributions: &[String],
 ) -> Result<(Vec<u8>, Vec<String>), RemapError> {
-    let mini_n = super::walk_modules::module_count(mini);
-    if mini_n != 1 {
-        return Err(RemapError::NotSingle(mini_n));
+    if super::walk_modules::module_count(mini) == 0 {
+        return Err(RemapError::NotSingle(0));
     }
 
     let meta = TailMetadata::build(mini)?;
@@ -5609,18 +5608,20 @@ pub(super) fn validate_composed_module_records(bytes: &[u8]) -> Result<(), Remap
     validate_composed_module_records_with_pristine(bytes, None)
 }
 
-/// Walk the single module entry in `mini` (TMap key + module value) and collect every
-/// function's ByteCode span + every embedded int64 ref. Mirrors `walk_modules::read_module_c`
-/// but records byte offsets.
+/// Walk every module entry in `mini` (TMap key + module value) and collect every function's
+/// ByteCode span + every embedded int64 ref into one span set with absolute offsets. Mirrors
+/// `walk_modules::read_module_c` but records byte offsets. A multi-module mini is one rewrite
+/// unit, so its modules share one span set; `module`/`inner_module` name the last module read.
 fn collect_module_spans(mini: &[u8]) -> Result<ModuleSpans, WireError> {
     preflight_mini_module_work(mini)?;
     let mut c = Cursor::at(mini, CacheHeader::SIZE);
-    let module = c.read_fstring()?; // TMap key
-    let mut spans = ModuleSpans {
-        module,
-        ..ModuleSpans::default()
-    };
-    read_module_spans(&mut c, mini, &mut spans, None, None)?;
+    let count = super::walk_modules::module_count(mini) as usize;
+    c.ensure_minimum_remaining(count, 60, "Modules")?;
+    let mut spans = ModuleSpans::default();
+    for _ in 0..count {
+        spans.module = c.read_fstring()?; // TMap key
+        read_module_spans(&mut c, mini, &mut spans, None, None)?;
+    }
     Ok(spans)
 }
 
@@ -7597,10 +7598,18 @@ fn analyze_bytecode_for_new_symbols(
 }
 
 fn target_module_names(mini: &[u8]) -> Result<HashSet<String>, WireError> {
-    let mut c = Cursor::at(mini, CacheHeader::SIZE);
-    c.read_fstring()?; // outer TMap key is not a declaring-module identity
-    let inner = c.read_sia()?;
-    Ok([inner].into_iter().filter(|s| !s.is_empty()).collect())
+    // Every module of the mini declares symbols; the outer TMap keys are not declaring-module
+    // identities, the inner `ModuleName` of each entry is.
+    let mut names = HashSet::new();
+    for (_, start, _) in super::walk_modules::module_ranges(mini)? {
+        let mut c = Cursor::at(mini, start);
+        c.read_fstring()?;
+        let inner = c.read_sia()?;
+        if !inner.is_empty() {
+            names.insert(inner);
+        }
+    }
+    Ok(names)
 }
 
 fn close_type_dependencies(
@@ -9436,7 +9445,7 @@ fn finish_new_symbol_remap(
     // A prepared mini is generation-bound to the exact target cache. This also makes the
     // low-level extract-remap output directly consumable by the strict sequential guard.
     out.extend_from_slice(&pristine_header[..0x14]);
-    out.extend_from_slice(&1u32.to_le_bytes());
+    out.extend_from_slice(&super::walk_modules::module_count(extracted_mini).to_le_bytes());
     out.extend_from_slice(&module_bytes);
     out.extend_from_slice(&tail);
     Ok((out, total))
@@ -9506,8 +9515,8 @@ impl LoadoutScriptIdPlanBuilder {
                 mini: header.hash,
             });
         }
-        if header.type_count != 1 {
-            return Err(RemapError::NotSingle(header.type_count));
+        if header.type_count == 0 {
+            return Err(RemapError::NotSingle(0));
         }
         let next_minis =
             self.inspected_count
@@ -9656,8 +9665,8 @@ pub(super) fn remap_module_to_base_with_loadout_plan(
             mini: mini_header.hash,
         });
     }
-    if mini_header.type_count != 1 {
-        return Err(RemapError::NotSingle(mini_header.type_count));
+    if mini_header.type_count == 0 {
+        return Err(RemapError::NotSingle(0));
     }
     let bound_identity_fingerprint = loadout
         .inspected_minis
@@ -9698,9 +9707,8 @@ fn remap_module_allow_new(
     extracted_mini: &[u8],
     base: &[u8],
 ) -> Result<(Vec<u8>, RemapCounts), RemapError> {
-    let mini_n = super::walk_modules::module_count(extracted_mini);
-    if mini_n != 1 {
-        return Err(RemapError::NotSingle(mini_n));
+    if super::walk_modules::module_count(extracted_mini) == 0 {
+        return Err(RemapError::NotSingle(0));
     }
     preflight_mini_module_work(extracted_mini)?;
     preflight_cache_module_work(base)?;
@@ -9726,8 +9734,8 @@ pub fn remap_module_to_base(
     preflight_mini_module_work(extracted_mini)?;
     preflight_cache_module_work(base)?;
     let mini_n = super::walk_modules::module_count(extracted_mini);
-    if mini_n != 1 {
-        return Err(RemapError::NotSingle(mini_n));
+    if mini_n == 0 {
+        return Err(RemapError::NotSingle(0));
     }
 
     let regen = SymTables::build(extracted_mini)?;
@@ -9842,12 +9850,12 @@ pub fn remap_module_to_base(
         });
     }
 
-    // Emit: FGuid+magic (from mini) + Modules count=1 + module bytes + 7 empty tables.
+    // Emit: FGuid+magic (from base) + Modules count + module bytes + 7 empty tables.
     let mut out = Vec::with_capacity(CacheHeader::SIZE + module_bytes.len() + 28);
     // Canonicalize the prepared artifact to the exact target generation. Callers that use this
     // low-level API directly therefore receive the same generation binding as compile-module.
     out.extend_from_slice(&base[..0x14]); // target FGuid + magic
-    out.extend_from_slice(&1u32.to_le_bytes()); // Modules count = 1
+    out.extend_from_slice(&mini_n.to_le_bytes()); // Modules count, unchanged from the input
     out.extend_from_slice(&module_bytes);
     out.extend_from_slice(&[0u8; 28]); // 7 tables × int32 count 0
     Ok((out, total))

--- a/crates/gore-as/src/cache/splice.rs
+++ b/crates/gore-as/src/cache/splice.rs
@@ -1,11 +1,13 @@
-//! Splice one game-compiled module into the shipped cache (Weg B).
+//! Splice game-compiled modules into the shipped cache (Weg B).
 //!
 //! Per `work/reversing/gore-as/findings/container-splice.md` §5: insert the mini-cache's
-//! single module entry immediately before the base cache's global tail tables, and bump
-//! the `Modules` count at 0x14 by one. The runtime may not enforce the FGuid, but GORE does:
+//! module entries immediately before the base cache's global tail tables, and bump the
+//! `Modules` count at 0x14 by the number of inserted modules. A mini-cache carries one or more
+//! modules; a multi-module mini is composed as one unit, so references between its own modules
+//! resolve through its own tail rows. The runtime may not enforce the FGuid, but GORE does:
 //! prepared minis are bound to the exact base generation before composition.
 //!
-//! [`splice`] is the strict **case-(b)** fast path: the mini module references no global
+//! [`splice`] is the strict **case-(b)** fast path: the mini modules reference no global
 //! types (its 7 tail tables are 28 zero bytes). [`splice_auto`] also supports **case-(a)**
 //! class-/native-reference-bearing modules by merging their minimal tail-table rows with
 //! collision checks.
@@ -51,8 +53,10 @@ pub enum SpliceError {
     Header(#[from] super::header::HeaderError),
     #[error("walk error: {0}")]
     Wire(#[from] WireError),
-    #[error("mini-cache must contain exactly 1 module, found {0}")]
+    #[error("mini-cache must contain exactly 1 module for a single-target operation, found {0}")]
     MiniNotSingle(u32),
+    #[error("mini-cache contains no modules")]
+    MiniEmpty,
     #[error(
         "mini-cache has non-empty global tables ({0} trailing bytes): strict splice only accepts referenceless modules; use splice_auto for a remapped class/function-bearing mini"
     )]
@@ -708,6 +712,34 @@ impl SequentialMiniGuard {
         Ok(composed)
     }
 
+    /// Validate `mini` and fold every one of its modules onto `running`: existing modules are
+    /// replaced in place, new ones are appended. This is the composition for a multi-module mini
+    /// that edits shipped modules and adds new ones as one unit.
+    pub fn compose_upsert(&mut self, running: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
+        self.require_running_state(running)?;
+        let prospective = checked_composed_capacity(&[running.len(), mini.len()])?;
+        let scan_bytes = u64::try_from(prospective)
+            .unwrap_or(u64::MAX)
+            .saturating_mul(2);
+        checked_usage_add(
+            self.usage.composed_scan_bytes,
+            scan_bytes,
+            "composed validation scan bytes",
+            MAX_SEQUENTIAL_COMPOSED_SCAN_BYTES,
+        )?;
+        let (prepared, delta) = self.stage(mini)?;
+        let composed = upsert_modules(running, &prepared)?;
+        self.base
+            .reference_context
+            .validate_composed_declarations(&composed)
+            .map_err(SpliceError::ComposedModule)?;
+        let mut delta = delta;
+        delta.usage.composed_scan_bytes = scan_bytes;
+        self.commit(delta);
+        self.expected_running_sha256 = Sha256::digest(&composed).into();
+        Ok(composed)
+    }
+
     fn require_running_state(&self, running: &[u8]) -> Result<(), SpliceError> {
         if !self.composition_state_valid
             || <[u8; 32]>::from(Sha256::digest(running)) != self.expected_running_sha256
@@ -723,9 +755,8 @@ impl SequentialMiniGuard {
         checked_composed_capacity(&[mini.len()])?;
         checked_usage_add(self.usage.minis, 1, "mini count", MAX_SEQUENTIAL_MINIS)?;
         let header = CacheHeader::parse(mini)?;
-        let count = header.type_count;
-        if count != 1 {
-            return Err(SpliceError::MiniNotSingle(count));
+        if header.type_count == 0 {
+            return Err(SpliceError::MiniEmpty);
         }
         let mini_guid = header.hash;
         if mini_guid != self.base.base_guid {
@@ -886,16 +917,34 @@ impl SequentialMiniGuard {
     }
 }
 
-/// Append `mini`'s single referenceless module to `base`, returning the new cache bytes.
+/// The mini's declared module count, refusing an empty mini before any walk.
+fn nonempty_module_count(mini: &[u8]) -> Result<u32, SpliceError> {
+    match module_count(mini) {
+        0 => Err(SpliceError::MiniEmpty),
+        count => Ok(count),
+    }
+}
+
+/// Refuse to append any mini module whose outer key already exists in `base`. The first
+/// colliding name in mini order is reported.
+fn ensure_no_name_collision(base: &[u8], mini: &[u8]) -> Result<(), SpliceError> {
+    let base_names: HashSet<String> = module_names(base)?.into_iter().collect();
+    if let Some(name) = module_names(mini)?
+        .into_iter()
+        .find(|name| base_names.contains(name))
+    {
+        return Err(SpliceError::NameCollision(name));
+    }
+    Ok(())
+}
+
+/// Append every referenceless module of `mini` to `base`, returning the new cache bytes.
 ///
 /// This is a low-level composition primitive. It validates the mechanical container shape but
 /// does not establish generation binding or executable-reference authority. Publishing callers
 /// must use [`SequentialMiniGuard::compose_add`] instead.
 pub fn splice(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
-    let mini_n = module_count(mini);
-    if mini_n != 1 {
-        return Err(SpliceError::MiniNotSingle(mini_n));
-    }
+    let mini_n = nonempty_module_count(mini)?;
 
     let mini_tail = module_region_end(mini)?;
     let trailing = &mini[mini_tail..];
@@ -903,13 +952,9 @@ pub fn splice(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
         return Err(SpliceError::MiniHasGlobalRefs(trailing.len()));
     }
 
-    // The mini's module entry = TMap (FString key + module value) at [0x18 .. mini_tail].
+    // The mini's module entries = TMap (FString key + module value) at [0x18 .. mini_tail].
     let mod_bytes = &mini[CacheHeader::SIZE..mini_tail];
-
-    let new_name = module_names(mini)?.into_iter().next().unwrap_or_default();
-    if module_names(base)?.iter().any(|n| n == &new_name) {
-        return Err(SpliceError::NameCollision(new_name));
-    }
+    ensure_no_name_collision(base, mini)?;
 
     let base_tail = module_region_end(base)?;
     let base_count = module_count(base);
@@ -917,9 +962,9 @@ pub fn splice(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
     let capacity = checked_composed_capacity(&[base.len(), mod_bytes.len()])?;
     let mut out = Vec::with_capacity(capacity);
     out.extend_from_slice(&base[..0x14]); // FGuid + magic
-    out.extend_from_slice(&(base_count + 1).to_le_bytes()); // bumped Modules count
+    out.extend_from_slice(&(base_count + mini_n).to_le_bytes()); // bumped Modules count
     out.extend_from_slice(&base[CacheHeader::SIZE..base_tail]); // all existing modules
-    out.extend_from_slice(mod_bytes); // the new module, before the tail tables
+    out.extend_from_slice(mod_bytes); // the new modules, before the tail tables
     out.extend_from_slice(&base[base_tail..]); // global tail tables, unchanged
     finish_composition(out)
 }
@@ -932,10 +977,7 @@ pub fn splice(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
 /// the guard. The caller owns sequential guard history; this function deliberately does not
 /// construct or advance a guard itself.
 pub fn splice_auto(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
-    let mini_n = module_count(mini);
-    if mini_n != 1 {
-        return Err(SpliceError::MiniNotSingle(mini_n));
-    }
+    nonempty_module_count(mini)?;
     let mini_tail = module_region_end(mini)?;
     if mini[mini_tail..].iter().all(|&x| x == 0) {
         splice(base, mini)
@@ -944,7 +986,7 @@ pub fn splice_auto(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
     }
 }
 
-/// Case-(a): append the mini's module AND merge its 7 global tail-table entries into the
+/// Case-(a): append the mini's modules AND merge its 7 global tail-table entries into the
 /// base cache (per `case-a-tables-and-exec.md` §3). Used when the mini references native
 /// types/functions (its tail tables are non-empty), e.g. a class or a PrintString call.
 ///
@@ -952,10 +994,7 @@ pub fn splice_auto(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
 /// [`SequentialMiniGuard::compose_add`] so the mini is validated against its pristine base before
 /// any rows are merged.
 pub fn splice_case_a(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
-    let mini_n = module_count(mini);
-    if mini_n != 1 {
-        return Err(SpliceError::MiniNotSingle(mini_n));
-    }
+    let mini_n = nonempty_module_count(mini)?;
 
     let base_tail = module_region_end(base)?;
     let mini_tail = module_region_end(mini)?;
@@ -977,11 +1016,7 @@ pub fn splice_case_a(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
         });
     }
 
-    // Module name collision.
-    let new_name = module_names(mini)?.into_iter().next().unwrap_or_default();
-    if module_names(base)?.iter().any(|n| n == &new_name) {
-        return Err(SpliceError::NameCollision(new_name));
-    }
+    ensure_no_name_collision(base, mini)?;
 
     let mod_bytes = &mini[CacheHeader::SIZE..mini_tail];
     let base_count = module_count(base);
@@ -990,9 +1025,9 @@ pub fn splice_case_a(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
         checked_composed_capacity(&[base.len(), mod_bytes.len(), mini.len() - mini_tail])?;
     let mut out = Vec::with_capacity(capacity);
     out.extend_from_slice(&base[..0x14]);
-    out.extend_from_slice(&(base_count + 1).to_le_bytes());
+    out.extend_from_slice(&(base_count + mini_n).to_le_bytes());
     out.extend_from_slice(&base[CacheHeader::SIZE..base_tail]); // existing modules
-    out.extend_from_slice(mod_bytes); // new module, before tables
+    out.extend_from_slice(mod_bytes); // new modules, before tables
 
     append_merged_tables(&mut out, base, &base_tt, mini, &mini_tt);
     finish_composition(out)
@@ -1055,26 +1090,117 @@ fn append_merged_tables(
 /// every ref the module's bytecode uses is present, and `replace_module`'s merge folds them into
 /// the base.
 pub fn extract_module(cache: &[u8], target_name: &str) -> Result<Vec<u8>, SpliceError> {
+    extract_modules(cache, &[target_name])
+}
+
+/// Extract several modules from `cache` into one standalone multi-module mini-cache (in cache
+/// order, followed by the cache's FULL global tail tables). See [`extract_module`]; a mini built
+/// this way is one composition unit, so modules that reference each other stay resolvable.
+pub fn extract_modules(cache: &[u8], target_names: &[&str]) -> Result<Vec<u8>, SpliceError> {
+    if target_names.is_empty() {
+        return Err(SpliceError::MiniEmpty);
+    }
     super::remap::preflight_cache_module_work(cache)?;
     super::remap::preflight_tail_tables(cache)?;
     let ranges = module_ranges(cache)?;
-    let matches: Vec<_> = ranges
-        .iter()
-        .filter(|(n, _, _)| n == target_name)
-        .cloned()
-        .collect();
-    let (_, start, end) = match matches.as_slice() {
-        [entry] => entry.clone(),
-        [] => return Err(SpliceError::NameNotFound(target_name.to_string())),
-        _ => return Err(SpliceError::AmbiguousTarget(target_name.to_string())),
-    };
+    let mut selected = Vec::with_capacity(target_names.len());
+    let mut requested = HashSet::new();
+    for &target_name in target_names {
+        if !requested.insert(target_name) {
+            return Err(SpliceError::AmbiguousTarget(target_name.to_string()));
+        }
+        let matches: Vec<usize> = ranges
+            .iter()
+            .enumerate()
+            .filter_map(|(index, (n, _, _))| (n == target_name).then_some(index))
+            .collect();
+        match matches.as_slice() {
+            [index] => selected.push(*index),
+            [] => return Err(SpliceError::NameNotFound(target_name.to_string())),
+            _ => return Err(SpliceError::AmbiguousTarget(target_name.to_string())),
+        }
+    }
+    selected.sort_unstable();
     let tail_off = module_region_end(cache)?;
-    let mut out = Vec::with_capacity(0x18 + (end - start) + (cache.len() - tail_off));
+    let module_bytes: usize = selected
+        .iter()
+        .map(|&index| ranges[index].2 - ranges[index].1)
+        .sum();
+    let mut out = Vec::with_capacity(0x18 + module_bytes + (cache.len() - tail_off));
     out.extend_from_slice(&cache[..0x14]); // FGuid + magic
-    out.extend_from_slice(&1u32.to_le_bytes()); // Modules count = 1
-    out.extend_from_slice(&cache[start..end]); // the one module's TMap entry
+    out.extend_from_slice(&(selected.len() as u32).to_le_bytes()); // Modules count
+    for index in selected {
+        let (_, start, end) = &ranges[index];
+        out.extend_from_slice(&cache[*start..*end]); // the module's TMap entry
+    }
     out.extend_from_slice(&cache[tail_off..]); // full global tail tables
     Ok(out)
+}
+
+/// Fold every module of `mini` onto `base`: a module whose outer key already exists in `base` is
+/// replaced in place, every other module is appended, and the mini's tail rows are merged once
+/// (mini wins on key collision, StaticNames appends). This is the multi-module counterpart of
+/// [`replace_module`] + [`splice_case_a`] for a mini that edits and adds modules together.
+///
+/// This is a low-level composition primitive. Publishing callers must use
+/// [`SequentialMiniGuard::compose_upsert`].
+pub fn upsert_modules(base: &[u8], mini: &[u8]) -> Result<Vec<u8>, SpliceError> {
+    let mini_n = nonempty_module_count(mini)?;
+    let base_tail = module_region_end(base)?;
+    let mini_tail = module_region_end(mini)?;
+    let base_tt = parse_tail_tables(base, base_tail)?;
+    if base_tt.end != base.len() {
+        return Err(SpliceError::TailNotAtEof {
+            which: "base",
+            got: base_tt.end,
+            len: base.len(),
+        });
+    }
+    let mini_tt = parse_tail_tables(mini, mini_tail)?;
+    if mini_tt.end != mini.len() {
+        return Err(SpliceError::TailNotAtEof {
+            which: "mini",
+            got: mini_tt.end,
+            len: mini.len(),
+        });
+    }
+
+    let base_ranges = module_ranges(base)?;
+    let mini_ranges = module_ranges(mini)?;
+    let mut replacements: HashMap<&str, usize> = HashMap::new();
+    for (index, (name, _, _)) in mini_ranges.iter().enumerate() {
+        if replacements.insert(name.as_str(), index).is_some() {
+            return Err(SpliceError::ModuleKeyCollision(name.clone()));
+        }
+    }
+    let base_names: HashSet<&str> = base_ranges.iter().map(|(n, _, _)| n.as_str()).collect();
+    let appended: Vec<usize> = mini_ranges
+        .iter()
+        .enumerate()
+        .filter(|(_, (name, _, _))| !base_names.contains(name.as_str()))
+        .map(|(index, _)| index)
+        .collect();
+
+    let capacity = checked_composed_capacity(&[base.len(), mini.len()])?;
+    let mut out = Vec::with_capacity(capacity);
+    out.extend_from_slice(&base[..0x14]);
+    out.extend_from_slice(&(module_count(base) + appended.len() as u32).to_le_bytes());
+    for (name, start, end) in &base_ranges {
+        match replacements.get(name.as_str()) {
+            Some(&index) => {
+                let (_, mini_start, mini_end) = &mini_ranges[index];
+                out.extend_from_slice(&mini[*mini_start..*mini_end]);
+            }
+            None => out.extend_from_slice(&base[*start..*end]),
+        }
+    }
+    for index in appended {
+        let (_, start, end) = &mini_ranges[index];
+        out.extend_from_slice(&mini[*start..*end]);
+    }
+    debug_assert!(replacements.len() == mini_n as usize);
+    append_merged_tables(&mut out, base, &base_tt, mini, &mini_tt);
+    finish_composition(out)
 }
 
 /// Rewrite an extracted (regen-tables) 1-module mini's bytecode refs to the VANILLA `base`'s

--- a/crates/gore-as/src/compile.rs
+++ b/crates/gore-as/src/compile.rs
@@ -7073,6 +7073,20 @@ fn resolve_missing_path_via_existing_ancestor_v1(
     }
 }
 
+/// Resolve a full-graph side-output path (compiled cache, mini-cache, receipt) the way the
+/// path-layout preflight does, without creating anything: existing ancestors are canonicalized and
+/// the missing suffix is appended lexically. Front ends compare the results to reject two outputs
+/// that name the same file, or nest inside one another, through different spellings.
+pub fn resolve_projected_output_path_v1(path: &Path, label: &str) -> Result<PathBuf, CompileError> {
+    resolve_missing_path_via_existing_ancestor_v1(path, label)
+}
+
+/// Whether `path` is `root` or lives inside it, using the same case/UNC folding as the full-graph
+/// containment checks. Both inputs should already be resolved.
+pub fn resolved_path_is_within_v1(path: &Path, root: &Path) -> bool {
+    path_is_within_v1(path, root)
+}
+
 fn preflight_full_graph_publication_v1(opts: &FullGraphCompileOptsV1) -> Result<(), CompileError> {
     let (parent, destination, pending) = full_graph_publication_paths_v1(&opts.output_path)?;
     let game_root = opts

--- a/crates/gore-as/src/compile.rs
+++ b/crates/gore-as/src/compile.rs
@@ -6920,10 +6920,18 @@ struct FullGraphPublicationFailureV1 {
 }
 
 fn preflight_full_graph_path_layout_v1(opts: &FullGraphCompileOptsV1) -> Result<(), CompileError> {
-    if !opts.game_dir.is_absolute()
-        || !opts.work_dir.is_absolute()
-        || !opts.output_path.is_absolute()
-    {
+    preflight_full_graph_path_layout_paths_v1(&opts.game_dir, &opts.work_dir, &opts.output_path)
+}
+
+/// The complete full-graph path-layout preflight on bare paths, so a front end can refuse a
+/// layout the compiler would reject before it plans the complete source graph (a multi-minute
+/// step on the shipped tree). Identical to the check the compiler repeats before running.
+pub fn preflight_full_graph_path_layout_paths_v1(
+    game_dir: &Path,
+    work_dir: &Path,
+    output_path: &Path,
+) -> Result<(), CompileError> {
+    if !game_dir.is_absolute() || !work_dir.is_absolute() || !output_path.is_absolute() {
         return Err(CompileError::Other(
             "full-graph game, work, and output paths must be absolute".to_owned(),
         ));
@@ -6936,24 +6944,22 @@ fn preflight_full_graph_path_layout_v1(opts: &FullGraphCompileOptsV1) -> Result<
             )
         })
     };
-    if contains_dot_component(&opts.work_dir) || contains_dot_component(&opts.output_path) {
+    if contains_dot_component(work_dir) || contains_dot_component(output_path) {
         return Err(CompileError::Other(
             "full-graph work/output paths must not contain `.` or `..` components".to_owned(),
         ));
     }
-    let requested_output_parent = opts
-        .output_path
+    let requested_output_parent = output_path
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
         .ok_or_else(|| {
             CompileError::Other("full-graph output has no parent directory".to_owned())
         })?;
-    let game_root = opts
-        .game_dir
+    let game_root = game_dir
         .canonicalize()
         .map_err(|error| CompileError::Io(format!("resolving game root: {error}")))?;
     let projected_work_root =
-        resolve_missing_path_via_existing_ancestor_v1(&opts.work_dir, "full-graph work directory")?;
+        resolve_missing_path_via_existing_ancestor_v1(work_dir, "full-graph work directory")?;
     let projected_output_parent = resolve_missing_path_via_existing_ancestor_v1(
         requested_output_parent,
         "full-graph output parent",
@@ -6984,13 +6990,13 @@ fn preflight_full_graph_path_layout_v1(opts: &FullGraphCompileOptsV1) -> Result<
         ));
     }
 
-    ensure_real_directory(&opts.work_dir).map_err(|error| {
+    ensure_real_directory(work_dir).map_err(|error| {
         CompileError::Io(format!("preparing full-graph work directory: {error}"))
     })?;
     ensure_real_directory(requested_output_parent).map_err(|error| {
         CompileError::Io(format!("preparing full-graph output parent: {error}"))
     })?;
-    let work_root = opts.work_dir.canonicalize().map_err(|error| {
+    let work_root = work_dir.canonicalize().map_err(|error| {
         CompileError::Io(format!("resolving full-graph work directory: {error}"))
     })?;
     let output_parent = requested_output_parent.canonicalize().map_err(|error| {

--- a/crates/gore-as/tests/splice_test.rs
+++ b/crates/gore-as/tests/splice_test.rs
@@ -427,3 +427,158 @@ fn splice_into_real_cache() {
         out.len()
     );
 }
+
+// ── multi-module minis ───────────────────────────────────────────────────────────────────────────
+
+/// A referenceless mini carrying `modules` plus `static_names` (T6 is unkeyed and needs no
+/// declaration authority, so it is the one non-empty tail a synthetic mini can carry safely).
+fn multi_module_mini(modules: &[(&str, &str)], static_names: &[&str]) -> Vec<u8> {
+    let mut out = empty_modules_cache(modules);
+    out.truncate(out.len() - 7 * 4);
+    for table in 0..7 {
+        if table == 5 {
+            out.extend_from_slice(&(static_names.len() as u32).to_le_bytes());
+            for name in static_names {
+                out.extend_from_slice(&sia(name));
+            }
+        } else {
+            out.extend_from_slice(&0u32.to_le_bytes());
+        }
+    }
+    out
+}
+
+#[test]
+fn splice_appends_every_module_of_a_referenceless_multi_module_mini() {
+    let base = empty_modules_cache(&[("Base.One", "Base.One"), ("Base.Two", "Base.Two")]);
+    let mini = empty_modules_cache(&[("Mod.A", "Mod.A"), ("Mod.B", "Mod.B")]);
+
+    let out = splice(&base, &mini).expect("two referenceless modules splice");
+
+    assert_eq!(module_count(&out), 4);
+    assert_eq!(
+        module_names(&out).unwrap(),
+        ["Base.One", "Base.Two", "Mod.A", "Mod.B"]
+    );
+    let tail = module_region_end(&out).unwrap();
+    assert_eq!(&out[tail..], &[0u8; 7 * 4], "empty tail tables preserved");
+}
+
+#[test]
+fn splice_auto_merges_the_tail_of_a_multi_module_mini_once() {
+    let base = multi_module_mini(&[("Base.One", "Base.One")], &["BaseName"]);
+    let mini = multi_module_mini(&[("Mod.A", "Mod.A"), ("Mod.B", "Mod.B")], &["NameA", "NameB"]);
+
+    let out = splice_auto(&base, &mini).expect("case-a multi-module splice");
+
+    assert_eq!(module_names(&out).unwrap(), ["Base.One", "Mod.A", "Mod.B"]);
+    let tail = module_region_end(&out).unwrap();
+    let tables = parse_tail_tables(&out, tail).unwrap();
+    assert_eq!(tables.end, out.len());
+    assert_eq!(tables.tables[5].count, 3, "StaticNames appended once for the whole mini");
+}
+
+#[test]
+fn splice_rejects_a_multi_module_mini_when_any_module_already_exists() {
+    let base = empty_modules_cache(&[("Base.One", "Base.One"), ("Mod.B", "Mod.B")]);
+    let mini = empty_modules_cache(&[("Mod.A", "Mod.A"), ("Mod.B", "Mod.B")]);
+
+    let err = splice(&base, &mini).unwrap_err();
+    assert!(
+        matches!(&err, SpliceError::NameCollision(name) if name == "Mod.B"),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn splice_rejects_a_mini_without_modules() {
+    let base = empty_modules_cache(&[("Base.One", "Base.One")]);
+    let mini = empty_modules_cache(&[]);
+
+    let err = splice(&base, &mini).unwrap_err();
+    assert!(matches!(err, SpliceError::MiniEmpty), "got {err:?}");
+    let err = splice_auto(&base, &mini).unwrap_err();
+    assert!(matches!(err, SpliceError::MiniEmpty), "got {err:?}");
+}
+
+#[test]
+fn replace_module_keeps_requiring_a_single_module_mini() {
+    let base = empty_modules_cache(&[("Base.One", "Base.One")]);
+    let mini = empty_modules_cache(&[("Mod.A", "Mod.A"), ("Mod.B", "Mod.B")]);
+
+    let err = replace_module(&base, &mini, "Base.One").unwrap_err();
+    assert!(matches!(err, SpliceError::MiniNotSingle(2)), "got {err:?}");
+}
+
+#[test]
+fn sequential_guard_composes_a_multi_module_mini_as_one_add() {
+    let base = multi_module_mini(&[("Base.One", "Base.One")], &["BaseName"]);
+    let mut mini = multi_module_mini(&[("Mod.A", "Mod.A"), ("Mod.B", "Mod.B")], &["NameA"]);
+    mini[..16].copy_from_slice(&base[..16]); // generation-bound to the base GUID
+
+    let mut guard = SequentialMiniGuard::new(&base).unwrap();
+    let out = guard.compose_add(&base, &mini).expect("guarded multi-module add");
+
+    assert_eq!(module_names(&out).unwrap(), ["Base.One", "Mod.A", "Mod.B"]);
+    let tail = module_region_end(&out).unwrap();
+    let tables = parse_tail_tables(&out, tail).unwrap();
+    assert_eq!(tables.tables[5].count, 2);
+}
+
+#[test]
+fn upsert_replaces_existing_modules_in_place_and_appends_new_ones() {
+    use gore_as::cache::splice::upsert_modules;
+    let base = multi_module_mini(
+        &[("Base.One", "Base.One"), ("Shared.Edit", "Shared.Edit"), ("Base.Two", "Base.Two")],
+        &["BaseName"],
+    );
+    let mini = multi_module_mini(
+        &[("Shared.Edit", "Shared.Edit.v2"), ("Mod.New", "Mod.New")],
+        &["NameNew"],
+    );
+
+    let out = upsert_modules(&base, &mini).expect("upsert");
+
+    assert_eq!(module_count(&out), 4);
+    assert_eq!(
+        module_names(&out).unwrap(),
+        ["Base.One", "Shared.Edit", "Base.Two", "Mod.New"]
+    );
+    // The edited entry now carries the mini's bytes (its inner name changed to `.v2`).
+    let ranges = module_ranges(&out).unwrap();
+    let (_, start, end) = &ranges[1];
+    assert!(out[*start..*end]
+        .windows(b"Shared.Edit.v2".len())
+        .any(|w| w == b"Shared.Edit.v2"));
+    let tail = module_region_end(&out).unwrap();
+    let tables = parse_tail_tables(&out, tail).unwrap();
+    assert_eq!(tables.end, out.len());
+    assert_eq!(tables.tables[5].count, 2);
+}
+
+#[test]
+fn extract_modules_keeps_cache_order_and_rejects_bad_requests() {
+    use gore_as::cache::splice::extract_modules;
+    let cache = multi_module_mini(
+        &[("Mod.A", "Mod.A"), ("Mod.B", "Mod.B"), ("Mod.C", "Mod.C")],
+        &["Name"],
+    );
+
+    let mini = extract_modules(&cache, &["Mod.C", "Mod.A"]).expect("extract two");
+    assert_eq!(module_names(&mini).unwrap(), ["Mod.A", "Mod.C"]);
+    let tail = module_region_end(&mini).unwrap();
+    assert_eq!(&mini[tail..], &cache[module_region_end(&cache).unwrap()..]);
+
+    assert!(matches!(
+        extract_modules(&cache, &["Mod.A", "Mod.A"]).unwrap_err(),
+        SpliceError::AmbiguousTarget(_)
+    ));
+    assert!(matches!(
+        extract_modules(&cache, &["Mod.X"]).unwrap_err(),
+        SpliceError::NameNotFound(_)
+    ));
+    assert!(matches!(
+        extract_modules(&cache, &[]).unwrap_err(),
+        SpliceError::MiniEmpty
+    ));
+}

--- a/crates/gore-mcp/src/spec/groups/script.rs
+++ b/crates/gore-mcp/src/spec/groups/script.rs
@@ -519,6 +519,15 @@ const STANDALONE_COMPILE_ARGS: &[ArgSpec] = &[
         true,
     ),
     ArgSpec::new(
+        "mini",
+        Long("mini"),
+        Path,
+        "Also publish a deployable multi-module mini-cache holding only the authored Add/Edit \
+         modules, remapped to the pristine cache. Point a bundle spec's `scripts[].mini_cache` \
+         at it when a mod spans several modules.",
+        false,
+    ),
+    ArgSpec::new(
         "work_dir",
         Long("work-dir"),
         Path,

--- a/crates/gore-mcp/src/spec/groups/script.rs
+++ b/crates/gore-mcp/src/spec/groups/script.rs
@@ -638,8 +638,16 @@ const SPLICE_ARGS: &[ArgSpec] = &[
         "mini",
         Positional { order: 1 },
         Path,
-        "Mini-cache from -as-generate-precompiled-data (one primitive-only module).",
+        "Base-bound mini-cache from `compile-module`, `compile --mini` or `extract-remap`.",
         true,
+    ),
+    ArgSpec::new(
+        "upsert",
+        Switch("upsert"),
+        Bool,
+        "Replace modules that already exist in the base in place instead of refusing them; new \
+         modules are still appended. Needed for a multi-module mini that edits a shipped module.",
+        false,
     ),
     ArgSpec::new(
         "out",

--- a/crates/gore-mcp/src/spec/groups/script.rs
+++ b/crates/gore-mcp/src/spec/groups/script.rs
@@ -355,6 +355,15 @@ const COMPILE_ARGS: &[ArgSpec] = &[
         true,
     ),
     ArgSpec::new(
+        "mini",
+        Long("mini"),
+        Path,
+        "Also publish a deployable multi-module mini-cache holding only the authored Add/Edit \
+         modules, remapped to the pristine cache. Point a bundle spec's `scripts[].mini_cache` \
+         at it when a mod spans several modules.",
+        false,
+    ),
+    ArgSpec::new(
         "work_dir",
         Long("work-dir"),
         Path,

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -5413,6 +5413,29 @@ fn charge_script_phase_bytes(
     Ok(())
 }
 
+/// A multi-module `edit` composes as an upsert, so it must really edit something: refuse a mini
+/// none of whose modules exists in the running cache, exactly as a single-module edit of a
+/// missing target fails. An all-new mini is declared with op `add`.
+pub(crate) fn require_multi_module_edit_target(
+    running: &[u8],
+    mini: &[u8],
+    manifest_module: &str,
+) -> Result<()> {
+    let carried = gore_as::cache::walk_modules::module_names(mini)
+        .map_err(|error| ModError::Other(format!("reading script mini modules: {error}")))?;
+    let existing: std::collections::HashSet<String> =
+        gore_as::cache::walk_modules::module_names(running)
+            .map_err(|error| ModError::Other(format!("reading script cache modules: {error}")))?
+            .into_iter()
+            .collect();
+    if carried.iter().any(|name| existing.contains(name)) {
+        return Ok(());
+    }
+    Err(ModError::Other(format!(
+        "script edit {manifest_module:?} carries modules {carried:?}, none of which exists in the script cache; declare an all-new mini with op \"add\""
+    )))
+}
+
 /// Persist one canonicalized mini without retaining its bytes in memory. `used` is a phase-local
 /// disk-output budget, deliberately separate from both source-read passes.
 pub(crate) fn seal_script_mini(
@@ -8310,6 +8333,7 @@ fn prepare(
                         }
                         // A multi-module mini edits and adds its modules as one unit.
                         "edit" if gore_as::cache::walk_modules::module_count(&mini) > 1 => {
+                            require_multi_module_edit_target(&running, &mini, &e.module)?;
                             script_merge_guard
                                 .compose_upsert(&running, &mini)
                                 .map_err(|err| {

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -8308,6 +8308,14 @@ fn prepare(
                                     ModError::Other(format!("splice {}: {err}", e.module))
                                 })?
                         }
+                        // A multi-module mini edits and adds its modules as one unit.
+                        "edit" if gore_as::cache::walk_modules::module_count(&mini) > 1 => {
+                            script_merge_guard
+                                .compose_upsert(&running, &mini)
+                                .map_err(|err| {
+                                    ModError::Other(format!("replace {}: {err}", e.module))
+                                })?
+                        }
                         "edit" => script_merge_guard
                             .compose_edit(&running, &mini, &e.module)
                             .map_err(|err| {

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -5413,9 +5413,27 @@ fn charge_script_phase_bytes(
     Ok(())
 }
 
+/// A multi-module entry's `module_name` must name one of the modules the mini carries, whatever
+/// its op: otherwise a mistyped target is ignored while composition rewrites whatever the mini
+/// happens to hold, and the same bundle that deploys here is rejected by Manager import.
+pub(crate) fn require_multi_module_carried_target(
+    mini: &[u8],
+    op: &str,
+    manifest_module: &str,
+) -> Result<()> {
+    let carried = gore_as::cache::walk_modules::module_names(mini)
+        .map_err(|error| ModError::Other(format!("reading script mini modules: {error}")))?;
+    if carried.iter().any(|name| name == manifest_module) {
+        return Ok(());
+    }
+    Err(ModError::Other(format!(
+        "script {op} {manifest_module:?} names a module the mini does not carry (it carries {carried:?})"
+    )))
+}
+
 /// A multi-module `edit` composes as an upsert, so it must really edit something: refuse a mini
-/// none of whose modules exists in the running cache, exactly as a single-module edit of a
-/// missing target fails. An all-new mini is declared with op `add`.
+/// none of whose modules exists in the running cache, exactly as a single-module edit of a missing
+/// target fails. An all-new mini is declared with op `add`.
 pub(crate) fn require_multi_module_edit_target(
     running: &[u8],
     mini: &[u8],
@@ -5423,14 +5441,6 @@ pub(crate) fn require_multi_module_edit_target(
 ) -> Result<()> {
     let carried = gore_as::cache::walk_modules::module_names(mini)
         .map_err(|error| ModError::Other(format!("reading script mini modules: {error}")))?;
-    // The declared target must be one of the carried modules. Otherwise a mistyped `module_name`
-    // would be ignored while the upsert quietly rewrites whatever the mini happens to carry; the
-    // single-module edit of an unknown target fails, and so must this one.
-    if !carried.iter().any(|name| name == manifest_module) {
-        return Err(ModError::Other(format!(
-            "script edit {manifest_module:?} names a module the mini does not carry (it carries {carried:?})"
-        )));
-    }
     let existing: std::collections::HashSet<String> =
         gore_as::cache::walk_modules::module_names(running)
             .map_err(|error| ModError::Other(format!("reading script cache modules: {error}")))?
@@ -8331,6 +8341,11 @@ fn prepare(
                         &mut canonical_read_bytes,
                         MAX_SCRIPT_MINI_TOTAL_BYTES,
                     )?;
+                    // Every multi-module entry must name one of its carried modules, whatever
+                    // its op; an edit additionally needs an existing target.
+                    if gore_as::cache::walk_modules::module_count(&mini) > 1 {
+                        require_multi_module_carried_target(&mini, &e.op, &e.module)?;
+                    }
                     running = match e.op.as_str() {
                         "add" => {
                             script_merge_guard

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -5423,6 +5423,14 @@ pub(crate) fn require_multi_module_edit_target(
 ) -> Result<()> {
     let carried = gore_as::cache::walk_modules::module_names(mini)
         .map_err(|error| ModError::Other(format!("reading script mini modules: {error}")))?;
+    // The declared target must be one of the carried modules. Otherwise a mistyped `module_name`
+    // would be ignored while the upsert quietly rewrites whatever the mini happens to carry; the
+    // single-module edit of an unknown target fails, and so must this one.
+    if !carried.iter().any(|name| name == manifest_module) {
+        return Err(ModError::Other(format!(
+            "script edit {manifest_module:?} names a module the mini does not carry (it carries {carried:?})"
+        )));
+    }
     let existing: std::collections::HashSet<String> =
         gore_as::cache::walk_modules::module_names(running)
             .map_err(|error| ModError::Other(format!("reading script cache modules: {error}")))?

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -1409,16 +1409,19 @@ fn apply_loadout_with_limits(
             ModError::Other(format!("cannot reserve script target lists: {error}"))
         })?;
         for (_, module, mini_payload) in &scripts {
-            let carried = read_pending_payload(
+            // A read or budget failure is fatal here: swallowing it would let a later mini hide
+            // the modules it carries from winner reduction. Only an unparseable payload falls
+            // back to its manifest name; inspection reports that payload with its real error.
+            let mini = read_pending_payload(
                 mini_payload,
                 "script mini-cache target scan",
                 limits.max_mini_bytes,
                 &mut target_scan_bytes,
                 limits.max_mini_total_bytes,
-            )
-            .ok()
-            .and_then(|mini| gore_as::cache::walk_modules::module_names(&mini).ok())
-            .filter(|names| names.iter().any(|name| name == module));
+            )?;
+            let carried = gore_as::cache::walk_modules::module_names(&mini)
+                .ok()
+                .filter(|names| names.iter().any(|name| name == module));
             targets.push(carried.unwrap_or_else(|| vec![module.clone()]));
         }
         let (winning_scripts, winner_edits_after_add, shadowed_add_targets) =

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -400,14 +400,19 @@ fn snapshot_raw_payload(
 /// module it carries and is dropped when a later entry re-targets all of them; a mini that would
 /// lose only some of its modules is refused, because a multi-module mini composes as one unit and
 /// its stale rows for the replaced module would otherwise stay in the ID plan and the tail. The
-/// returned set records winning edits whose target was introduced by an earlier, now-shadowed add;
+/// returned sets record winning edits whose target was introduced by an earlier, now-shadowed add,
+/// plus every module such shadowed adds carried;
 /// composition may retry those winners as adds if the effective base does not already contain the
 /// target. `analyze` uses the same target strings as `ScriptModule` identity, so this intentionally
 /// does not case-fold names.
 fn retain_last_script_target_winners(
     scripts: Vec<(String, String, PendingPayload)>,
     targets: Vec<Vec<String>>,
-) -> crate::Result<(Vec<(String, String, PendingPayload)>, BTreeSet<String>)> {
+) -> crate::Result<(
+    Vec<(String, String, PendingPayload)>,
+    BTreeSet<String>,
+    BTreeSet<String>,
+)> {
     debug_assert_eq!(scripts.len(), targets.len());
     let mut last_by_target = BTreeMap::<String, usize>::new();
     for (index, entry_targets) in targets.iter().enumerate() {
@@ -446,7 +451,7 @@ fn retain_last_script_target_winners(
             )));
         }
     }
-    Ok((winners, winner_edits_after_add))
+    Ok((winners, winner_edits_after_add, prior_add_targets))
 }
 
 fn validate_standalone_script_candidate(
@@ -1416,7 +1421,7 @@ fn apply_loadout_with_limits(
             .filter(|names| names.iter().any(|name| name == module));
             targets.push(carried.unwrap_or_else(|| vec![module.clone()]));
         }
-        let (winning_scripts, winner_edits_after_add) =
+        let (winning_scripts, winner_edits_after_add, shadowed_add_targets) =
             retain_last_script_target_winners(scripts, targets)?;
         scripts = winning_scripts;
         let (base, pristine_source) =
@@ -1504,9 +1509,19 @@ fn apply_loadout_with_limits(
                 "add" => merge_guard
                     .compose_add(&acc, &mini)
                     .map_err(|e| ModError::Other(format!("splice {module}: {e}")))?,
-                // A multi-module mini edits and adds its modules as one unit.
+                // A multi-module mini edits and adds its modules as one unit. A module that an
+                // earlier, now-shadowed add introduced satisfies the edit-target requirement the
+                // same way a single-module edit may retry as an add after a shadowed add.
                 "edit" if gore_as::cache::walk_modules::module_count(&mini) > 1 => {
-                    crate::require_multi_module_edit_target(&acc, &mini, module)?;
+                    let carried = gore_as::cache::walk_modules::module_names(&mini).map_err(|e| {
+                        ModError::Other(format!("reading script mini modules for {module}: {e}"))
+                    })?;
+                    if !carried
+                        .iter()
+                        .any(|name| shadowed_add_targets.contains(name))
+                    {
+                        crate::require_multi_module_edit_target(&acc, &mini, module)?;
+                    }
                     merge_guard
                         .compose_upsert(&acc, &mini)
                         .map_err(|e| ModError::Other(format!("replace {module}: {e}")))?

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -2735,8 +2735,10 @@ mod tests {
         )
         .unwrap_err()
         .to_string();
+        // Mini reads are bounded in several phases (target scan, inventory, canonicalization) and
+        // each names its own budget. Assert the condition, not which phase happens to run first.
         assert!(
-            error.contains("script mini-cache payloads exceeds the 4 byte limit"),
+            error.contains("script mini-cache") && error.contains("exceeds the 4 byte limit"),
             "{error}"
         );
         assert_no_apply_artifacts(&script_game, &script_game.script_cache(), &base);

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -396,18 +396,18 @@ fn snapshot_raw_payload(
 
 /// Keep the last script entry for each exact module target while preserving the original order
 /// of all winners. `targets` lists every module each entry carries (a multi-module mini names only
-/// one of them in its manifest); an entry survives while it is the last contributor of at least one
-/// of its modules. The returned set records winning edits whose target was carried by an earlier,
-/// now-shadowed entry; composition may retry those winners as adds if the effective base does not
-/// already contain the target. `analyze` uses the same target strings as `ScriptModule` identity,
-/// so this intentionally does not case-fold names.
+/// one of them in its manifest). An entry survives only when it is the last contributor of every
+/// module it carries and is dropped when a later entry re-targets all of them; a mini that would
+/// lose only some of its modules is refused, because a multi-module mini composes as one unit and
+/// its stale rows for the replaced module would otherwise stay in the ID plan and the tail. The
+/// returned set records winning edits whose target was introduced by an earlier, now-shadowed add;
+/// composition may retry those winners as adds if the effective base does not already contain the
+/// target. `analyze` uses the same target strings as `ScriptModule` identity, so this intentionally
+/// does not case-fold names.
 fn retain_last_script_target_winners(
     scripts: Vec<(String, String, PendingPayload)>,
     targets: Vec<Vec<String>>,
-) -> crate::Result<(
-    Vec<(String, String, PendingPayload, Vec<String>)>,
-    BTreeSet<String>,
-)> {
+) -> crate::Result<(Vec<(String, String, PendingPayload)>, BTreeSet<String>)> {
     debug_assert_eq!(scripts.len(), targets.len());
     let mut last_by_target = BTreeMap::<String, usize>::new();
     for (index, entry_targets) in targets.iter().enumerate() {
@@ -422,21 +422,28 @@ fn retain_last_script_target_winners(
         .map_err(|error| {
             ModError::Other(format!("cannot reserve winning script entries: {error}"))
         })?;
-    let mut shadowed_targets = BTreeSet::new();
+    let mut prior_add_targets = BTreeSet::new();
     let mut winner_edits_after_add = BTreeSet::new();
     for (index, (script, entry_targets)) in scripts.into_iter().zip(targets).enumerate() {
-        let wins = entry_targets
+        let shadowed: Vec<&String> = entry_targets
             .iter()
-            .any(|module| last_by_target.get(module) == Some(&index));
-        if wins {
-            if script.0 == "edit" && shadowed_targets.contains(&script.1) {
+            .filter(|module| last_by_target.get(*module) != Some(&index))
+            .collect();
+        if shadowed.is_empty() {
+            if script.0 == "edit" && prior_add_targets.contains(&script.1) {
                 winner_edits_after_add.insert(script.1.clone());
             }
-            winners.push((script.0, script.1, script.2, entry_targets));
+            winners.push(script);
+        } else if shadowed.len() == entry_targets.len() {
+            if script.0 == "add" {
+                prior_add_targets.extend(entry_targets);
+            }
         } else {
-            // A shadowed entry may have introduced modules the base lacks; a later edit of such
-            // a module must be allowed to land as an add.
-            shadowed_targets.extend(entry_targets);
+            return Err(ModError::Other(format!(
+                "script mini {} of {:?} carries modules {entry_targets:?}, but later entries re-target {shadowed:?}: a multi-module mini composes as one unit, so disable or reorder one of them",
+                script.2.rel.display(),
+                script.2.entry
+            )));
         }
     }
     Ok((winners, winner_edits_after_add))
@@ -1411,14 +1418,7 @@ fn apply_loadout_with_limits(
         }
         let (winning_scripts, winner_edits_after_add) =
             retain_last_script_target_winners(scripts, targets)?;
-        let scripts: Vec<(String, String, PendingPayload)> = winning_scripts
-            .iter()
-            .map(|(op, module, payload, _)| (op.clone(), module.clone(), payload.clone()))
-            .collect();
-        let script_targets: Vec<Vec<String>> = winning_scripts
-            .into_iter()
-            .map(|(_, _, _, targets)| targets)
-            .collect();
+        scripts = winning_scripts;
         let (base, pristine_source) =
             match rawfile_sources.remove(&raw_target_identity(&RawTarget::ScriptCache)) {
                 Some((_target, source)) => {
@@ -1493,25 +1493,14 @@ fn apply_loadout_with_limits(
             .map_err(|e| ModError::Other(format!("prepare script composition: {e}")))?;
         let mut acc = base;
         let mut canonical_read_bytes = 0u64;
-        // Modules already contributed by an earlier winning entry. A later entry that carries one
-        // of them replaces it (later wins), whatever op its manifest declares.
-        let mut contributed = BTreeSet::<String>::new();
-        for (((op, module, _), entry_targets), sealed) in
-            scripts.iter().zip(&script_targets).zip(canonical_minis)
-        {
+        for ((op, module, _), sealed) in scripts.iter().zip(canonical_minis) {
             let mini = crate::read_sealed_script_mini(
                 &sealed,
                 limits.max_mini_bytes,
                 &mut canonical_read_bytes,
                 limits.max_mini_total_bytes,
             )?;
-            let replaces_prior = entry_targets
-                .iter()
-                .any(|target| contributed.contains(target));
             acc = match op.as_str() {
-                _ if replaces_prior => merge_guard
-                    .compose_upsert(&acc, &mini)
-                    .map_err(|e| ModError::Other(format!("replace or splice {module}: {e}")))?,
                 "add" => merge_guard
                     .compose_add(&acc, &mini)
                     .map_err(|e| ModError::Other(format!("splice {module}: {e}")))?,
@@ -1531,7 +1520,6 @@ fn apply_loadout_with_limits(
                     )));
                 }
             };
-            contributed.extend(entry_targets.iter().cloned());
             ensure_generated_fits(acc.len(), limits, &budget)?;
         }
         stage_generated_output(&mut plan, gp.script_cache.clone(), acc, limits, &mut budget)?;
@@ -5351,15 +5339,13 @@ mod tests {
     }
 
     #[test]
-    fn apply_scripts_later_add_replaces_a_module_carried_by_a_multi_module_mini() {
+    fn apply_scripts_multi_module_mini_is_one_unit_under_later_wins() {
         use gore_as::cache::walk_modules::{collect_function_bytecodes, module_names};
         let g = FakeGame::new();
         let base = build_script_cache(&["_gore_base"]);
         fs::write(g.script_cache(), &base).unwrap();
 
-        // X carries two modules but names only `_gore_a`; Y later adds `_gore_b` alone. The
-        // Manager promises later-wins per module, so Y's `_gore_b` (which has one function) must
-        // replace X's empty one instead of colliding.
+        // X carries two modules but names only `_gore_a`; Y adds `_gore_b` alone.
         let multi = build_script_cache(&["_gore_a", "_gore_b"]);
         let mini_b = build_script_cache_with_static_name_and_keys(
             "_gore_b",
@@ -5372,30 +5358,33 @@ mod tests {
         let x = g.add_script_mod("script-x", "Script X", "add", "_gore_a", &multi);
         let y = g.add_script_mod("script-y", "Script Y", "add", "_gore_b", &mini_b);
 
-        apply_loadout(&g.root, &g.lib, &loadout(&[(&x, true), (&y, true)])).unwrap();
-        let live = fs::read(g.script_cache()).unwrap();
-        assert_eq!(
-            module_names(&live).unwrap(),
-            vec!["_gore_base", "_gore_a", "_gore_b"]
-        );
-        let functions = collect_function_bytecodes(&live).unwrap();
+        // Y later re-targets only one of X's modules: X would keep `_gore_a` but lose `_gore_b`,
+        // and its stale `_gore_b` rows cannot be pruned from the plan or the tail. Refuse.
+        let error = apply_loadout(&g.root, &g.lib, &loadout(&[(&x, true), (&y, true)]))
+            .unwrap_err()
+            .to_string();
         assert!(
-            functions.iter().any(|f| f.func.starts_with("_gore_b::")),
-            "Y's `_gore_b` (with a function) must have replaced X's empty module: {:?}",
-            functions.iter().map(|f| f.func.clone()).collect::<Vec<_>>()
+            error.contains("composes as one unit") && error.contains("_gore_b"),
+            "{error}"
+        );
+        assert_eq!(
+            module_names(&fs::read(g.script_cache()).unwrap()).unwrap(),
+            vec!["_gore_base"],
+            "a refused loadout must leave the pristine cache untouched"
         );
 
-        // The reverse order: X is later and carries `_gore_b` too, so Y contributes nothing and
-        // is shadowed entirely; X composes alone as a plain add of both modules.
+        // X later carries `_gore_b` too, so Y contributes nothing and is dropped; X composes alone.
         apply_loadout(&g.root, &g.lib, &loadout(&[(&y, true), (&x, true)])).unwrap();
         let live = fs::read(g.script_cache()).unwrap();
         assert_eq!(
             module_names(&live).unwrap(),
             vec!["_gore_base", "_gore_a", "_gore_b"]
         );
-        let functions = collect_function_bytecodes(&live).unwrap();
         assert!(
-            !functions.iter().any(|f| f.func.starts_with("_gore_b::")),
+            !collect_function_bytecodes(&live)
+                .unwrap()
+                .iter()
+                .any(|f| f.func.starts_with("_gore_b::")),
             "X's empty `_gore_b` must have won over Y's"
         );
     }

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -1505,9 +1505,12 @@ fn apply_loadout_with_limits(
                     .compose_add(&acc, &mini)
                     .map_err(|e| ModError::Other(format!("splice {module}: {e}")))?,
                 // A multi-module mini edits and adds its modules as one unit.
-                "edit" if gore_as::cache::walk_modules::module_count(&mini) > 1 => merge_guard
-                    .compose_upsert(&acc, &mini)
-                    .map_err(|e| ModError::Other(format!("replace {module}: {e}")))?,
+                "edit" if gore_as::cache::walk_modules::module_count(&mini) > 1 => {
+                    crate::require_multi_module_edit_target(&acc, &mini, module)?;
+                    merge_guard
+                        .compose_upsert(&acc, &mini)
+                        .map_err(|e| ModError::Other(format!("replace {module}: {e}")))?
+                }
                 "edit" if winner_edits_after_add.contains(module) => merge_guard
                     .compose_edit_or_add(&acc, &mini, module)
                     .map_err(|e| ModError::Other(format!("replace or splice {module}: {e}")))?,

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -1508,6 +1508,12 @@ fn apply_loadout_with_limits(
                 &mut canonical_read_bytes,
                 limits.max_mini_total_bytes,
             )?;
+            // Every multi-module entry must name one of its carried modules, whatever its op;
+            // an edit additionally needs an existing target, checked in its arm, which knows
+            // about targets an earlier shadowed add introduced.
+            if gore_as::cache::walk_modules::module_count(&mini) > 1 {
+                crate::require_multi_module_carried_target(&mini, op, module)?;
+            }
             acc = match op.as_str() {
                 "add" => merge_guard
                     .compose_add(&acc, &mini)

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -1462,6 +1462,10 @@ fn apply_loadout_with_limits(
                 "add" => merge_guard
                     .compose_add(&acc, &mini)
                     .map_err(|e| ModError::Other(format!("splice {module}: {e}")))?,
+                // A multi-module mini edits and adds its modules as one unit.
+                "edit" if gore_as::cache::walk_modules::module_count(&mini) > 1 => merge_guard
+                    .compose_upsert(&acc, &mini)
+                    .map_err(|e| ModError::Other(format!("replace {module}: {e}")))?,
                 "edit" if winner_edits_after_add.contains(module) => merge_guard
                     .compose_edit_or_add(&acc, &mini, module)
                     .map_err(|e| ModError::Other(format!("replace or splice {module}: {e}")))?,

--- a/crates/gore-mod/src/mgr/apply.rs
+++ b/crates/gore-mod/src/mgr/apply.rs
@@ -394,17 +394,26 @@ fn snapshot_raw_payload(
     Ok((candidate, len))
 }
 
-/// Keep the last script entry for each exact manifest module target while preserving the original
-/// order of all winners. The returned set records winning edits whose target was introduced by an
-/// earlier, now-shadowed add; composition may retry those winners as adds if the effective base does
-/// not already contain the target. `analyze` uses the authored target string as `ScriptModule`
-/// identity, so this intentionally does not case-fold names or infer identity from mini contents.
+/// Keep the last script entry for each exact module target while preserving the original order
+/// of all winners. `targets` lists every module each entry carries (a multi-module mini names only
+/// one of them in its manifest); an entry survives while it is the last contributor of at least one
+/// of its modules. The returned set records winning edits whose target was carried by an earlier,
+/// now-shadowed entry; composition may retry those winners as adds if the effective base does not
+/// already contain the target. `analyze` uses the same target strings as `ScriptModule` identity,
+/// so this intentionally does not case-fold names.
 fn retain_last_script_target_winners(
     scripts: Vec<(String, String, PendingPayload)>,
-) -> crate::Result<(Vec<(String, String, PendingPayload)>, BTreeSet<String>)> {
+    targets: Vec<Vec<String>>,
+) -> crate::Result<(
+    Vec<(String, String, PendingPayload, Vec<String>)>,
+    BTreeSet<String>,
+)> {
+    debug_assert_eq!(scripts.len(), targets.len());
     let mut last_by_target = BTreeMap::<String, usize>::new();
-    for (index, (_, module, _)) in scripts.iter().enumerate() {
-        last_by_target.insert(module.clone(), index);
+    for (index, entry_targets) in targets.iter().enumerate() {
+        for module in entry_targets {
+            last_by_target.insert(module.clone(), index);
+        }
     }
 
     let mut winners = Vec::new();
@@ -413,16 +422,21 @@ fn retain_last_script_target_winners(
         .map_err(|error| {
             ModError::Other(format!("cannot reserve winning script entries: {error}"))
         })?;
-    let mut prior_add_targets = BTreeSet::new();
+    let mut shadowed_targets = BTreeSet::new();
     let mut winner_edits_after_add = BTreeSet::new();
-    for (index, script) in scripts.into_iter().enumerate() {
-        if last_by_target.get(&script.1) == Some(&index) {
-            if script.0 == "edit" && prior_add_targets.contains(&script.1) {
+    for (index, (script, entry_targets)) in scripts.into_iter().zip(targets).enumerate() {
+        let wins = entry_targets
+            .iter()
+            .any(|module| last_by_target.get(module) == Some(&index));
+        if wins {
+            if script.0 == "edit" && shadowed_targets.contains(&script.1) {
                 winner_edits_after_add.insert(script.1.clone());
             }
-            winners.push(script);
-        } else if script.0 == "add" {
-            prior_add_targets.insert(script.1.clone());
+            winners.push((script.0, script.1, script.2, entry_targets));
+        } else {
+            // A shadowed entry may have introduced modules the base lacks; a later edit of such
+            // a module must be allowed to land as an add.
+            shadowed_targets.extend(entry_targets);
         }
     }
     Ok((winners, winner_edits_after_add))
@@ -1372,11 +1386,39 @@ fn apply_loadout_with_limits(
                 "invalid script op {op:?} for module {module:?}"
             )));
         }
-        // Conflict analysis and the UI promise exact-target later-wins semantics. Reduce before
-        // inventory, canonicalization, and composition so a shadowed mini cannot still collide in
-        // the global ID plan or attempt a duplicate module splice.
-        let (winning_scripts, winner_edits_after_add) = retain_last_script_target_winners(scripts)?;
-        scripts = winning_scripts;
+        // Conflict analysis and the UI promise exact-target later-wins semantics for every module
+        // a mini carries, not only the one its manifest names. Read the carried module names first
+        // (a mini that cannot be read here fails with its real error in the passes below), then
+        // reduce before inventory, canonicalization, and composition so a shadowed mini cannot
+        // still collide in the global ID plan or attempt a duplicate module splice.
+        let mut target_scan_bytes = 0u64;
+        let mut targets = Vec::new();
+        targets.try_reserve_exact(scripts.len()).map_err(|error| {
+            ModError::Other(format!("cannot reserve script target lists: {error}"))
+        })?;
+        for (_, module, mini_payload) in &scripts {
+            let carried = read_pending_payload(
+                mini_payload,
+                "script mini-cache target scan",
+                limits.max_mini_bytes,
+                &mut target_scan_bytes,
+                limits.max_mini_total_bytes,
+            )
+            .ok()
+            .and_then(|mini| gore_as::cache::walk_modules::module_names(&mini).ok())
+            .filter(|names| names.iter().any(|name| name == module));
+            targets.push(carried.unwrap_or_else(|| vec![module.clone()]));
+        }
+        let (winning_scripts, winner_edits_after_add) =
+            retain_last_script_target_winners(scripts, targets)?;
+        let scripts: Vec<(String, String, PendingPayload)> = winning_scripts
+            .iter()
+            .map(|(op, module, payload, _)| (op.clone(), module.clone(), payload.clone()))
+            .collect();
+        let script_targets: Vec<Vec<String>> = winning_scripts
+            .into_iter()
+            .map(|(_, _, _, targets)| targets)
+            .collect();
         let (base, pristine_source) =
             match rawfile_sources.remove(&raw_target_identity(&RawTarget::ScriptCache)) {
                 Some((_target, source)) => {
@@ -1451,14 +1493,25 @@ fn apply_loadout_with_limits(
             .map_err(|e| ModError::Other(format!("prepare script composition: {e}")))?;
         let mut acc = base;
         let mut canonical_read_bytes = 0u64;
-        for ((op, module, _), sealed) in scripts.iter().zip(canonical_minis) {
+        // Modules already contributed by an earlier winning entry. A later entry that carries one
+        // of them replaces it (later wins), whatever op its manifest declares.
+        let mut contributed = BTreeSet::<String>::new();
+        for (((op, module, _), entry_targets), sealed) in
+            scripts.iter().zip(&script_targets).zip(canonical_minis)
+        {
             let mini = crate::read_sealed_script_mini(
                 &sealed,
                 limits.max_mini_bytes,
                 &mut canonical_read_bytes,
                 limits.max_mini_total_bytes,
             )?;
+            let replaces_prior = entry_targets
+                .iter()
+                .any(|target| contributed.contains(target));
             acc = match op.as_str() {
+                _ if replaces_prior => merge_guard
+                    .compose_upsert(&acc, &mini)
+                    .map_err(|e| ModError::Other(format!("replace or splice {module}: {e}")))?,
                 "add" => merge_guard
                     .compose_add(&acc, &mini)
                     .map_err(|e| ModError::Other(format!("splice {module}: {e}")))?,
@@ -1478,6 +1531,7 @@ fn apply_loadout_with_limits(
                     )));
                 }
             };
+            contributed.extend(entry_targets.iter().cloned());
             ensure_generated_fits(acc.len(), limits, &budget)?;
         }
         stage_generated_output(&mut plan, gp.script_cache.clone(), acc, limits, &mut budget)?;
@@ -5294,6 +5348,56 @@ mod tests {
 
         run(false);
         run(true);
+    }
+
+    #[test]
+    fn apply_scripts_later_add_replaces_a_module_carried_by_a_multi_module_mini() {
+        use gore_as::cache::walk_modules::{collect_function_bytecodes, module_names};
+        let g = FakeGame::new();
+        let base = build_script_cache(&["_gore_base"]);
+        fs::write(g.script_cache(), &base).unwrap();
+
+        // X carries two modules but names only `_gore_a`; Y later adds `_gore_b` alone. The
+        // Manager promises later-wins per module, so Y's `_gore_b` (which has one function) must
+        // replace X's empty one instead of colliding.
+        let multi = build_script_cache(&["_gore_a", "_gore_b"]);
+        let mini_b = build_script_cache_with_static_name_and_keys(
+            "_gore_b",
+            "FromY",
+            "TypeY",
+            41,
+            41,
+            0x0801_0041,
+        );
+        let x = g.add_script_mod("script-x", "Script X", "add", "_gore_a", &multi);
+        let y = g.add_script_mod("script-y", "Script Y", "add", "_gore_b", &mini_b);
+
+        apply_loadout(&g.root, &g.lib, &loadout(&[(&x, true), (&y, true)])).unwrap();
+        let live = fs::read(g.script_cache()).unwrap();
+        assert_eq!(
+            module_names(&live).unwrap(),
+            vec!["_gore_base", "_gore_a", "_gore_b"]
+        );
+        let functions = collect_function_bytecodes(&live).unwrap();
+        assert!(
+            functions.iter().any(|f| f.func.starts_with("_gore_b::")),
+            "Y's `_gore_b` (with a function) must have replaced X's empty module: {:?}",
+            functions.iter().map(|f| f.func.clone()).collect::<Vec<_>>()
+        );
+
+        // The reverse order: X is later and carries `_gore_b` too, so Y contributes nothing and
+        // is shadowed entirely; X composes alone as a plain add of both modules.
+        apply_loadout(&g.root, &g.lib, &loadout(&[(&y, true), (&x, true)])).unwrap();
+        let live = fs::read(g.script_cache()).unwrap();
+        assert_eq!(
+            module_names(&live).unwrap(),
+            vec!["_gore_base", "_gore_a", "_gore_b"]
+        );
+        let functions = collect_function_bytecodes(&live).unwrap();
+        assert!(
+            !functions.iter().any(|f| f.func.starts_with("_gore_b::")),
+            "X's empty `_gore_b` must have won over Y's"
+        );
     }
 
     #[test]

--- a/crates/gore-mod/src/mgr/import.rs
+++ b/crates/gore-mod/src/mgr/import.rs
@@ -5710,18 +5710,31 @@ fn goremod_components(
                 // Conflict targets are every module the mini actually carries: a multi-module
                 // mini names only one of them in its manifest entry. Fall back to the manifest
                 // name when the payload cannot be read here; inspection validates it later.
+                // Each distinct payload is read once and the whole scan shares the aggregate
+                // script budget, so a short manifest pointing many entries at one large mini
+                // cannot turn this best-effort pass into unbounded I/O.
                 let mut targets: Vec<String> = Vec::new();
+                let mut scanned: BTreeMap<String, Option<Vec<String>>> = BTreeMap::new();
+                let mut scan_bytes = 0u64;
                 for e in &entries {
-                    let carried = read_bounded_bundle_file(
-                        bundle_dir,
-                        Path::new(&e.mini),
-                        "script mini-cache payload",
-                        crate::MAX_SCRIPT_MINI_BYTES,
-                    )
-                    .ok()
-                    .and_then(|mini| gore_as::cache::walk_modules::module_names(&mini).ok())
-                    .filter(|names| !names.is_empty());
-                    match carried {
+                    if !scanned.contains_key(&e.mini) {
+                        let remaining =
+                            crate::MAX_SCRIPT_MINI_TOTAL_BYTES.saturating_sub(scan_bytes);
+                        let carried = read_bounded_bundle_file(
+                            bundle_dir,
+                            Path::new(&e.mini),
+                            "script mini-cache target scan",
+                            crate::MAX_SCRIPT_MINI_BYTES.min(remaining),
+                        )
+                        .ok()
+                        .and_then(|mini| {
+                            scan_bytes = scan_bytes.saturating_add(mini.len() as u64);
+                            gore_as::cache::walk_modules::module_names(&mini).ok()
+                        })
+                        .filter(|names| !names.is_empty());
+                        scanned.insert(e.mini.clone(), carried);
+                    }
+                    match scanned.get(&e.mini).and_then(Clone::clone) {
                         Some(names) => targets.extend(names),
                         None => targets.push(e.module.clone()),
                     }

--- a/crates/gore-mod/src/mgr/import.rs
+++ b/crates/gore-mod/src/mgr/import.rs
@@ -5707,8 +5707,27 @@ fn goremod_components(
                     limits.max_manifest_bytes,
                 )?;
                 let entries: Vec<ScriptEntry> = serde_json::from_slice(&bytes)?;
-                let mut targets: Vec<String> = entries.iter().map(|e| e.module.clone()).collect();
+                // Conflict targets are every module the mini actually carries: a multi-module
+                // mini names only one of them in its manifest entry. Fall back to the manifest
+                // name when the payload cannot be read here; inspection validates it later.
+                let mut targets: Vec<String> = Vec::new();
+                for e in &entries {
+                    let carried = read_bounded_bundle_file(
+                        bundle_dir,
+                        Path::new(&e.mini),
+                        "script mini-cache payload",
+                        crate::MAX_SCRIPT_MINI_BYTES,
+                    )
+                    .ok()
+                    .and_then(|mini| gore_as::cache::walk_modules::module_names(&mini).ok())
+                    .filter(|names| !names.is_empty());
+                    match carried {
+                        Some(names) => targets.extend(names),
+                        None => targets.push(e.module.clone()),
+                    }
+                }
                 targets.sort();
+                targets.dedup();
                 ComponentInfo::AngelScriptPatch {
                     rel: join_rel(prefix, path),
                     targets,
@@ -6088,7 +6107,13 @@ fn validate_inspected_gore_bundle(
                                 entry.mini
                             ))
                         })?;
-                    if module_names.as_slice() != [entry.module.as_str()] {
+                    // A multi-module mini names one of its modules in the manifest; a
+                    // single-module mini must name exactly that module.
+                    let manifest_names_mini = match module_names.as_slice() {
+                        [only] => only == &entry.module,
+                        names => names.iter().any(|name| name == &entry.module),
+                    };
+                    if !manifest_names_mini {
                         return Err(ModError::Other(format!(
                             "script mini-cache {:?} declares modules {module_names:?}, but its manifest names {:?}",
                             entry.mini, entry.module

--- a/crates/gore/CHANGELOG.md
+++ b/crates/gore/CHANGELOG.md
@@ -5,6 +5,13 @@ uses the matching version section as the GitHub release notes.
 
 ## [Unreleased]
 
+- Support multi-module mini-caches: `gore as compile --mini` publishes the
+  authored modules as one deployable mini, and build, deploy, the Manager and
+  `as splice` compose it as one unit. Qualified in game with a two-module
+  Diego dialog fixture whose topic text comes from a new provider module.
+- `gore as compile` refuses an invalid work-directory/output layout before it
+  plans the complete source graph instead of minutes later.
+
 ## [0.3.0] - 2026-09-02
 
 - Add `gore dialog list`, `tree`, `show`, `export` and `text` for inspecting

--- a/crates/gore/CHANGELOG.md
+++ b/crates/gore/CHANGELOG.md
@@ -7,8 +7,9 @@ uses the matching version section as the GitHub release notes.
 
 - Support multi-module mini-caches: `gore as compile --mini` publishes the
   authored modules as one deployable mini, and build, deploy, the Manager and
-  `as splice` compose it as one unit. Qualified in game with a two-module
-  Diego dialog fixture whose topic text comes from a new provider module.
+  `as splice --upsert` compose it as one unit. Qualified in game with a
+  two-module Diego dialog fixture whose topic text comes from a new provider
+  module.
 - `gore as compile` refuses an invalid work-directory/output layout before it
   plans the complete source graph instead of minutes later.
 

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -2243,9 +2243,9 @@ fn compile_full_graph_command(
     // success line, and neutralize the already published complete cache when it cannot be
     // produced, exactly like a failed generation receipt, so a retry is not blocked by a
     // half-finished no-clobber output. Nothing else has been published at this point.
-    let mini_report = match mini_path.as_ref() {
+    let published_mini = match mini_path.as_ref() {
         Some(mini_path) => match publish_full_graph_mini(&artifact, &opts.base_cache, mini_path) {
-            Ok(report) => Some(report),
+            Ok(published) => Some(published),
             Err(error) => {
                 return fail_after_full_graph_side_output_error(
                     &artifact,
@@ -2283,7 +2283,7 @@ fn compile_full_graph_command(
                     return fail_after_full_graph_side_output_error(
                         &artifact,
                         "GENERATION_RECEIPT",
-                        mini_path.as_deref(),
+                        published_mini.as_ref(),
                         format!("building {}: {error}", receipt_path.display()),
                     );
                 }
@@ -2294,7 +2294,7 @@ fn compile_full_graph_command(
             return fail_after_full_graph_side_output_error(
                 &artifact,
                 "GENERATION_RECEIPT",
-                mini_path.as_deref(),
+                published_mini.as_ref(),
                 format!("publishing {}: {error}", receipt_path.display()),
             );
         }
@@ -2317,10 +2317,27 @@ fn compile_full_graph_command(
         artifact.byte_len(),
         artifact.sha256()
     );
-    if let Some(report) = mini_report {
-        print!("{report}");
+    if let Some(published) = published_mini {
+        print!("{}", published.report);
     }
     Ok(())
+}
+
+/// A published multi-module mini-cache retained through its exact creation handle, so a later
+/// failure of this command can neutralize the bytes it wrote without trusting the path again.
+struct PublishedMini {
+    path: PathBuf,
+    file: std::fs::File,
+    report: String,
+}
+
+impl PublishedMini {
+    /// Reduce the written mini to zero bytes through the retained handle. A zero-byte file at the
+    /// destination is never a usable mini-cache and is reported for removal before a retry.
+    fn neutralize(&self) -> std::io::Result<()> {
+        self.file.set_len(0)?;
+        self.file.sync_all()
+    }
 }
 
 /// Reduce a selectively composed complete cache to a deployable multi-module mini-cache: the
@@ -2330,7 +2347,7 @@ fn publish_full_graph_mini(
     artifact: &gore_as::compile::FullGraphCompileArtifactV1,
     base_cache: &[u8],
     mini_path: &Path,
-) -> Result<String> {
+) -> Result<PublishedMini> {
     use gore_as::compile::FullGraphCompileOperationV1;
     use std::fmt::Write as _;
     let authored: Vec<(&str, FullGraphCompileOperationV1)> = artifact
@@ -2370,13 +2387,14 @@ fn publish_full_graph_mini(
         .open(mini_path)
         .with_context(|| format!("creating {}", mini_path.display()))?;
     if let Err(error) = std::io::Write::write_all(&mut file, &mini).and_then(|()| file.sync_all()) {
-        // Never leave a truncated artifact behind: it would block the no-clobber preflight of
-        // the next run and could be mistaken for a usable mini-cache.
-        drop(file);
-        let cleanup = std::fs::remove_file(mini_path)
-            .err()
-            .map(|remove| format!("; removing the partial file failed too: {remove}"))
-            .unwrap_or_default();
+        // Never leave a truncated artifact behind that could be mistaken for a usable mini-cache.
+        // Neutralize through the exact handle just created: the path may already point at a
+        // different file when another process can write to the destination directory.
+        let cleanup = file
+            .set_len(0)
+            .and_then(|()| file.sync_all())
+            .map(|()| "; the partial file was reduced to zero bytes and must be removed before retrying".to_owned())
+            .unwrap_or_else(|neutralize| format!("; neutralizing the partial file failed too: {neutralize}"));
         bail!("writing {}: {error}{cleanup}", mini_path.display());
     }
     let has_edit = authored
@@ -2410,23 +2428,35 @@ fn publish_full_graph_mini(
             .map(|name| name.to_string_lossy().into_owned())
             .unwrap_or_default()
     );
-    Ok(report)
+    Ok(PublishedMini {
+        path: mini_path.to_path_buf(),
+        file,
+        report,
+    })
 }
 
 /// A side output of the full-graph command (mini-cache, receipt) could not be produced after the
 /// complete cache was already published. The command's product is all-or-nothing: reduce the
 /// retained cache to zero bytes so the next run is not blocked by a no-clobber destination that
-/// looks like a usable result, and remove an already published mini-cache that would otherwise
-/// describe the neutralized cache.
+/// looks like a usable result, and neutralize an already published mini-cache through its retained
+/// handle so it cannot describe the neutralized cache.
 fn fail_after_full_graph_side_output_error<T>(
     artifact: &gore_as::compile::FullGraphCompileArtifactV1,
     label: &str,
-    published_mini: Option<&Path>,
+    published_mini: Option<&PublishedMini>,
     primary: String,
 ) -> Result<T> {
     let mini_cleanup = published_mini
-        .and_then(|path| std::fs::remove_file(path).err().map(|error| (path, error)))
-        .map(|(path, error)| format!("; removing the published mini-cache {} failed too: {error}", path.display()))
+        .map(|mini| match mini.neutralize() {
+            Ok(()) => format!(
+                "; the published mini-cache at {} was reduced to zero bytes and must be removed before retrying",
+                mini.path.display()
+            ),
+            Err(error) => format!(
+                "; neutralizing the published mini-cache at {} failed too: {error}",
+                mini.path.display()
+            ),
+        })
         .unwrap_or_default();
     match artifact.neutralize() {
         Ok(()) => bail!(

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -2342,7 +2342,10 @@ fn publish_full_graph_mini(
     if authored.is_empty() {
         bail!("no authored Add/Edit module to place in a mini-cache");
     }
-    let composed = std::fs::read(artifact.path())
+    // Read the exact retained handle, never the path: the output directory may be writable by
+    // another process, and a swapped file must not become the source of the mini.
+    let composed = gore_as::generation_receipt_v2::read_full_graph_compile_output_bytes_v2(artifact)
+        .map_err(anyhow::Error::new)
         .with_context(|| format!("reading the composed cache {}", artifact.path().display()))?;
     let names: Vec<&str> = authored.iter().map(|(name, _)| *name).collect();
     let extracted = gore_as::cache::splice::extract_modules(&composed, &names)

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -1968,10 +1968,35 @@ fn compile_full_graph_command(
     let mini_path = mini
         .map(|path| absolute_cli_path(path, "multi-module mini-cache"))
         .transpose()?;
-    if let Some(path) = mini_path.as_ref() {
-        if path == &out || receipt_path.as_ref().is_some_and(|receipt| receipt == path) {
-            bail!("mini-cache path must differ from the compiled cache and receipt paths");
+    // Two side outputs may name the same file, or nest inside one another, through different
+    // spellings of the same directory. Compare the projected paths before any preflight creates a
+    // directory, so a bad layout cannot surface only after the expensive graph work.
+    {
+        let mut resolved: Vec<(&'static str, PathBuf)> = Vec::new();
+        for (label, path) in [
+            ("compiled cache", Some(&out)),
+            ("multi-module mini-cache", mini_path.as_ref()),
+            ("generation receipt", receipt_path.as_ref()),
+        ] {
+            let Some(path) = path else { continue };
+            let projected = gore_as::compile::resolve_projected_output_path_v1(path, label)
+                .map_err(anyhow::Error::new)
+                .with_context(|| format!("resolving the {label} destination"))?;
+            for (other_label, other) in &resolved {
+                if gore_as::compile::resolved_path_is_within_v1(&projected, other)
+                    || gore_as::compile::resolved_path_is_within_v1(other, &projected)
+                {
+                    bail!(
+                        "the {label} and {other_label} destinations resolve to the same path or nest inside one another: {} vs {}",
+                        projected.display(),
+                        other.display()
+                    );
+                }
+            }
+            resolved.push((label, projected));
         }
+    }
+    if let Some(path) = mini_path.as_ref() {
         // The same resolved layout check the compiled cache gets: a lexical comparison would
         // accept an aliased or symlinked spelling of the workspace, and the next compile's tree
         // reset would then delete the published mini.

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -294,6 +294,11 @@ pub enum AsCmd {
         /// game installation.
         #[arg(short, long)]
         out: PathBuf,
+        /// Also publish a deployable multi-module mini-cache holding only the authored Add/Edit
+        /// modules, remapped to the pristine cache. This is the artifact a bundle spec's
+        /// `scripts[].mini_cache` should point at when a mod spans several modules.
+        #[arg(long, value_name = "PATH")]
+        mini: Option<PathBuf>,
         /// Existing private workspace outside the game installation. GORE recreates only its
         /// fixed `tree` child and uses this root for isolated standalone scratch directories.
         #[arg(long, value_name = "DIR")]
@@ -1918,6 +1923,7 @@ impl gore_as::compile::StandaloneCompilerRunnerV1 for CompileModuleStandaloneRun
 fn compile_full_graph_command(
     src: PathBuf,
     out: PathBuf,
+    mini: Option<PathBuf>,
     work_dir: PathBuf,
     game: Option<PathBuf>,
     no_diagnostics: bool,
@@ -1940,6 +1946,11 @@ fn compile_full_graph_command(
     if out == work_dir || out.starts_with(&work_dir) {
         bail!("full-graph output must not be inside the compiler workspace");
     }
+    // The compiler repeats this preflight only after the complete source graph has been
+    // planned, which takes many minutes on the shipped tree. Run the identical check up front.
+    gore_as::compile::preflight_full_graph_path_layout_paths_v1(&game, &work_dir, &out)
+        .map_err(anyhow::Error::new)
+        .context("full-graph path layout")?;
     let receipt_path = compiler
         .generation_receipt
         .map(|path| absolute_cli_path(path, "generation receipt"))
@@ -1949,6 +1960,21 @@ fn compile_full_graph_command(
     }
     if let Some(path) = receipt_path.as_ref() {
         validate_auxiliary_output_path(path, &game, "generation receipt")?;
+    }
+    let mini_path = mini
+        .map(|path| absolute_cli_path(path, "multi-module mini-cache"))
+        .transpose()?;
+    if let Some(path) = mini_path.as_ref() {
+        if path == &out || receipt_path.as_ref().is_some_and(|receipt| receipt == path) {
+            bail!("mini-cache path must differ from the compiled cache and receipt paths");
+        }
+        if path == &work_dir || path.starts_with(&work_dir) {
+            bail!("mini-cache output must not be inside the compiler workspace");
+        }
+        validate_auxiliary_output_path(path, &game, "multi-module mini-cache")?;
+        if path.exists() {
+            bail!("mini-cache output already exists: {}", path.display());
+        }
     }
 
     let executable_path = compiler_executable_path(&game);
@@ -2250,6 +2276,78 @@ fn compile_full_graph_command(
         artifact.module_count(),
         artifact.byte_len(),
         artifact.sha256()
+    );
+    if let Some(mini_path) = mini_path {
+        publish_full_graph_mini(&artifact, &opts.base_cache, &mini_path)?;
+    }
+    Ok(())
+}
+
+/// Reduce a selectively composed complete cache to a deployable multi-module mini-cache: the
+/// authored Add/Edit modules are extracted with the composed tail and remapped against the
+/// sealed pristine base, so the mini carries only its own new rows and is bound to the base GUID.
+fn publish_full_graph_mini(
+    artifact: &gore_as::compile::FullGraphCompileArtifactV1,
+    base_cache: &[u8],
+    mini_path: &Path,
+) -> Result<()> {
+    use gore_as::compile::FullGraphCompileOperationV1;
+    let authored: Vec<(&str, FullGraphCompileOperationV1)> = artifact
+        .changes()
+        .iter()
+        .filter(|change| change.operation != FullGraphCompileOperationV1::Delete)
+        .map(|change| (change.module_name.as_str(), change.operation))
+        .collect();
+    if authored.is_empty() {
+        bail!("no authored Add/Edit module to place in a mini-cache");
+    }
+    let composed = std::fs::read(artifact.path())
+        .with_context(|| format!("reading the composed cache {}", artifact.path().display()))?;
+    let names: Vec<&str> = authored.iter().map(|(name, _)| *name).collect();
+    let extracted = gore_as::cache::splice::extract_modules(&composed, &names)
+        .context("extracting the authored modules from the composed cache")?;
+    let (mini, _counts) = gore_as::cache::remap::remap_module_to_base_with_options(
+        &extracted,
+        base_cache,
+        gore_as::cache::remap::RemapOptions {
+            allow_new_symbols: true,
+        },
+    )
+    .context("remapping the authored modules to the pristine cache")?;
+    // Prove the mini composes back onto the sealed base before publishing it.
+    let mut guard = gore_as::cache::splice::SequentialMiniGuard::new(base_cache)
+        .context("validating the pristine base for the mini-cache self-check")?;
+    guard
+        .compose_upsert(base_cache, &mini)
+        .context("multi-module mini-cache does not compose onto the pristine base")?;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(mini_path)
+        .with_context(|| format!("creating {}", mini_path.display()))?;
+    std::io::Write::write_all(&mut file, &mini)
+        .and_then(|()| file.sync_all())
+        .with_context(|| format!("writing {}", mini_path.display()))?;
+    let has_edit = authored
+        .iter()
+        .any(|(_, op)| *op == FullGraphCompileOperationV1::Edit);
+    println!(
+        "multi-module mini-cache -> {} ({} modules, {} bytes)",
+        mini_path.display(),
+        names.len(),
+        mini.len()
+    );
+    for (name, op) in &authored {
+        println!("  {:<4} {name}", format!("{op:?}").to_lowercase());
+    }
+    println!(
+        "bundle spec entry: {{ \"op\": \"{}\", \"module_name\": \"{}\", \"mini_cache\": \"{}\" }}",
+        if has_edit { "edit" } else { "add" },
+        names[0],
+        mini_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default()
     );
     Ok(())
 }
@@ -3112,6 +3210,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
         AsCmd::Compile {
             src,
             out,
+            mini,
             work_dir,
             game,
             no_diagnostics,
@@ -3122,6 +3221,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             compile_full_graph_command(
                 src,
                 out,
+                mini,
                 work_dir,
                 game,
                 no_diagnostics,

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -2382,6 +2382,13 @@ fn publish_full_graph_mini(
     let has_edit = authored
         .iter()
         .any(|(_, op)| *op == FullGraphCompileOperationV1::Edit);
+    // Name an edited shipped module in the spec entry when there is one: deploy requires an
+    // `edit` mini to carry at least one module that exists in the cache.
+    let spec_module = authored
+        .iter()
+        .find(|(_, op)| *op == FullGraphCompileOperationV1::Edit)
+        .map(|(name, _)| *name)
+        .unwrap_or(names[0]);
     let mut report = String::new();
     let _ = writeln!(
         report,
@@ -2397,7 +2404,7 @@ fn publish_full_graph_mini(
         report,
         "bundle spec entry: {{ \"op\": \"{}\", \"module_name\": \"{}\", \"mini_cache\": \"{}\" }}",
         if has_edit { "edit" } else { "add" },
-        names[0],
+        spec_module,
         mini_path
             .file_name()
             .map(|name| name.to_string_lossy().into_owned())

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -2116,6 +2116,19 @@ fn compile_full_graph_command(
         }
     };
     let (changes, final_manifest) = plan.into_parts();
+    if mini_path.is_some()
+        && !changes.iter().any(|change| {
+            change.operation != gore_as::compile::FullGraphCompileOperationV1::Delete
+        })
+    {
+        let error = anyhow::anyhow!(
+            "--mini needs at least one added or edited module, but the source tree matches the target cache"
+        );
+        return match guard.take() {
+            Some(guard) => Err(release_compile_guard_after_error(guard, error)),
+            None => Err(error),
+        };
+    }
     let opts = FullGraphCompileOptsV1 {
         game_dir: game.clone(),
         work_dir: work_dir.clone(),
@@ -2269,6 +2282,22 @@ fn compile_full_graph_command(
             fallback.detail()
         );
     }
+    // The mini is part of this command's product: derive it before reporting success, and
+    // neutralize the already published complete cache when it cannot be produced, exactly like a
+    // failed generation receipt, so a retry is not blocked by a half-finished no-clobber output.
+    let mini_report = match mini_path.as_ref() {
+        Some(mini_path) => match publish_full_graph_mini(&artifact, &opts.base_cache, mini_path) {
+            Ok(report) => Some(report),
+            Err(error) => {
+                return fail_after_full_graph_side_output_error(
+                    &artifact,
+                    "MINI_CACHE",
+                    format!("publishing {}: {error:#}", mini_path.display()),
+                );
+            }
+        },
+        None => None,
+    };
     println!(
         "compiled complete graph with {} -> {} ({} modules, {} bytes, sha256 {})",
         used_backend,
@@ -2277,8 +2306,8 @@ fn compile_full_graph_command(
         artifact.byte_len(),
         artifact.sha256()
     );
-    if let Some(mini_path) = mini_path {
-        publish_full_graph_mini(&artifact, &opts.base_cache, &mini_path)?;
+    if let Some(report) = mini_report {
+        print!("{report}");
     }
     Ok(())
 }
@@ -2290,8 +2319,9 @@ fn publish_full_graph_mini(
     artifact: &gore_as::compile::FullGraphCompileArtifactV1,
     base_cache: &[u8],
     mini_path: &Path,
-) -> Result<()> {
+) -> Result<String> {
     use gore_as::compile::FullGraphCompileOperationV1;
+    use std::fmt::Write as _;
     let authored: Vec<(&str, FullGraphCompileOperationV1)> = artifact
         .changes()
         .iter()
@@ -2325,22 +2355,32 @@ fn publish_full_graph_mini(
         .create_new(true)
         .open(mini_path)
         .with_context(|| format!("creating {}", mini_path.display()))?;
-    std::io::Write::write_all(&mut file, &mini)
-        .and_then(|()| file.sync_all())
-        .with_context(|| format!("writing {}", mini_path.display()))?;
+    if let Err(error) = std::io::Write::write_all(&mut file, &mini).and_then(|()| file.sync_all()) {
+        // Never leave a truncated artifact behind: it would block the no-clobber preflight of
+        // the next run and could be mistaken for a usable mini-cache.
+        drop(file);
+        let cleanup = std::fs::remove_file(mini_path)
+            .err()
+            .map(|remove| format!("; removing the partial file failed too: {remove}"))
+            .unwrap_or_default();
+        bail!("writing {}: {error}{cleanup}", mini_path.display());
+    }
     let has_edit = authored
         .iter()
         .any(|(_, op)| *op == FullGraphCompileOperationV1::Edit);
-    println!(
+    let mut report = String::new();
+    let _ = writeln!(
+        report,
         "multi-module mini-cache -> {} ({} modules, {} bytes)",
         mini_path.display(),
         names.len(),
         mini.len()
     );
     for (name, op) in &authored {
-        println!("  {:<4} {name}", format!("{op:?}").to_lowercase());
+        let _ = writeln!(report, "  {:<4} {name}", format!("{op:?}").to_lowercase());
     }
-    println!(
+    let _ = writeln!(
+        report,
         "bundle spec entry: {{ \"op\": \"{}\", \"module_name\": \"{}\", \"mini_cache\": \"{}\" }}",
         if has_edit { "edit" } else { "add" },
         names[0],
@@ -2349,20 +2389,32 @@ fn publish_full_graph_mini(
             .map(|name| name.to_string_lossy().into_owned())
             .unwrap_or_default()
     );
-    Ok(())
+    Ok(report)
 }
 
 fn fail_after_full_graph_receipt_error<T>(
     artifact: &gore_as::compile::FullGraphCompileArtifactV1,
     primary: String,
 ) -> Result<T> {
+    fail_after_full_graph_side_output_error(artifact, "GENERATION_RECEIPT", primary)
+}
+
+/// A side output of the full-graph command (receipt, mini-cache) could not be produced after the
+/// complete cache was already published. The command's product is all-or-nothing: reduce the
+/// retained cache to zero bytes so the next run is not blocked by a no-clobber destination that
+/// looks like a usable result.
+fn fail_after_full_graph_side_output_error<T>(
+    artifact: &gore_as::compile::FullGraphCompileArtifactV1,
+    label: &str,
+    primary: String,
+) -> Result<T> {
     match artifact.neutralize() {
         Ok(()) => bail!(
-            "GENERATION_RECEIPT_PUBLICATION_FAILED_OUTPUT_NEUTRALIZED: {primary}; the exact retained cache at {} was reduced to zero bytes and must be removed before retrying",
+            "{label}_PUBLICATION_FAILED_OUTPUT_NEUTRALIZED: {primary}; the exact retained cache at {} was reduced to zero bytes and must be removed before retrying",
             artifact.path().display()
         ),
         Err(cleanup) => bail!(
-            "GENERATION_RECEIPT_RECOVERY_REQUIRED: {primary}; failed to neutralize the retained cache at {}: {cleanup}",
+            "{label}_RECOVERY_REQUIRED: {primary}; failed to neutralize the retained cache at {}: {cleanup}",
             artifact.path().display()
         ),
     }

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -2235,6 +2235,25 @@ fn compile_full_graph_command(
         "full-graph compiler succeeded without identifying the backend that produced the cache",
     )?;
 
+    // The mini is part of this command's product: derive it before the receipt and before any
+    // success line, and neutralize the already published complete cache when it cannot be
+    // produced, exactly like a failed generation receipt, so a retry is not blocked by a
+    // half-finished no-clobber output. Nothing else has been published at this point.
+    let mini_report = match mini_path.as_ref() {
+        Some(mini_path) => match publish_full_graph_mini(&artifact, &opts.base_cache, mini_path) {
+            Ok(report) => Some(report),
+            Err(error) => {
+                return fail_after_full_graph_side_output_error(
+                    &artifact,
+                    "MINI_CACHE",
+                    None,
+                    format!("publishing {}: {error:#}", mini_path.display()),
+                );
+            }
+        },
+        None => None,
+    };
+
     if let Some(receipt_path) = receipt_path.as_ref() {
         let authority = receipt_authority
             .as_ref()
@@ -2257,8 +2276,10 @@ fn compile_full_graph_command(
             ) {
                 Ok(receipt) => receipt,
                 Err(error) => {
-                    return fail_after_full_graph_receipt_error(
+                    return fail_after_full_graph_side_output_error(
                         &artifact,
+                        "GENERATION_RECEIPT",
+                        mini_path.as_deref(),
                         format!("building {}: {error}", receipt_path.display()),
                     );
                 }
@@ -2266,8 +2287,10 @@ fn compile_full_graph_command(
         if let Err(error) =
             gore_as::generation_receipt_v2::publish_generation_receipt_v2(receipt_path, &receipt)
         {
-            return fail_after_full_graph_receipt_error(
+            return fail_after_full_graph_side_output_error(
                 &artifact,
+                "GENERATION_RECEIPT",
+                mini_path.as_deref(),
                 format!("publishing {}: {error}", receipt_path.display()),
             );
         }
@@ -2282,22 +2305,6 @@ fn compile_full_graph_command(
             fallback.detail()
         );
     }
-    // The mini is part of this command's product: derive it before reporting success, and
-    // neutralize the already published complete cache when it cannot be produced, exactly like a
-    // failed generation receipt, so a retry is not blocked by a half-finished no-clobber output.
-    let mini_report = match mini_path.as_ref() {
-        Some(mini_path) => match publish_full_graph_mini(&artifact, &opts.base_cache, mini_path) {
-            Ok(report) => Some(report),
-            Err(error) => {
-                return fail_after_full_graph_side_output_error(
-                    &artifact,
-                    "MINI_CACHE",
-                    format!("publishing {}: {error:#}", mini_path.display()),
-                );
-            }
-        },
-        None => None,
-    };
     println!(
         "compiled complete graph with {} -> {} ({} modules, {} bytes, sha256 {})",
         used_backend,
@@ -2392,29 +2399,28 @@ fn publish_full_graph_mini(
     Ok(report)
 }
 
-fn fail_after_full_graph_receipt_error<T>(
-    artifact: &gore_as::compile::FullGraphCompileArtifactV1,
-    primary: String,
-) -> Result<T> {
-    fail_after_full_graph_side_output_error(artifact, "GENERATION_RECEIPT", primary)
-}
-
-/// A side output of the full-graph command (receipt, mini-cache) could not be produced after the
+/// A side output of the full-graph command (mini-cache, receipt) could not be produced after the
 /// complete cache was already published. The command's product is all-or-nothing: reduce the
 /// retained cache to zero bytes so the next run is not blocked by a no-clobber destination that
-/// looks like a usable result.
+/// looks like a usable result, and remove an already published mini-cache that would otherwise
+/// describe the neutralized cache.
 fn fail_after_full_graph_side_output_error<T>(
     artifact: &gore_as::compile::FullGraphCompileArtifactV1,
     label: &str,
+    published_mini: Option<&Path>,
     primary: String,
 ) -> Result<T> {
+    let mini_cleanup = published_mini
+        .and_then(|path| std::fs::remove_file(path).err().map(|error| (path, error)))
+        .map(|(path, error)| format!("; removing the published mini-cache {} failed too: {error}", path.display()))
+        .unwrap_or_default();
     match artifact.neutralize() {
         Ok(()) => bail!(
-            "{label}_PUBLICATION_FAILED_OUTPUT_NEUTRALIZED: {primary}; the exact retained cache at {} was reduced to zero bytes and must be removed before retrying",
+            "{label}_PUBLICATION_FAILED_OUTPUT_NEUTRALIZED: {primary}; the exact retained cache at {} was reduced to zero bytes and must be removed before retrying{mini_cleanup}",
             artifact.path().display()
         ),
         Err(cleanup) => bail!(
-            "{label}_RECOVERY_REQUIRED: {primary}; failed to neutralize the retained cache at {}: {cleanup}",
+            "{label}_RECOVERY_REQUIRED: {primary}; failed to neutralize the retained cache at {}: {cleanup}{mini_cleanup}",
             artifact.path().display()
         ),
     }

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -1950,27 +1950,17 @@ fn compile_full_graph_command(
     if out == work_dir || out.starts_with(&work_dir) {
         bail!("full-graph output must not be inside the compiler workspace");
     }
-    // The compiler repeats this preflight only after the complete source graph has been
-    // planned, which takes many minutes on the shipped tree. Run the identical check up front.
-    gore_as::compile::preflight_full_graph_path_layout_paths_v1(&game, &work_dir, &out)
-        .map_err(anyhow::Error::new)
-        .context("full-graph path layout")?;
     let receipt_path = compiler
         .generation_receipt
         .map(|path| absolute_cli_path(path, "generation receipt"))
         .transpose()?;
-    if receipt_path.as_ref().is_some_and(|path| path == &out) {
-        bail!("generation receipt path must differ from the compiled cache path");
-    }
-    if let Some(path) = receipt_path.as_ref() {
-        validate_auxiliary_output_path(path, &game, "generation receipt")?;
-    }
     let mini_path = mini
         .map(|path| absolute_cli_path(path, "multi-module mini-cache"))
         .transpose()?;
     // Two side outputs may name the same file, or nest inside one another, through different
-    // spellings of the same directory. Compare the projected paths before any preflight creates a
-    // directory, so a bad layout cannot surface only after the expensive graph work.
+    // spellings of the same directory. Compare the projected paths before ANY preflight below,
+    // because those create the output parents: an accepted nesting would otherwise leave a
+    // directory where a corrected retry wants its file.
     {
         let mut resolved: Vec<(&'static str, PathBuf)> = Vec::new();
         for (label, path) in [
@@ -1995,6 +1985,14 @@ fn compile_full_graph_command(
             }
             resolved.push((label, projected));
         }
+    }
+    // The compiler repeats this preflight only after the complete source graph has been
+    // planned, which takes many minutes on the shipped tree. Run the identical check up front.
+    gore_as::compile::preflight_full_graph_path_layout_paths_v1(&game, &work_dir, &out)
+        .map_err(anyhow::Error::new)
+        .context("full-graph path layout")?;
+    if let Some(path) = receipt_path.as_ref() {
+        validate_auxiliary_output_path(path, &game, "generation receipt")?;
     }
     if let Some(path) = mini_path.as_ref() {
         // The same resolved layout check the compiled cache gets: a lexical comparison would
@@ -2270,7 +2268,13 @@ fn compile_full_graph_command(
     // produced, exactly like a failed generation receipt, so a retry is not blocked by a
     // half-finished no-clobber output. Nothing else has been published at this point.
     let published_mini = match mini_path.as_ref() {
-        Some(mini_path) => match publish_full_graph_mini(&artifact, &opts.base_cache, mini_path) {
+        Some(mini_path) => match publish_full_graph_mini(
+            &artifact,
+            &opts.base_cache,
+            &game,
+            &work_dir,
+            mini_path,
+        ) {
             Ok(published) => Some(published),
             Err(error) => {
                 return fail_after_full_graph_side_output_error(
@@ -2372,6 +2376,8 @@ impl PublishedMini {
 fn publish_full_graph_mini(
     artifact: &gore_as::compile::FullGraphCompileArtifactV1,
     base_cache: &[u8],
+    game: &Path,
+    work_dir: &Path,
     mini_path: &Path,
 ) -> Result<PublishedMini> {
     use gore_as::compile::FullGraphCompileOperationV1;
@@ -2407,10 +2413,29 @@ fn publish_full_graph_mini(
     guard
         .compose_upsert(base_cache, &mini)
         .context("multi-module mini-cache does not compose onto the pristine base")?;
+    // Compilation takes minutes, and the layout checks ran before it. Re-resolve the destination
+    // now and repeat them, then create the file at the resolved path so a parent that was renamed
+    // or replaced with a symlink in the meantime cannot redirect the mini into the workspace or
+    // the game tree.
+    let file_name = mini_path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("mini-cache path has no file name"))?;
+    let parent = mini_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("mini-cache path has no parent directory"))?;
+    let destination = parent
+        .canonicalize()
+        .with_context(|| format!("resolving the mini-cache parent {}", parent.display()))?
+        .join(file_name);
+    gore_as::compile::preflight_full_graph_path_layout_paths_v1(game, work_dir, &destination)
+        .map_err(anyhow::Error::new)
+        .context("multi-module mini-cache path layout changed during compilation")?;
+    validate_auxiliary_output_path(&destination, game, "multi-module mini-cache")?;
     let mut file = std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .open(mini_path)
+        .open(&destination)
         .with_context(|| format!("creating {}", mini_path.display()))?;
     if let Err(error) = std::io::Write::write_all(&mut file, &mini).and_then(|()| file.sync_all()) {
         // Never leave a truncated artifact behind that could be mistaken for a usable mini-cache.

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -391,13 +391,17 @@ pub enum AsCmd {
         #[arg(short, long)]
         out: PathBuf,
     },
-    /// Splice a base-bound mini-cache module into a base cache.
+    /// Splice the modules of a base-bound mini-cache into a base cache.
     Splice {
         /// Base cache (e.g. PrecompiledScript_Shipping.Cache).
         base: PathBuf,
-        /// Base-bound mini-cache from `compile-module` or `extract-remap`; raw generator output
-        /// has a fresh GUID and is refused until it is remapped to this exact base.
+        /// Base-bound mini-cache from `compile-module`, `compile --mini` or `extract-remap`; raw
+        /// generator output has a fresh GUID and is refused until it is remapped to this exact base.
         mini: PathBuf,
+        /// Replace modules that already exist in the base in place instead of refusing them; new
+        /// modules are still appended. Needed for a multi-module mini that edits a shipped module.
+        #[arg(long)]
+        upsert: bool,
         /// Output path for the spliced cache.
         #[arg(short, long)]
         out: PathBuf,
@@ -3732,16 +3736,28 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 out.display()
             );
         }
-        AsCmd::Splice { base, mini, out } => {
+        AsCmd::Splice {
+            base,
+            mini,
+            upsert,
+            out,
+        } => {
             let base_b = read_module_cache(&base)?;
             let mini_b = read_module_cache(&mini)?;
             let before = module_count(&base_b);
             let mut guard = gore_as::cache::splice::SequentialMiniGuard::new(&base_b)
                 .context("validating splice base")?;
-            let spliced = guard.compose_add(&base_b, &mini_b).context("splicing")?;
+            let spliced = if upsert {
+                guard
+                    .compose_upsert(&base_b, &mini_b)
+                    .context("splicing (upsert)")?
+            } else {
+                guard.compose_add(&base_b, &mini_b).context("splicing")?
+            };
             std::fs::write(&out, &spliced).with_context(|| format!("writing {}", out.display()))?;
             println!(
-                "spliced: {} modules -> {} ; {} -> {} bytes ; wrote {}",
+                "spliced{}: {} modules -> {} ; {} -> {} bytes ; wrote {}",
+                if upsert { " (upsert)" } else { "" },
                 before,
                 module_count(&spliced),
                 base_b.len(),

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -1972,13 +1972,14 @@ fn compile_full_graph_command(
         if path == &out || receipt_path.as_ref().is_some_and(|receipt| receipt == path) {
             bail!("mini-cache path must differ from the compiled cache and receipt paths");
         }
-        if path == &work_dir || path.starts_with(&work_dir) {
-            bail!("mini-cache output must not be inside the compiler workspace");
-        }
+        // The same resolved layout check the compiled cache gets: a lexical comparison would
+        // accept an aliased or symlinked spelling of the workspace, and the next compile's tree
+        // reset would then delete the published mini.
+        gore_as::compile::preflight_full_graph_path_layout_paths_v1(&game, &work_dir, path)
+            .map_err(anyhow::Error::new)
+            .context("multi-module mini-cache path layout")?;
+        // Also covers no-clobber: an existing destination is refused here.
         validate_auxiliary_output_path(path, &game, "multi-module mini-cache")?;
-        if path.exists() {
-            bail!("mini-cache output already exists: {}", path.display());
-        }
     }
 
     let executable_path = compiler_executable_path(&game);

--- a/docs/guide/bundles.md
+++ b/docs/guide/bundles.md
@@ -24,6 +24,11 @@ Write a `spec.json`:
 }
 ```
 
+**A `scripts` entry may point at a multi-module mini-cache** (`gore as compile
+--mini`). Use `"op": "edit"` when any carried module edits a shipped one and
+`"add"` when all are new; `module_name` names one of the carried modules. See
+[scripts](scripts.md#multi-module-mini-caches).
+
 **Asset paths are resolved relative to the spec file's own directory.**
 `wav_path`, `ogg_path`, `image_path`, `mini_cache` and `source_path` may be
 written as bare filenames beside the spec, whatever directory you run `gore mod

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -354,7 +354,7 @@ Output directories must not exist and are never placed in the game tree.
 | `compile <SRC>` | `-o, --out` · `--mini <PATH>` · `--work-dir <DIR>` · `--game` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · `--no-diagnostics` · `--diagnostics-hook <DLL>` · `--diagnostics-inject-delay-ms <MS>` |
 | `compile-module` | `--op add\|edit` · `--module` · `--rel-path` · `--source` · `--work-dir` · `--allow-new-symbols` · `-o, --out` · `--game` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · diagnostics flags · five `--development-*` compiler-development overrides |
 | `replace <BASE> <MINI> <TARGET>` | `-o, --out` |
-| `splice <BASE> <MINI>` | `-o, --out` |
+| `splice <BASE> <MINI>` | `--upsert` · `-o, --out` |
 | `extract <CACHE> <MODULE>` | `-o, --out` |
 | `extract-remap <REGEN> <MODULE> <BASE>` | `--allow-new-symbols` · `-o, --out` |
 | `bytediff <VANILLA> <REGEN>` | `--module` · `--func` · `--verdict` · `--show-benign` · `--context <N>` · `--norm-slots` · `--no-norm-scope` · `--no-norm-reguard` · `--json <PATH>` · `--fail-on-semantic` |

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -351,7 +351,7 @@ Output directories must not exist and are never placed in the game tree.
 | `patch-tag-map <CACHE>` | `--selector <JSON>` · `--expected-hex` · `--replacement-hex` · `-o, --out` · `--json` |
 | `qualify` | `--game` · `--usmap <FILE>` · `--catalog <JSON>` · `--id <ID>` · `--label <TEXT>` · `--json` |
 | `diagnostics-check` | `--exe <EXE>` · `--game <GAME>` |
-| `compile <SRC>` | `-o, --out` · `--work-dir <DIR>` · `--game` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · `--no-diagnostics` · `--diagnostics-hook <DLL>` · `--diagnostics-inject-delay-ms <MS>` |
+| `compile <SRC>` | `-o, --out` · `--mini <PATH>` · `--work-dir <DIR>` · `--game` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · `--no-diagnostics` · `--diagnostics-hook <DLL>` · `--diagnostics-inject-delay-ms <MS>` |
 | `compile-module` | `--op add\|edit` · `--module` · `--rel-path` · `--source` · `--work-dir` · `--allow-new-symbols` · `-o, --out` · `--game` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · diagnostics flags · five `--development-*` compiler-development overrides |
 | `replace <BASE> <MINI> <TARGET>` | `-o, --out` |
 | `splice <BASE> <MINI>` | `-o, --out` |
@@ -368,8 +368,10 @@ Delete and are rejected; cyclic dependencies among new modules also fail
 closed. The raw whole-tree compiler regeneration is never the published cache.
 On BuildID `24878692`, one published selective product booted and loaded
 gameplay, rendered and selected its new same-module root, and executed a new
-provider call across modules from a shipped automatic topic. This runtime proof
-does not turn two dependent module minis into a supported package shape.
+provider call across modules from a shipped automatic topic. `--mini <PATH>`
+additionally publishes those Add/Edit modules as one multi-module mini-cache
+bound to the pristine cache, which bundles and the Manager compose as one unit;
+two independent module minis still cannot depend on one another.
 
 `patch-default`, `patch-tag-map` and `asset patch-fixed` never overwrite an
 existing output path. The `as` extract/splice family — `replace`, `splice`,

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -380,8 +380,9 @@ resolve inside the one file. Reference it from a bundle spec with a single
 entry: `op` is `edit` when any module edits a shipped one (existing modules are
 replaced in place, new ones appended, as one unit), `add` when every module is
 new; `module_name` names one of the carried modules. The command prints the
-exact entry. Every consumer — `gore mod build`, `deploy`, the Manager and
-`gore as splice` — composes such a mini as one unit.
+exact entry. `gore mod build`, `deploy` and the Manager compose such a mini as
+one unit. The low-level `gore as splice` only appends, so it accepts a mini
+whose modules are all new and refuses one that edits a shipped module.
 
 Qualified in game on 2026-09-03: a two-module mini (new provider module plus
 an edited Diego conversation whose new root topic takes its caption from the

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -381,7 +381,9 @@ entry: `op` is `edit` when any module edits a shipped one (existing modules are
 replaced in place, new ones appended, as one unit), `add` when every module is
 new; `module_name` names one of the carried modules. The command prints the
 exact entry. `gore mod build`, `deploy` and the Manager compose such a mini as
-one unit. The low-level `gore as splice` only appends, so it accepts a mini
+one unit: in a loadout it is shadowed only as a whole, and a later mod that
+re-targets some but not all of its modules is refused rather than partially
+overridden. The low-level `gore as splice` only appends, so it accepts a mini
 whose modules are all new and refuses one that edits a shipped module.
 
 Qualified in game on 2026-09-03: a two-module mini (new provider module plus

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -362,6 +362,32 @@ V1 build record produced only after the normal package was authenticated for
 that run; unlike the full-graph V2 receipt, it does not itself carry the product
 catalog identity. Normal users should not set the development overrides.
 
+## Multi-module mini-caches
+
+A mini-cache may carry more than one module. When a mod spans several
+modules — a new provider module plus an edited shipped module that calls it —
+compile them together and let `gore as compile` publish the mini next to the
+complete cache:
+
+```powershell
+gore as compile out_as -o full.Cache --mini MyMod.mini.Cache `
+  --work-dir .gore-as-work --backend standalone --game "$GAME"
+```
+
+The mini holds only the authored Add/Edit modules, remapped to the pristine
+cache like a `compile-module` output, so references between its own modules
+resolve inside the one file. Reference it from a bundle spec with a single
+entry: `op` is `edit` when any module edits a shipped one (existing modules are
+replaced in place, new ones appended, as one unit), `add` when every module is
+new; `module_name` names one of the carried modules. The command prints the
+exact entry. Every consumer — `gore mod build`, `deploy`, the Manager and
+`gore as splice` — composes such a mini as one unit.
+
+Qualified in game on 2026-09-03: a two-module mini (new provider module plus
+an edited Diego conversation whose new root topic takes its caption from the
+provider) compiled standalone, deployed, showed the provider's text as a
+selectable Diego topic at game start, and ended the conversation cleanly.
+
 ## Low-level splicing
 
 For debugging or custom pipelines the individual stages remain available:

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -383,8 +383,9 @@ new; `module_name` names one of the carried modules. The command prints the
 exact entry. `gore mod build`, `deploy` and the Manager compose such a mini as
 one unit: in a loadout it is shadowed only as a whole, and a later mod that
 re-targets some but not all of its modules is refused rather than partially
-overridden. The low-level `gore as splice` only appends, so it accepts a mini
-whose modules are all new and refuses one that edits a shipped module.
+overridden. The low-level `gore as splice` appends by default and refuses a
+mini that edits a shipped module; `gore as splice --upsert` replaces the
+existing modules in place and appends the new ones, like deploy does.
 
 Qualified in game on 2026-09-03: a two-module mini (new provider module plus
 an edited Diego conversation whose new root topic takes its caption from the


### PR DESCRIPTION
## Summary

A mini-cache may now carry more than one module and is composed as one unit, so a mod whose modules reference each other (a new provider module plus an edited shipped module that calls it) ships as a normal, composable mini instead of a complete-cache replacement.

- **gore-as splice**: `splice*` append every module of a mini; new `extract_modules`, `upsert_modules` and `SequentialMiniGuard::compose_upsert` (existing modules replaced in place, new ones appended, tail merged once). `replace_module` / `compose_edit` stay single-target (`MiniNotSingle`); an empty mini is `MiniEmpty`.
- **gore-as remap**: `collect_module_spans` walks every module into one span set, `target_module_names` returns every inner name, emitted minis keep the input module count; loadout plan and both remap entry points reject only empty minis.
- **CLI**: `gore as compile ... --mini <PATH>` publishes the authored Add/Edit modules as one deployable mini (extracted from the selective composition, remapped to the pristine cache, self-checked by recomposition) and prints the bundle spec entry. The full-graph path-layout preflight now runs before planning, so an invalid work/output layout fails in seconds instead of after the ~20-minute planning phase.
- **gore-mod**: `op: "edit"` on a multi-module mini composes as an upsert in single-mod deploy and Manager apply; import accepts a manifest `module` that is one of the carried modules; conflict targets are read from the mini itself. Spec and manifest formats are unchanged.
- **MCP spec** mirrors `--mini`; guide pages (`scripts`, `bundles`, `cli-reference`) and the changelog are updated.

Not covered: the Mod Studio Scripts tab still compiles each staged `.as` separately.

## Test plan

- [x] `cargo test -p gore-as --test splice_test --test remap_new_symbols_test --test walk_modules_test` (21 + 130 + 3), `cargo test -p gore-as --lib full_graph` (20)
- [x] `cargo test -p gore-mod` (509), `cargo test -p gore-mcp` (344); `cargo check -p gore-ffi`
- [x] In game (2026-09-03): two-module fixture (new `GoreMods.DiegoMultiProbe` + edited `Conversation_OC_STT_DIEGO` whose new root topic takes its caption from the provider) compiled with `--backend standalone --mini`, built, deployed; the topic appeared at Diego with the provider's text and ended the conversation cleanly; undeployed afterwards, pristine cache restored.
- [x] Wrong layout (`--work-dir` inside the output parent) now fails after 0 s with the preflight error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core script-cache composition, remapping, and mod loadout merging; mistakes could corrupt caches or apply partial overrides, though guarded composition and new validation/tests reduce exposure.
> 
> **Overview**
> **Multi-module mini-caches** are now first-class: a mini may carry several modules that reference each other and is composed as one unit instead of requiring one mini per module.
> 
> **Cache layer (`remap`, `splice`)**: Validation rejects only *empty* minis (not “exactly one”). `splice` / `splice_auto` / case-(a) append all mini modules and bump the module count accordingly; **`extract_modules`**, **`upsert_modules`**, and **`SequentialMiniGuard::compose_upsert`** replace existing outer keys in place, append new ones, and merge tail tables once. Remap/static-name rebasing walks every module in the mini and preserves the input module count on output. Single-target **`replace_module`** still requires exactly one module.
> 
> **CLI**: **`gore as compile --mini`** publishes a deployable multi-module mini (authored Add/Edit modules extracted from the selective build, remapped to pristine, self-checked via upsert). Early **path-layout preflight** and output-path collision checks avoid multi-minute failures. **`gore as splice --upsert`** mirrors deploy’s edit-in-place behavior.
> 
> **Mod pipeline**: Bundle import and Manager apply treat manifest `module_name` as one of the carried modules; conflict “later wins” applies to *all* modules in a mini (partial shadowing is refused). Multi-module **`edit`** uses **`compose_upsert`** in deploy and apply.
> 
> Docs, MCP args, changelog, and **`splice_test`** / apply integration tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda8fb1d9098814a7ccfd909199058571a5a990d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->