### PR TITLE
feat(as): compile against the deployment backup while a script mod stays installed

### DIFF
--- a/apps/mod-studio/CHANGELOG.md
+++ b/apps/mod-studio/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Compile against the deployment's pristine backup while a script mod stays
+  installed; no undeploy is needed between iterations.
 - Development baseline for the Gothic 1 Remake no-code modding GUI.
 - Accept the exact 2026-08-27/28 game generation (Steam BuildID 24878692) in
   project creation and NPC authoring, and keep strict standalone compiler

--- a/crates/gore-as/src/compile.rs
+++ b/crates/gore-as/src/compile.rs
@@ -1591,13 +1591,22 @@ fn compile_module_with_backend_v1_with_guard_and_optional_target(
     guard: InstallMutationGuard,
     target: Option<ValidatedCompilerTargetInputsV1>,
 ) -> CompileModuleReport {
+    let game_fallback_blocker = target.as_ref().and_then(|target| {
+        backup_pinned_target_blocker(target.shipping_cache_path(), &opts.game_dir)
+    });
     let guard = std::cell::RefCell::new(Some(guard));
     let target = std::cell::RefCell::new(target);
-    let mut report = compile_module_report_with_backend_runner_v1(
+    let mut report = compile_module_report_with_game_fallback_blocker(
         opts,
         mode,
         standalone,
+        game_fallback_blocker.clone(),
         |game_dir, source_tree| {
+            // An explicit `game` policy reaches this closure with the blocker still set: refuse
+            // before the guard is even taken, so nothing in the installation is touched.
+            if let Some(blocker) = game_fallback_blocker.as_ref() {
+                return Err(blocker.clone());
+            }
             let guard = guard
                 .borrow_mut()
                 .take()
@@ -1769,6 +1778,42 @@ where
         output_recovery_required: false,
         target_pins: None,
     }
+}
+
+/// [`compile_module_report_with_backend_runner_v1`] with a known reason the game backend must
+/// not run. `standalone-then-game` then runs the standalone compiler only and, when that fails,
+/// reports the standalone failure itself with the reason appended, instead of a refused game
+/// attempt that would hide the standalone diagnostics.
+fn compile_module_report_with_game_fallback_blocker<G>(
+    opts: &CompileOpts,
+    mode: CompilerBackendModeV1,
+    standalone: Option<&mut dyn StandaloneCompilerRunnerV1>,
+    game_fallback_blocker: Option<String>,
+    run_game: G,
+) -> CompileModuleReport
+where
+    G: FnOnce(&Path, &Path) -> Result<GameRunRegenExtendedReport, String>,
+{
+    let skipped_fallback = match (mode, game_fallback_blocker) {
+        (CompilerBackendModeV1::StandaloneThenGame, Some(blocker)) => Some(blocker),
+        _ => None,
+    };
+    let effective_mode = if skipped_fallback.is_some() {
+        CompilerBackendModeV1::Standalone
+    } else {
+        mode
+    };
+    let mut report =
+        compile_module_report_with_backend_runner_v1(opts, effective_mode, standalone, run_game);
+    if let Some(blocker) = skipped_fallback {
+        if let CompileModuleReportOutcome::Failed(error) = report.outcome {
+            report.outcome = CompileModuleReportOutcome::Failed(append_compile_error_note(
+                error,
+                &format!("the game fallback was not attempted: {blocker}"),
+            ));
+        }
+    }
+    report
 }
 
 fn compile_module_report_with_backend_runner_v1<G>(
@@ -2449,6 +2494,14 @@ where
                     format!("prepared full-graph source seal no longer matches: {error}"),
                 )
             })?;
+            if let Some(blocker) = target.borrow().as_ref().and_then(|target| {
+                backup_pinned_target_blocker(target.shipping_cache_path(), &opts.game_dir)
+            }) {
+                return Err(CompilerBackendFailureV1::new(
+                    CompilerBackendFailureKindV1::Preflight,
+                    blocker,
+                ));
+            }
             let input_pins = match target.borrow_mut().take() {
                 Some(target) => ProjectGameInputPins::from_compiler_target(target),
                 None => pin_game_input_seals(&opts.game_dir, &opts.base_cache, &opts.binds_cache)
@@ -4780,6 +4833,35 @@ fn target_shipping_is_live(target_shipping: &Path, script_dir: &Path) -> bool {
     ) {
         (Ok(target), Ok(live)) => target == live,
         _ => target_shipping == live,
+    }
+}
+
+/// Why the game compiler must not run on this qualified target, if it must not: the target's
+/// Shipping path is the deployment backup (a script mod is installed) rather than the live cache
+/// the game compiler regenerates into and restores. `None` when the target pins the live cache.
+fn backup_pinned_target_blocker(target_shipping: &Path, game_dir: &Path) -> Option<String> {
+    let script_dir = g1r_dir(game_dir).join("Script");
+    (!target_shipping_is_live(target_shipping, &script_dir)).then(|| {
+        format!(
+            "the qualified compiler target pins the deployment backup {} rather than the live \
+             Shipping cache; the game compiler regenerates into the live cache and cannot run \
+             while a script mod is installed (undeploy the mod first, or compile with the \
+             standalone backend)",
+            target_shipping.display()
+        )
+    })
+}
+
+fn append_compile_error_note(error: CompileError, note: &str) -> CompileError {
+    match error {
+        CompileError::Io(message) => CompileError::Io(format!("{message}; {note}")),
+        CompileError::Regen(message) => CompileError::Regen(format!("{message}; {note}")),
+        CompileError::NoRegen(message) => CompileError::NoRegen(format!("{message}; {note}")),
+        CompileError::Other(message) => CompileError::Other(format!("{message}; {note}")),
+        CompileError::ArtifactIo { message, artifact } => CompileError::ArtifactIo {
+            message: format!("{message}; {note}"),
+            artifact,
+        },
     }
 }
 
@@ -9035,7 +9117,8 @@ impl CompileTransaction {
                 vec![format!(
                     "the qualified compiler target pins the deployment backup {pinned} rather \
                      than the live Shipping cache; the game compiler cannot run while a script \
-                     mod is installed (the standalone compiler can, or undeploy the mod first)"
+                     mod is installed (undeploy the mod first, or compile with the standalone \
+                     backend)"
                 )],
             ));
         }
@@ -16133,6 +16216,89 @@ mod tests {
         assert!(!compile_lock_path(&game).exists());
         assert!(!install_mutation_lock_path(&game).exists());
         std::fs::remove_dir_all(base).unwrap();
+    }
+
+    #[test]
+    fn backup_pinned_target_blocker_names_the_backup_and_accepts_the_live_cache() {
+        let base = unique_test_root("backup-pinned-blocker");
+        let (game, shipping) = fake_install(&base);
+        let backup = deploy_bak_path(&shipping);
+        std::fs::write(&backup, b"OLD").unwrap();
+
+        assert!(backup_pinned_target_blocker(&shipping, &game).is_none());
+        let blocker = backup_pinned_target_blocker(&backup, &game)
+            .expect("a backup-pinned target blocks the game compiler");
+        assert!(blocker.contains("deployment backup"), "got: {blocker}");
+        assert!(
+            !blocker.contains("the standalone compiler can"),
+            "must not claim the standalone compiler succeeded: {blocker}"
+        );
+        std::fs::remove_dir_all(base).unwrap();
+    }
+
+    /// With the game fallback blocked, `standalone-then-game` reports the standalone failure
+    /// itself (its diagnostics included) plus a note, instead of a refused game attempt.
+    #[test]
+    fn standalone_then_game_keeps_the_standalone_failure_when_the_game_fallback_is_blocked() {
+        let root = unique_test_root("backend-v1-blocked-fallback");
+        std::fs::create_dir_all(&root).unwrap();
+        let opts = CompileOpts {
+            game_dir: root.join("game"),
+            op: "add".to_owned(),
+            module_name: "NewModule".to_owned(),
+            rel_path: "NewModule.as".to_owned(),
+            as_path: root.join("must-not-be-opened.as"),
+            source_override: Some(b"// fallback source\n".to_vec()),
+            work_dir: root.join("work"),
+            allow_new_symbols: true,
+            base_override: Some(cache_with_empty_modules(&[("Base", "Base.as")])),
+            binds_override: None,
+        };
+        let mut standalone = |_: StandaloneCompilerInputsV1<'_>| {
+            Err(CompilerBackendFailureV1::new(
+                CompilerBackendFailureKindV1::Unsupported,
+                "unsupported test construct",
+            ))
+        };
+        let game_calls = std::cell::Cell::new(0u8);
+
+        let report = compile_module_report_with_game_fallback_blocker(
+            &opts,
+            CompilerBackendModeV1::StandaloneThenGame,
+            Some(&mut standalone),
+            Some("the target pins the deployment backup".to_owned()),
+            |_, _| {
+                game_calls.set(game_calls.get().saturating_add(1));
+                panic!("the blocked game fallback must not run")
+            },
+        );
+
+        let CompileModuleReportOutcome::Failed(error) = &report.outcome else {
+            panic!("a failed standalone attempt without a fallback must fail")
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains("unsupported test construct"),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("game fallback was not attempted"),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("the target pins the deployment backup"),
+            "got: {message}"
+        );
+        assert_eq!(
+            report.backend_name(),
+            Some(CompilerBackendNameV1::Standalone)
+        );
+        assert!(report.standalone_attempted());
+        assert!(!report.game_attempted());
+        assert!(report.fallback_reason().is_none());
+        assert_eq!(game_calls.get(), 0);
+        drop(report);
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/crates/gore-as/src/compile.rs
+++ b/crates/gore-as/src/compile.rs
@@ -4769,6 +4769,20 @@ fn vanilla_cache(game_dir: &Path) -> PathBuf {
         .join("PrecompiledScript_Shipping.Cache")
 }
 
+/// Whether a qualified target's Shipping path names the live cache of `script_dir`. Both are
+/// resolved through the filesystem so a differently spelled path to the same file still counts
+/// as live; only when either cannot be resolved does the lexical comparison decide.
+fn target_shipping_is_live(target_shipping: &Path, script_dir: &Path) -> bool {
+    let live = script_dir.join("PrecompiledScript_Shipping.Cache");
+    match (
+        std::fs::canonicalize(target_shipping),
+        std::fs::canonicalize(&live),
+    ) {
+        (Ok(target), Ok(live)) => target == live,
+        _ => target_shipping == live,
+    }
+}
+
 /// The deploy backup path for a live cache: the live path with `.gore-bak` APPENDED to the full
 /// filename (so `…Shipping.Cache` -> `…Shipping.Cache.gore-bak`). Mirrors gore-mod's `bak_path`;
 /// built via `OsString::push` (NOT `with_extension`, which would clobber the `.Cache` extension).
@@ -9002,6 +9016,27 @@ impl CompileTransaction {
                 game_dir,
                 mutation_guard,
                 vec![error],
+            ));
+        }
+        // The game compiler regenerates INTO the live Shipping cache, and the exact restore
+        // afterwards reopens the target pin as that live file. A target validated against the
+        // deployment backup (a script mod is installed) would restore the original over the mod,
+        // so it is refused here, before the first install mutation. The standalone compiler keeps
+        // working from the backup; the game compiler needs the live cache as its base.
+        if let Some(pinned) = project_input_pins
+            .as_ref()
+            .and_then(|pins| pins.target_paths.as_ref())
+            .filter(|paths| !target_shipping_is_live(paths.shipping_cache(), script_dir))
+            .map(|paths| paths.shipping_cache().display().to_string())
+        {
+            return Err(finalize_compile_transaction_begin_failure(
+                game_dir,
+                mutation_guard,
+                vec![format!(
+                    "the qualified compiler target pins the deployment backup {pinned} rather \
+                     than the live Shipping cache; the game compiler cannot run while a script \
+                     mod is installed (the standalone compiler can, or undeploy the mod first)"
+                )],
             ));
         }
         // The caller briefly released and identity-repinned qualified target directories to
@@ -16029,6 +16064,74 @@ mod tests {
         assert!(!compile_lock_path(&game).exists());
         assert!(!install_mutation_lock_path(&game).exists());
         drop(report);
+        std::fs::remove_dir_all(base).unwrap();
+    }
+
+    /// While a script mod is installed, the compiler target is validated against the deployment
+    /// backup. The game compiler regenerates INTO the live cache and restores it from the target
+    /// pin afterwards, so that pin must name the live cache; a target pinned on the backup is
+    /// refused before the first install mutation instead of restoring the original over the mod.
+    #[cfg(windows)]
+    #[test]
+    fn game_transaction_refuses_a_target_pinned_on_the_deployment_backup() {
+        let base = unique_test_root("qualified-target-backup-refused");
+        let (game, shipping) = fake_install(&base);
+        let _game_process = StatedGameProcess::not_running();
+        let script = shipping.parent().unwrap();
+        let binds = script.join("Binds.Cache");
+        std::fs::write(&binds, b"BINDS").unwrap();
+        let backup = deploy_bak_path(&shipping);
+        std::fs::write(&backup, b"OLD").unwrap();
+        std::fs::write(&shipping, b"MODDED").unwrap();
+        let executable = game
+            .join("G1R")
+            .join("Binaries")
+            .join("Win64")
+            .join("G1R-Win64-Shipping.exe");
+        let src = base.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("Mod.as"), b"script").unwrap();
+
+        let pins = ProjectGameInputPins {
+            _executable: Some(open_regular_file_no_follow_read(&executable).unwrap()),
+            shipping: open_regular_file_no_follow_read(&backup).unwrap(),
+            _binds: open_regular_file_no_follow_read(&binds).unwrap(),
+            _directory_pins: Vec::new(),
+            target_paths: Some(
+                crate::compiler_target::CompilerTargetOwnedPathsV1::for_test(
+                    executable,
+                    backup.clone(),
+                    binds,
+                ),
+            ),
+        };
+        let guard = InstallMutationGuard::acquire(&game, "gore-as:compile").unwrap();
+        let generated = std::cell::Cell::new(false);
+        let result = game_run_regen_with_install_report_with_guard_and_pins_and_after_restore(
+            &game,
+            &src,
+            guard,
+            pins,
+            |_, _, dev| {
+                generated.set(true);
+                let bytes = valid_cache();
+                std::fs::write(dev, &bytes).unwrap();
+                GeneratorRunResult::confirmed(Ok(bytes))
+            },
+            |_, _| Ok(()),
+        );
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("a backup-pinned target must be refused"),
+        };
+
+        assert!(error.contains("deployment backup"), "got: {error}");
+        assert!(!generated.get(), "the game compiler must not launch");
+        assert_eq!(std::fs::read(&shipping).unwrap(), b"MODDED");
+        assert_eq!(std::fs::read(&backup).unwrap(), b"OLD");
+        assert!(!compile_bak_path(&shipping).exists());
+        assert!(!compile_lock_path(&game).exists());
+        assert!(!install_mutation_lock_path(&game).exists());
         std::fs::remove_dir_all(base).unwrap();
     }
 

--- a/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
@@ -301,11 +301,32 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
     // While a script mod is installed the compiler base is the deployment backup, which the
     // game compiler cannot restore over the live cache: `standalone_then_game` runs the
     // standalone compiler only, takes no install guard, and says so in its evidence.
+    // The selection does not depend on a resolved package: without one, the game backend
+    // would otherwise be entered against an installed mod.
+    let pristine_source = available_package
+        .as_ref()
+        .and_then(|resolved| resolved.pristine_source.clone())
+        .or_else(|| gore_mod::pristine_script_cache_source(&game_root).ok());
+    if requested == CompilerBackendWireV2::Game {
+        if let Some(source) = pristine_source.as_ref().filter(|source| source.from_backup) {
+            return fail_v2_preflight_with_optional_guard(
+                None,
+                Failure::new(
+                    "AUTHORING_REVISION3_PROJECT_COMPILER_INSTALL_UNAVAILABLE",
+                    format!(
+                        "the game compiler cannot run while a script mod is installed: the \
+                         compiler base is the deployment backup {}, which the game compiler \
+                         would restore over the live cache; use the standalone backend or \
+                         undeploy the mod first",
+                        source.path.display()
+                    ),
+                ),
+            );
+        }
+    }
     let skipped_game_fallback = crate::script_compile_report::skipped_game_fallback_note(
         requested,
-        available_package
-            .as_ref()
-            .and_then(|resolved| resolved.pristine_source.as_ref()),
+        pristine_source.as_ref(),
     )
     .map(|note| {
         json!({
@@ -315,9 +336,6 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
         })
     });
     let skip_game_fallback = skipped_game_fallback.is_some();
-    if skip_game_fallback {
-        unavailable_fallback = skipped_game_fallback.clone();
-    }
     let mut guard = if requested == CompilerBackendWireV2::Standalone || skip_game_fallback {
         None
     } else {
@@ -471,14 +489,21 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
         && standalone_runner.is_none()
     {
         debug_assert!(guard.is_none());
-        let failure = runner_unavailable
-            .as_ref()
-            .expect("strict standalone reached execution only with a qualified package");
+        // A strict standalone request reaches this point only with a qualified package; a
+        // skipped game fallback may reach it with no package at all, in which case the package
+        // resolution reason is the failure.
+        let failure_text = match runner_unavailable.as_ref() {
+            Some(failure) => failure.to_string(),
+            None => unavailable_fallback
+                .as_ref()
+                .and_then(|reason| reason["detail"].as_str().map(str::to_owned))
+                .unwrap_or_else(|| "no standalone compiler package is available".to_owned()),
+        };
         let closing = close_revalidation(&selection, &game_root, &inputs.catalog, &inputs.shipping);
         if !closing.is_exact() {
             return Err(map_closing_failure(closing));
         }
-        let mut failure_detail = Value::String(failure.to_string());
+        let mut failure_detail = Value::String(failure_text);
         let mut private_paths = vec![
             private_workspace.root.path(),
             private_workspace.work_dir.as_path(),
@@ -617,11 +642,14 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
     };
     let closing = closing.get();
     report.finish_while_target_pinned(|report| {
+        // A skipped game fallback is evidence only when the standalone attempt failed.
+        let skipped_fallback = skipped_game_fallback
+            .filter(|_| matches!(report.outcome, FullGraphCompileOutcomeV1::Failed(_)));
         let mut compiler_backend = full_graph_backend_evidence_v2(
             &report,
             requested,
             authority.as_ref().map(|authority| authority.identity()),
-            unavailable_fallback,
+            unavailable_fallback.or(skipped_fallback),
         );
         let mut private_paths = vec![
             private_workspace.root.path(),

--- a/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
@@ -298,7 +298,27 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
         }
     }
 
-    let mut guard = if requested == CompilerBackendWireV2::Standalone {
+    // While a script mod is installed the compiler base is the deployment backup, which the
+    // game compiler cannot restore over the live cache: `standalone_then_game` runs the
+    // standalone compiler only, takes no install guard, and says so in its evidence.
+    let skipped_game_fallback = crate::script_compile_report::skipped_game_fallback_note(
+        requested,
+        available_package
+            .as_ref()
+            .and_then(|resolved| resolved.pristine_source.as_ref()),
+    )
+    .map(|note| {
+        json!({
+            "failed_backend": CompilerBackendNameV1::Game.as_str(),
+            "failure_kind": "preflight",
+            "detail": note,
+        })
+    });
+    let skip_game_fallback = skipped_game_fallback.is_some();
+    if skip_game_fallback {
+        unavailable_fallback = skipped_game_fallback.clone();
+    }
+    let mut guard = if requested == CompilerBackendWireV2::Standalone || skip_game_fallback {
         None
     } else {
         Some(
@@ -447,7 +467,9 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
         }
     }
 
-    if requested == CompilerBackendWireV2::Standalone && standalone_runner.is_none() {
+    if (requested == CompilerBackendWireV2::Standalone || skip_game_fallback)
+        && standalone_runner.is_none()
+    {
         debug_assert!(guard.is_none());
         let failure = runner_unavailable
             .as_ref()
@@ -486,7 +508,7 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
             false,
             false,
             authority.as_ref().map(|authority| authority.identity()),
-            None,
+            skipped_game_fallback,
         );
         return project_response(&selection, &graph, manifest, game_inputs, compiler, closing);
     }
@@ -528,6 +550,19 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
                 .take()
                 .expect("qualified standalone execution retains exact target inputs"),
         ),
+        CompilerBackendWireV2::StandaloneThenGame if skip_game_fallback => {
+            debug_assert!(guard.is_none());
+            compile_full_graph_standalone_v1_with_target(
+                &compiler_opts,
+                standalone_runner
+                    .as_mut()
+                    .expect("a skipped game fallback keeps the standalone runner"),
+                audit,
+                target
+                    .take()
+                    .expect("qualified standalone execution retains exact target inputs"),
+            )
+        }
         CompilerBackendWireV2::StandaloneThenGame if standalone_runner.is_some() => {
             compile_full_graph_with_backend_v1_with_guard_and_target(
                 &compiler_opts,

--- a/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
@@ -348,6 +348,22 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
             })?,
         )
     };
+    // The selection above ran before the guard; a deploy landing in between installs a mod the
+    // game compiler must not run on. A game-capable request re-selects under the guard.
+    if guard.is_some() {
+        if let Some(source) = crate::script_compile_report::installed_script_mod(&game_root) {
+            return fail_v2_preflight_with_optional_guard(
+                guard.take(),
+                Failure::new(
+                    "AUTHORING_REVISION3_PROJECT_COMPILER_INSTALL_UNAVAILABLE",
+                    format!(
+                        "a script mod was installed after the compiler selected its base ({}); the game compiler cannot run on the deployment backup, retry the check (the standalone compiler will be used)",
+                        source.path.display()
+                    ),
+                ),
+            );
+        }
+    }
     let (catalog, shipping, binds) = match build_fresh_game_inputs(&game_root) {
         Ok(inputs) => inputs,
         Err(failure) => {

--- a/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
@@ -252,8 +252,8 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
     let mut unavailable_fallback = None;
     if requested != CompilerBackendWireV2::Game {
         match resolve_product_standalone_compiler_for_game_v1(&game_root) {
-            Ok(ResolvedProductStandaloneCompilerV1::Available(package)) => {
-                available_package = Some(package);
+            Ok(ResolvedProductStandaloneCompilerV1::Available(resolved)) => {
+                available_package = Some(resolved);
             }
             Ok(ResolvedProductStandaloneCompilerV1::BundleAbsent) => {
                 if requested == CompilerBackendWireV2::Standalone {
@@ -324,9 +324,14 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
         shipping,
         binds,
     };
-    if let Some(package) = available_package.as_ref() {
+    if let Some(resolved) = available_package.as_ref() {
+        let package = &resolved.package;
         if package.target_inputs().shipping_cache() != inputs.shipping
             || package.target_inputs().binds_cache() != inputs.binds
+            || resolved
+                .pristine_source
+                .as_ref()
+                .is_some_and(|source| !source.matches(package.target_inputs().shipping_cache()))
         {
             return fail_v2_preflight_with_optional_guard(
                 guard.take(),
@@ -377,7 +382,9 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
 
     if graph.modules.is_empty() {
         let closing = close_revalidation(&selection, &game_root, &inputs.catalog, &inputs.shipping);
-        let package_identity = available_package.as_ref().map(|package| package.identity());
+        let package_identity = available_package
+            .as_ref()
+            .map(|resolved| resolved.package.identity());
         let mut compiler = if let Some(mut held) = guard.take() {
             match held.release() {
                 Ok(()) if closing.is_exact() => empty_compiler_evidence(),
@@ -428,7 +435,8 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
     let mut authority = None;
     let mut target = None;
     let mut runner_unavailable = None;
-    if let Some(package) = available_package.take() {
+    if let Some(resolved) = available_package.take() {
+        let package = resolved.package;
         let runner = package.sidecar_runner(private_workspace.scratch_dir.clone());
         let (package_authority, target_inputs) = package.into_execution_parts();
         authority = Some(package_authority);

--- a/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
@@ -264,8 +264,10 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
             "detail": note,
         })
     });
-    let standalone_only =
-        requested == CompilerBackendWireV2::Standalone || early_installed.is_some();
+    // An empty project needs no compiler at all, so a skipped fallback must not turn a package
+    // failure into an error there; only a strict standalone request keeps that behaviour.
+    let standalone_only = requested == CompilerBackendWireV2::Standalone
+        || (early_installed.is_some() && !graph.modules.is_empty());
     if requested != CompilerBackendWireV2::Game {
         match resolve_product_standalone_compiler_for_game_v1(&game_root) {
             Ok(ResolvedProductStandaloneCompilerV1::Available(resolved)) => {

--- a/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_project_compiler_revision3.rs
@@ -250,43 +250,62 @@ fn check_revision3_project_compiler_v2_inner(input: &str) -> Result<Value, Failu
     // lock. A qualified target remains pinned from here through both explicit fallback attempts.
     let mut available_package = None;
     let mut unavailable_fallback = None;
+    // While a script mod is installed the game fallback is unavailable even without a package:
+    // the package cause is reported as on the strict path, with the skipped fallback attached.
+    let early_installed = crate::script_compile_report::installed_script_mod(&game_root);
+    let early_skipped_note = crate::script_compile_report::skipped_game_fallback_note(
+        requested,
+        early_installed.as_ref(),
+    )
+    .map(|note| {
+        json!({
+            "failed_backend": CompilerBackendNameV1::Game.as_str(),
+            "failure_kind": "preflight",
+            "detail": note,
+        })
+    });
+    let standalone_only =
+        requested == CompilerBackendWireV2::Standalone || early_installed.is_some();
     if requested != CompilerBackendWireV2::Game {
         match resolve_product_standalone_compiler_for_game_v1(&game_root) {
             Ok(ResolvedProductStandaloneCompilerV1::Available(resolved)) => {
                 available_package = Some(resolved);
             }
             Ok(ResolvedProductStandaloneCompilerV1::BundleAbsent) => {
-                if requested == CompilerBackendWireV2::Standalone {
-                    return unavailable_standalone_project_response(
+                if standalone_only {
+                    return unavailable_standalone_project_response_with_fallback(
                         &selection,
                         &mut graph,
                         requested,
                         "AUTHORING_REVISION3_PROJECT_STANDALONE_BUNDLE_ABSENT",
                         BUNDLE_ABSENT_DETAIL,
+                        early_skipped_note.clone(),
                     );
                 }
                 unavailable_fallback = Some(bundle_absent_fallback_reason());
             }
             Ok(ResolvedProductStandaloneCompilerV1::Unavailable(reason)) => {
-                if requested == CompilerBackendWireV2::Standalone {
-                    return unavailable_standalone_project_response(
+                if standalone_only {
+                    return unavailable_standalone_project_response_with_fallback(
                         &selection,
                         &mut graph,
                         requested,
                         "AUTHORING_REVISION3_PROJECT_STANDALONE_PACKAGE_UNAVAILABLE",
                         format!("{:?}: {}", reason.kind(), reason.detail()),
+                        early_skipped_note.clone(),
                     );
                 }
                 unavailable_fallback = Some(package_unavailable_fallback_reason(&reason));
             }
             Err(message) => {
-                if requested == CompilerBackendWireV2::Standalone {
-                    return unavailable_standalone_project_response(
+                if standalone_only {
+                    return unavailable_standalone_project_response_with_fallback(
                         &selection,
                         &mut graph,
                         requested,
                         "AUTHORING_REVISION3_PROJECT_STANDALONE_PACKAGE_LOCATION",
                         message,
+                        early_skipped_note.clone(),
                     );
                 }
                 unavailable_fallback = Some(json!({
@@ -750,6 +769,21 @@ fn unavailable_standalone_project_response(
     code: &'static str,
     message: impl Into<String>,
 ) -> Result<Value, Failure> {
+    unavailable_standalone_project_response_with_fallback(
+        selection, graph, requested, code, message, None,
+    )
+}
+
+/// [`unavailable_standalone_project_response`] carrying a fallback reason: the game fallback was
+/// skipped for an installed script mod before the standalone package turned out unavailable.
+fn unavailable_standalone_project_response_with_fallback(
+    selection: &InitialSelection,
+    graph: &mut ClosedModuleGraph,
+    requested: CompilerBackendWireV2,
+    code: &'static str,
+    message: impl Into<String>,
+    fallback: Option<Value>,
+) -> Result<Value, Failure> {
     // Package absence is established before game-input authority exists. Coverage still binds the
     // exact persisted closed graph, but does not pretend that Quest source was natively regenerated.
     for module in &mut graph.modules {
@@ -766,7 +800,7 @@ fn unavailable_standalone_project_response(
         0,
         "not_created",
     );
-    compiler["compiler_backend"] = backend_evidence(requested, None, false, false, None);
+    compiler["compiler_backend"] = backend_evidence(requested, None, false, false, fallback);
     project_response(
         selection,
         graph,

--- a/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
@@ -753,7 +753,7 @@ where
     let mut runner_unavailable = None;
     let mut runner = match package.sidecar_runner(staging.path().to_path_buf()) {
         Ok(runner) => Some(runner),
-        Err(failure) if requested == CompilerBackendWireV2::Standalone => {
+        Err(failure) if effective == CompilerBackendWireV2::Standalone => {
             let mut detail = Value::String(failure.to_string());
             redact_private_paths(
                 &mut detail,
@@ -765,7 +765,7 @@ where
                     package.profile_root(),
                 ],
             );
-            return product_preflight_failure(
+            return product_preflight_failure_with_fallback(
                 selection,
                 None,
                 &derived,
@@ -777,6 +777,7 @@ where
                         .as_str()
                         .unwrap_or("standalone runner initialization failed"),
                 ),
+                skipped_game_fallback.clone(),
             );
         }
         Err(failure) => {
@@ -897,6 +898,22 @@ fn product_preflight_failure(
     package: &gore_as::standalone_package_resolver::ProductStandaloneCompilerPackageIdentityV1,
     failure: Failure,
 ) -> Result<Value, Failure> {
+    product_preflight_failure_with_fallback(
+        selection, guard, derived, requested, package, failure, None,
+    )
+}
+
+/// [`product_preflight_failure`] carrying a fallback reason, for a preflight that happens after
+/// the game fallback was already skipped for an installed script mod.
+fn product_preflight_failure_with_fallback(
+    selection: InitialSelection,
+    guard: Option<InstallMutationGuard>,
+    derived: &DerivedModule,
+    requested: CompilerBackendWireV2,
+    package: &gore_as::standalone_package_resolver::ProductStandaloneCompilerPackageIdentityV1,
+    failure: Failure,
+    fallback: Option<Value>,
+) -> Result<Value, Failure> {
     let recovery = failure.code.contains("RECOVERY_REQUIRED");
     let mut response = match guard {
         Some(guard) if recovery => release_existing_recovery(selection, guard, derived, failure)?,
@@ -910,7 +927,7 @@ fn product_preflight_failure(
     };
     if response.get("compiler").is_some() {
         response["compiler"]["compiler_backend"] =
-            backend_evidence_with_package(requested, None, false, false, Some(package), None);
+            backend_evidence_with_package(requested, None, false, false, Some(package), fallback);
     }
     Ok(response)
 }

--- a/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
@@ -590,7 +590,26 @@ where
     let initial_derived = DerivedModule {
         generated: selection.persisted_module.clone(),
     };
-    let mut guard = if requested == CompilerBackendWireV2::StandaloneThenGame {
+    // While a script mod is installed the compiler base is the deployment backup, which the
+    // game compiler cannot restore over the live cache: `standalone_then_game` runs the
+    // standalone compiler only, takes no install guard, and says so in its evidence.
+    let skipped_game_fallback = crate::script_compile_report::skipped_game_fallback_note(
+        requested,
+        pristine_source.as_ref(),
+    )
+    .map(|note| {
+        json!({
+            "failed_backend": CompilerBackendNameV1::Game.as_str(),
+            "failure_kind": "preflight",
+            "detail": note,
+        })
+    });
+    let effective = if skipped_game_fallback.is_some() {
+        CompilerBackendWireV2::Standalone
+    } else {
+        requested
+    };
+    let mut guard = if effective == CompilerBackendWireV2::StandaloneThenGame {
         match acquire_compile_install_mutation(game_root) {
             Ok(guard) => Some(guard),
             Err(message) => {
@@ -788,7 +807,7 @@ where
         inject_delay: Duration::from_secs(2),
     };
     let mut strict_target = Some(target);
-    let report = if requested == CompilerBackendWireV2::Standalone {
+    let report = if effective == CompilerBackendWireV2::Standalone {
         compile_module_with_backend_v1(
             &opts,
             &diagnostics,
@@ -815,7 +834,9 @@ where
             let result_backend = report.backend_name();
             let standalone_attempted = report.standalone_attempted();
             let game_attempted = report.game_attempted();
-            let mut fallback = runner_unavailable.or_else(|| {
+            let skipped_fallback = skipped_game_fallback
+                .filter(|_| matches!(report.outcome, CompileModuleReportOutcome::Failed(_)));
+            let mut fallback = runner_unavailable.or(skipped_fallback).or_else(|| {
                 report.fallback_reason().map(|reason| {
                     json!({
                         "failed_backend": reason.failed_backend().as_str(),

--- a/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
@@ -700,6 +700,28 @@ where
     } else {
         None
     };
+    // The target was resolved before the guard; a deploy landing in between installs a script
+    // mod the game fallback must not run on while leaving the original's bytes in place. Ask
+    // again now that the guard is held.
+    if let Some(held) = guard.take() {
+        if let Some(source) = crate::script_compile_report::installed_script_mod(game_root) {
+            return product_preflight_failure(
+                selection,
+                Some(held),
+                &initial_derived,
+                requested,
+                package.identity(),
+                Failure::new(
+                    "AUTHORING_REVISION3_GAME_BACKEND_UNAVAILABLE",
+                    format!(
+                        "a script mod was installed after the compiler target was resolved ({}); the game fallback cannot run on the deployment backup, retry the check (the standalone compiler will be used)",
+                        source.path.display()
+                    ),
+                ),
+            );
+        }
+        guard = Some(held);
+    }
 
     let derived = match derive() {
         Ok(module) => module,

--- a/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
@@ -39,7 +39,8 @@ use crate::script_compile_report::{
 use crate::standalone_compiler_package::{
     backend_evidence, backend_evidence_with_package, bundle_absent_fallback_reason,
     package_unavailable_fallback_reason, resolve_product_standalone_compiler_for_game_v1,
-    CompilerBackendWireV2, ResolvedProductStandaloneCompilerV1, BUNDLE_ABSENT_DETAIL,
+    CompilerBackendWireV2, ResolvedProductPackageV1, ResolvedProductStandaloneCompilerV1,
+    BUNDLE_ABSENT_DETAIL,
 };
 
 pub(super) const QUEST_COMMAND: &str = "authoring_store_check_revision3_quest_compiler_v1";
@@ -292,13 +293,13 @@ fn check_revision3_quest_compiler_v2_inner(input: &str) -> Result<Value, Failure
                 ))
             }
         }
-        ResolvedProductStandaloneCompilerV1::Available(package) => {
+        ResolvedProductStandaloneCompilerV1::Available(resolved) => {
             let selection = open_quest_selection_v2(&payload)?;
             run_product_managed_check(
                 selection,
                 Path::new(&payload.game_root),
                 requested,
-                package,
+                resolved,
                 || {
                     derive_quest_module(
                         &payload.expected_head_json,
@@ -393,13 +394,13 @@ fn check_revision3_npc_compiler_v2_inner(input: &str) -> Result<Value, Failure> 
                 ))
             }
         }
-        ResolvedProductStandaloneCompilerV1::Available(package) => {
+        ResolvedProductStandaloneCompilerV1::Available(resolved) => {
             let selection = open_npc_selection_v2(&payload)?;
             run_product_managed_check(
                 selection,
                 Path::new(&payload.game_root),
                 requested,
-                package,
+                resolved,
                 || derive_npc_module(&payload.expected_head_json, &payload.npc_id, &payload.root),
             )
         }
@@ -575,13 +576,17 @@ fn run_product_managed_check<D>(
     selection: InitialSelection,
     game_root: &Path,
     requested: CompilerBackendWireV2,
-    package: gore_as::standalone_package_resolver::AvailableProductStandaloneCompilerPackageV1,
+    resolved: ResolvedProductPackageV1,
     derive: D,
 ) -> Result<Value, Failure>
 where
     D: FnOnce() -> Result<DerivedModule, Failure>,
 {
     debug_assert!(requested != CompilerBackendWireV2::Game);
+    let ResolvedProductPackageV1 {
+        package,
+        pristine_source,
+    } = resolved;
     let initial_derived = DerivedModule {
         generated: selection.persisted_module.clone(),
     };
@@ -660,6 +665,9 @@ where
     }
     if inputs.shipping.as_slice() != package.target_inputs().shipping_cache()
         || inputs.binds.as_slice() != package.target_inputs().binds_cache()
+        || pristine_source
+            .as_ref()
+            .is_some_and(|source| !source.matches(package.target_inputs().shipping_cache()))
     {
         return product_preflight_failure(
             selection,

--- a/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
@@ -1161,6 +1161,19 @@ where
             return managed_response(&selection, &initial_derived, compiler, false);
         }
     };
+    // The dispatch probe ran without the guard; a deploy may have landed in between. The game
+    // compiler must not run on an installed script mod, so ask again now that the guard is held.
+    if let Some(source) = crate::script_compile_report::installed_script_mod(game_root) {
+        return release_after_preflight(
+            selection,
+            guard,
+            &initial_derived,
+            Failure::new(
+                "AUTHORING_REVISION3_GAME_BACKEND_UNAVAILABLE",
+                crate::script_compile_report::game_backend_unavailable_detail(&source),
+            ),
+        );
+    }
 
     let (guard, derived) = match derive(guard) {
         GuardedDerivation::Ready { guard, module } => (guard, module),

--- a/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
+++ b/crates/gore-ffi/src/authoring_story_compiler_revision3.rs
@@ -213,7 +213,32 @@ fn check_revision3_quest_compiler_v2_inner(input: &str) -> Result<Value, Failure
     let payload: QuestWirePayloadV2 = parse_exact_wire(input, QUEST_COMMAND_V2)?;
     let requested = payload.compiler_backend;
     let v1 = quest_v1_wire(&payload);
+    // While a script mod is installed the game backend must not run: an explicit game request
+    // is refused, and a fallback without a package reports the standalone failure with the
+    // skipped fallback as evidence.
+    let installed =
+        crate::script_compile_report::installed_script_mod(Path::new(&payload.game_root));
+    let skipped_game_fallback =
+        crate::script_compile_report::skipped_game_fallback_note(requested, installed.as_ref())
+            .map(|note| {
+                json!({
+                    "failed_backend": CompilerBackendNameV1::Game.as_str(),
+                    "failure_kind": "preflight",
+                    "detail": note,
+                })
+            });
+    let standalone_only = requested == CompilerBackendWireV2::Standalone || installed.is_some();
     if requested == CompilerBackendWireV2::Game {
+        if let Some(source) = installed.as_ref() {
+            let selection = open_quest_selection_v2(&payload)?;
+            return strict_standalone_preflight_response(
+                selection,
+                requested,
+                "AUTHORING_REVISION3_GAME_BACKEND_UNAVAILABLE",
+                &crate::script_compile_report::game_backend_unavailable_detail(source),
+                None,
+            );
+        }
         let (response, game_attempted) = check_revision3_quest_compiler_v1_with_attempt(&v1)?;
         return Ok(attach_managed_backend_evidence(
             response,
@@ -224,14 +249,15 @@ fn check_revision3_quest_compiler_v2_inner(input: &str) -> Result<Value, Failure
     let resolution =
         match resolve_product_standalone_compiler_for_game_v1(Path::new(&payload.game_root)) {
             Ok(resolution) => resolution,
-            Err(message) if requested == CompilerBackendWireV2::Standalone => {
+            Err(message) if standalone_only => {
                 let selection = open_quest_selection_v2(&payload)?;
-                return strict_standalone_preflight_response(
+                return preflight_response_with_fallback(
                     selection,
                     requested,
                     "AUTHORING_REVISION3_STANDALONE_PACKAGE_LOCATION",
                     &message,
                     None,
+                    skipped_game_fallback,
                 );
             }
             Err(message) => {
@@ -251,14 +277,15 @@ fn check_revision3_quest_compiler_v2_inner(input: &str) -> Result<Value, Failure
         };
     match resolution {
         ResolvedProductStandaloneCompilerV1::BundleAbsent => {
-            if requested == CompilerBackendWireV2::Standalone {
+            if standalone_only {
                 let selection = open_quest_selection_v2(&payload)?;
-                strict_standalone_preflight_response(
+                preflight_response_with_fallback(
                     selection,
                     requested,
                     "AUTHORING_REVISION3_STANDALONE_BUNDLE_ABSENT",
                     BUNDLE_ABSENT_DETAIL,
                     None,
+                    skipped_game_fallback,
                 )
             } else {
                 let (response, game_attempted) =
@@ -272,14 +299,15 @@ fn check_revision3_quest_compiler_v2_inner(input: &str) -> Result<Value, Failure
             }
         }
         ResolvedProductStandaloneCompilerV1::Unavailable(reason) => {
-            if requested == CompilerBackendWireV2::Standalone {
+            if standalone_only {
                 let selection = open_quest_selection_v2(&payload)?;
-                strict_standalone_preflight_response(
+                preflight_response_with_fallback(
                     selection,
                     requested,
                     "AUTHORING_REVISION3_STANDALONE_PACKAGE_UNAVAILABLE",
                     &format!("{:?}: {}", reason.kind(), reason.detail()),
                     None,
+                    skipped_game_fallback,
                 )
             } else {
                 let fallback = package_unavailable_fallback_reason(&reason);
@@ -317,7 +345,32 @@ fn check_revision3_npc_compiler_v2_inner(input: &str) -> Result<Value, Failure> 
     let payload: NpcWirePayloadV2 = parse_exact_wire(input, NPC_COMMAND_V2)?;
     let requested = payload.compiler_backend;
     let v1 = npc_v1_wire(&payload);
+    // While a script mod is installed the game backend must not run: an explicit game request
+    // is refused, and a fallback without a package reports the standalone failure with the
+    // skipped fallback as evidence.
+    let installed =
+        crate::script_compile_report::installed_script_mod(Path::new(&payload.game_root));
+    let skipped_game_fallback =
+        crate::script_compile_report::skipped_game_fallback_note(requested, installed.as_ref())
+            .map(|note| {
+                json!({
+                    "failed_backend": CompilerBackendNameV1::Game.as_str(),
+                    "failure_kind": "preflight",
+                    "detail": note,
+                })
+            });
+    let standalone_only = requested == CompilerBackendWireV2::Standalone || installed.is_some();
     if requested == CompilerBackendWireV2::Game {
+        if let Some(source) = installed.as_ref() {
+            let selection = open_npc_selection_v2(&payload)?;
+            return strict_standalone_preflight_response(
+                selection,
+                requested,
+                "AUTHORING_REVISION3_GAME_BACKEND_UNAVAILABLE",
+                &crate::script_compile_report::game_backend_unavailable_detail(source),
+                None,
+            );
+        }
         let (response, game_attempted) = check_revision3_npc_compiler_v1_with_attempt(&v1)?;
         return Ok(attach_managed_backend_evidence(
             response,
@@ -328,14 +381,15 @@ fn check_revision3_npc_compiler_v2_inner(input: &str) -> Result<Value, Failure> 
     let resolution =
         match resolve_product_standalone_compiler_for_game_v1(Path::new(&payload.game_root)) {
             Ok(resolution) => resolution,
-            Err(message) if requested == CompilerBackendWireV2::Standalone => {
+            Err(message) if standalone_only => {
                 let selection = open_npc_selection_v2(&payload)?;
-                return strict_standalone_preflight_response(
+                return preflight_response_with_fallback(
                     selection,
                     requested,
                     "AUTHORING_REVISION3_STANDALONE_PACKAGE_LOCATION",
                     &message,
                     None,
+                    skipped_game_fallback,
                 );
             }
             Err(message) => {
@@ -354,14 +408,15 @@ fn check_revision3_npc_compiler_v2_inner(input: &str) -> Result<Value, Failure> 
         };
     match resolution {
         ResolvedProductStandaloneCompilerV1::BundleAbsent => {
-            if requested == CompilerBackendWireV2::Standalone {
+            if standalone_only {
                 let selection = open_npc_selection_v2(&payload)?;
-                strict_standalone_preflight_response(
+                preflight_response_with_fallback(
                     selection,
                     requested,
                     "AUTHORING_REVISION3_STANDALONE_BUNDLE_ABSENT",
                     BUNDLE_ABSENT_DETAIL,
                     None,
+                    skipped_game_fallback,
                 )
             } else {
                 let (response, game_attempted) = check_revision3_npc_compiler_v1_with_attempt(&v1)?;
@@ -374,14 +429,15 @@ fn check_revision3_npc_compiler_v2_inner(input: &str) -> Result<Value, Failure> 
             }
         }
         ResolvedProductStandaloneCompilerV1::Unavailable(reason) => {
-            if requested == CompilerBackendWireV2::Standalone {
+            if standalone_only {
                 let selection = open_npc_selection_v2(&payload)?;
-                strict_standalone_preflight_response(
+                preflight_response_with_fallback(
                     selection,
                     requested,
                     "AUTHORING_REVISION3_STANDALONE_PACKAGE_UNAVAILABLE",
                     &format!("{:?}: {}", reason.kind(), reason.detail()),
                     None,
+                    skipped_game_fallback,
                 )
             } else {
                 let fallback = package_unavailable_fallback_reason(&reason);
@@ -416,12 +472,27 @@ fn strict_standalone_preflight_response(
         &gore_as::standalone_package_resolver::ProductStandaloneCompilerPackageIdentityV1,
     >,
 ) -> Result<Value, Failure> {
+    preflight_response_with_fallback(selection, requested, code, detail, package, None)
+}
+
+/// [`strict_standalone_preflight_response`] carrying a fallback reason: the game fallback was
+/// skipped for an installed script mod before the standalone package turned out unavailable.
+fn preflight_response_with_fallback(
+    selection: InitialSelection,
+    requested: CompilerBackendWireV2,
+    code: &'static str,
+    detail: &str,
+    package: Option<
+        &gore_as::standalone_package_resolver::ProductStandaloneCompilerPackageIdentityV1,
+    >,
+    fallback: Option<Value>,
+) -> Result<Value, Failure> {
     let derived = DerivedModule {
         generated: selection.persisted_module.clone(),
     };
     let mut compiler = preflight_compiler_evidence(code, detail, false);
     compiler["compiler_backend"] =
-        backend_evidence_with_package(requested, None, false, false, package, None);
+        backend_evidence_with_package(requested, None, false, false, package, fallback);
     managed_response(&selection, &derived, compiler, false)
 }
 

--- a/crates/gore-ffi/src/script_compile_report.rs
+++ b/crates/gore-ffi/src/script_compile_report.rs
@@ -875,27 +875,29 @@ fn compile_report_with_available_product_package(
         }
     };
     if !target_matches_pristine {
-        if requested == CompilerBackendWireV2::Standalone {
-            return attach_backend_evidence(
-                standalone_target_not_pristine_failure(),
-                backend_evidence_with_package(
-                    requested,
-                    None,
-                    false,
-                    false,
-                    Some(authority.identity()),
-                    None,
-                ),
-            );
-        }
-        runner_unavailable.get_or_insert_with(|| {
-            json!({
-                "failed_backend": CompilerBackendNameV1::Standalone.as_str(),
-                "failure_kind": "preflight",
-                "detail": "the authenticated standalone compiler target is the live deployed Shipping cache, not the deployment-aware pristine base; using the explicitly allowed game fallback",
-            })
-        });
-        runner = None;
+        // The target was pinned on the selected pristine source, so a mismatch is not an
+        // installed mod but a base that changed in between: fail closed in every mode rather
+        // than launching the game compiler over a moving base.
+        let failure = pristine_base_changed_failure();
+        let failure = match guard.take() {
+            Some(guard) => release_guard_after_preflight_failure(
+                guard,
+                failure,
+                "compiler base changed before launch",
+            ),
+            None => failure,
+        };
+        return attach_backend_evidence(
+            failure,
+            backend_evidence_with_package(
+                requested,
+                None,
+                false,
+                false,
+                Some(authority.identity()),
+                runner_unavailable.clone(),
+            ),
+        );
     }
     let opts = CompileOpts {
         game_dir: game_dir.clone(),
@@ -1017,10 +1019,10 @@ fn qualified_target_pristine_script_cache(
     Ok((pristine, target_matches_pristine))
 }
 
-fn standalone_target_not_pristine_failure() -> Value {
+fn pristine_base_changed_failure() -> Value {
     preflight_failure(
-        "COMPILE_STANDALONE_TARGET_NOT_PRISTINE",
-        "the authenticated standalone compiler target uses the live Shipping cache, but the deployment-aware pristine cache differs; reset or undeploy active script mods before compiling"
+        "COMPILE_PRISTINE_BASE_CHANGED",
+        "the pinned standalone compiler target no longer holds the deployment-aware pristine script cache: the base changed between selecting it and pinning it (a deployment change or a game update ran alongside); retry the compile"
             .to_owned(),
     )
 }
@@ -1836,11 +1838,17 @@ mod tests {
         assert_eq!(fallback_base, b"pristine");
         assert!(!fallback_matches);
 
-        let rejected = standalone_target_not_pristine_failure();
+        let rejected = pristine_base_changed_failure();
         assert_eq!(
             rejected["compile_error"]["code"],
-            "COMPILE_STANDALONE_TARGET_NOT_PRISTINE"
+            "COMPILE_PRISTINE_BASE_CHANGED"
         );
+        let message = rejected["compile_error"]["message"].as_str().unwrap();
+        assert!(
+            message.contains("changed between selecting it and pinning it"),
+            "got: {message}"
+        );
+        assert!(!message.contains("undeploy"), "got: {message}");
         assert_eq!(rejected["install_restore"], "not_started");
         assert_eq!(rejected["recovery_required"], false);
     }

--- a/crates/gore-ffi/src/script_compile_report.rs
+++ b/crates/gore-ffi/src/script_compile_report.rs
@@ -887,6 +887,35 @@ fn compile_report_with_available_product_package(
             }
         }
     };
+    // The target was resolved before the guard; a deploy landing in between installs a script
+    // mod the game fallback must not run on while leaving the original's bytes in place. Ask
+    // again now that the guard is held.
+    if let Some(held) = guard.take() {
+        if let Some(source) = installed_script_mod(&game_dir) {
+            return attach_backend_evidence(
+                release_guard_after_preflight_failure(
+                    held,
+                    preflight_failure(
+                        "COMPILE_GAME_BACKEND_UNAVAILABLE",
+                        format!(
+                            "a script mod was installed after the compiler target was resolved ({}); the game fallback cannot run on the deployment backup, retry the compile (the standalone compiler will be used)",
+                            source.path.display()
+                        ),
+                    ),
+                    "a script mod was installed before launch",
+                ),
+                backend_evidence_with_package(
+                    requested,
+                    None,
+                    false,
+                    false,
+                    Some(authority.identity()),
+                    runner_unavailable.clone(),
+                ),
+            );
+        }
+        guard = Some(held);
+    }
     let (base_override, target_matches_pristine) = match qualified_target_pristine_script_cache(
         &game_dir,
         strict_target

--- a/crates/gore-ffi/src/script_compile_report.rs
+++ b/crates/gore-ffi/src/script_compile_report.rs
@@ -1190,6 +1190,18 @@ fn compile_report_v1_payload_recording_attempt(
         Ok(guard) => guard,
         Err(message) => return install_guard_failure(&game_dir, message),
     };
+    // The dispatch probe ran without the guard; a deploy may have landed in between. The game
+    // compiler must not run on an installed script mod, so ask again now that the guard is held.
+    if let Some(source) = installed_script_mod(&game_dir) {
+        return release_guard_after_preflight_failure(
+            guard,
+            preflight_failure(
+                "COMPILE_GAME_BACKEND_UNAVAILABLE",
+                game_backend_unavailable_detail(&source),
+            ),
+            "the game compiler cannot run on an installed script mod",
+        );
+    }
     // Do not silently fall back to an arbitrary live/backup choice here. The exact base used for
     // remapping must be the same drift-aware pristine base that deployment would later splice.
     let base_override = match gore_mod::pristine_script_cache(&game_dir) {

--- a/crates/gore-ffi/src/script_compile_report.rs
+++ b/crates/gore-ffi/src/script_compile_report.rs
@@ -33,7 +33,8 @@ use crate::err;
 use crate::standalone_compiler_package::{
     backend_evidence, backend_evidence_with_package, bundle_absent_fallback_reason,
     package_unavailable_fallback_reason, resolve_product_standalone_compiler_for_game_v1,
-    CompilerBackendWireV2, ResolvedProductStandaloneCompilerV1, BUNDLE_ABSENT_DETAIL,
+    CompilerBackendWireV2, ResolvedProductPackageV1, ResolvedProductStandaloneCompilerV1,
+    BUNDLE_ABSENT_DETAIL,
 };
 
 pub(super) const COMMAND: &str = "script_compile_report_v1";
@@ -728,8 +729,8 @@ fn compile_report_v2_product_payload(
                 )
             }
         }
-        ResolvedProductStandaloneCompilerV1::Available(package) => {
-            compile_report_with_available_product_package(payload, requested, package)
+        ResolvedProductStandaloneCompilerV1::Available(resolved) => {
+            compile_report_with_available_product_package(payload, requested, resolved)
         }
     }
 }
@@ -737,9 +738,13 @@ fn compile_report_v2_product_payload(
 fn compile_report_with_available_product_package(
     payload: CompileWirePayload,
     requested: CompilerBackendWireV2,
-    package: gore_as::standalone_package_resolver::AvailableProductStandaloneCompilerPackageV1,
+    resolved: ResolvedProductPackageV1,
 ) -> Value {
     debug_assert!(requested != CompilerBackendWireV2::Game);
+    let ResolvedProductPackageV1 {
+        package,
+        pristine_source,
+    } = resolved;
     let game_dir = PathBuf::from(&payload.game_dir);
     let staging = match OwnedCompileStaging::create(Path::new(&payload.work_dir), &game_dir) {
         Ok(staging) => staging,
@@ -850,6 +855,7 @@ fn compile_report_with_available_product_package(
             .as_ref()
             .expect("the authenticated target remains pinned before execution")
             .shipping_cache(),
+        pristine_source.as_ref(),
     ) {
         Ok(base) => base,
         Err(failure) => {
@@ -996,9 +1002,13 @@ fn attach_backend_evidence(mut response: Value, evidence: Value) -> Value {
     response
 }
 
+/// The pinned target must hold the current deployment-aware pristine cache AND, when the target
+/// was resolved on a selected pristine source, the bytes that selection named: equal bytes under
+/// a different selected identity are a base that changed between selection and pin.
 fn qualified_target_pristine_script_cache(
     game_dir: &Path,
     qualified_shipping: &[u8],
+    selected: Option<&gore_mod::PristineScriptCacheSource>,
 ) -> Result<(Vec<u8>, bool), Value> {
     let pristine = gore_mod::pristine_script_cache(game_dir).map_err(|error| {
         let message = error.to_string();
@@ -1015,7 +1025,8 @@ fn qualified_target_pristine_script_cache(
             )
         }
     })?;
-    let target_matches_pristine = qualified_shipping == pristine.as_slice();
+    let target_matches_pristine = qualified_shipping == pristine.as_slice()
+        && selected.is_none_or(|source| source.matches(qualified_shipping));
     Ok((pristine, target_matches_pristine))
 }
 
@@ -1829,14 +1840,26 @@ mod tests {
         fs::write(script.join("PrecompiledScript_Shipping.Cache"), b"pristine").unwrap();
 
         let (accepted, accepted_matches) =
-            qualified_target_pristine_script_cache(&game, b"pristine").unwrap();
+            qualified_target_pristine_script_cache(&game, b"pristine", None).unwrap();
         assert_eq!(accepted, b"pristine");
         assert!(accepted_matches);
 
         let (fallback_base, fallback_matches) =
-            qualified_target_pristine_script_cache(&game, b"deployed").unwrap();
+            qualified_target_pristine_script_cache(&game, b"deployed", None).unwrap();
         assert_eq!(fallback_base, b"pristine");
         assert!(!fallback_matches);
+
+        // The selection made before the pin must still be the pristine cache read after it:
+        // equal bytes under a different selected identity are a base that changed in between.
+        let stale = gore_mod::pristine_script_cache_source(&game).unwrap();
+        fs::write(script.join("PrecompiledScript_Shipping.Cache"), b"replaced").unwrap();
+        let (_, replaced_matches) =
+            qualified_target_pristine_script_cache(&game, b"replaced", Some(&stale)).unwrap();
+        assert!(!replaced_matches);
+        let fresh = gore_mod::pristine_script_cache_source(&game).unwrap();
+        let (_, fresh_matches) =
+            qualified_target_pristine_script_cache(&game, b"replaced", Some(&fresh)).unwrap();
+        assert!(fresh_matches);
 
         let rejected = pristine_base_changed_failure();
         assert_eq!(

--- a/crates/gore-ffi/src/script_compile_report.rs
+++ b/crates/gore-ffi/src/script_compile_report.rs
@@ -1080,7 +1080,7 @@ fn qualified_target_pristine_script_cache(
 /// Why standalone_then_game skips its game fallback, when it does: the compiler base is the
 /// deployment backup, which the game compiler cannot restore over the live cache. Only that
 /// policy has a fallback to skip; a strict standalone or game request never gets this note.
-fn skipped_game_fallback_note(
+pub(crate) fn skipped_game_fallback_note(
     requested: CompilerBackendWireV2,
     pristine_source: Option<&gore_mod::PristineScriptCacheSource>,
 ) -> Option<String> {

--- a/crates/gore-ffi/src/script_compile_report.rs
+++ b/crates/gore-ffi/src/script_compile_report.rs
@@ -748,23 +748,12 @@ fn compile_report_with_available_product_package(
     // While a script mod is installed the compiler base is the deployment backup, which the
     // game compiler cannot restore over the live cache: `standalone_then_game` runs the
     // standalone compiler only and says so in its evidence.
-    let game_fallback_note = pristine_source
-        .as_ref()
-        .filter(|source| source.from_backup)
-        .map(|source| {
-            format!(
-                "the game fallback is unavailable while a script mod is installed: the compiler \
-                 base is the deployment backup {}, which the game compiler cannot restore over \
-                 the live cache",
-                source.path.display()
-            )
-        });
-    let effective =
-        if requested == CompilerBackendWireV2::StandaloneThenGame && game_fallback_note.is_some() {
-            CompilerBackendWireV2::Standalone
-        } else {
-            requested
-        };
+    let game_fallback_note = skipped_game_fallback_note(requested, pristine_source.as_ref());
+    let effective = if game_fallback_note.is_some() {
+        CompilerBackendWireV2::Standalone
+    } else {
+        requested
+    };
     let game_dir = PathBuf::from(&payload.game_dir);
     let staging = match OwnedCompileStaging::create(Path::new(&payload.work_dir), &game_dir) {
         Ok(staging) => staging,
@@ -1086,6 +1075,26 @@ fn qualified_target_pristine_script_cache(
     let target_matches_pristine = qualified_shipping == pristine.as_slice()
         && selected.is_none_or(|source| source.matches(qualified_shipping));
     Ok((pristine, target_matches_pristine))
+}
+
+/// Why standalone_then_game skips its game fallback, when it does: the compiler base is the
+/// deployment backup, which the game compiler cannot restore over the live cache. Only that
+/// policy has a fallback to skip; a strict standalone or game request never gets this note.
+fn skipped_game_fallback_note(
+    requested: CompilerBackendWireV2,
+    pristine_source: Option<&gore_mod::PristineScriptCacheSource>,
+) -> Option<String> {
+    if requested != CompilerBackendWireV2::StandaloneThenGame {
+        return None;
+    }
+    pristine_source
+        .filter(|source| source.from_backup)
+        .map(|source| {
+            format!(
+                "the game fallback is unavailable while a script mod is installed: the compiler base is the deployment backup {}, which the game compiler cannot restore over the live cache",
+                source.path.display()
+            )
+        })
 }
 
 /// The pristine base the mini was remapped against must still be the deployment-aware original
@@ -1975,6 +1984,67 @@ mod tests {
             message.contains("changed during compilation"),
             "got: {message}"
         );
+    }
+
+    /// Only `standalone_then_game` has a game fallback to skip. A strict `standalone` request
+    /// that fails while a script mod is installed must not report a skipped fallback.
+    #[test]
+    fn a_skipped_game_fallback_is_only_evidence_for_standalone_then_game() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let script = game.join("G1R/Script");
+        fs::create_dir_all(&script).unwrap();
+        let live = script.join("PrecompiledScript_Shipping.Cache");
+        fs::write(&live, b"pristine").unwrap();
+        let untouched = gore_mod::pristine_script_cache_source(&game).unwrap();
+        let backup = PathBuf::from(format!("{}.gore-bak", live.display()));
+        fs::write(&backup, b"pristine").unwrap();
+        fs::write(&live, b"deployed").unwrap();
+        let recorded_live = fs::canonicalize(&live).unwrap();
+        let recorded_backup = fs::canonicalize(&backup).unwrap();
+        let identity = |bytes: &[u8]| format!("sha256:{:x}", Sha256::digest(bytes));
+        let mut record = gore_mod::DeployRecord {
+            mod_name: "fixture".to_owned(),
+            backups: vec![(
+                recorded_live.display().to_string(),
+                recorded_backup.display().to_string(),
+                true,
+            )],
+            ..Default::default()
+        };
+        record
+            .deployed_hashes
+            .insert(recorded_live.display().to_string(), identity(b"deployed"));
+        record
+            .backup_hashes
+            .insert(recorded_backup.display().to_string(), identity(b"pristine"));
+        fs::write(
+            game.join("gore-mod.deployed.json"),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+        let installed = gore_mod::pristine_script_cache_source(&game).unwrap();
+        assert!(installed.from_backup);
+
+        assert!(
+            skipped_game_fallback_note(CompilerBackendWireV2::Standalone, Some(&installed))
+                .is_none()
+        );
+        assert!(
+            skipped_game_fallback_note(CompilerBackendWireV2::Game, Some(&installed)).is_none()
+        );
+        assert!(skipped_game_fallback_note(
+            CompilerBackendWireV2::StandaloneThenGame,
+            Some(&untouched)
+        )
+        .is_none());
+        assert!(
+            skipped_game_fallback_note(CompilerBackendWireV2::StandaloneThenGame, None).is_none()
+        );
+        let note =
+            skipped_game_fallback_note(CompilerBackendWireV2::StandaloneThenGame, Some(&installed))
+                .expect("standalone_then_game skips its game fallback on a backup-pinned base");
+        assert!(note.contains("game fallback is unavailable"), "got: {note}");
     }
 
     fn request(payload: Value) -> String {

--- a/crates/gore-ffi/src/script_compile_report.rs
+++ b/crates/gore-ffi/src/script_compile_report.rs
@@ -749,6 +749,13 @@ fn compile_report_with_available_product_package(
     // game compiler cannot restore over the live cache: `standalone_then_game` runs the
     // standalone compiler only and says so in its evidence.
     let game_fallback_note = skipped_game_fallback_note(requested, pristine_source.as_ref());
+    let skipped_game_fallback = game_fallback_note.as_ref().map(|note| {
+        json!({
+            "failed_backend": CompilerBackendNameV1::Game.as_str(),
+            "failure_kind": "preflight",
+            "detail": note,
+        })
+    });
     let effective = if game_fallback_note.is_some() {
         CompilerBackendWireV2::Standalone
     } else {
@@ -799,7 +806,7 @@ fn compile_report_with_available_product_package(
                     false,
                     false,
                     Some(authority.identity()),
-                    None,
+                    skipped_game_fallback,
                 ),
             );
         }
@@ -999,16 +1006,8 @@ fn compile_report_with_available_product_package(
     let result_backend = report.backend_name();
     let standalone_attempted = report.standalone_attempted();
     let game_attempted = report.game_attempted();
-    let skipped_fallback = game_fallback_note
-        .as_ref()
-        .filter(|_| matches!(report.outcome, CompileModuleReportOutcome::Failed(_)))
-        .map(|note| {
-            json!({
-                "failed_backend": CompilerBackendNameV1::Game.as_str(),
-                "failure_kind": "preflight",
-                "detail": note,
-            })
-        });
+    let skipped_fallback = skipped_game_fallback
+        .filter(|_| matches!(report.outcome, CompileModuleReportOutcome::Failed(_)));
     let fallback = runner_unavailable.or(skipped_fallback).or_else(|| {
         report.fallback_reason().map(|reason| {
             json!({

--- a/crates/gore-ffi/src/script_compile_report.rs
+++ b/crates/gore-ffi/src/script_compile_report.rs
@@ -631,6 +631,15 @@ pub(super) fn compile_report_v2_raw(input: &str) -> Value {
     let requested = payload.compiler_backend;
     match requested {
         CompilerBackendWireV2::Game => {
+            if let Some(source) = installed_script_mod(Path::new(&payload.game_dir)) {
+                return attach_backend_evidence(
+                    preflight_failure(
+                        "COMPILE_GAME_BACKEND_UNAVAILABLE",
+                        game_backend_unavailable_detail(&source),
+                    ),
+                    backend_evidence(requested, None, false, false, None),
+                );
+            }
             let (response, game_attempted) =
                 compile_report_v1_payload_with_attempt(payload.into_v1());
             attach_backend_evidence(
@@ -655,13 +664,26 @@ fn compile_report_v2_product_payload(
     requested: CompilerBackendWireV2,
 ) -> Value {
     let game_dir = PathBuf::from(&payload.game_dir);
+    // While a script mod is installed the game fallback is unavailable even without a package:
+    // the failure that would have caused the fallback is reported instead, with the skipped
+    // fallback as evidence.
+    let installed = installed_script_mod(&game_dir);
+    let skipped_game_fallback =
+        skipped_game_fallback_note(requested, installed.as_ref()).map(|note| {
+            json!({
+                "failed_backend": CompilerBackendNameV1::Game.as_str(),
+                "failure_kind": "preflight",
+                "detail": note,
+            })
+        });
+    let standalone_only = requested == CompilerBackendWireV2::Standalone || installed.is_some();
     let resolution = match resolve_product_standalone_compiler_for_game_v1(&game_dir) {
         Ok(resolution) => resolution,
         Err(message) => {
-            if requested == CompilerBackendWireV2::Standalone {
+            if standalone_only {
                 return attach_backend_evidence(
                     preflight_failure("COMPILE_STANDALONE_PACKAGE_LOCATION", message),
-                    backend_evidence(requested, None, false, false, None),
+                    backend_evidence(requested, None, false, false, skipped_game_fallback),
                 );
             }
             let (response, game_attempted) = compile_report_v1_payload_with_attempt(payload);
@@ -683,13 +705,13 @@ fn compile_report_v2_product_payload(
     };
     match resolution {
         ResolvedProductStandaloneCompilerV1::BundleAbsent => {
-            if requested == CompilerBackendWireV2::Standalone {
+            if standalone_only {
                 attach_backend_evidence(
                     preflight_failure(
                         "COMPILE_STANDALONE_BUNDLE_ABSENT",
                         BUNDLE_ABSENT_DETAIL.to_owned(),
                     ),
-                    backend_evidence(requested, None, false, false, None),
+                    backend_evidence(requested, None, false, false, skipped_game_fallback),
                 )
             } else {
                 let (response, game_attempted) = compile_report_v1_payload_with_attempt(payload);
@@ -706,13 +728,13 @@ fn compile_report_v2_product_payload(
             }
         }
         ResolvedProductStandaloneCompilerV1::Unavailable(reason) => {
-            if requested == CompilerBackendWireV2::Standalone {
+            if standalone_only {
                 attach_backend_evidence(
                     preflight_failure(
                         "COMPILE_STANDALONE_PACKAGE_UNAVAILABLE",
                         format!("{:?}: {}", reason.kind(), reason.detail()),
                     ),
-                    backend_evidence(requested, None, false, false, None),
+                    backend_evidence(requested, None, false, false, skipped_game_fallback),
                 )
             } else {
                 let fallback = package_unavailable_fallback_reason(&reason);
@@ -1074,6 +1096,26 @@ fn qualified_target_pristine_script_cache(
     let target_matches_pristine = qualified_shipping == pristine.as_slice()
         && selected.is_none_or(|source| source.matches(qualified_shipping));
     Ok((pristine, target_matches_pristine))
+}
+
+/// The script mod installed in `game_dir`, if the deployment-aware pristine source is a backup
+/// the deployment owns. The game backend must not run then: it regenerates into the live cache
+/// and would restore the original over the mod.
+pub(crate) fn installed_script_mod(game_dir: &Path) -> Option<gore_mod::PristineScriptCacheSource> {
+    gore_mod::pristine_script_cache_source(game_dir)
+        .ok()
+        .filter(|source| source.from_backup)
+}
+
+pub(crate) fn game_backend_unavailable_detail(
+    source: &gore_mod::PristineScriptCacheSource,
+) -> String {
+    format!(
+        "the game compiler cannot run while a script mod is installed: the compiler base is the \
+         deployment backup {}, which the game compiler would restore over the live cache; use the \
+         standalone backend or undeploy the mod first",
+        source.path.display()
+    )
 }
 
 /// Why standalone_then_game skips its game fallback, when it does: the compiler base is the
@@ -2044,6 +2086,56 @@ mod tests {
             skipped_game_fallback_note(CompilerBackendWireV2::StandaloneThenGame, Some(&installed))
                 .expect("standalone_then_game skips its game fallback on a backup-pinned base");
         assert!(note.contains("game fallback is unavailable"), "got: {note}");
+    }
+
+    /// The legacy game dispatch asks this before it runs: only a backup the deployment owns
+    /// means a script mod is installed.
+    #[test]
+    fn installed_script_mod_needs_an_owned_backup() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let script = game.join("G1R/Script");
+        fs::create_dir_all(&script).unwrap();
+        let live = script.join("PrecompiledScript_Shipping.Cache");
+        fs::write(&live, b"pristine").unwrap();
+        assert!(installed_script_mod(&game).is_none());
+        assert!(installed_script_mod(&root.path().join("missing")).is_none());
+
+        let backup = PathBuf::from(format!("{}.gore-bak", live.display()));
+        fs::write(&backup, b"pristine").unwrap();
+        fs::write(&live, b"deployed").unwrap();
+        let recorded_live = fs::canonicalize(&live).unwrap();
+        let recorded_backup = fs::canonicalize(&backup).unwrap();
+        let identity = |bytes: &[u8]| format!("sha256:{:x}", Sha256::digest(bytes));
+        let mut record = gore_mod::DeployRecord {
+            mod_name: "fixture".to_owned(),
+            backups: vec![(
+                recorded_live.display().to_string(),
+                recorded_backup.display().to_string(),
+                true,
+            )],
+            ..Default::default()
+        };
+        record
+            .deployed_hashes
+            .insert(recorded_live.display().to_string(), identity(b"deployed"));
+        record
+            .backup_hashes
+            .insert(recorded_backup.display().to_string(), identity(b"pristine"));
+        fs::write(
+            game.join("gore-mod.deployed.json"),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+
+        let installed = installed_script_mod(&game).expect("an owned backup is an installed mod");
+        assert!(installed.from_backup);
+        let detail = game_backend_unavailable_detail(&installed);
+        assert!(detail.contains("script mod is installed"), "got: {detail}");
+        assert!(
+            detail.contains(&installed.path.display().to_string()),
+            "got: {detail}"
+        );
     }
 
     fn request(payload: Value) -> String {

--- a/crates/gore-ffi/src/script_compile_report.rs
+++ b/crates/gore-ffi/src/script_compile_report.rs
@@ -745,6 +745,26 @@ fn compile_report_with_available_product_package(
         package,
         pristine_source,
     } = resolved;
+    // While a script mod is installed the compiler base is the deployment backup, which the
+    // game compiler cannot restore over the live cache: `standalone_then_game` runs the
+    // standalone compiler only and says so in its evidence.
+    let game_fallback_note = pristine_source
+        .as_ref()
+        .filter(|source| source.from_backup)
+        .map(|source| {
+            format!(
+                "the game fallback is unavailable while a script mod is installed: the compiler \
+                 base is the deployment backup {}, which the game compiler cannot restore over \
+                 the live cache",
+                source.path.display()
+            )
+        });
+    let effective =
+        if requested == CompilerBackendWireV2::StandaloneThenGame && game_fallback_note.is_some() {
+            CompilerBackendWireV2::Standalone
+        } else {
+            requested
+        };
     let game_dir = PathBuf::from(&payload.game_dir);
     let staging = match OwnedCompileStaging::create(Path::new(&payload.work_dir), &game_dir) {
         Ok(staging) => staging,
@@ -767,7 +787,7 @@ fn compile_report_with_available_product_package(
     let mut runner_unavailable = None;
     let mut runner = match runner {
         Ok(runner) => Some(runner),
-        Err(failure) if requested == CompilerBackendWireV2::Standalone => {
+        Err(failure) if effective == CompilerBackendWireV2::Standalone => {
             let mut failure_detail = Value::String(failure.to_string());
             crate::authoring_story_compiler_revision3::redact_private_paths(
                 &mut failure_detail,
@@ -829,7 +849,7 @@ fn compile_report_with_available_product_package(
         );
     }
     let mut strict_target = Some(target);
-    let mut guard = if requested == CompilerBackendWireV2::Standalone {
+    let mut guard = if effective == CompilerBackendWireV2::Standalone {
         None
     } else {
         match acquire_guard(&game_dir) {
@@ -923,7 +943,7 @@ fn compile_report_with_available_product_package(
                 .to_vec(),
         ),
     };
-    let report = if requested == CompilerBackendWireV2::Standalone {
+    let report = if effective == CompilerBackendWireV2::Standalone {
         // `target` remains alive for the whole attempt and pins EXE/Shipping/Binds without ever
         // acquiring the install-mutation guard or touching the selected installation.
         let report = compile_module_with_backend_v1(
@@ -959,10 +979,48 @@ fn compile_report_with_available_product_package(
                 .expect("the authenticated target is transferred once"),
         )
     };
+    // The module path has no transaction hook for a closing audit: re-read the deployment-aware
+    // original before the mini is published and discard a mini whose base changed meanwhile.
+    let mut report = report;
+    if let (CompileModuleReportOutcome::Compiled(_), Some(source)) =
+        (&report.outcome, pristine_source.as_ref())
+    {
+        if let Err(message) = closing_base_audit(
+            &game_dir,
+            source,
+            opts.base_override.as_deref().unwrap_or_default(),
+        ) {
+            let previous = std::mem::replace(
+                &mut report.outcome,
+                CompileModuleReportOutcome::Failed(gore_as::compile::CompileError::Other(
+                    message.clone(),
+                )),
+            );
+            if let CompileModuleReportOutcome::Compiled(mut output) = previous {
+                if let Err(error) = output.neutralize_retained_artifact() {
+                    report.outcome = CompileModuleReportOutcome::Failed(
+                        gore_as::compile::CompileError::Other(format!(
+                            "{message}; discarding the compiled mini-cache also failed: {error}"
+                        )),
+                    );
+                }
+            }
+        }
+    }
     let result_backend = report.backend_name();
     let standalone_attempted = report.standalone_attempted();
     let game_attempted = report.game_attempted();
-    let fallback = runner_unavailable.or_else(|| {
+    let skipped_fallback = game_fallback_note
+        .as_ref()
+        .filter(|_| matches!(report.outcome, CompileModuleReportOutcome::Failed(_)))
+        .map(|note| {
+            json!({
+                "failed_backend": CompilerBackendNameV1::Game.as_str(),
+                "failure_kind": "preflight",
+                "detail": note,
+            })
+        });
+    let fallback = runner_unavailable.or(skipped_fallback).or_else(|| {
         report.fallback_reason().map(|reason| {
             json!({
                 "failed_backend": reason.failed_backend().as_str(),
@@ -1028,6 +1086,29 @@ fn qualified_target_pristine_script_cache(
     let target_matches_pristine = qualified_shipping == pristine.as_slice()
         && selected.is_none_or(|source| source.matches(qualified_shipping));
     Ok((pristine, target_matches_pristine))
+}
+
+/// The pristine base the mini was remapped against must still be the deployment-aware original
+/// now that the compiler has run, by selection and by bytes.
+fn closing_base_audit(
+    game_dir: &Path,
+    selected: &gore_mod::PristineScriptCacheSource,
+    base: &[u8],
+) -> Result<(), String> {
+    let current = gore_mod::pristine_script_cache_source(game_dir).map_err(|error| {
+        format!("re-reading the deployment-aware pristine script cache: {error}")
+    })?;
+    if current.identity != selected.identity || !current.matches(base) {
+        return Err(format!(
+            "the pristine script cache changed during compilation: the compiler used {} ({}), but \
+             the deployment-aware original is now {} ({}); retry the compile",
+            selected.path.display(),
+            selected.identity,
+            current.path.display(),
+            current.identity
+        ));
+    }
+    Ok(())
 }
 
 fn pristine_base_changed_failure() -> Value {
@@ -1874,6 +1955,26 @@ mod tests {
         assert!(!message.contains("undeploy"), "got: {message}");
         assert_eq!(rejected["install_restore"], "not_started");
         assert_eq!(rejected["recovery_required"], false);
+    }
+
+    #[test]
+    fn closing_base_audit_refuses_a_base_that_changed_during_compilation() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let script = game.join("G1R/Script");
+        fs::create_dir_all(&script).unwrap();
+        let live = script.join("PrecompiledScript_Shipping.Cache");
+        fs::write(&live, b"pristine-cache").unwrap();
+        let selected = gore_mod::pristine_script_cache_source(&game).unwrap();
+
+        closing_base_audit(&game, &selected, b"pristine-cache").unwrap();
+
+        fs::write(&live, b"updated-by-the-game").unwrap();
+        let message = closing_base_audit(&game, &selected, b"pristine-cache").unwrap_err();
+        assert!(
+            message.contains("changed during compilation"),
+            "got: {message}"
+        );
     }
 
     fn request(payload: Value) -> String {

--- a/crates/gore-ffi/src/standalone_compiler_package.rs
+++ b/crates/gore-ffi/src/standalone_compiler_package.rs
@@ -53,21 +53,14 @@ pub(super) fn resolve_product_standalone_compiler_for_game_v1(
     game_dir: &Path,
 ) -> Result<ResolvedProductStandaloneCompilerV1, String> {
     let host_module = current_ffi_module_path()?;
-    let install_root = gore_mod::semantic_install_root(game_dir);
-    let g1r = install_root.join("G1R");
-    let executable = g1r
-        .join("Binaries")
-        .join("Win64")
-        .join("G1R-Win64-Shipping.exe");
-    let shipping_cache = g1r.join("Script").join("PrecompiledScript_Shipping.Cache");
-    let binds_cache = g1r.join("Script").join("Binds.Cache");
+    let paths = compiler_target_paths_for_game_v1(game_dir);
     Ok(
         match resolve_embedded_product_standalone_compiler_package_for_inputs_v1(
             &host_module,
             CompilerTargetInputPathsV1 {
-                executable: &executable,
-                shipping_cache: &shipping_cache,
-                binds_cache: &binds_cache,
+                executable: &paths.executable,
+                shipping_cache: &paths.shipping_cache,
+                binds_cache: &paths.binds_cache,
             },
         ) {
             ProductStandaloneCompilerPackageResolutionV1::BundleAbsent => {
@@ -81,6 +74,43 @@ pub(super) fn resolve_product_standalone_compiler_for_game_v1(
             }
         },
     )
+}
+
+/// The physical target files of the selected installation.
+///
+/// The Shipping cache is the deployment-aware pristine source: while a script mod is installed
+/// that is the deployment's `*.gore-bak`, so the installed mod stays in place and the compiler
+/// still validates its target against the original the deployment preserved. When no source can
+/// be selected (no cache, an interrupted deployment awaiting recovery) the live cache is named
+/// instead, and the authoritative pristine read every route performs after pinning the target
+/// reports the real problem under its own code.
+pub(super) struct CompilerTargetPathsV1 {
+    pub(super) executable: PathBuf,
+    pub(super) shipping_cache: PathBuf,
+    pub(super) binds_cache: PathBuf,
+    pub(super) pristine_source: Option<gore_mod::PristineScriptCacheSource>,
+}
+
+pub(super) fn compiler_target_paths_for_game_v1(game_dir: &Path) -> CompilerTargetPathsV1 {
+    let install_root = gore_mod::semantic_install_root(game_dir);
+    let g1r = install_root.join("G1R");
+    let executable = g1r
+        .join("Binaries")
+        .join("Win64")
+        .join("G1R-Win64-Shipping.exe");
+    let live_shipping_cache = g1r.join("Script").join("PrecompiledScript_Shipping.Cache");
+    let binds_cache = g1r.join("Script").join("Binds.Cache");
+    let pristine_source = gore_mod::pristine_script_cache_source(game_dir).ok();
+    let shipping_cache = pristine_source
+        .as_ref()
+        .map(|source| source.path.clone())
+        .unwrap_or(live_shipping_cache);
+    CompilerTargetPathsV1 {
+        executable,
+        shipping_cache,
+        binds_cache,
+        pristine_source,
+    }
 }
 
 pub(super) fn backend_evidence(
@@ -196,6 +226,72 @@ fn current_ffi_module_path() -> Result<PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
+
+    /// Writes the on-disk state a script deployment leaves behind: the modded live cache, the
+    /// pristine `*.gore-bak`, and a deploy record that authenticates both.
+    fn install_script_mod_record(game: &Path, pristine: &[u8], deployed: &[u8]) -> PathBuf {
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        let backup = PathBuf::from(format!("{}.gore-bak", live.display()));
+        std::fs::write(&backup, pristine).unwrap();
+        std::fs::write(&live, deployed).unwrap();
+        let recorded_live = std::fs::canonicalize(&live).unwrap();
+        let recorded_backup = std::fs::canonicalize(&backup).unwrap();
+        let identity = |bytes: &[u8]| format!("sha256:{:x}", Sha256::digest(bytes));
+        let mut record = gore_mod::DeployRecord {
+            mod_name: "fixture".to_owned(),
+            backups: vec![(
+                recorded_live.display().to_string(),
+                recorded_backup.display().to_string(),
+                true,
+            )],
+            ..Default::default()
+        };
+        record
+            .deployed_hashes
+            .insert(recorded_live.display().to_string(), identity(deployed));
+        record
+            .backup_hashes
+            .insert(recorded_backup.display().to_string(), identity(pristine));
+        std::fs::write(
+            game.join("gore-mod.deployed.json"),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+        backup
+    }
+
+    /// The Shipping target follows the deployment-aware pristine source: the live cache while
+    /// nothing is deployed, the deployment's backup while a script mod is installed, and the live
+    /// cache again when the source cannot be selected at all (the authoritative pristine read
+    /// after the pin then reports the real problem).
+    #[test]
+    fn target_paths_follow_the_deployment_aware_pristine_source() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let script = game.join("G1R/Script");
+        std::fs::create_dir_all(&script).unwrap();
+        let live = script.join("PrecompiledScript_Shipping.Cache");
+
+        let missing = compiler_target_paths_for_game_v1(&game);
+        assert_eq!(missing.shipping_cache, live);
+        assert!(missing.pristine_source.is_none());
+
+        std::fs::write(&live, b"pristine").unwrap();
+        let untouched = compiler_target_paths_for_game_v1(&game);
+        assert_eq!(untouched.shipping_cache, live);
+        assert!(!untouched.pristine_source.unwrap().from_backup);
+
+        let backup = install_script_mod_record(&game, b"pristine", b"deployed");
+        let installed = compiler_target_paths_for_game_v1(&game);
+        assert_eq!(installed.shipping_cache, backup);
+        assert!(installed.pristine_source.unwrap().from_backup);
+        assert_eq!(
+            installed.executable,
+            game.join("G1R/Binaries/Win64/G1R-Win64-Shipping.exe")
+        );
+        assert_eq!(installed.binds_cache, script.join("Binds.Cache"));
+    }
 
     #[test]
     fn empty_product_catalog_resolves_before_untrusted_target_paths() {

--- a/crates/gore-ffi/src/standalone_compiler_package.rs
+++ b/crates/gore-ffi/src/standalone_compiler_package.rs
@@ -42,7 +42,16 @@ impl CompilerBackendWireV2 {
 pub(super) enum ResolvedProductStandaloneCompilerV1 {
     BundleAbsent,
     Unavailable(ProductStandaloneCompilerPackageUnavailableV1),
-    Available(AvailableProductStandaloneCompilerPackageV1),
+    Available(ResolvedProductPackageV1),
+}
+
+/// An authenticated package together with the pristine source its Shipping target was validated
+/// against, so the check after the pin can prove the pinned bytes are the selected original and
+/// not merely whatever the pristine selection returns afterwards.
+#[derive(Debug)]
+pub(super) struct ResolvedProductPackageV1 {
+    pub(super) package: AvailableProductStandaloneCompilerPackageV1,
+    pub(super) pristine_source: Option<gore_mod::PristineScriptCacheSource>,
 }
 
 /// Resolve one product-authenticated compiler package for the exact selected installation.
@@ -70,7 +79,10 @@ pub(super) fn resolve_product_standalone_compiler_for_game_v1(
                 ResolvedProductStandaloneCompilerV1::Unavailable(reason)
             }
             ProductStandaloneCompilerPackageResolutionV1::Available(package) => {
-                ResolvedProductStandaloneCompilerV1::Available(package)
+                ResolvedProductStandaloneCompilerV1::Available(ResolvedProductPackageV1 {
+                    package,
+                    pristine_source: paths.pristine_source,
+                })
             }
         },
     )

--- a/crates/gore-mcp/src/spec/groups/script.rs
+++ b/crates/gore-mcp/src/spec/groups/script.rs
@@ -348,7 +348,7 @@ const EXPECT_BASE: ArgSpec = ArgSpec::new(
 const EXPECT_BASE_SHA256: ArgSpec = ArgSpec::new(
     "expect_base_sha256",
     Long("expect-base-sha256"),
-    Hex,
+    Str,
     "Refuse to compile unless the selected original script cache has this SHA-256 (64 hex \
      digits, `sha256:` prefix optional). Never selects the base.",
     false,
@@ -1123,6 +1123,24 @@ pub const AS_COMPILE_MODULE: GroupSpec = GroupSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The CLI accepts the documented `sha256:` prefix. A Hex pre-check would refuse it before
+    /// the spawn, so the MCP argument stays a plain string and the CLI remains the validator.
+    #[test]
+    fn the_expected_base_sha256_reaches_the_cli_unchecked() {
+        for args in [
+            COMPILE_ARGS,
+            COMPILE_MODULE_ARGS,
+            STANDALONE_COMPILE_ARGS,
+            STANDALONE_COMPILE_MODULE_ARGS,
+        ] {
+            let spec = args
+                .iter()
+                .find(|spec| spec.name == "expect_base_sha256")
+                .expect("expect_base_sha256 is declared");
+            assert_eq!(spec.kind, Str);
+        }
+    }
     use crate::spec::Class;
 
     #[test]

--- a/crates/gore-mcp/src/spec/groups/script.rs
+++ b/crates/gore-mcp/src/spec/groups/script.rs
@@ -127,6 +127,11 @@ const DIAGNOSTICS_DELAY: ArgSpec = ArgSpec::new(
 .with_default("2000");
 
 const DIAGNOSTICS_CONFLICT: &[&[&str]] = &[&["no_diagnostics", "diagnostics_hook"]];
+const EXPECT_BASE_CONFLICT: &[&[&str]] = &[&["expect_base", "expect_base_sha256"]];
+const COMPILE_CONFLICTS: &[&[&str]] = &[
+    &["no_diagnostics", "diagnostics_hook"],
+    &["expect_base", "expect_base_sha256"],
+];
 
 const DECODE_HEADER_ARGS: &[ArgSpec] = &[CACHE_FILE];
 
@@ -988,7 +993,7 @@ const AS_COMMANDS: &[CommandSpec] = &[
             .also_writes(&[("work_dir", Derived::Child("tree"))]),
         T_COMPILE,
     )
-    .at_most_one(DIAGNOSTICS_CONFLICT)
+    .at_most_one(COMPILE_CONFLICTS)
     .guide("scripts"),
     CommandSpec::new(
         "compile-module",
@@ -1000,7 +1005,7 @@ const AS_COMMANDS: &[CommandSpec] = &[
             .writes_into(&["out", "generation_receipt"]),
         T_COMPILE,
     )
-    .at_most_one(DIAGNOSTICS_CONFLICT)
+    .at_most_one(COMPILE_CONFLICTS)
     .guide("scripts"),
     // These five publish with a plain `std::fs::write` over whatever is at the destination
     // (cmd/as_cache.rs) -- unlike `patch-default` and `patch-tag-map`, which refuse an occupied
@@ -1072,6 +1077,7 @@ const STANDALONE_COMPILE_COMMANDS: &[CommandSpec] = &[CommandSpec::new(
     Safety::write().also_writes(&[("work_dir", Derived::Child("tree"))]),
     T_COMPILE,
 )
+.at_most_one(EXPECT_BASE_CONFLICT)
 .forced(&["--backend", "standalone"])
 .hides_cli_flags(&[
     "no-diagnostics",
@@ -1098,6 +1104,7 @@ const STANDALONE_COMPILE_MODULE_COMMANDS: &[CommandSpec] = &[CommandSpec::new(
         .writes_into(&["out", "generation_receipt"]),
     T_COMPILE,
 )
+.at_most_one(EXPECT_BASE_CONFLICT)
 .forced(&["--backend", "standalone"])
 .hides_cli_flags(&[
     "development-standalone-sidecar",
@@ -1123,6 +1130,28 @@ pub const AS_COMPILE_MODULE: GroupSpec = GroupSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// clap declares the two expectation flags as conflicting; the MCP layer must enforce the
+    /// same contract instead of spawning a CLI that fails at argument parsing.
+    #[test]
+    fn the_expectation_flags_are_mutually_exclusive_on_every_compile_route() {
+        for (group, sub) in [
+            (&AS, "compile"),
+            (&AS, "compile-module"),
+            (&AS_COMPILE, "compile"),
+            (&AS_COMPILE_MODULE, "compile-module"),
+        ] {
+            let command = group.command(sub).expect("compiler command");
+            assert!(
+                command
+                    .at_most_one_of
+                    .iter()
+                    .any(|set| *set == ["expect_base", "expect_base_sha256"]),
+                "{}/{sub} lacks the expect_base conflict set",
+                group.tool
+            );
+        }
+    }
 
     /// The CLI accepts the documented `sha256:` prefix. A Hex pre-check would refuse it before
     /// the spawn, so the MCP argument stays a plain string and the CLI remains the validator.

--- a/crates/gore-mcp/src/spec/groups/script.rs
+++ b/crates/gore-mcp/src/spec/groups/script.rs
@@ -336,6 +336,24 @@ const DIAGNOSTICS_CHECK_ARGS: &[ArgSpec] = &[
     GAME,
 ];
 
+const EXPECT_BASE: ArgSpec = ArgSpec::new(
+    "expect_base",
+    Long("expect-base"),
+    Path,
+    "Refuse to compile unless the selected original script cache is byte-identical to this \
+     file, for example a frozen copy of the vanilla cache. Never selects the base.",
+    false,
+);
+
+const EXPECT_BASE_SHA256: ArgSpec = ArgSpec::new(
+    "expect_base_sha256",
+    Long("expect-base-sha256"),
+    Hex,
+    "Refuse to compile unless the selected original script cache has this SHA-256 (64 hex \
+     digits, `sha256:` prefix optional). Never selects the base.",
+    false,
+);
+
 const COMPILE_ARGS: &[ArgSpec] = &[
     ArgSpec::new(
         "src",
@@ -371,6 +389,8 @@ const COMPILE_ARGS: &[ArgSpec] = &[
         true,
     ),
     GAME,
+    EXPECT_BASE,
+    EXPECT_BASE_SHA256,
     ArgSpec::new(
         "backend",
         Long("backend"),
@@ -441,6 +461,8 @@ const COMPILE_MODULE_ARGS: &[ArgSpec] = &[
         true,
     ),
     GAME,
+    EXPECT_BASE,
+    EXPECT_BASE_SHA256,
     ArgSpec::new(
         "backend",
         Long("backend"),
@@ -535,6 +557,8 @@ const STANDALONE_COMPILE_ARGS: &[ArgSpec] = &[
         true,
     ),
     GAME,
+    EXPECT_BASE,
+    EXPECT_BASE_SHA256,
     ArgSpec::new(
         "generation_receipt",
         Long("generation-receipt"),
@@ -595,6 +619,8 @@ const STANDALONE_COMPILE_MODULE_ARGS: &[ArgSpec] = &[
         true,
     ),
     GAME,
+    EXPECT_BASE,
+    EXPECT_BASE_SHA256,
     ArgSpec::new(
         "generation_receipt",
         Long("generation-receipt"),

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -11364,14 +11364,69 @@ pub(crate) fn bak_path(live: &Path) -> PathBuf {
 /// Reuses the same [`read_pristine_bounded`]/[`read_record`] logic so the compile base matches
 /// the bytes the splice will later be applied against. Never writes.
 pub fn pristine_script_cache(game_root: &Path) -> Result<Vec<u8>> {
-    let script_cache = resolve_game_paths(game_root).script_cache;
-    let record = read_record(game_root)?;
+    let (script_cache, record) = pristine_script_cache_inputs(game_root)?;
     let prior = record.as_ref().map(|stored| &stored.record);
-    if prior.is_some_and(|record| record.phase == DeployPhase::RecoveryRequired) {
-        return Err(recovery_required_error());
-    }
     read_pristine_bounded(&script_cache, prior, MAX_PRISTINE_PATCH_BYTES)
         .map(|(bytes, _drifted)| bytes)
+}
+
+/// Where the pristine precompiled-script cache lives right now, and which bytes it holds.
+///
+/// Compiler routes validate their standalone target against exactly this file, so an installed
+/// script mod can stay in place while its next version is compiled against the original the
+/// deployment preserved. The selection is the one [`pristine_script_cache`] reads from: the
+/// record-authenticated `*.gore-bak` while a deployment owns the cache, the live file when
+/// nothing is deployed there, and the live file again once it drifted from what was deployed (a
+/// game update made the backup stale). Never writes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PristineScriptCacheSource {
+    /// The file holding the pristine bytes.
+    pub path: PathBuf,
+    /// `sha256:<hex>` of the pristine bytes at selection time, in the deploy record's notation.
+    pub identity: String,
+    /// True when `path` is the deployment's `*.gore-bak` rather than the live cache.
+    pub from_backup: bool,
+    /// True when the live cache no longer matches what was deployed there, so the backup is
+    /// stale and the live cache is the pristine one.
+    pub drifted: bool,
+}
+
+impl PristineScriptCacheSource {
+    /// Whether `bytes` are exactly the bytes this selection named. A caller that pinned `path`
+    /// after selecting it proves with this that nothing replaced the file in between.
+    pub fn matches(&self, bytes: &[u8]) -> bool {
+        sha256_bytes(bytes) == self.identity
+    }
+}
+
+/// Select the pristine precompiled-script cache source for `game_root` without reading it.
+/// Refuses with `RECOVERY_REQUIRED` while an interrupted deployment awaits recovery, exactly
+/// like [`pristine_script_cache`].
+pub fn pristine_script_cache_source(game_root: &Path) -> Result<PristineScriptCacheSource> {
+    let (script_cache, record) = pristine_script_cache_inputs(game_root)?;
+    let prior = record.as_ref().map(|stored| &stored.record);
+    ensure_pristine_sources_bounded(&script_cache, MAX_PRISTINE_PATCH_BYTES)?;
+    let source = select_pristine_source(&script_cache, prior)?;
+    let from_backup = source.path != script_cache;
+    Ok(PristineScriptCacheSource {
+        path: source.path,
+        identity: source.basis.pristine,
+        from_backup,
+        drifted: source.drifted,
+    })
+}
+
+/// The live script-cache path and the deploy record both pristine selections start from.
+fn pristine_script_cache_inputs(game_root: &Path) -> Result<(PathBuf, Option<StoredDeployRecord>)> {
+    let script_cache = resolve_game_paths(game_root).script_cache;
+    let record = read_record(game_root)?;
+    if record
+        .as_ref()
+        .is_some_and(|stored| stored.record.phase == DeployPhase::RecoveryRequired)
+    {
+        return Err(recovery_required_error());
+    }
+    Ok((script_cache, record))
 }
 
 fn file_identities_for_path(record: &DeployRecord, path: &Path) -> Vec<String> {
@@ -18987,6 +19042,115 @@ mod tests {
         assert!(!bak_path(&live).exists());
         assert_eq!(std::fs::read(record_path(&game)).unwrap(), record_before);
         assert_no_manager_pre_mutation_residue(&game);
+    }
+
+    /// Installs a synthetic one-module script mod into `game`, whose live cache must already
+    /// carry a module cache with the same `guid`. Returns the pristine bytes deploy preserved.
+    fn install_synthetic_script_mod(scratch: &Path, game: &Path, guid: [u8; 16]) -> Vec<u8> {
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        let base = std::fs::read(&live).unwrap();
+        let bundle = scratch.join("bundle");
+        std::fs::create_dir_all(bundle.join("scripts")).unwrap();
+        std::fs::write(
+            bundle.join("scripts/0_Mod.cache"),
+            test_script_cache_with_guid("_gore_mod", guid),
+        )
+        .unwrap();
+        std::fs::write(
+            bundle.join("scripts/manifest.json"),
+            serde_json::to_vec(&vec![ScriptEntry {
+                op: "add".into(),
+                module: "_gore_mod".into(),
+                mini: "scripts/0_Mod.cache".into(),
+            }])
+            .unwrap(),
+        )
+        .unwrap();
+        let manifest = ModManifest {
+            format: 1,
+            mod_meta: ModMeta {
+                name: "InstalledScriptMod".into(),
+                version: "1".into(),
+                author: "offline-test".into(),
+            },
+            components: vec![Component::AngelScriptPatch {
+                path: "scripts".into(),
+            }],
+        };
+        std::fs::write(
+            bundle.join("gore-mod.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        deploy(&bundle, game).unwrap();
+        assert_ne!(std::fs::read(&live).unwrap(), base);
+        base
+    }
+
+    /// The compiler routes ask WHERE the pristine cache lives so they can validate their target
+    /// against that file: the live cache while nothing is deployed, the record-authenticated
+    /// `*.gore-bak` while a script mod is installed, and the (updated) live cache again once a
+    /// game update made that backup stale. Every answer carries the identity of the bytes it
+    /// names so a caller can prove it pinned the selected base.
+    #[test]
+    fn pristine_script_cache_source_names_the_backup_while_a_script_mod_is_installed() {
+        let dir = tempfile::tempdir().unwrap();
+        let game = manager_recovery_test_game(dir.path());
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        let guid = [0x41; 16];
+        std::fs::write(&live, test_script_cache_with_guid("_gore_base", guid)).unwrap();
+
+        let untouched = pristine_script_cache_source(&game).unwrap();
+        assert_eq!(untouched.path, live);
+        assert!(!untouched.from_backup);
+        assert!(!untouched.drifted);
+        let base = std::fs::read(&live).unwrap();
+        assert_eq!(untouched.identity, sha256_bytes(&base));
+        assert!(untouched.matches(&base));
+
+        let base = install_synthetic_script_mod(dir.path(), &game, guid);
+
+        let installed = pristine_script_cache_source(&game).unwrap();
+        assert_eq!(installed.path, bak_path(&live));
+        assert!(installed.from_backup);
+        assert!(!installed.drifted);
+        assert_eq!(installed.identity, sha256_bytes(&base));
+        assert!(installed.matches(&base));
+        assert!(!installed.matches(&std::fs::read(&live).unwrap()));
+        assert_eq!(pristine_script_cache(&game).unwrap(), base);
+
+        // A game update replaced the live cache underneath the deployment: the backup is stale
+        // and the updated live cache is the pristine source again.
+        let updated = test_script_cache_with_guid("_gore_base", [0x42; 16]);
+        std::fs::write(&live, &updated).unwrap();
+        let drifted = pristine_script_cache_source(&game).unwrap();
+        assert_eq!(drifted.path, live);
+        assert!(!drifted.from_backup);
+        assert!(drifted.drifted);
+        assert!(drifted.matches(&updated));
+        assert_eq!(pristine_script_cache(&game).unwrap(), updated);
+    }
+
+    #[test]
+    fn pristine_script_cache_source_returns_to_the_live_cache_after_undeploy() {
+        let dir = tempfile::tempdir().unwrap();
+        let game = manager_recovery_test_game(dir.path());
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        let guid = [0x43; 16];
+        std::fs::write(&live, test_script_cache_with_guid("_gore_base", guid)).unwrap();
+        let base = install_synthetic_script_mod(dir.path(), &game, guid);
+        assert!(pristine_script_cache_source(&game).unwrap().from_backup);
+
+        undeploy(&game)
+            .unwrap()
+            .expect("the script mod was installed");
+
+        let restored = pristine_script_cache_source(&game).unwrap();
+        assert_eq!(restored.path, live);
+        assert!(!restored.from_backup);
+        assert!(!restored.drifted);
+        assert!(restored.matches(&base));
+        assert!(!bak_path(&live).exists());
     }
 
     #[test]

--- a/crates/gore-mod/src/lib.rs
+++ b/crates/gore-mod/src/lib.rs
@@ -11407,11 +11407,29 @@ pub fn pristine_script_cache_source(game_root: &Path) -> Result<PristineScriptCa
     let prior = record.as_ref().map(|stored| &stored.record);
     ensure_pristine_sources_bounded(&script_cache, MAX_PRISTINE_PATCH_BYTES)?;
     let source = select_pristine_source(&script_cache, prior)?;
-    let from_backup = source.path != script_cache;
+    // Only a backup the active deployment owns means a script mod is installed. The selection
+    // also admits an unowned `*.gore-bak` that is byte-identical to the live cache; the live
+    // cache is then the same original, and the one every compiler backend can work from.
+    let owned_backup = source.path != script_cache
+        && prior.is_some_and(|record| {
+            backup_hash_for_path(&source.path, &record.backup_hashes).is_some()
+                || record
+                    .backups
+                    .iter()
+                    .any(|(stored_live, stored_backup, _)| {
+                        same_path(&script_cache, stored_live)
+                            && same_path(&source.path, stored_backup)
+                    })
+        });
+    let path = if owned_backup {
+        source.path
+    } else {
+        script_cache
+    };
     Ok(PristineScriptCacheSource {
-        path: source.path,
+        path,
         identity: source.basis.pristine,
-        from_backup,
+        from_backup: owned_backup,
         drifted: source.drifted,
     })
 }
@@ -19129,6 +19147,26 @@ mod tests {
         assert!(drifted.drifted);
         assert!(drifted.matches(&updated));
         assert_eq!(pristine_script_cache(&game).unwrap(), updated);
+    }
+
+    /// A `*.gore-bak` nobody owns is admitted only when it is byte-identical to the live cache,
+    /// so the live cache is the same original: no script mod is installed, and every compiler
+    /// backend may work from the live file.
+    #[test]
+    fn pristine_script_cache_source_treats_an_unowned_identical_backup_as_live() {
+        let dir = tempfile::tempdir().unwrap();
+        let game = manager_recovery_test_game(dir.path());
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        let base = test_script_cache_with_guid("_gore_base", [0x44; 16]);
+        std::fs::write(&live, &base).unwrap();
+        std::fs::write(bak_path(&live), &base).unwrap();
+
+        let source = pristine_script_cache_source(&game).unwrap();
+        assert_eq!(source.path, live);
+        assert!(!source.from_backup);
+        assert!(!source.drifted);
+        assert!(source.matches(&base));
+        assert_eq!(pristine_script_cache(&game).unwrap(), base);
     }
 
     #[test]

--- a/crates/gore/CHANGELOG.md
+++ b/crates/gore/CHANGELOG.md
@@ -5,6 +5,9 @@ uses the matching version section as the GitHub release notes.
 
 ## [Unreleased]
 
+- `gore as compile` and `compile-module` no longer require undeploying an
+  installed script mod first; the compiler target is the deployment's pristine
+  backup.
 - Support multi-module mini-caches: `gore as compile --mini` publishes the
   authored modules as one deployable mini, and build, deploy, the Manager and
   `as splice --upsert` compose it as one unit. Qualified in game with a

--- a/crates/gore/CHANGELOG.md
+++ b/crates/gore/CHANGELOG.md
@@ -8,6 +8,8 @@ uses the matching version section as the GitHub release notes.
 - `gore as compile` and `compile-module` no longer require undeploying an
   installed script mod first; the compiler target is the deployment's pristine
   backup.
+- `--expect-base <CACHE>` / `--expect-base-sha256 <HEX>` on `gore as compile`
+  and `compile-module` refuse to compile against any original but the given one.
 - Support multi-module mini-caches: `gore as compile --mini` publishes the
   authored modules as one deployable mini, and build, deploy, the Manager and
   `as splice --upsert` compose it as one unit. Qualified in game with a

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -1815,14 +1815,38 @@ fn guarded_pristine_script_cache(
     }
 }
 
+/// The Shipping cache file the standalone compiler target is validated against: the
+/// deployment-aware pristine source. While a script mod is installed that is the deployment's
+/// `*.gore-bak`, so the installed mod stays in place and the compiler still works from the
+/// original the deployment preserved; otherwise it is the live cache.
+fn compiler_shipping_source(game: &Path) -> Result<gore_mod::PristineScriptCacheSource> {
+    gore_mod::pristine_script_cache_source(game)
+        .context("selecting the deployment-aware pristine script cache")
+}
+
+fn announce_compiler_shipping_source(source: &gore_mod::PristineScriptCacheSource) {
+    if source.from_backup {
+        eprintln!(
+            "compiling against the deployment backup {} (the installed script mod stays in place)",
+            source.path.display()
+        );
+    }
+}
+
+/// Prove that the pinned compiler target holds the pristine base: its bytes must be the current
+/// deployment-aware pristine cache AND the bytes selected before the pin was taken. Anything else
+/// means the base changed in between (a deployment change or a game update ran alongside), which
+/// is a retry and never a reason to remove the installed mod.
 fn require_qualified_target_pristine_base(
+    selected: &gore_mod::PristineScriptCacheSource,
     qualified_shipping: &[u8],
     pristine: Vec<u8>,
 ) -> Result<Vec<u8>> {
-    if qualified_shipping != pristine {
+    if qualified_shipping != pristine || !selected.matches(qualified_shipping) {
         bail!(
-            "standalone compiler target uses the live Shipping cache, but the deployment-aware \
-             pristine script cache differs; reset or undeploy active script mods before compiling"
+            "the standalone compiler target no longer holds the deployment-aware pristine script \
+             cache: the base changed between selecting it and pinning it (a deployment change or \
+             a game update ran alongside); retry the compile"
         );
     }
     Ok(pristine)
@@ -1831,10 +1855,11 @@ fn require_qualified_target_pristine_base(
 fn qualified_target_pristine_script_cache(
     game: &Path,
     target: &gore_as::compiler_target::ValidatedCompilerTargetInputsV1,
+    selected: &gore_mod::PristineScriptCacheSource,
 ) -> Result<Vec<u8>> {
     let pristine = gore_mod::pristine_script_cache(game)
         .context("reading the deployment-aware pristine script cache")?;
-    require_qualified_target_pristine_base(target.shipping_cache(), pristine)
+    require_qualified_target_pristine_base(selected, target.shipping_cache(), pristine)
 }
 
 fn compiler_binds_path(game: &Path) -> PathBuf {
@@ -1855,15 +1880,6 @@ fn compiler_executable_path(game: &Path) -> PathBuf {
     g1r.join("Binaries")
         .join("Win64")
         .join("G1R-Win64-Shipping.exe")
-}
-
-fn compiler_shipping_path(game: &Path) -> PathBuf {
-    let g1r = if game.file_name().is_some_and(|name| name == "G1R") {
-        game.to_path_buf()
-    } else {
-        game.join("G1R")
-    };
-    g1r.join("Script").join("PrecompiledScript_Shipping.Cache")
 }
 
 enum ProductStandaloneRunnerV1 {
@@ -2006,7 +2022,9 @@ fn compile_full_graph_command(
     }
 
     let executable_path = compiler_executable_path(&game);
-    let shipping_path = compiler_shipping_path(&game);
+    let shipping_source = compiler_shipping_source(&game)?;
+    announce_compiler_shipping_source(&shipping_source);
+    let shipping_path = shipping_source.path.clone();
     let binds_path = compiler_binds_path(&game);
     let host_module = std::env::current_exe().context("resolving the GORE host executable")?;
     let resolution = gore_as::standalone_package_resolver::resolve_embedded_product_standalone_compiler_package_for_inputs_v1(
@@ -2101,7 +2119,7 @@ fn compile_full_graph_command(
         }
     }
     let (base_cache, binds_cache) = if let Some(target) = target.as_ref() {
-        let base = match qualified_target_pristine_script_cache(&game, target) {
+        let base = match qualified_target_pristine_script_cache(&game, target, &shipping_source) {
             Ok(base) => base,
             Err(error) => {
                 return match guard.take() {
@@ -3406,7 +3424,9 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             )?;
             let requested_mode: gore_as::compile::CompilerBackendModeV1 = compiler.backend.into();
             let executable_path = compiler_executable_path(&game);
-            let shipping_path = compiler_shipping_path(&game);
+            let shipping_source = compiler_shipping_source(&game)?;
+            announce_compiler_shipping_source(&shipping_source);
+            let shipping_path = shipping_source.path.clone();
             let binds_path = compiler_binds_path(&game);
             let target_paths = gore_as::compiler_target::CompilerTargetInputPathsV1 {
                 executable: &executable_path,
@@ -3547,7 +3567,8 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                     }
                     Some(acquired)
                 };
-                let base = match qualified_target_pristine_script_cache(&game, target) {
+                let base = qualified_target_pristine_script_cache(&game, target, &shipping_source);
+                let base = match base {
                     Ok(base) => base,
                     Err(error) => {
                         return match guard {
@@ -6112,20 +6133,117 @@ mod default_cli_tests {
         assert!(dropped.load(std::sync::atomic::Ordering::SeqCst));
     }
 
+    /// Writes the on-disk state a script deployment leaves behind: the modded live cache, the
+    /// pristine `*.gore-bak`, and a deploy record that authenticates both.
+    fn install_script_mod_record(game: &Path, pristine: &[u8], deployed: &[u8]) -> PathBuf {
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        let backup = PathBuf::from(format!("{}.gore-bak", live.display()));
+        std::fs::write(&backup, pristine).unwrap();
+        std::fs::write(&live, deployed).unwrap();
+        // Production deploy records persist canonical paths even when the caller uses an alias.
+        let recorded_live = std::fs::canonicalize(&live).unwrap();
+        let recorded_backup = std::fs::canonicalize(&backup).unwrap();
+        let identity = |bytes: &[u8]| format!("sha256:{:x}", Sha256::digest(bytes));
+        let mut record = gore_mod::DeployRecord {
+            mod_name: "fixture".to_owned(),
+            backups: vec![(
+                recorded_live.display().to_string(),
+                recorded_backup.display().to_string(),
+                true,
+            )],
+            ..Default::default()
+        };
+        record
+            .deployed_hashes
+            .insert(recorded_live.display().to_string(), identity(deployed));
+        record
+            .backup_hashes
+            .insert(recorded_backup.display().to_string(), identity(pristine));
+        std::fs::write(
+            game.join("gore-mod.deployed.json"),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+        backup
+    }
+
+    /// While a script mod is installed, the compiler target is validated against the
+    /// deployment's pristine backup, not the modded live cache, so the mod stays installed while
+    /// its next version compiles.
     #[test]
-    fn standalone_target_must_match_the_deployment_aware_pristine_base() {
-        let pristine = b"pristine-cache".to_vec();
+    fn compiler_shipping_source_is_the_deployment_backup_while_a_script_mod_is_installed() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let script = game.join("G1R/Script");
+        std::fs::create_dir_all(&script).unwrap();
+        let live = script.join("PrecompiledScript_Shipping.Cache");
+        std::fs::write(&live, b"pristine").unwrap();
+
+        let untouched = compiler_shipping_source(&game).unwrap();
+        assert_eq!(untouched.path, live);
+        assert!(!untouched.from_backup);
+        assert!(untouched.matches(b"pristine"));
+
+        let backup = install_script_mod_record(&game, b"pristine", b"deployed");
+        let installed = compiler_shipping_source(&game).unwrap();
+        assert_eq!(installed.path, backup);
+        assert!(installed.from_backup);
+        assert!(installed.matches(b"pristine"));
+        assert!(!installed.matches(b"deployed"));
+        assert_eq!(std::fs::read(&live).unwrap(), b"deployed");
+    }
+
+    #[test]
+    fn standalone_target_must_carry_the_selected_pristine_base() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"pristine-cache").unwrap();
+        let selected = compiler_shipping_source(&game).unwrap();
+
+        // The pinned target holds the current pristine bytes, which are the bytes selected
+        // before the pin.
         assert_eq!(
-            require_qualified_target_pristine_base(b"pristine-cache", pristine.clone()).unwrap(),
-            pristine
+            require_qualified_target_pristine_base(
+                &selected,
+                b"pristine-cache",
+                b"pristine-cache".to_vec()
+            )
+            .unwrap(),
+            b"pristine-cache"
         );
+
+        // The pinned target is not the current pristine cache: the base changed between the
+        // selection and the pin. That asks for a retry, not for an undeploy.
         let error = require_qualified_target_pristine_base(
+            &selected,
             b"live-cache-with-active-mod",
             b"pristine-cache".to_vec(),
         )
         .unwrap_err()
         .to_string();
-        assert!(error.contains("deployment-aware pristine script cache differs"));
+        assert!(
+            error.contains("changed between selecting it and pinning it"),
+            "got: {error}"
+        );
+        assert!(!error.contains("undeploy"), "got: {error}");
+
+        // The pinned target equals the current pristine cache, but not the bytes selected before
+        // the pin: the selection flipped underneath the compile.
+        std::fs::write(&live, b"other-cache").unwrap();
+        let flipped = compiler_shipping_source(&game).unwrap();
+        let error = require_qualified_target_pristine_base(
+            &flipped,
+            b"pristine-cache",
+            b"pristine-cache".to_vec(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("changed between selecting it and pinning it"),
+            "got: {error}"
+        );
     }
 
     #[test]

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -1817,7 +1817,16 @@ fn guarded_pristine_script_cache(
     // The bytes read under the guard must still be the original selected before it. The game
     // backend has no pinned target handle, so this comparison is its equivalent of the post-pin
     // check on the standalone path.
-    let outcome = match gore_mod::pristine_script_cache(game) {
+    // A deploy landing before the guard leaves the original's bytes in place (its backup holds
+    // them) while installing a mod the game compiler must not run on, so the source is selected
+    // again under the guard and not only compared by identity.
+    let outcome = match compiler_shipping_source(game).map_err(|error| error.to_string()) {
+        Err(error) => Err(error),
+        Ok(current) if current.from_backup => Err(format!(
+            "a script mod was installed after the compiler selected its base ({}); the game compiler cannot run on the deployment backup, retry the compile (the standalone compiler will be used)",
+            current.path.display()
+        )),
+        Ok(_) => match gore_mod::pristine_script_cache(game) {
         Ok(base) if selected.matches(&base) => Ok(base),
         Ok(_) => Err(
             "the pristine script cache changed between selecting it and reading it (a \
@@ -1827,6 +1836,7 @@ fn guarded_pristine_script_cache(
         Err(error) => Err(format!(
             "reading the drift-aware pristine script cache: {error}"
         )),
+        },
     };
     match outcome {
         Ok(base) => Ok((base, guard)),
@@ -6539,6 +6549,27 @@ mod default_cli_tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("changed during compilation"), "got: {error}");
+    }
+
+    /// A deploy landing between the selection and the guard leaves the bytes unchanged (the
+    /// backup holds the same original) but installs a mod the game compiler must not run on.
+    /// The guarded read therefore re-selects the source instead of trusting the identity alone.
+    #[test]
+    fn game_backend_refuses_a_script_mod_installed_after_selection() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"pristine").unwrap();
+        let selected = compiler_shipping_source(&game).unwrap();
+        assert!(!selected.from_backup);
+
+        install_script_mod_record(&game, b"pristine", b"deployed");
+        let error = guarded_pristine_script_cache(&game, &selected)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("script mod"), "got: {error}");
+        assert!(!game.join(".gore-install-mutation.lock").exists());
     }
 
     #[test]

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -1945,6 +1945,61 @@ fn require_expected_base(
     Ok(())
 }
 
+/// The compiler policy actually run for `requested` given where the original was found. While
+/// a script mod is installed the base is the deployment backup, which the game compiler cannot
+/// restore over the live cache: an explicit `game` policy is refused up front, and
+/// `standalone-then-game` runs the standalone compiler only, announcing the skipped fallback.
+fn effective_compile_mode(
+    requested: gore_as::compile::CompilerBackendModeV1,
+    source: &gore_mod::PristineScriptCacheSource,
+) -> Result<(gore_as::compile::CompilerBackendModeV1, Option<String>)> {
+    use gore_as::compile::CompilerBackendModeV1 as Mode;
+    if !source.from_backup {
+        return Ok((requested, None));
+    }
+    match requested {
+        Mode::Standalone => Ok((Mode::Standalone, None)),
+        Mode::StandaloneThenGame => Ok((
+            Mode::Standalone,
+            Some(
+                "the game fallback is unavailable while a script mod is installed (the compiler \
+                 base is the deployment backup, which the game compiler cannot restore over the \
+                 live cache); compiling with the standalone backend only"
+                    .to_owned(),
+            ),
+        )),
+        Mode::Game => bail!(
+            "the game compiler cannot run while a script mod is installed: the compiler base is \
+             the deployment backup {}, which the game compiler would restore over the live cache; \
+             use --backend standalone, or undeploy the mod first",
+            source.path.display()
+        ),
+    }
+}
+
+/// The closing check of `compile-module`: the pristine base the mini was remapped against must
+/// still be the deployment-aware pristine cache now that the compiler has run, by selection and
+/// by bytes. `gore as compile` audits this inside the full-graph transaction; the module path has
+/// no such hook, so it re-reads here before the mini is published.
+fn audit_compile_module_base(
+    game: &Path,
+    selected: &gore_mod::PristineScriptCacheSource,
+    base: &[u8],
+) -> Result<()> {
+    let current = compiler_shipping_source(game)?;
+    if current.identity != selected.identity || !current.matches(base) {
+        bail!(
+            "the pristine script cache changed during compilation: the compiler used {} ({}), \
+             but the deployment-aware original is now {} ({}); retry the compile",
+            selected.path.display(),
+            selected.identity,
+            current.path.display(),
+            current.identity
+        );
+    }
+    Ok(())
+}
+
 /// Prove that the pinned compiler target holds the pristine base: its bytes must be the current
 /// deployment-aware pristine cache AND the bytes selected before the pin was taken. Anything else
 /// means the base changed in between (a deployment change or a game update ran alongside), which
@@ -2152,7 +2207,11 @@ fn compile_full_graph_command(
         },
     );
 
-    let requested_mode: CompilerBackendModeV1 = compiler.backend.into();
+    let (requested_mode, game_fallback_note) =
+        effective_compile_mode(compiler.backend.into(), &shipping_source)?;
+    if let Some(note) = game_fallback_note.as_deref() {
+        eprintln!("{note}");
+    }
     let mut standalone_runner: Option<ProductStandaloneRunnerV1> = None;
     let mut receipt_authority = None;
     let mut target = None;
@@ -3544,7 +3603,6 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 gore_as::generation_receipt::MAX_GENERATION_SOURCE_FILE_BYTES_V1 as u64,
                 "AS_COMPILE_SOURCE",
             )?;
-            let requested_mode: gore_as::compile::CompilerBackendModeV1 = compiler.backend.into();
             let executable_path = compiler_executable_path(&game);
             let shipping_source = compiler_shipping_source(&game)?;
             announce_compiler_shipping_source(&shipping_source);
@@ -3552,6 +3610,11 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 require_expected_base(&shipping_source, expected)?;
             }
             let shipping_path = shipping_source.path.clone();
+            let (requested_mode, game_fallback_note) =
+                effective_compile_mode(compiler.backend.into(), &shipping_source)?;
+            if let Some(note) = game_fallback_note.as_deref() {
+                eprintln!("{note}");
+            }
             let binds_path = compiler_binds_path(&game);
             let target_paths = gore_as::compiler_target::CompilerTargetInputPathsV1 {
                 executable: &executable_path,
@@ -3843,6 +3906,21 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                     return Err(anyhow::Error::new(error)).context("compiling module");
                 }
             };
+            let mut compiled = compiled;
+            if let Err(audit) =
+                audit_compile_module_base(&opts.game_dir, &shipping_source, &base_override)
+            {
+                let cleanup = compiled
+                    .neutralize_retained_artifact()
+                    .err()
+                    .map(|error| {
+                        format!("; discarding the compiled mini-cache also failed: {error}")
+                    })
+                    .unwrap_or_default();
+                return Err(
+                    audit.context(format!("the compiled mini-cache was discarded{cleanup}"))
+                );
+            }
             let used_backend = used_backend.context(
                 "compiler succeeded without reporting the backend that produced its output",
             )?;
@@ -6403,6 +6481,62 @@ mod default_cli_tests {
             "got: {error}"
         );
         assert!(!game.join(".gore-install-mutation.lock").exists());
+    }
+
+    /// While a script mod is installed the compiler base is the deployment backup, which the
+    /// game compiler cannot restore over the live cache: `game` is refused up front and
+    /// `standalone-then-game` runs the standalone compiler only, saying so.
+    #[test]
+    fn effective_compile_mode_skips_the_game_fallback_while_a_script_mod_is_installed() {
+        use gore_as::compile::CompilerBackendModeV1 as Mode;
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"pristine").unwrap();
+        let untouched = compiler_shipping_source(&game).unwrap();
+        for mode in [Mode::Standalone, Mode::Game, Mode::StandaloneThenGame] {
+            let (effective, note) = effective_compile_mode(mode, &untouched).unwrap();
+            assert_eq!(effective, mode);
+            assert!(note.is_none());
+        }
+
+        install_script_mod_record(&game, b"pristine", b"deployed");
+        let installed = compiler_shipping_source(&game).unwrap();
+        let (effective, note) = effective_compile_mode(Mode::Standalone, &installed).unwrap();
+        assert_eq!(effective, Mode::Standalone);
+        assert!(note.is_none());
+        let (effective, note) =
+            effective_compile_mode(Mode::StandaloneThenGame, &installed).unwrap();
+        assert_eq!(effective, Mode::Standalone);
+        let note = note.expect("the skipped fallback is announced");
+        assert!(note.contains("game fallback"), "got: {note}");
+        let error = effective_compile_mode(Mode::Game, &installed)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("script mod is installed"), "got: {error}");
+        assert!(error.contains("--backend standalone"), "got: {error}");
+    }
+
+    /// The module path has no transaction hook for a closing audit, so the CLI re-reads the
+    /// deployment-aware pristine source before it publishes the mini and refuses a base that
+    /// changed while the compiler ran.
+    #[test]
+    fn compile_module_base_audit_refuses_a_base_that_changed_during_compilation() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"pristine-cache").unwrap();
+        let selected = compiler_shipping_source(&game).unwrap();
+
+        audit_compile_module_base(&game, &selected, b"pristine-cache").unwrap();
+
+        std::fs::write(&live, b"updated-by-the-game").unwrap();
+        let error = audit_compile_module_base(&game, &selected, b"pristine-cache")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("changed during compilation"), "got: {error}");
     }
 
     #[test]

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -307,6 +307,14 @@ pub enum AsCmd {
         /// path, then Steam auto-detect.
         #[arg(long)]
         game: Option<PathBuf>,
+        /// Refuse to compile unless the selected original script cache is byte-identical to this
+        /// file, for example a frozen copy of the vanilla cache. Never selects the base.
+        #[arg(long, value_name = "CACHE", conflicts_with = "expect_base_sha256")]
+        expect_base: Option<PathBuf>,
+        /// Refuse to compile unless the selected original script cache has this SHA-256
+        /// (64 hex digits, `sha256:` prefix optional). Never selects the base.
+        #[arg(long, value_name = "HEX")]
+        expect_base_sha256: Option<String>,
         /// Disable the optional runtime compiler-diagnostic hook and use the normal generator.
         #[arg(long, conflicts_with = "diagnostics_hook")]
         no_diagnostics: bool,
@@ -358,6 +366,14 @@ pub enum AsCmd {
         /// Game install root. Falls back to configured path, then Steam auto-detect.
         #[arg(long)]
         game: Option<PathBuf>,
+        /// Refuse to compile unless the selected original script cache is byte-identical to this
+        /// file, for example a frozen copy of the vanilla cache. Never selects the base.
+        #[arg(long, value_name = "CACHE", conflicts_with = "expect_base_sha256")]
+        expect_base: Option<PathBuf>,
+        /// Refuse to compile unless the selected original script cache has this SHA-256
+        /// (64 hex digits, `sha256:` prefix optional). Never selects the base.
+        #[arg(long, value_name = "HEX")]
+        expect_base_sha256: Option<String>,
         /// Disable the optional runtime compiler-diagnostic hook and use the normal generator.
         #[arg(long, conflicts_with = "diagnostics_hook")]
         no_diagnostics: bool,
@@ -1793,25 +1809,37 @@ fn acquire_compile_guard(game: &Path) -> Result<gore_as::compile::InstallMutatio
 
 fn guarded_pristine_script_cache(
     game: &Path,
+    selected: &gore_mod::PristineScriptCacheSource,
 ) -> Result<(Vec<u8>, gore_as::compile::InstallMutationGuard)> {
     let mut guard = acquire_compile_guard(game)
         .map_err(anyhow::Error::msg)
         .context("acquiring the AngelScript install-mutation guard")?;
-    match gore_mod::pristine_script_cache(game) {
+    // The bytes read under the guard must still be the original selected before it. The game
+    // backend has no pinned target handle, so this comparison is its equivalent of the post-pin
+    // check on the standalone path.
+    let outcome = match gore_mod::pristine_script_cache(game) {
+        Ok(base) if selected.matches(&base) => Ok(base),
+        Ok(_) => Err(
+            "the pristine script cache changed between selecting it and reading it (a \
+             deployment change or a game update ran alongside); retry the compile"
+                .to_owned(),
+        ),
+        Err(error) => Err(format!(
+            "reading the drift-aware pristine script cache: {error}"
+        )),
+    };
+    match outcome {
         Ok(base) => Ok((base, guard)),
-        Err(error) => {
-            let primary = format!("reading the drift-aware pristine script cache: {error}");
-            match guard.release() {
-                Ok(()) => Err(anyhow::Error::msg(primary)),
-                Err(release) => {
-                    guard.preserve_for_manual_recovery();
-                    bail!(
-                        "COMPILE_RECOVERY_REQUIRED: {primary}; additionally failed to release the \
-                         pre-held install-mutation guard: {release}"
-                    )
-                }
+        Err(primary) => match guard.release() {
+            Ok(()) => Err(anyhow::Error::msg(primary)),
+            Err(release) => {
+                guard.preserve_for_manual_recovery();
+                bail!(
+                    "COMPILE_RECOVERY_REQUIRED: {primary}; additionally failed to release the \
+                     pre-held install-mutation guard: {release}"
+                )
             }
-        }
+        },
     }
 }
 
@@ -1831,6 +1859,90 @@ fn announce_compiler_shipping_source(source: &gore_mod::PristineScriptCacheSourc
             source.path.display()
         );
     }
+}
+
+/// What `--expect-base` / `--expect-base-sha256` demand of the selected original. Neither form
+/// selects the base: the deployment-aware selection stays the only source of truth, and the
+/// expectation merely refuses a compile whose original is not the one the caller vouches for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExpectedBase {
+    /// `sha256:<hex>` in the deploy record's notation.
+    Identity(String),
+    /// A file whose bytes the selected original must equal.
+    File(PathBuf),
+}
+
+const EXPECTED_BASE_MAX_BYTES: u64 = 512 * 1024 * 1024;
+
+fn expected_base_from_args(
+    file: Option<PathBuf>,
+    sha256: Option<String>,
+) -> Result<Option<ExpectedBase>> {
+    if let Some(path) = file {
+        return Ok(Some(ExpectedBase::File(path)));
+    }
+    let Some(raw) = sha256 else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    let hex = trimmed
+        .get(..7)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("sha256:"))
+        .map_or(trimmed, |_| &trimmed[7..]);
+    if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!(
+            "--expect-base-sha256 must be 64 hex digits (a `sha256:` prefix is optional), got {raw:?}"
+        );
+    }
+    Ok(Some(ExpectedBase::Identity(format!(
+        "sha256:{}",
+        hex.to_ascii_lowercase()
+    ))))
+}
+
+fn base_identity(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+fn describe_shipping_source(source: &gore_mod::PristineScriptCacheSource) -> &'static str {
+    if source.from_backup {
+        "the deployment backup"
+    } else if source.drifted {
+        "the live cache, updated since the deployment"
+    } else {
+        "the live cache"
+    }
+}
+
+/// Refuse to go on unless the selected original is the one the caller vouches for.
+fn require_expected_base(
+    source: &gore_mod::PristineScriptCacheSource,
+    expected: &ExpectedBase,
+) -> Result<()> {
+    let (expected_identity, vouched_by) = match expected {
+        ExpectedBase::Identity(identity) => (identity.clone(), "--expect-base-sha256".to_owned()),
+        ExpectedBase::File(path) => {
+            let bytes = read_regular_bounded(path, EXPECTED_BASE_MAX_BYTES, "AS_EXPECTED_BASE")
+                .with_context(|| format!("reading the expected base file {}", path.display()))?;
+            (
+                base_identity(&bytes),
+                format!("--expect-base {}", path.display()),
+            )
+        }
+    };
+    if source.identity != expected_identity {
+        bail!(
+            "the selected original script cache is not the expected one: {} ({}) has {}, but {} \
+             vouches for {}",
+            source.path.display(),
+            describe_shipping_source(source),
+            source.identity,
+            vouched_by,
+            expected_identity
+        );
+    }
+    eprintln!("the selected original matches the expected base ({expected_identity})");
+    Ok(())
 }
 
 /// Prove that the pinned compiler target holds the pristine base: its bytes must be the current
@@ -1946,6 +2058,7 @@ fn compile_full_graph_command(
     mini: Option<PathBuf>,
     work_dir: PathBuf,
     game: Option<PathBuf>,
+    expected_base: Option<ExpectedBase>,
     no_diagnostics: bool,
     diagnostics_hook: Option<PathBuf>,
     diagnostics_inject_delay_ms: u64,
@@ -2024,6 +2137,9 @@ fn compile_full_graph_command(
     let executable_path = compiler_executable_path(&game);
     let shipping_source = compiler_shipping_source(&game)?;
     announce_compiler_shipping_source(&shipping_source);
+    if let Some(expected) = expected_base.as_ref() {
+        require_expected_base(&shipping_source, expected)?;
+    }
     let shipping_path = shipping_source.path.clone();
     let binds_path = compiler_binds_path(&game);
     let host_module = std::env::current_exe().context("resolving the GORE host executable")?;
@@ -2132,7 +2248,7 @@ fn compile_full_graph_command(
     } else if requested_mode == CompilerBackendModeV1::Standalone {
         unreachable!("strict standalone availability was checked above")
     } else {
-        let (base, acquired) = guarded_pristine_script_cache(&game)?;
+        let (base, acquired) = guarded_pristine_script_cache(&game, &shipping_source)?;
         guard = Some(acquired);
         let binds =
             match read_regular_bounded(&binds_path, DEFAULT_BINDS_MAX_BYTES, "AS_FULL_GRAPH_BINDS")
@@ -3384,6 +3500,8 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             mini,
             work_dir,
             game,
+            expect_base,
+            expect_base_sha256,
             no_diagnostics,
             diagnostics_hook,
             diagnostics_inject_delay_ms,
@@ -3395,6 +3513,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 mini,
                 work_dir,
                 game,
+                expected_base_from_args(expect_base, expect_base_sha256)?,
                 no_diagnostics,
                 diagnostics_hook,
                 diagnostics_inject_delay_ms,
@@ -3410,12 +3529,15 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             allow_new_symbols,
             out,
             game,
+            expect_base,
+            expect_base_sha256,
             no_diagnostics,
             diagnostics_hook,
             diagnostics_inject_delay_ms,
             compiler,
         } => {
             let game = gore_loc::config::game_root(game).context("resolving game path")?;
+            let expected_base = expected_base_from_args(expect_base, expect_base_sha256)?;
             let work_dir = resolve_compile_module_work_dir(work_dir, &game)?;
             let source_bytes = read_regular_bounded(
                 &source,
@@ -3426,6 +3548,9 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             let executable_path = compiler_executable_path(&game);
             let shipping_source = compiler_shipping_source(&game)?;
             announce_compiler_shipping_source(&shipping_source);
+            if let Some(expected) = expected_base.as_ref() {
+                require_expected_base(&shipping_source, expected)?;
+            }
             let shipping_path = shipping_source.path.clone();
             let binds_path = compiler_binds_path(&game);
             let target_paths = gore_as::compiler_target::CompilerTargetInputPathsV1 {
@@ -3581,7 +3706,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             } else if requested_mode == gore_as::compile::CompilerBackendModeV1::Standalone {
                 unreachable!("strict standalone availability was checked above")
             } else {
-                let (base, guard) = guarded_pristine_script_cache(&game)?;
+                let (base, guard) = guarded_pristine_script_cache(&game, &shipping_source)?;
                 (base, Some(guard))
             };
             let binds_override = standalone_target
@@ -6194,6 +6319,93 @@ mod default_cli_tests {
     }
 
     #[test]
+    fn expected_base_sha256_is_normalized_and_validated() {
+        let hex = "ab".repeat(32);
+        assert_eq!(
+            expected_base_from_args(None, Some(format!("SHA256:{}", hex.to_uppercase()))).unwrap(),
+            Some(ExpectedBase::Identity(format!("sha256:{hex}")))
+        );
+        assert_eq!(expected_base_from_args(None, None).unwrap(), None);
+        assert_eq!(
+            expected_base_from_args(Some(PathBuf::from("frozen.Cache")), None).unwrap(),
+            Some(ExpectedBase::File(PathBuf::from("frozen.Cache")))
+        );
+        for bad in ["abc", &"zz".repeat(32), ""] {
+            let error = expected_base_from_args(None, Some(bad.to_owned()))
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("64 hex digits"), "got: {error}");
+        }
+    }
+
+    /// `--expect-base` / `--expect-base-sha256` never choose the base; they only refuse a compile
+    /// whose selected original is not the one the caller vouches for.
+    #[test]
+    fn expected_base_must_match_the_selected_original() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"pristine-cache").unwrap();
+        let selected = compiler_shipping_source(&game).unwrap();
+        let identity = format!("sha256:{:x}", Sha256::digest(b"pristine-cache"));
+        let other = format!("sha256:{:x}", Sha256::digest(b"other-cache"));
+
+        require_expected_base(&selected, &ExpectedBase::Identity(identity.clone())).unwrap();
+        let error = require_expected_base(&selected, &ExpectedBase::Identity(other.clone()))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(&other), "got: {error}");
+        assert!(error.contains(&identity), "got: {error}");
+        assert!(
+            error.contains(&selected.path.display().to_string()),
+            "the message must name the selected original: {error}"
+        );
+
+        let same = root.path().join("frozen.Cache");
+        std::fs::write(&same, b"pristine-cache").unwrap();
+        require_expected_base(&selected, &ExpectedBase::File(same)).unwrap();
+        let different = root.path().join("different.Cache");
+        std::fs::write(&different, b"other-cache").unwrap();
+        let error = require_expected_base(&selected, &ExpectedBase::File(different.clone()))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(&other), "got: {error}");
+        assert!(error.contains(&identity), "got: {error}");
+        assert!(
+            error.contains(&different.display().to_string()),
+            "the message must name the expected file: {error}"
+        );
+        let missing = root.path().join("missing.Cache");
+        let error = require_expected_base(&selected, &ExpectedBase::File(missing))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("missing.Cache"), "got: {error}");
+    }
+
+    /// The game backend reads its base after the selection; those bytes must still be the
+    /// selected original, exactly like the pinned standalone target.
+    #[test]
+    fn game_backend_base_must_still_be_the_selected_original() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"selected").unwrap();
+        let selected = compiler_shipping_source(&game).unwrap();
+
+        std::fs::write(&live, b"replaced").unwrap();
+        let error = guarded_pristine_script_cache(&game, &selected)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("changed between selecting it and reading it"),
+            "got: {error}"
+        );
+        assert!(!game.join(".gore-install-mutation.lock").exists());
+    }
+
+    #[test]
     fn standalone_target_must_carry_the_selected_pristine_base() {
         let root = tempfile::tempdir().unwrap();
         let game = root.path().join("game");
@@ -6298,7 +6510,8 @@ mod default_cli_tests {
         )
         .unwrap();
 
-        let (base, mut guard) = guarded_pristine_script_cache(&game).unwrap();
+        let selected = compiler_shipping_source(&game).unwrap();
+        let (base, mut guard) = guarded_pristine_script_cache(&game, &selected).unwrap();
         assert_eq!(base, b"authoritative-pristine");
         let contender = gore_as::compile::InstallMutationGuard::acquire(&game, "gore-mod:deploy")
             .expect_err("deploy must remain blocked after the authoritative read");
@@ -6315,9 +6528,13 @@ mod default_cli_tests {
     fn compile_module_cli_releases_guard_when_pristine_selection_fails() {
         let root = tempfile::tempdir().unwrap();
         let game = root.path().join("game");
-        std::fs::create_dir_all(&game).unwrap();
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"selected").unwrap();
+        let selected = compiler_shipping_source(&game).unwrap();
+        std::fs::remove_file(&live).unwrap();
 
-        let error = guarded_pristine_script_cache(&game)
+        let error = guarded_pristine_script_cache(&game, &selected)
             .unwrap_err()
             .to_string();
         assert!(error.contains("pristine script cache"), "got: {error}");

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -2029,11 +2029,31 @@ fn require_qualified_target_pristine_base(
     Ok(pristine)
 }
 
+/// The selection made before the guard must still hold once the guard is held. A deploy landing
+/// in between leaves the pinned bytes and the backup identical to the original while installing
+/// a script mod on the live cache, which only a fresh selection notices.
+fn require_unchanged_selection(
+    game: &Path,
+    selected: &gore_mod::PristineScriptCacheSource,
+) -> Result<()> {
+    let current = compiler_shipping_source(game)?;
+    if current.from_backup != selected.from_backup
+        || current.identity != selected.identity
+        || current.path != selected.path
+    {
+        bail!(
+            "the deployment-aware pristine script cache changed between selecting it and pinning it (a deployment change or a game update ran alongside); retry the compile"
+        );
+    }
+    Ok(())
+}
+
 fn qualified_target_pristine_script_cache(
     game: &Path,
     target: &gore_as::compiler_target::ValidatedCompilerTargetInputsV1,
     selected: &gore_mod::PristineScriptCacheSource,
 ) -> Result<Vec<u8>> {
+    require_unchanged_selection(game, selected)?;
     let pristine = gore_mod::pristine_script_cache(game)
         .context("reading the deployment-aware pristine script cache")?;
     require_qualified_target_pristine_base(selected, target.shipping_cache(), pristine)
@@ -6570,6 +6590,29 @@ mod default_cli_tests {
             .to_string();
         assert!(error.contains("script mod"), "got: {error}");
         assert!(!game.join(".gore-install-mutation.lock").exists());
+    }
+
+    /// The qualified-target path selects its base before the guard too. A deploy landing in
+    /// between keeps the pinned bytes and the backup identical to the original, so only a fresh
+    /// selection under the guard notices the installed mod.
+    #[test]
+    fn qualified_target_selection_must_survive_the_guard() {
+        let root = tempfile::tempdir().unwrap();
+        let game = root.path().join("game");
+        let live = game.join("G1R/Script/PrecompiledScript_Shipping.Cache");
+        std::fs::create_dir_all(live.parent().unwrap()).unwrap();
+        std::fs::write(&live, b"pristine").unwrap();
+        let selected = compiler_shipping_source(&game).unwrap();
+        require_unchanged_selection(&game, &selected).unwrap();
+
+        install_script_mod_record(&game, b"pristine", b"deployed");
+        let error = require_unchanged_selection(&game, &selected)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("changed between selecting it and pinning it"),
+            "got: {error}"
+        );
     }
 
     #[test]

--- a/crates/gore/src/cmd/as_cache.rs
+++ b/crates/gore/src/cmd/as_cache.rs
@@ -2207,8 +2207,9 @@ fn compile_full_graph_command(
         },
     );
 
-    let (requested_mode, game_fallback_note) =
-        effective_compile_mode(compiler.backend.into(), &shipping_source)?;
+    let requested_mode: CompilerBackendModeV1 = compiler.backend.into();
+    let (effective_mode, game_fallback_note) =
+        effective_compile_mode(requested_mode, &shipping_source)?;
     if let Some(note) = game_fallback_note.as_deref() {
         eprintln!("{note}");
     }
@@ -2218,7 +2219,7 @@ fn compile_full_graph_command(
     let mut package_unavailable = None;
     match resolution {
         ProductStandaloneCompilerPackageResolutionV1::Available(available) => {
-            let runner = (requested_mode != CompilerBackendModeV1::Game)
+            let runner = (effective_mode != CompilerBackendModeV1::Game)
                 .then(|| available.sidecar_runner(work_dir.clone()));
             let (authority, target_inputs) = available.into_execution_parts();
             receipt_authority = Some(authority);
@@ -2235,7 +2236,7 @@ fn compile_full_graph_command(
                             error.kind().as_str()
                         );
                         package_unavailable = Some(detail.clone());
-                        if requested_mode == CompilerBackendModeV1::StandaloneThenGame {
+                        if effective_mode == CompilerBackendModeV1::StandaloneThenGame {
                             standalone_runner =
                                 Some(ProductStandaloneRunnerV1::Unavailable { detail });
                         }
@@ -2250,7 +2251,7 @@ fn compile_full_graph_command(
             package_unavailable = Some(format!("{:?}: {}", reason.kind(), reason.detail()));
         }
     }
-    if requested_mode == CompilerBackendModeV1::Standalone && standalone_runner.is_none() {
+    if effective_mode == CompilerBackendModeV1::Standalone && standalone_runner.is_none() {
         bail!(
             "standalone compiler unavailable: {}",
             package_unavailable
@@ -2266,7 +2267,7 @@ fn compile_full_graph_command(
                 .unwrap_or("no product-authenticated package matched the installed target")
         );
     }
-    if requested_mode == CompilerBackendModeV1::StandaloneThenGame {
+    if effective_mode == CompilerBackendModeV1::StandaloneThenGame {
         if let Some(reason) = package_unavailable.as_deref() {
             eprintln!(
                 "standalone package unavailable; explicit game fallback remains enabled: {reason}"
@@ -2275,7 +2276,7 @@ fn compile_full_graph_command(
     }
 
     let mut guard = None;
-    if requested_mode != CompilerBackendModeV1::Standalone {
+    if effective_mode != CompilerBackendModeV1::Standalone {
         if let Some(target) = target.as_mut() {
             // Target validation pins every parent directory without delete sharing. Keep the exact
             // EXE/Shipping/Binds file handles open, release only those directory handles while the
@@ -2304,7 +2305,7 @@ fn compile_full_graph_command(
             }
         };
         (base, target.binds_cache().to_vec())
-    } else if requested_mode == CompilerBackendModeV1::Standalone {
+    } else if effective_mode == CompilerBackendModeV1::Standalone {
         unreachable!("strict standalone availability was checked above")
     } else {
         let (base, acquired) = guarded_pristine_script_cache(&game, &shipping_source)?;
@@ -2368,7 +2369,7 @@ fn compile_full_graph_command(
     let audit_base = opts.base_cache.clone();
     let audit_binds = opts.binds_cache.clone();
     let closing_audit = move || audit_full_graph_inputs(&audit_game, &audit_base, &audit_binds);
-    let report = match requested_mode {
+    let report = match effective_mode {
         CompilerBackendModeV1::Standalone => {
             gore_as::compile::compile_full_graph_standalone_v1_with_target(
                 &opts,
@@ -2389,7 +2390,7 @@ fn compile_full_graph_command(
                     gore_as::compile::compile_full_graph_with_backend_v1_with_guard_and_target(
                         &opts,
                         &diagnostics,
-                        requested_mode,
+                        effective_mode,
                         standalone_runner
                             .as_mut()
                             .map(|runner| runner as &mut dyn StandaloneCompilerRunnerV1),
@@ -2401,7 +2402,7 @@ fn compile_full_graph_command(
                 None => gore_as::compile::compile_full_graph_with_backend_v1_with_guard(
                     &opts,
                     &diagnostics,
-                    requested_mode,
+                    effective_mode,
                     standalone_runner
                         .as_mut()
                         .map(|runner| runner as &mut dyn StandaloneCompilerRunnerV1),
@@ -3610,8 +3611,9 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 require_expected_base(&shipping_source, expected)?;
             }
             let shipping_path = shipping_source.path.clone();
-            let (requested_mode, game_fallback_note) =
-                effective_compile_mode(compiler.backend.into(), &shipping_source)?;
+            let requested_mode: gore_as::compile::CompilerBackendModeV1 = compiler.backend.into();
+            let (effective_mode, game_fallback_note) =
+                effective_compile_mode(requested_mode, &shipping_source)?;
             if let Some(note) = game_fallback_note.as_deref() {
                 eprintln!("{note}");
             }
@@ -3653,7 +3655,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 );
                 match resolution {
                     ProductStandaloneCompilerPackageResolutionV1::Available(available) => {
-                        let runner = (requested_mode
+                        let runner = (effective_mode
                             != gore_as::compile::CompilerBackendModeV1::Game)
                             .then(|| available.sidecar_runner(work_dir.clone()));
                         let (authority, target) = available.into_execution_parts();
@@ -3672,7 +3674,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                                         error.kind().as_str()
                                     );
                                     package_unavailable = Some(detail.clone());
-                                    if requested_mode
+                                    if effective_mode
                                         == gore_as::compile::CompilerBackendModeV1::StandaloneThenGame
                                     {
                                         standalone_runner = Some(
@@ -3696,7 +3698,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                             Some(format!("{:?}: {}", reason.kind(), reason.detail()));
                     }
                 }
-                if requested_mode == gore_as::compile::CompilerBackendModeV1::Standalone
+                if effective_mode == gore_as::compile::CompilerBackendModeV1::Standalone
                     && standalone_runner.is_none()
                 {
                     bail!(
@@ -3715,7 +3717,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                         )
                     );
                 }
-                if requested_mode == gore_as::compile::CompilerBackendModeV1::StandaloneThenGame {
+                if effective_mode == gore_as::compile::CompilerBackendModeV1::StandaloneThenGame {
                     if let Some(reason) = package_unavailable.as_deref() {
                         eprintln!(
                             "standalone compiler unavailable; using the visible game fallback: \
@@ -3733,7 +3735,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
             }
 
             let (base_override, guard) = if let Some(target) = standalone_target.as_mut() {
-                let guard = if requested_mode == gore_as::compile::CompilerBackendModeV1::Standalone
+                let guard = if effective_mode == gore_as::compile::CompilerBackendModeV1::Standalone
                 {
                     None
                 } else {
@@ -3766,7 +3768,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                     }
                 };
                 (base, guard)
-            } else if requested_mode == gore_as::compile::CompilerBackendModeV1::Standalone {
+            } else if effective_mode == gore_as::compile::CompilerBackendModeV1::Standalone {
                 unreachable!("strict standalone availability was checked above")
             } else {
                 let (base, guard) = guarded_pristine_script_cache(&game, &shipping_source)?;
@@ -3830,7 +3832,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                     gore_as::compile::compile_module_with_backend_v1_with_guard_and_target(
                         &opts,
                         &diagnostics,
-                        requested_mode,
+                        effective_mode,
                         standalone.as_mut().map(|runner| {
                             runner as &mut dyn gore_as::compile::StandaloneCompilerRunnerV1
                         }),
@@ -3841,7 +3843,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 (Some(guard), None) => gore_as::compile::compile_module_with_backend_v1_with_guard(
                     &opts,
                     &diagnostics,
-                    requested_mode,
+                    effective_mode,
                     standalone.as_mut().map(|runner| {
                         runner as &mut dyn gore_as::compile::StandaloneCompilerRunnerV1
                     }),
@@ -3858,7 +3860,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                     gore_as::compile::compile_module_with_backend_v1(
                         &opts,
                         &diagnostics,
-                        requested_mode,
+                        effective_mode,
                         pinned_standalone.as_mut().map(|runner| {
                             runner as &mut dyn gore_as::compile::StandaloneCompilerRunnerV1
                         }),
@@ -3867,7 +3869,7 @@ pub fn run(cmd: AsCmd) -> Result<()> {
                 (None, None) => gore_as::compile::compile_module_with_backend_v1(
                     &opts,
                     &diagnostics,
-                    requested_mode,
+                    effective_mode,
                     standalone.as_mut().map(|runner| {
                         runner as &mut dyn gore_as::compile::StandaloneCompilerRunnerV1
                     }),

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -351,8 +351,8 @@ Output directories must not exist and are never placed in the game tree.
 | `patch-tag-map <CACHE>` | `--selector <JSON>` · `--expected-hex` · `--replacement-hex` · `-o, --out` · `--json` |
 | `qualify` | `--game` · `--usmap <FILE>` · `--catalog <JSON>` · `--id <ID>` · `--label <TEXT>` · `--json` |
 | `diagnostics-check` | `--exe <EXE>` · `--game <GAME>` |
-| `compile <SRC>` | `-o, --out` · `--mini <PATH>` · `--work-dir <DIR>` · `--game` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · `--no-diagnostics` · `--diagnostics-hook <DLL>` · `--diagnostics-inject-delay-ms <MS>` |
-| `compile-module` | `--op add\|edit` · `--module` · `--rel-path` · `--source` · `--work-dir` · `--allow-new-symbols` · `-o, --out` · `--game` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · diagnostics flags · five `--development-*` compiler-development overrides |
+| `compile <SRC>` | `-o, --out` · `--mini <PATH>` · `--work-dir <DIR>` · `--game` · `--expect-base <CACHE>` · `--expect-base-sha256 <HEX>` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · `--no-diagnostics` · `--diagnostics-hook <DLL>` · `--diagnostics-inject-delay-ms <MS>` |
+| `compile-module` | `--op add\|edit` · `--module` · `--rel-path` · `--source` · `--work-dir` · `--allow-new-symbols` · `-o, --out` · `--game` · `--expect-base <CACHE>` · `--expect-base-sha256 <HEX>` · `--backend standalone\|game\|standalone-then-game` (default `standalone-then-game`) · `--generation-receipt <RECEIPT.json>` · diagnostics flags · five `--development-*` compiler-development overrides |
 | `replace <BASE> <MINI> <TARGET>` | `-o, --out` |
 | `splice <BASE> <MINI>` | `--upsert` · `-o, --out` |
 | `extract <CACHE> <MODULE>` | `-o, --out` |

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -206,6 +206,20 @@ These are enforced, not advisory:
   artifacts and cross-tool ownership are retained and no usable compile result
   is returned.
 
+### Compiling while a script mod is installed
+
+An installed script mod does not have to be undeployed before its next version
+compiles. Every compile route validates the standalone compiler target against
+the deployment-aware pristine cache: while a deployment owns the script cache
+that is the `*.gore-bak` its record authenticates, otherwise the live file (also
+after a game update, when the backup is stale and the updated live cache is the
+new original). The CLI says so when it compiles against the backup. The pinned
+base is checked again after the pin and, for `gore as compile`, at the end of
+the run; if it changed in between, the compile fails closed and asks for a
+retry rather than an undeploy. The installed version is replaced only by the
+next `gore mod deploy` or Manager apply, which rebuild from the same pristine
+backup.
+
 ### Compiler diagnostics
 
 Strict `standalone` returns the bundled compiler's native diagnostics with the

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -221,10 +221,11 @@ next `gore mod deploy` or Manager apply, which rebuild from the same pristine
 backup.
 
 This holds for the standalone compiler. The game compiler regenerates into the
-live cache and restores it from the pinned target afterwards, so a target
-validated against the backup is refused before any install change; with a
-script mod installed, a game-capable policy reports that refusal as the
-fallback reason and only the standalone result counts.
+live cache and restores it from the pinned target afterwards, so it cannot run
+while a script mod is installed: `--backend game` is refused up front, and
+`standalone-then-game` runs the standalone compiler only, saying that the game
+fallback was skipped. Should the standalone compile fail, its own diagnostics
+are what you see, with that note appended.
 
 To pin which original a compile may use, pass `--expect-base <CACHE>` (a file
 the selected original must equal byte for byte, for example a frozen copy of

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -220,6 +220,12 @@ retry rather than an undeploy. The installed version is replaced only by the
 next `gore mod deploy` or Manager apply, which rebuild from the same pristine
 backup.
 
+This holds for the standalone compiler. The game compiler regenerates into the
+live cache and restores it from the pinned target afterwards, so a target
+validated against the backup is refused before any install change; with a
+script mod installed, a game-capable policy reports that refusal as the
+fallback reason and only the standalone result counts.
+
 To pin which original a compile may use, pass `--expect-base <CACHE>` (a file
 the selected original must equal byte for byte, for example a frozen copy of
 the vanilla cache) or `--expect-base-sha256 <HEX>`. Both refuse the compile

--- a/docs/guide/scripts.md
+++ b/docs/guide/scripts.md
@@ -220,6 +220,12 @@ retry rather than an undeploy. The installed version is replaced only by the
 next `gore mod deploy` or Manager apply, which rebuild from the same pristine
 backup.
 
+To pin which original a compile may use, pass `--expect-base <CACHE>` (a file
+the selected original must equal byte for byte, for example a frozen copy of
+the vanilla cache) or `--expect-base-sha256 <HEX>`. Both refuse the compile
+when the selected original differs and print both hashes; neither picks the
+base. The deployment-aware selection stays the only source of truth.
+
 ### Compiler diagnostics
 
 Strict `standalone` returns the bundled compiler's native diagnostics with the
@@ -290,6 +296,7 @@ gore as compile-module --op add --module MyMod.Dialog `
 | `--work-dir <DIR>` | Existing workspace outside the game installation (emitted tree + intermediate cache). |
 | `--allow-new-symbols` | Retain minimal rows for classes/functions/names absent from the pristine cache. |
 | `-o, --out <PATH>` | The remapped 1-module mini-cache. |
+| `--expect-base <CACHE>` / `--expect-base-sha256 <HEX>` | Refuse to compile unless the selected original is this file's bytes / has this SHA-256. Neither selects the base; both exist on `compile` as well. |
 
 The high-level `dialog new-topic` scaffold uses the same compiler command in a
 more specific shape. A new root or direct sub-topic is appended to the


### PR DESCRIPTION
## Summary

Iterating on an installed script mod no longer needs undeploy → compile → deploy.

- Every product compile route (`gore as compile`, `gore as compile-module`, the MCP compile tools, Studio's script compile and the managed project/story compilers) used to validate the standalone compiler target against the **live** `PrecompiledScript_Shipping.Cache`, while the base it emits and remaps against came from gore-mod's deployment-aware pristine selection. With a script mod deployed the two differed and the routes refused with "reset or undeploy active script mods before compiling".
- gore-mod now exposes the pristine **source**, not just its bytes: `pristine_script_cache_source` names the file the selection picks (the record-authenticated `*.gore-bak` while a deployment owns the cache, the live file otherwise, the live file again after a game update made the backup stale) together with its SHA-256 identity. An unowned backup that is byte-identical to the live cache counts as the live cache, not as an installed mod.
- The CLI and the FFI package resolver build the compiler target from that path. The target handle pins the pristine file for the whole attempt, the installed mod stays in place, and the CLI says so (`compiling against the deployment backup …`).
- The check after the pin remains and now also proves the pinned bytes carry the identity selected before the pin (CLI, Studio script compile, managed project/story compilers). A mismatch fails closed asking for a retry (`COMPILE_PRISTINE_BASE_CHANGED` on the wire). `compile-module` (CLI and Studio) re-reads the deployment-aware original after the compiler ran and discards a mini whose base changed meanwhile, as the full-graph closing audit already did.
- The game compiler regenerates into the live cache and restores it from the pinned target, so it never runs on a backup-based base: the transaction refuses such a target before its first install mutation; `--backend game` (and the explicit `game` policy on every Studio route, including the legacy dispatch) is refused up front; `standalone-then-game` runs the standalone compiler only and reports the standalone result with the skipped fallback noted (CLI stderr, Studio evidence, only on failure) instead of a refused game attempt hiding the standalone diagnostics. A package that is absent or unavailable then reports its own cause with the skipped fallback attached; an empty project still needs no compiler. Every route re-selects the pristine source once the install-mutation guard is held, so a deploy landing between selection and guard cannot reach the game compiler.
- New `--expect-base <CACHE>` / `--expect-base-sha256 <HEX>` on `compile` and `compile-module` let a caller vouch for the original: they refuse a compile whose selected original differs (naming both hashes and where the original came from) and never select the base themselves. Receipts seal the caller's requested policy, not the effective one. The MCP compile tools declare both arguments as a plain string (the CLI validates the optional `sha256:` prefix) and as mutually exclusive.
- Guide (`scripts.md`, `cli-reference.md`) and changelogs updated.

Unchanged: drift handling, and the fact that the installed version is only replaced by the next `gore mod deploy` / Manager apply, which rebuild from the same pristine backup.

## Test plan

- [x] `cargo test -p gore-mod` (513 passed; new: source names the backup while a mod is installed, drift and undeploy return to live, unowned identical backup counts as live)
- [x] `cargo test -p gore-as` (632 passed; new: backup-pinned target refused before the first install mutation, blocker detection, standalone-then-game keeps the standalone failure when the fallback is blocked)
- [x] `cargo test -p gore` (377 passed + integration; new: target path from the backup, post-pin identity check, expectation parsing/matching, guarded game-backend read and post-guard re-selection, fallback policy, closing base audit)
- [x] `cargo test -p gore-ffi` (525 passed; new: resolver target paths follow the pristine source, identity-aware post-pin check, closing base audit, skipped-fallback gating, installed-mod probe, changed failure code)
- [x] `cargo test -p gore-mcp` (346 passed; new: expectation argument kinds and conflict sets)
- [x] `scripts/check_docs_links.py` clean; rustfmt clean on the touched regions
- [x] Installed CLI smoke test on a fake install with a recorded script deployment: announces the backup base, honours both expectation flags, never asks for an undeploy
- [x] Cursor Bugbot and Codex clean on the final head after twelve review rounds
- [ ] Real in-game iteration: keep the NPC test mod installed, change it, compile, deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
